### PR TITLE
fix: log same error message on api 401 as on login error to allow fail2ban blocking

### DIFF
--- a/apps/server/src/services/auth.ts
+++ b/apps/server/src/services/auth.ts
@@ -159,6 +159,7 @@ function checkCredentials(req: Request, res: Response, next: NextFunction) {
 
     if (!passwordEncryptionService.verifyPassword(password)) {
         res.setHeader("Content-Type", "text/plain").status(401).send("Incorrect password");
+        log.info(`WARNING: Wrong password from ${req.ip}, rejecting.`);
     } else {
         next();
     }


### PR DESCRIPTION
Added same log statement for server sync setup wrong password as for login wrong password to allow fail2ban blocking.
See comment https://github.com/TriliumNext/Trilium/issues/6781#issuecomment-3221404215