### PR TITLE
feat: Add configurable date/time format for Alt+T shortcut

### DIFF
--- a/src/public/app/services/utils.js
+++ b/src/public/app/services/utils.js
@@ -81,23 +81,25 @@ function formatDateISO(date) {
 // In utils.js
 // import dayjs from 'dayjs'; // Assuming dayjs is available in this scope
 
+// new version
 function formatDateTime(date, userSuppliedFormat) {
-    const DEFAULT_FORMAT = 'YYYY-MM-DD HH:mm';
-    let formatToUse = DEFAULT_FORMAT; 
+    let formatToUse;
 
     if (userSuppliedFormat && typeof userSuppliedFormat === 'string' && userSuppliedFormat.trim() !== "") {
         formatToUse = userSuppliedFormat.trim();
+    } else {
+        formatToUse = 'YYYY-MM-DD HH:mm'; // Trilium's default format
     }
 
     if (!date) {
-        date = new Date(); 
+        date = new Date();
     }
 
     try {
         return dayjs(date).format(formatToUse);
     } catch (e) {
-        console.warn(`Trilium: Day.js encountered an error with format string "${formatToUse}". Falling back to default. Error: ${e.message}`);
-        return dayjs(date).format(DEFAULT_FORMAT); 
+        console.warn(`Day.js: Invalid format string "${formatToUse}". Falling back. Error:`, e.message);
+        return dayjs(date).format('YYYY-MM-DD HH:mm');
     }
 }
 

--- a/src/public/app/services/utils.js
+++ b/src/public/app/services/utils.js
@@ -73,8 +73,32 @@ function formatDateISO(date) {
     return `${date.getFullYear()}-${padNum(date.getMonth() + 1)}-${padNum(date.getDate())}`;
 }
 
-function formatDateTime(date) {
-    return `${formatDate(date)} ${formatTime(date)}`;
+// old version
+// function formatDateTime(date) {
+//     return `${formatDate(date)} ${formatTime(date)}`;
+// }
+
+// In utils.js
+// import dayjs from 'dayjs'; // Assuming dayjs is available in this scope
+
+function formatDateTime(date, userSuppliedFormat) {
+    const DEFAULT_FORMAT = 'YYYY-MM-DD HH:mm';
+    let formatToUse = DEFAULT_FORMAT; 
+
+    if (userSuppliedFormat && typeof userSuppliedFormat === 'string' && userSuppliedFormat.trim() !== "") {
+        formatToUse = userSuppliedFormat.trim();
+    }
+
+    if (!date) {
+        date = new Date(); 
+    }
+
+    try {
+        return dayjs(date).format(formatToUse);
+    } catch (e) {
+        console.warn(`Trilium: Day.js encountered an error with format string "${formatToUse}". Falling back to default. Error: ${e.message}`);
+        return dayjs(date).format(DEFAULT_FORMAT); 
+    }
 }
 
 function localNowDateTime() {

--- a/src/public/app/widgets/type_widgets/content_widget.js
+++ b/src/public/app/widgets/type_widgets/content_widget.js
@@ -8,6 +8,7 @@ import KeyboardShortcutsOptions from "./options/shortcuts.js";
 import HeadingStyleOptions from "./options/text_notes/heading_style.js";
 import TableOfContentsOptions from "./options/text_notes/table_of_contents.js";
 import HighlightsListOptions from "./options/text_notes/highlights_list.js";
+import DateTimeFormatOptions from "./options/text_notes/date_time_format.js";
 import TextAutoReadOnlySizeOptions from "./options/text_notes/text_auto_read_only_size.js";
 import VimKeyBindingsOptions from "./options/code_notes/vim_key_bindings.js";
 import WrapLinesOptions from "./options/code_notes/wrap_lines.js";
@@ -66,6 +67,7 @@ const CONTENT_WIDGETS = {
         HeadingStyleOptions,
         TableOfContentsOptions,
         HighlightsListOptions,
+        DateTimeFormatOptions,
         TextAutoReadOnlySizeOptions
     ],
     _optionsCodeNotes: [

--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -109,9 +109,9 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
             (await mimeTypesService.getMimeTypes())
                 .filter(mt => mt.enabled)
                 .map(mt => ({
-                        language: mt.mime.toLowerCase().replace(/[\W_]+/g,"-"),
-                        label: mt.title
-                    }));
+                    language: mt.mime.toLowerCase().replace(/[\W_]+/g, "-"),
+                    label: mt.title
+                }));
 
         // CKEditor since version 12 needs the element to be visible before initialization. At the same time,
         // we want to avoid flicker - i.e., show editor only once everything is ready. That's why we have separate
@@ -211,7 +211,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         this.watchdog?.editor.editing.view.focus();
     }
 
