### PR TITLE
Fix: activate the nearest path when opening a cloned note

### DIFF
--- a/apps/client/src/services/tree.ts
+++ b/apps/client/src/services/tree.ts
@@ -79,8 +79,8 @@ async function resolveNotePathToSegments(notePath: string, hoistedNoteId = "root
                         You can ignore this message as it is mostly harmless.`
                     );
                 }
-
-                const bestNotePath = child.getBestNotePath(hoistedNoteId);
+                const activeNotePath = appContext.tabManager.getActiveContextNotePath();
+                const bestNotePath = child.getBestNotePath(hoistedNoteId, activeNotePath);
 
                 if (bestNotePath) {
                     const pathToRoot = bestNotePath.reverse().slice(1);


### PR DESCRIPTION
```
root
└─ A
   ├─ B
   │  └─ C (clone)
   │      └─ D
   └─ E
       └─ C
           └─ D
```

When opening the **C (clone)** note and clicking its child note **D** (in the `note-list-container`),

* **Actual activated path** (the path selected in the left note tree):

```
root > A > E > C > D
```

* **Expected activated path** (the correct path showing the clone’s location):

```
root > A > B > C (clone) > D
```
