### PR TITLE
Add an option to disable WAL.

### DIFF
--- a/src/services/sql.js
+++ b/src/services/sql.js
@@ -11,7 +11,9 @@ const cls = require('./cls');
 const fs = require("fs-extra");
 
 const dbConnection = new Database(dataDir.DOCUMENT_PATH);
-dbConnection.pragma('journal_mode = WAL');
+if (process.env.TRILIUM_DB_DISABLE_WAL !== "1") {
+    dbConnection.pragma('journal_mode = WAL');
+}
 
 const LOG_ALL_QUERIES = false;
 


### PR DESCRIPTION
Related: https://github.com/zadam/trilium/discussions/3029

SQLite variants/extensions like [mvSQLite](https://github.com/losfair/mvsqlite) and [LiteFS](https://github.com/superfly/litefs) do not support WAL. By adding a environment variable option to disable WAL we can get Trilium working on these systems.