-    show() {}
+    show() { }
 
     getEditor() {
         return this.watchdog?.editor;
@@ -225,10 +225,29 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         }
     }
 
-    insertDateTimeToTextCommand() {
-        const date = new Date();
-        const dateString = utils.formatDateTime(date);
+    // old version
+    // insertDateTimeToTextCommand() {
+    //     const date = new Date();
+    //     const dateString = utils.formatDateTime(date);
 
+    //     this.addTextToEditor(dateString);
+    // }
+
+    // new version
+    async insertDateTimeToTextCommand() {
+        const date = new Date();
+        let userPreferredFormat = ""; //Default
+
+        try {
+            const allOptions = await server.get('options');
+            
+            if (allOptions && typeof allOptions.customDateTimeFormatString === 'string') {
+                userPreferredFormat = allOptions.customDateTimeFormatString;
+            }
+        } catch (e) {
+            console.error("Trilium: Failed to fetch options for custom date/time format. Using default.", e);
+        }
+        const dateString = utils.formatDateTime(date, userPreferredFormat);
         this.addTextToEditor(dateString);
     }
 
@@ -237,7 +256,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
 
         this.watchdog.editor.model.change(writer => {
             const insertPosition = this.watchdog.editor.model.document.selection.getFirstPosition();
-            writer.insertText(linkTitle, {linkHref: linkHref}, insertPosition);
+            writer.insertText(linkTitle, { linkHref: linkHref }, insertPosition);
         });
     }
 
@@ -250,7 +269,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         });
     }
 
