### PR TITLE
Tree context menu: reorder the note types of "Insert (child) note..."

### DIFF
--- a/apps/client/src/services/note_types.ts
+++ b/apps/client/src/services/note_types.ts
@@ -8,18 +8,35 @@ const SEPARATOR = { title: "----" };
 
 async function getNoteTypeItems(command?: TreeCommandNames) {
     const items: MenuItem<TreeCommandNames>[] = [
+        // The suggested note type ordering method: insert the item into the corresponding group,
+        // then ensure the items within the group are ordered alphabetically.
+        // Please keep the order synced with the listing found also in aps/client/src/widgets/note_types.ts.
+
+        // The default note type (always the first item)
         { title: t("note_types.text"), command, type: "text", uiIcon: "bx bx-note" },
-        { title: t("note_types.code"), command, type: "code", uiIcon: "bx bx-code" },
-        { title: t("note_types.saved-search"), command, type: "search", uiIcon: "bx bx-file-find" },
-        { title: t("note_types.relation-map"), command, type: "relationMap", uiIcon: "bx bxs-network-chart" },
-        { title: t("note_types.note-map"), command, type: "noteMap", uiIcon: "bx bxs-network-chart" },
-        { title: t("note_types.render-note"), command, type: "render", uiIcon: "bx bx-extension" },
+        
+        // Text notes group
         { title: t("note_types.book"), command, type: "book", uiIcon: "bx bx-book" },
-        { title: t("note_types.mermaid-diagram"), command, type: "mermaid", uiIcon: "bx bx-selection" },
+
+        // Graphic notes
         { title: t("note_types.canvas"), command, type: "canvas", uiIcon: "bx bx-pen" },
-        { title: t("note_types.web-view"), command, type: "webView", uiIcon: "bx bx-globe-alt" },
-        { title: t("note_types.mind-map"), command, type: "mindMap", uiIcon: "bx bx-sitemap" },
+        { title: t("note_types.mermaid-diagram"), command, type: "mermaid", uiIcon: "bx bx-selection" },
+        
+        // Map notes
         { title: t("note_types.geo-map"), command, type: "geoMap", uiIcon: "bx bx-map-alt" },
+        { title: t("note_types.mind-map"), command, type: "mindMap", uiIcon: "bx bx-sitemap" },
+        { title: t("note_types.note-map"), command, type: "noteMap", uiIcon: "bx bxs-network-chart" },
+        { title: t("note_types.relation-map"), command, type: "relationMap", uiIcon: "bx bxs-network-chart" },
+
+        // Misc note types
+        { title: t("note_types.render-note"), command, type: "render", uiIcon: "bx bx-extension" },
+        { title: t("note_types.saved-search"), command, type: "search", uiIcon: "bx bx-file-find" },
+        { title: t("note_types.web-view"), command, type: "webView", uiIcon: "bx bx-globe-alt" },
+
+        // Code notes
+        { title: t("note_types.code"), command, type: "code", uiIcon: "bx bx-code" },
+
+        // Templates
         ...await getBuiltInTemplates(command),
         ...await getUserTemplates(command)
     ];

--- a/apps/client/src/widgets/note_type.ts
+++ b/apps/client/src/widgets/note_type.ts
@@ -19,6 +19,7 @@ interface NoteTypeMapping {
 const NOTE_TYPES: NoteTypeMapping[] = [
     // The suggested note type ordering method: insert the item into the corresponding group,
     // then ensure the items within the group are ordered alphabetically.
+    // Please keep the order synced with the listing found also in apps/client/src/services/note_types.ts.
 
     // The default note type (always the first item)
     { type: "text", mime: "text/html", title: t("note_types.text"), selectable: true },


### PR DESCRIPTION
Reorder the types to match the ribbon's "Note type" combo.