### PR TITLE
upgrade node v14.17.6 for gitpod since optional chaining is required

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@ image:
   file: .gitpod.dockerfile
 
 tasks:
-    - before: nvm install 10 && nvm use 10
+    - before: nvm install 14.17.6 && nvm use 14.17.6
       init: npm install
       command: npm run start-server
 


### PR DESCRIPTION
Optional chaining is required in the backend codebase. Therefore we need to upgrade default gitpod version. I used the version from the Dockerfile.