### PR TITLE
fix #248: crossorigin attribute is needed when including with type="module"

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -236,7 +236,7 @@
 
     <link href="/stylesheets/style.css" rel="stylesheet">
 
-    <script src="/javascripts/services/bootstrap.js" type="module"></script>
+    <script src="/javascripts/services/bootstrap.js" crossorigin type="module"></script>
 
     <link rel="stylesheet" type="text/css" href="/libraries/jam/css/jam.min.css">
 

--- a/src/views/setup.ejs
+++ b/src/views/setup.ejs
@@ -129,6 +129,6 @@
 
 <script src="/libraries/knockout.min.js"></script>
 
-<script src="/javascripts/setup.js" type="module"></script>
+<script src="/javascripts/setup.js" crossorigin type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
As discussed in #248.

Tested on Linux Mozilla Firefox 63.0.3 and Chromium 70.0.3538.110.