### PR TITLE
Fix math panel overflow - closes #2056

### DIFF
--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -297,6 +297,8 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
     }
 
     preventMathInputOverflow() {
+        const editor = this.textEditor;
+
         const balloon = editor.plugins.get('MathUI')._balloon;
         const formView = editor.plugins.get('MathUI').formView;
         


### PR DESCRIPTION
The issue was originally caused by the math plugin only allowing the balloon to show up below the target. This pull request allows it to show on top as well, fixing the overflow issue.