### PR TITLE
(fix)redirectBareDomain not working when MFA is on

### DIFF
--- a/apps/server/src/services/auth.ts
+++ b/apps/server/src/services/auth.ts
@@ -26,20 +26,8 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
     if (isElectron || noAuthentication) {
         next();
         return;
-    } else if (currentTotpStatus !== lastAuthState.totpEnabled || currentSsoStatus !== lastAuthState.ssoEnabled) {
-        req.session.destroy((err) => {
-            if (err) console.error('Error destroying session:', err);
-            res.redirect('login');
-        });
-        return;
-    } else if (currentSsoStatus) {
-        if (req.oidc?.isAuthenticated() && req.session.loggedIn) {
-            next();
-            return;
-        }
-        res.redirect('login');
-        return;
     } else if (!req.session.loggedIn && !noAuthentication) {
+        // check redirectBareDomain option first
 
         // cannot use options.getOptionBool currently => it will throw an error on new installations
         // TriliumNextTODO: look into potentially creating an getOptionBoolOrNull instead
@@ -54,6 +42,19 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
             }
         }
         res.redirect(hasRedirectBareDomain ? "share" : "login");
+    } else if (currentTotpStatus !== lastAuthState.totpEnabled || currentSsoStatus !== lastAuthState.ssoEnabled) {
+        req.session.destroy((err) => {
+            if (err) console.error('Error destroying session:', err);
+            res.redirect('login');
+        });
+        return;
+    } else if (currentSsoStatus) {
+        if (req.oidc?.isAuthenticated() && req.session.loggedIn) {
+            next();
+            return;
+        }
+        res.redirect('login');
+        return;
     } else {
         next();
     }


### PR DESCRIPTION
Try to fix #6910 by:

refactor: move redirectBareDomain check earlier

- Move the `if (hasRedirectBareDomain)` check ahead of the MFA check.
- This allows the server to redirect to the share root when MFA is on.

This change should not affect or break any subsequent logic.