### PR TITLE
feat: create a more seamless PWA top bar

### DIFF
--- a/apps/client/src/assets/manifest.webmanifest
+++ b/apps/client/src/assets/manifest.webmanifest
@@ -7,6 +7,9 @@
     "display": "standalone",
     "scope": "/",
     "start_url": "/",
+    "display_override": [
+        "window-controls-overlay"
+    ],
     "icons": [
         {
             "src": "icon.png",

--- a/apps/client/src/desktop.ts
+++ b/apps/client/src/desktop.ts
@@ -45,6 +45,10 @@ if (utils.isElectron()) {
     electronContextMenu.setupContextMenu();
 }
 
+if (utils.isPWA()) {
+    initPWATopbarColor();
+}
+
 function initOnElectron() {
     const electron: typeof Electron = utils.dynamicRequire("electron");
     electron.ipcRenderer.on("globalShortcut", async (event, actionName) => appContext.triggerCommand(actionName));
@@ -112,4 +116,21 @@ function initDarkOrLightMode(style: CSSStyleDeclaration) {
 
     const { nativeTheme } = utils.dynamicRequire("@electron/remote") as typeof ElectronRemote;
     nativeTheme.themeSource = themeSource;
+}
+
+function initPWATopbarColor() {
+    const tracker = $("#background-color-tracker");
+
+    if (tracker.length) {
+        const applyThemeColor = () => {
+            let meta = $("meta[name='theme-color']");
+            if (!meta.length) {
+                meta = $(`<meta name="theme-color">`).appendTo($("head"));
+            }
+            meta.attr("content", tracker.css("color"));
+        };
+
+        tracker.on("transitionend", applyThemeColor);
+        applyThemeColor();
+    }
 }

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -149,6 +149,18 @@ export function isElectron() {
     return !!(window && window.process && window.process.type);
 }
 
+/**
+ * Returns `true` if the client is running as a PWA, otherwise `false`.
+ */
+export function isPWA() {
+    return (
+        window.matchMedia('(display-mode: standalone)').matches
+        || window.matchMedia('(display-mode: window-controls-overlay)').matches
+        || window.navigator.standalone
+        || window.navigator.windowControlsOverlay
+    );
+}
+
 export function isMac() {
     return navigator.platform.indexOf("Mac") > -1;
 }
@@ -891,6 +903,7 @@ export default {
     localNowDateTime,
     now,
     isElectron,
+    isPWA,
     isMac,
     isCtrlKey,
     assertArguments,

--- a/apps/server/src/assets/views/desktop.ejs
+++ b/apps/server/src/assets/views/desktop.ejs
@@ -29,6 +29,10 @@
     }
 </style>
 
+<!-- Required for match the PWA's top bar color with the theme -->
+<!-- This works even when the user directly changes --root-background in CSS -->
+<div id="background-color-tracker" style="position: absolute; visibility: hidden; color: var(--root-background); transition: color 1ms;"></div>
+
 <!-- Required for correct loading of scripts in Electron -->
 <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
 


### PR DESCRIPTION
## Summary

This PR adds `display_override` to the PWA manifest to use the `window-controls-overlay` display mode when the browser supports it.
This generally provides a toggle in the browser to collapse and expand the top bar, giving a feel closer to a native application as shown below.

| Vertical layout | Horizontal layout |
| -- | -- |
| <img width="882" height="847" alt="image" src="https://github.com/user-attachments/assets/9dd6b092-65a3-470a-b99c-52547dfc1b21" /> | <img width="1008" height="924" alt="image" src="https://github.com/user-attachments/assets/cc4ea976-2c4b-43e7-b11b-429893d10a5c" /> |

Users can still use the previous method if it is not needed, And this behaves the same way as the VS Code PWA.

<table><tr><td valign="center"><img width="342" height="100" alt="Screenshot From 2025-09-12 23-54-23" src="https://github.com/user-attachments/assets/bfa20d45-16d7-4768-b702-9d2a6bcff6a1" /></td><td valign="center"><img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/90b1d22a-7742-446b-b332-5b3ec39aeec0" /></td></tr></table>

<details>
<summary>
More Screenshot: On windows chrome PWA
</summary>
<img width="1132" height="1137" alt="image" src="https://github.com/user-attachments/assets/fc97f7ec-9858-47a2-bdf2-581682b41b59" />
</details>

## Topbar color change

Additionally, it observes changes in the '--root-background' value to match the color of the top bar area with the background. Through this, even if the user directly changes the color using CSS, the top bar's color is reflected in real-time.
This is not implemented through polling, but via the transitionend event, so the performance impact is negligible.
The active top bar color is applied only to the PWA desktop layout.

## Minor issue

<img width="1751" height="442" alt="image" src="https://github.com/user-attachments/assets/ee595e01-7321-421d-988f-fb1d5d858c46" />

There are a few minor issues. In environments like macOS where window controls are on the left, using the vertical layout can cause overlapping because menubar may not properly account for `env(titlebar-area-x)`

To fix this, we could consider applying a `margin-top` to the menubar with the value `calc( clamp(0px, env(titlebar-area-x), 1px) * ( env(titlebar-area-y) + env(titlebar-area-height) ) )`. However, I decided not to include this in the current PR as it could affect the entire layout and I believe it requires further discussion.
