### PR TITLE
Stop note map simulation if not visible

### DIFF
--- a/src/public/app/widgets/containers/ribbon_container.js
+++ b/src/public/app/widgets/containers/ribbon_container.js
@@ -198,6 +198,10 @@ export default class RibbonContainer extends NoteContextAwareWidget {
                 }
             }
         } else {
+            const activeChild = this.getActiveRibbonWidget();
+            if (activeChild) {
+                activeChild.handleEvent('deactivated', {});
+            }
             this.lastActiveComponentId = null;
         }
     }

--- a/src/public/app/widgets/note_detail.js
+++ b/src/public/app/widgets/note_detail.js
@@ -217,6 +217,9 @@ export default class NoteDetailWidget extends NoteContextAwareWidget {
 
     async beforeNoteSwitchEvent({noteContext}) {
         if (this.isNoteContext(noteContext.ntxId)) {
+            for (const x of this.children) {
+                x.handleEvent("deactivated", {});
+            }
             await this.spacedUpdate.updateNowIfNecessary();
         }
     }

--- a/src/public/app/widgets/note_map.js
+++ b/src/public/app/widgets/note_map.js
@@ -138,6 +138,11 @@ export default class NoteMapWidget extends NoteContextAwareWidget {
         this.renderData(data);
     }
 
+    deactivatedEvent() {
+        this.graph.stopAnimation();
+        this.graph = null;
+    }
+
     getMapRootNoteId() {
         if (this.widgetMode === 'ribbon') {
             return this.noteId;

--- a/src/public/app/widgets/type_widgets/note_map.js
+++ b/src/public/app/widgets/type_widgets/note_map.js
@@ -23,4 +23,8 @@ export default class NoteMapTypeWidget extends TypeWidget {
     async doRefresh(note) {
         await this.noteMapWidget.refresh();
     }
+
+    deactivatedEvent() {
+        this.noteMapWidget.deactivatedEvent();
+    }
 }


### PR DESCRIPTION
Without this fix, Trilium will be sluggish for a while (usually less than a minute) after closing a large note map.