### PR TITLE
fix(collapse-subtree): improve performance of collapsing subtrees from O(n) to O(v)

### DIFF
--- a/apps/server/src/routes/api/branches.ts
+++ b/apps/server/src/routes/api/branches.ts
@@ -163,6 +163,7 @@ function setExpandedForSubtree(req: Request) {
             SELECT branches.branchId, branches.noteId FROM branches
                 JOIN tree ON branches.parentNoteId = tree.noteId
             WHERE branches.isDeleted = 0
+                AND branches.isExpanded = 1
         )
         SELECT branchId FROM tree`,
         [branchId]


### PR DESCRIPTION
Collapsing the note tree was slow O(n), and is now O(v).

Just one line in the backend fixed it (basically the query to the sqlite was just very slightly off)

n = number of existing notes (stresstested with 250 k notes, this was creating lag on my computer 3-4 s delay)
v = opened sub-notes (stresstested with 250 k notes is instant < 1 s dealy)

So yeah lets have fast collapse of note tree !!
<img width="203" height="76" alt="image" src="https://github.com/user-attachments/assets/a5bbfbf6-d737-44a8-b96c-81f15c765790" />