-    addTextToActiveEditorEvent({text}) {
+    addTextToActiveEditorEvent({ text }) {
         if (!this.isActive()) {
             return;
         }
@@ -283,7 +302,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         return !selection.isCollapsed;
     }
 
-    async executeWithTextEditorEvent({callback, resolve, ntxId}) {
+    async executeWithTextEditorEvent({ callback, resolve, ntxId }) {
         if (!this.isNoteContext(ntxId)) {
             return;
         }
@@ -300,7 +319,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
     addLinkToTextCommand() {
         const selectedText = this.getSelectedText();
 
-        this.triggerCommand('showAddLinkDialog', {textTypeWidget: this, text: selectedText})
+        this.triggerCommand('showAddLinkDialog', { textTypeWidget: this, text: selectedText })
     }
 
     getSelectedText() {
@@ -347,29 +366,29 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
     }
 
     addIncludeNoteToTextCommand() {
-        this.triggerCommand("showIncludeNoteDialog", {textTypeWidget: this});
+        this.triggerCommand("showIncludeNoteDialog", { textTypeWidget: this });
     }
 
     addIncludeNote(noteId, boxSize) {
-        this.watchdog.editor.model.change( writer => {
+        this.watchdog.editor.model.change(writer => {
             // Insert <includeNote>*</includeNote> at the current selection position
             // in a way that will result in creating a valid model structure
             this.watchdog.editor.model.insertContent(writer.createElement('includeNote', {
                 noteId: noteId,
                 boxSize: boxSize
             }));
-        } );
+        });
     }
 
     async addImage(noteId) {
         const note = await froca.getNote(noteId);
 
-        this.watchdog.editor.model.change( writer => {
+        this.watchdog.editor.model.change(writer => {
             const encodedTitle = encodeURIComponent(note.title);
             const src = `api/images/${note.noteId}/${encodedTitle}`;
 
-            this.watchdog.editor.execute( 'insertImage', { source: src } );
-        } );
+            this.watchdog.editor.execute('insertImage', { source: src });
+        });
     }
 
     async createNoteForReferenceLink(title) {
@@ -385,7 +404,7 @@ export default class EditableTextTypeWidget extends AbstractTextTypeWidget {
         return resp.note.getBestNotePathString();
     }
 
-    async refreshIncludedNoteEvent({noteId}) {
+    async refreshIncludedNoteEvent({ noteId }) {
         this.refreshIncludedNote(this.$editor, noteId);
     }
 }

--- a/src/public/app/widgets/type_widgets/editable_text.js
+++ b/src/public/app/widgets/type_widgets/editable_text.js
@@ -9,6 +9,7 @@ import AbstractTextTypeWidget from "./abstract_text_type_widget.js";
 import link from "../../services/link.js";
 import appContext from "../../components/app_context.js";
 import dialogService from "../../services/dialog.js";
+import server from '../../services/server.js';
 
 const ENABLE_INSPECTOR = false;
 

--- a/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
+++ b/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
@@ -9,11 +9,13 @@ const TPL = `
         Uses <a href="https://day.js.org/docs/en/display/format" target="_blank" rel="noopener noreferrer">Day.js format tokens</a>.
         Refer to the Day.js documentation for valid tokens.
     </p>
-    <p>
-        <strong>Important:</strong> If you provide a string that Day.js cannot interpret as a format,
-        the literal string you typed might be inserted. If the format string is empty, or if Day.js
-        encounters an internal error with your format, a default format (e.g., YYYY-MM-DD HH:mm) will be used.
-    </p>
+<p>
+    <strong>Important:</strong> If you provide a format string that Day.js does not recognize
+    (e.g., mostly plain text without valid <a href="https://day.js.org/docs/en/display/format" target="_blank" rel="noopener noreferrer">Day.js tokens</a>),
+    the text you typed might be inserted literally. If the format string is left empty,
+    or if Day.js encounters a critical internal error with your format,
+    a default format (e.g., YYYY-MM-DD HH:mm) will be used.
+</p>
 
     <div class="form-group">
         <label for="customDateTimeFormatInput" style="margin-right: 10px;">Format String:</label>
@@ -39,8 +41,8 @@ export default class DateTimeFormatOptions extends OptionsWidget {
         //listen to input
         this.$formatInput.on("input", () => {
             const formatString = this.$formatInput.val();
-            
-            this.updateOption("customDateTimeFormatString", formatString); 
+
+            this.updateOption("customDateTimeFormatString", formatString);
         });
 
         return this.$widget; //render method to return the widget
@@ -49,7 +51,7 @@ export default class DateTimeFormatOptions extends OptionsWidget {
     async optionsLoaded(options) {
         const currentFormat = options.customDateTimeFormatString || "";
 
-        
+
         if (this.$formatInput) {
             this.$formatInput.val(currentFormat);
         } else {

--- a/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
+++ b/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
@@ -1,0 +1,74 @@
+import OptionsWidget from "../options_widget.js";
+
+const TPL = `
+<div class="options-section">
+    <h4>Custom Date/Time Format (Alt+T)</h4>
+
+    <p>
+        Define a custom format for the date and time inserted using the Alt+T shortcut.
+        Uses <a href="https://day.js.org/docs/en/display/format" target="_blank" rel="noopener noreferrer">Day.js format tokens</a>.
+        Refer to the Day.js documentation for valid tokens.
+    </p>
+    <p>
+        <strong>Important:</strong> If you provide a string that Day.js cannot interpret as a format,
+        the literal string you typed might be inserted. If the format string is empty, or if Day.js
+        encounters an internal error with your format, a default format (e.g., YYYY-MM-DD HH:mm) will be used.
+    </p>
+
+    <div class="form-group">
+        <label for="customDateTimeFormatInput" style="margin-right: 10px;">Format String:</label>
+        <input type="text" id="customDateTimeFormatInput" class="form-control custom-datetime-format-input" placeholder="e.g., DD/MM/YYYY HH:mm:ss or dddd, MMMM D" style="width: 300px; display: inline-block;">
+    </div>
+    <p style="margin-top: 5px;">
+        <em>Examples of valid Day.js formats:</em>
+        <code>YYYY-MM-DD HH:mm</code> (Default-like),
+        <code>DD.MM.YYYY</code>,
+        <code>MMMM D, YYYY h:mm A</code>,
+        <code>[Today is] dddd</code>
+    </p>
+</div>
+`;
+
+export default class DateTimeFormatOptions extends OptionsWidget {
+    doRender() {
+        this.$widget = $(TPL);
+        this.$formatInput = this.$widget.find(
+            "input.custom-datetime-format-input"
+        );
+
+        //listen to input
+        this.$formatInput.on("input", () => {
+            const formatString = this.$formatInput.val();
+            
+            this.updateOption("customDateTimeFormatString", formatString); 
+        });
+
+        return this.$widget; //render method to return the widget
+    }
+
+    async optionsLoaded(options) {
+        //todo: update the key in updateOption
+        const currentFormat = options.customDateTimeFormatString || "";
+
+        
+        if (this.$formatInput) {
+            this.$formatInput.val(currentFormat);
+        } else {
+
+            console.warn(
+                "DateTimeFormatOptions: $formatInput not initialized when optionsLoaded was called. Attempting to find again."
+            );
+            const inputField = this.$widget.find(
+                "input.custom-datetime-format-input"
+            );
+            if (inputField.length) {
+                this.$formatInput = inputField;
+                this.$formatInput.val(currentFormat);
+            } else {
+                console.error(
+                    "DateTimeFormatOptions: Could not find format input field in optionsLoaded."
+                );
+            }
+        }
+    }
+}

--- a/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
+++ b/src/public/app/widgets/type_widgets/options/text_notes/date_time_format.js
@@ -47,7 +47,6 @@ export default class DateTimeFormatOptions extends OptionsWidget {
     }
 
     async optionsLoaded(options) {
-        //todo: update the key in updateOption
         const currentFormat = options.customDateTimeFormatString || "";
 
         

--- a/src/routes/api/options.js
+++ b/src/routes/api/options.js
@@ -57,7 +57,8 @@ const ALLOWED_OPTIONS = new Set([
     'customSearchEngineName',
     'customSearchEngineUrl',
     'promotedAttributesOpenInRibbon',
-    'editedNotesOpenInRibbon'
+    'editedNotesOpenInRibbon',
+    'customDateTimeFormatString'
 ]);
 
 function getOptions() {


### PR DESCRIPTION
## Summary:

This pull request introduces a user-configurable date/time format for the `Alt+T` keyboard shortcut. Users can now define their preferred date and time string format using Day.js tokens via a new setting, providing greater flexibility.

**Changes Implemented:**

*   **New Setting UI:**
    *   A "Custom Date/Time Format (Alt+T)" section has been added under "Options" -> "Text Notes".
    *   Users can input a <a href="https://day.js.org/docs/en/display/format" target="_blank" rel="noopener noreferrer">Day.js compatible format string</a>.
    *   The UI provides examples, a link to Day.js documentation, and clear explanations of behavior with valid, empty, or unrecognized format strings.
*   **Shortcut Logic Update:**
    *   The `Alt+T` command (`insertDateTimeToTextCommand`) now attempts to retrieve the custom format string from application options.
*   **Formatting Utility Enhancement:**
    *   The `utils.formatDateTime` function has been updated to use `dayjs` with the user-supplied format string.
    *   If the custom format string is empty, or if Day.js encounters a critical internal error processing the format, the system gracefully falls back to the default Trilium format (e.g., `YYYY-MM-DD HH:mm`).
    *   Unrecognized format strings (that don't cause Day.js errors) may result in literal or partially transformed text insertion, as described in the UI.
*   **Backend Configuration:**
    *   Updated the server-side list of allowed options (ALLOWED_OPTIONS in src/routes/api/options.js) to include the new customDateTimeFormatString key, enabling it to be saved.

## How to Test:

1.  Navigate to "Options" -> "Text Notes".
2.  Locate the "Custom Date/Time Format (Alt+T)" section.
3.  Enter a valid Day.js format string (e.g., `DD/MM/YYYY HH:mm:ss`, `MMMM D, YYYY`).
4.  Go to any text note and press `Alt+T`. The date and time should be inserted using the custom format (assuming the option saved correctly).
5.  Clear the format string in the options.
6.  Press `Alt+T` in a text note. The date and time should revert to the default Trilium format.

## Note on Saving Options During Testing:

While developing this feature on my Windows 11, I sometimes encountered errors in the console (like "EPERM: operation not permitted" related to session files, followed by "ERR_HTTP_HEADERS_SENT") when trying to save changes in the Options screen. This happened not just with my new setting, but also when changing other existing Trilium options.

It seems like there might be something in my local setup (perhaps related to file access or another program) that occasionally interferes with how Trilium saves options or session data.

The custom date/time formatting feature itself should work correctly if the option saves properly.

## Related Issue:

This feature addresses the user need for more flexible date formatting, similar to what was requested in issue #4906.
Closes #4906

---

## Screenshots:

![Screenshot 2025-05-17 014130](https://github.com/user-attachments/assets/c376b63e-d023-4e14-b6f4-6ba8d4515420)
![Screenshot 2025-05-17 014001](https://github.com/user-attachments/assets/a2d37068-87cc-485b-8697-7ae12fa61c00)
![image](https://github.com/user-attachments/assets/4f6ab923-cba9-4d60-aa9b-0aad021884f8)



