### PR TITLE
Added zen mode to mobile layout

### DIFF
--- a/apps/client/src/layouts/mobile_layout.ts
+++ b/apps/client/src/layouts/mobile_layout.ts
@@ -26,6 +26,7 @@ import TabRowWidget from "../widgets/tab_row.js";
 import RefreshButton from "../widgets/floating_buttons/refresh_button.js";
 import MobileEditorToolbar from "../widgets/ribbon_widgets/mobile_editor_toolbar.js";
 import { applyModals } from "./layout_commons.js";
+import CloseZenButton from "../widgets/close_zen_button.js";
 
 const MOBILE_CSS = `
 <style>
@@ -174,7 +175,8 @@ export default class MobileLayout {
                     .id("mobile-bottom-bar")
                     .child(new TabRowWidget().css("height", "40px"))
                     .child(new FlexContainer("row").class("horizontal").css("height", "53px").child(new LauncherContainer(true)).child(new GlobalMenuWidget(true)).id("launcher-pane"))
-            );
+            )
+            .child(new CloseZenButton());
         applyModals(rootContainer);
         return rootContainer;
     }

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1886,6 +1886,7 @@ body.zen #launcher-container,
 body.zen #launcher-pane,
 body.zen #left-pane,
 body.zen #right-pane,
+body.zen #mobile-sidebar-wrapper,
 body.zen .tab-row-container,
 body.zen .tab-row-widget,
 body.zen .ribbon-container:not(:has(.classic-toolbar-widget.visible)),
@@ -1893,7 +1894,8 @@ body.zen .ribbon-container:has(.classic-toolbar-widget.visible) .ribbon-top-row,
 body.zen .ribbon-container .ribbon-body:not(:has(.classic-toolbar-widget.visible)),
 body.zen .note-icon-widget,
 body.zen .title-row .button-widget,
-body.zen .floating-buttons-children > *:not(.bx-edit-alt) {
+body.zen .floating-buttons-children > *:not(.bx-edit-alt),
+body.zen .action-button {
     display: none !important;
 }
 
@@ -1933,6 +1935,10 @@ body.zen .note-title-widget,
 body.zen .note-title-widget input {
     font-size: 1rem !important;
     background: transparent !important;
+}
+
+body.zen #detail-container {
+    width: 100%;
 }
 
 /* Content renderer */

--- a/apps/client/src/widgets/buttons/global_menu.ts
+++ b/apps/client/src/widgets/buttons/global_menu.ts
@@ -363,7 +363,6 @@ export default class GlobalMenuWidget extends BasicWidget {
 
         this.$zoomState = this.$widget.find(".zoom-state");
         this.$toggleZenMode = this.$widget.find('[data-trigger-command="toggleZenMode"');
-        this.$toggleZenMode.toggle(!utils.isMobile());
         this.$widget.on("show.bs.dropdown", () => this.#onShown());
         if (this.tooltip) {
             this.$widget.on("hide.bs.dropdown", () => this.tooltip.enable());

--- a/apps/client/src/widgets/close_zen_button.ts
+++ b/apps/client/src/widgets/close_zen_button.ts
@@ -1,5 +1,6 @@
 import BasicWidget from "./basic_widget.js";
 import { t } from "../services/i18n.js";
+import utils from "../services/utils.js";
 
 const TPL = /*html*/`\
 <div class="close-zen-container">
@@ -28,6 +29,10 @@ const TPL = /*html*/`\
         -webkit-app-region: no-drag;
     }
 
+    body.zen .mobile-close-zen-container {
+        top: -2px;
+    }
+
     body.zen.electron:not(.platform-darwin):not(.native-titlebar) .close-zen-container {
         left: calc(env(titlebar-area-width) - var(--zen-button-size) - 2px);
         right: unset;
@@ -40,6 +45,7 @@ export default class CloseZenButton extends BasicWidget {
 
     doRender(): void {
         this.$widget = $(TPL);
+        this.$widget.toggleClass("mobile-close-zen-container", utils.isMobile())
     }
 
     zenChangedEvent() {


### PR DESCRIPTION
With this change, zen mode is also available through the menu in the mobile layout. While zen mode doesn't provide a huge benefit on a phone, this feature can be useful when working on a tablet by allowing you to have both the mobile controls as well as the option to hide those controls without having to switch back to the desktop layout first.

Note: a future improvement for the usage of the mobile layout on a tablet could be to also allow the user to enable it in the electron app, but this is enough for me for now