### PR TITLE
fix(client): Use number sorting for number columns in Table view

### DIFF
--- a/apps/client/src/widgets/collections/table/columns.tsx
+++ b/apps/client/src/widgets/collections/table/columns.tsx
@@ -30,7 +30,8 @@ const labelTypeMappings: Record<ColumnType, Partial<ColumnDefinition>> = {
         editor: "datetime"
     },
     number: {
-        editor: "number"
+        editor: "number",
+        sorter: "number"
     },
     time: {
         editor: "input"


### PR DESCRIPTION
A simple column definition fix to set the Tabulator sorter to the numeric one for number columns instead of string sorting.
This means that e.g. 1, 8, 13, 23 will sort ascending in that way, instead of becoming 1, 13, 23, 8.