### PR TITLE
Add week notes to frontend script api

### DIFF
--- a/src/public/app/services/date_notes.js
+++ b/src/public/app/services/date_notes.js
@@ -24,6 +24,15 @@ async function getDateNote(date) {
 }
 
 /** @return {NoteShort} */
+async function getWeekNote(date) {
+    const note = await server.get('special-notes/week/' + date, "date-note");
+
+    await ws.waitForMaxKnownEntityChangeId();
+
+    return await froca.getNote(note.noteId);
+}
+
+/** @return {NoteShort} */
 async function getMonthNote(month) {
     const note = await server.get('special-notes/month/' + month, "date-note");
 
@@ -63,6 +72,7 @@ export default {
     getInboxNote,
     getTodayNote,
     getDateNote,
+    getWeekNote,
     getMonthNote,
     getYearNote,
     createSqlConsole,

--- a/src/public/app/services/frontend_script_api.js
+++ b/src/public/app/services/frontend_script_api.js
@@ -397,6 +397,15 @@ function FrontendScriptApi(startNote, currentNote, originEntity = null, $contain
     this.getDateNote = dateNotesService.getDateNote;
 
     /**
+     * Returns date-note for the first date of the week of the given date. If it doesn't exist, it is automatically created.
+     *
+     * @method
+     * @param {string} date - e.g. "2019-04-29"
+     * @return {Promise<NoteShort>}
+     */
+     this.getWeekNote = dateNotesService.getWeekNote;
+
+    /**
      * Returns month-note. If it doesn't exist, it is automatically created.
      *
      * @method

--- a/src/routes/api/special_notes.js
+++ b/src/routes/api/special_notes.js
@@ -14,6 +14,10 @@ function getDateNote(req) {
     return dateNoteService.getDateNote(req.params.date);
 }
 
+function getWeekNote(req) {
+    return dateNoteService.getWeekNote(req.params.date);
+}
+
 function getMonthNote(req) {
     return dateNoteService.getMonthNote(req.params.month);
 }
@@ -65,6 +69,7 @@ function getHoistedNote() {
 module.exports = {
     getInboxNote,
     getDateNote,
+    getWeekNote,
     getMonthNote,
     getYearNote,
     getDateNotesForMonth,

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -262,6 +262,7 @@ function register(app) {
 
     apiRoute(GET, '/api/special-notes/inbox/:date', specialNotesRoute.getInboxNote);
     apiRoute(GET, '/api/special-notes/date/:date', specialNotesRoute.getDateNote);
+    apiRoute(GET, '/api/special-notes/week/:date', specialNotesRoute.getWeekNote);
     apiRoute(GET, '/api/special-notes/month/:month', specialNotesRoute.getMonthNote);
     apiRoute(GET, '/api/special-notes/year/:year', specialNotesRoute.getYearNote);
     apiRoute(GET, '/api/special-notes/notes-for-month/:month', specialNotesRoute.getDateNotesForMonth);


### PR DESCRIPTION
Note: getWeekNote can take `startOfTheWeek` as options but is not passed to the api route.