### PR TITLE
Apply note wrapper on mobile

### DIFF
--- a/apps/client/src/layouts/mobile_layout.tsx
+++ b/apps/client/src/layouts/mobile_layout.tsx
@@ -22,6 +22,7 @@ import FloatingButtons from "../widgets/FloatingButtons.jsx";
 import { MOBILE_FLOATING_BUTTONS } from "../widgets/FloatingButtonsDefinitions.jsx";
 import ToggleSidebarButton from "../widgets/mobile_widgets/toggle_sidebar_button.jsx";
 import CloseZenModeButton from "../widgets/close_zen_button.js";
+import NoteWrapperWidget from "../widgets/note_wrapper.js";
 import MobileDetailMenu from "../widgets/mobile_widgets/mobile_detail_menu.js";
 
 const MOBILE_CSS = `
@@ -131,30 +132,33 @@ export default class MobileLayout {
                             .child(new FlexContainer("column").filling().id("mobile-sidebar-wrapper").child(new QuickSearchWidget()).child(new NoteTreeWidget().cssBlock(FANCYTREE_CSS)))
                     )
                     .child(
-                        new ScreenContainer("detail", "column")
+                        new ScreenContainer("detail", "row")
                             .id("detail-container")
                             .class("d-sm-flex d-md-flex d-lg-flex d-xl-flex col-12 col-sm-7 col-md-8 col-lg-9")
                             .child(
-                                new FlexContainer("row")
-                                    .contentSized()
-                                    .css("font-size", "larger")
-                                    .css("align-items", "center")
-                                    .child(<ToggleSidebarButton />)
-                                    .child(<NoteTitleWidget />)
-                                    .child(<MobileDetailMenu />)
+                                new NoteWrapperWidget()
+                                    .child(
+                                        new FlexContainer("row")
+                                            .contentSized()
+                                            .css("font-size", "larger")
+                                            .css("align-items", "center")
+                                            .child(<ToggleSidebarButton />)
+                                            .child(<NoteTitleWidget />)
+                                            .child(<MobileDetailMenu />)
+                                    )
+                                    .child(<SharedInfoWidget />)
+                                    .child(<FloatingButtons items={MOBILE_FLOATING_BUTTONS} />)
+                                    .child(new PromotedAttributesWidget())
+                                    .child(
+                                        new ScrollingContainer()
+                                            .filling()
+                                            .contentSized()
+                                            .child(new NoteDetailWidget())
+                                            .child(new NoteListWidget(false))
+                                            .child(<FilePropertiesWrapper />)
+                                    )
+                                    .child(<MobileEditorToolbar />)
                             )
-                            .child(<SharedInfoWidget />)
-                            .child(<FloatingButtons items={MOBILE_FLOATING_BUTTONS} />)
-                            .child(new PromotedAttributesWidget())
-                            .child(
-                                new ScrollingContainer()
-                                    .filling()
-                                    .contentSized()
-                                    .child(new NoteDetailWidget())
-                                    .child(new NoteListWidget(false))
-                                    .child(<FilePropertiesWrapper />)
-                            )
-                            .child(<MobileEditorToolbar />)
                     )
             )
             .child(

--- a/apps/client/src/widgets/note_wrapper.ts
+++ b/apps/client/src/widgets/note_wrapper.ts
@@ -29,11 +29,15 @@ export default class NoteWrapperWidget extends FlexContainer<BasicWidget> {
         this.refresh();
     }
 
-    noteSwitchedEvent() {
+    noteSwitchedEvent({ noteContext }: EventData<"setNoteContext">) {
+        this.noteContext = noteContext;
+
         this.refresh();
     }
 
-    activeContextChangedEvent() {
+    activeContextChangedEvent({ noteContext }: EventData<"setNoteContext">) {
+        this.noteContext = noteContext;
+
         this.refresh();
     }
 

--- a/apps/client/src/widgets/note_wrapper.ts
+++ b/apps/client/src/widgets/note_wrapper.ts
@@ -23,7 +23,9 @@ export default class NoteWrapperWidget extends FlexContainer<BasicWidget> {
         this.refresh();
     }
 
-    noteSwitchedAndActivatedEvent() {
+    noteSwitchedAndActivatedEvent({ noteContext }: EventData<"setNoteContext">) {
+        this.noteContext = noteContext;
+
         this.refresh();
     }
 


### PR DESCRIPTION
I apologize if I made any mistakes due to insufficient knowledge of the code base, this is just my attempt at fixing #6798, which I did by adding the wrapper widget to the mobile layout and then making sure it still receives the note context to apply the css class.