### PR TITLE
feat(search): add create into inbox to search

### DIFF
--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -360,7 +360,7 @@ export type CommandMappings = {
 
     // Table view
     addNewRow: CommandData & {
-        customOpts?: CreateNoteWithUrlOpts;
+        customOpts?: CreateNoteWithLinkOpts;
     };
     addNewTableColumn: CommandData & {
         columnToEdit?: ColumnComponent;

--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -360,8 +360,7 @@ export type CommandMappings = {
 
     // Table view
     addNewRow: CommandData & {
-        customOpts: CreateNoteOpts;
-        parentNotePath?: string;
+        customOpts?: CreateNoteWithUrlOpts;
     };
     addNewTableColumn: CommandData & {
         columnToEdit?: ColumnComponent;

--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -360,7 +360,7 @@ export type CommandMappings = {
 
     // Table view
     addNewRow: CommandData & {
-        customOpts: BaseCreateNoteOpts;
+        customOpts: CreateNoteOpts;
         parentNotePath?: string;
     };
     addNewTableColumn: CommandData & {

--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -360,7 +360,7 @@ export type CommandMappings = {
 
     // Table view
     addNewRow: CommandData & {
-        customOpts: CreateNoteOpts;
+        customOpts: BaseCreateNoteOpts;
         parentNotePath?: string;
     };
     addNewTableColumn: CommandData & {

--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -10,7 +10,7 @@ import { initLocale, t } from "../services/i18n.js";
 import keyboardActionsService from "../services/keyboard_actions.js";
 import linkService, { type ViewScope } from "../services/link.js";
 import type LoadResults from "../services/load_results.js";
-import type { CreateNoteOpts } from "../services/note_create.js";
+import type { CreateNoteOpts, CreateNoteWithLinkOpts } from "../services/note_create.js";
 import options from "../services/options.js";
 import toast from "../services/toast.js";
 import utils, { hasTouchBar } from "../services/utils.js";

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            { target: CreateNoteTarget.IntoInbox } as CreateNoteIntoInboxOpts
+            { target: "into" } as CreateNoteIntoInboxOpts
         );
     }
 

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -25,23 +25,7 @@ export default class Entrypoints extends Component {
     }
 
     async createNoteIntoInboxCommand() {
-        const inboxNote = await dateNoteService.getInboxNote();
-        if (!inboxNote) {
-            console.warn("Missing inbox note.");
-            return;
-        }
-
-        const { note } = await server.post<CreateChildrenResponse>(`notes/${inboxNote.noteId}/children?target=into`, {
-            content: "",
-            type: "text",
-            isProtected: inboxNote.isProtected && protectedSessionHolder.isProtectedSessionAvailable()
-        });
-
-        await ws.waitForMaxKnownEntityChangeId();
-
-        await appContext.tabManager.openTabWithNoteWithHoisting(note.noteId, { activate: true });
-
-        appContext.triggerEvent("focusAndSelectTitle", { isNewNote: true });
+        await noteCreateService.createNoteIntoInbox();
     }
 
     async toggleNoteHoistingCommand({ noteId = appContext.tabManager.getActiveContextNoteId() }) {

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -12,7 +12,7 @@ import utils from "../services/utils.js";
 import ws from "../services/ws.js";
 import appContext, { type NoteCommandData } from "./app_context.js";
 import Component from "./component.js";
-import noteCreateService, { CreateNoteIntoInboxOpts, CreateNoteTarget } from "../services/note_create.js";
+import noteCreateService from "../services/note_create.js";
 
 export default class Entrypoints extends Component {
     constructor() {

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            { target: "into" } as CreateNoteIntoInboxOpts
+            { target: "inbox" } as CreateNoteIntoInboxOpts
         );
     }
 

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -12,6 +12,7 @@ import utils from "../services/utils.js";
 import ws from "../services/ws.js";
 import appContext, { type NoteCommandData } from "./app_context.js";
 import Component from "./component.js";
+import noteCreateService, { CreateNoteTarget } from "../services/note_create.js";
 
 export default class Entrypoints extends Component {
     constructor() {
@@ -25,7 +26,9 @@ export default class Entrypoints extends Component {
     }
 
     async createNoteIntoInboxCommand() {
-        await noteCreateService.createNoteIntoInbox();
+        await noteCreateService.createNote(
+            CreateNoteTarget.IntoInbox
+        );
     }
 
     async toggleNoteHoistingCommand({ noteId = appContext.tabManager.getActiveContextNoteId() }) {

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            { target: "inbox" } as CreateNoteIntoInboxOpts
+            { target: "inbox" }
         );
     }
 

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            { target: "inbox" }
+            { target: "default" }
         );
     }
 

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            CreateNoteTarget.IntoInbox
+            { target: CreateNoteTarget.IntoInbox } as CreateNoteIntoInboxURLOpts
         );
     }
 

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -12,7 +12,7 @@ import utils from "../services/utils.js";
 import ws from "../services/ws.js";
 import appContext, { type NoteCommandData } from "./app_context.js";
 import Component from "./component.js";
-import noteCreateService, { CreateNoteTarget } from "../services/note_create.js";
+import noteCreateService, { CreateNoteIntoInboxOpts, CreateNoteTarget } from "../services/note_create.js";
 
 export default class Entrypoints extends Component {
     constructor() {
@@ -27,7 +27,7 @@ export default class Entrypoints extends Component {
 
     async createNoteIntoInboxCommand() {
         await noteCreateService.createNote(
-            { target: CreateNoteTarget.IntoInbox } as CreateNoteIntoInboxURLOpts
+            { target: CreateNoteTarget.IntoInbox } as CreateNoteIntoInboxOpts
         );
     }
 

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -1,5 +1,5 @@
 import appContext, { type EventData } from "./app_context.js";
-import noteCreateService from "../services/note_create.js";
+import noteCreateService, { CreateNoteTarget, CreateNoteIntoURLOpts, CreateNoteAfterURLOpts } from "../services/note_create.js";
 import treeService from "../services/tree.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import Component from "./component.js";
@@ -48,10 +48,15 @@ export default class MainTreeExecutors extends Component {
             return;
         }
 
-        await noteCreateService.createNoteIntoPath(activeNoteContext.notePath, {
-            isProtected: activeNoteContext.note.isProtected,
-            saveSelection: false
-        });
+        await noteCreateService.createNote(
+            CreateNoteTarget.IntoNoteURL,
+            {
+                parentNoteUrl: activeNoteContext.notePath,
+                isProtected: activeNoteContext.note.isProtected,
+                saveSelection: false,
+                promptForType: false,
+            } as CreateNoteIntoURLOpts
+        );
     }
 
     async createNoteAfterCommand() {
@@ -72,11 +77,14 @@ export default class MainTreeExecutors extends Component {
             return;
         }
 
-        await noteCreateService.createNoteIntoPath(parentNotePath, {
-            target: "after",
-            targetBranchId: node.data.branchId,
-            isProtected: isProtected,
-            saveSelection: false
-        });
+        await noteCreateService.createNote(
+            CreateNoteTarget.AfterNoteURL,
+            {
+                parentNoteUrl: parentNotePath,
+                targetBranchId: node.data.branchId,
+                isProtected: isProtected,
+                saveSelection: false
+            } as CreateNoteAfterURLOpts
+        );
     }
 }

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -1,5 +1,5 @@
 import appContext, { type EventData } from "./app_context.js";
-import noteCreateService, { CreateNoteTarget, CreateNoteIntoURLOpts, CreateNoteAfterURLOpts } from "../services/note_create.js";
+import noteCreateService, { CreateNoteTarget, CreateNoteIntoUrlOpts, CreateNoteAfterUrlOpts } from "../services/note_create.js";
 import treeService from "../services/tree.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import Component from "./component.js";
@@ -55,7 +55,7 @@ export default class MainTreeExecutors extends Component {
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
                 promptForType: false,
-            } as CreateNoteIntoURLOpts
+            } as CreateNoteIntoUrlOpts
         );
     }
 
@@ -84,7 +84,7 @@ export default class MainTreeExecutors extends Component {
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,
                 saveSelection: false
-            } as CreateNoteAfterURLOpts
+            } as CreateNoteAfterUrlOpts
         );
     }
 }

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -1,5 +1,5 @@
 import appContext, { type EventData } from "./app_context.js";
-import noteCreateService, { CreateNoteWithUrlOpts } from "../services/note_create.js";
+import noteCreateService from "../services/note_create.js";
 import treeService from "../services/tree.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import Component from "./component.js";

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -1,5 +1,5 @@
 import appContext, { type EventData } from "./app_context.js";
-import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteAfterUrlOpts } from "../services/note_create.js";
+import noteCreateService, { CreateNoteWithUrlOpts } from "../services/note_create.js";
 import treeService from "../services/tree.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import Component from "./component.js";
@@ -55,7 +55,7 @@ export default class MainTreeExecutors extends Component {
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
                 promptForType: false,
-            } as CreateNoteIntoUrlOpts
+            } as CreateNoteWithUrlOpts
         );
     }
 
@@ -84,7 +84,7 @@ export default class MainTreeExecutors extends Component {
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,
                 saveSelection: false
-            } as CreateNoteAfterUrlOpts
+            } as CreateNoteWithUrlOpts
         );
     }
 }

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -51,7 +51,7 @@ export default class MainTreeExecutors extends Component {
         await noteCreateService.createNote(
             {
                 target: "into",
-                parentNoteUrl: activeNoteContext.notePath,
+                parentNoteLink: activeNoteContext.notePath,
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
                 promptForType: false,
@@ -80,7 +80,7 @@ export default class MainTreeExecutors extends Component {
         await noteCreateService.createNote(
             {
                 target: "after",
-                parentNoteUrl: parentNotePath,
+                parentNoteLink: parentNotePath,
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,
                 saveSelection: false

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -1,5 +1,5 @@
 import appContext, { type EventData } from "./app_context.js";
-import noteCreateService, { CreateNoteTarget, CreateNoteIntoUrlOpts, CreateNoteAfterUrlOpts } from "../services/note_create.js";
+import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteAfterUrlOpts } from "../services/note_create.js";
 import treeService from "../services/tree.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import Component from "./component.js";
@@ -50,7 +50,7 @@ export default class MainTreeExecutors extends Component {
 
         await noteCreateService.createNote(
             {
-                target: CreateNoteTarget.IntoNoteURL,
+                target: "into",
                 parentNoteUrl: activeNoteContext.notePath,
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
@@ -79,7 +79,7 @@ export default class MainTreeExecutors extends Component {
 
         await noteCreateService.createNote(
             {
-                target: CreateNoteTarget.AfterNoteURL,
+                target: "after",
                 parentNoteUrl: parentNotePath,
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -49,8 +49,8 @@ export default class MainTreeExecutors extends Component {
         }
 
         await noteCreateService.createNote(
-            CreateNoteTarget.IntoNoteURL,
             {
+                target: CreateNoteTarget.IntoNoteURL,
                 parentNoteUrl: activeNoteContext.notePath,
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
@@ -78,8 +78,8 @@ export default class MainTreeExecutors extends Component {
         }
 
         await noteCreateService.createNote(
-            CreateNoteTarget.AfterNoteURL,
             {
+                target: CreateNoteTarget.AfterNoteURL,
                 parentNoteUrl: parentNotePath,
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -55,7 +55,7 @@ export default class MainTreeExecutors extends Component {
                 isProtected: activeNoteContext.note.isProtected,
                 saveSelection: false,
                 promptForType: false,
-            } as CreateNoteWithUrlOpts
+            }
         );
     }
 
@@ -84,7 +84,7 @@ export default class MainTreeExecutors extends Component {
                 targetBranchId: node.data.branchId,
                 isProtected: isProtected,
                 saveSelection: false
-            } as CreateNoteWithUrlOpts
+            }
         );
     }
 }

--- a/apps/client/src/components/main_tree_executors.ts
+++ b/apps/client/src/components/main_tree_executors.ts
@@ -48,7 +48,7 @@ export default class MainTreeExecutors extends Component {
             return;
         }
 
-        await noteCreateService.createNote(activeNoteContext.notePath, {
+        await noteCreateService.createNoteIntoPath(activeNoteContext.notePath, {
             isProtected: activeNoteContext.note.isProtected,
             saveSelection: false
         });
@@ -72,7 +72,7 @@ export default class MainTreeExecutors extends Component {
             return;
         }
 
-        await noteCreateService.createNote(parentNotePath, {
+        await noteCreateService.createNoteIntoPath(parentNotePath, {
             target: "after",
             targetBranchId: node.data.branchId,
             isProtected: isProtected,

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -261,7 +261,7 @@ export default class RootCommandExecutor extends Component {
                         messages: [],
                         title: "New AI Chat"
                     }),
-                } as CreateNoteIntoUrlOpts
+                } as CreateNoteWithUrlOpts
             );
 
             if (!result.note) {

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -262,7 +262,7 @@ export default class RootCommandExecutor extends Component {
                         messages: [],
                         title: "New AI Chat"
                     }),
-                } as CreateNoteWithUrlOpts
+                }
             );
 
             if (!result.note) {

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -44,7 +44,7 @@ export default class RootCommandExecutor extends Component {
     }
 
     async searchInSubtreeCommand({ notePath }: CommandListenerData<"searchInSubtree">) {
-        const noteId = treeService.getNoteIdFromUrl(notePath);
+        const noteId = treeService.getNoteIdFromLink(notePath);
 
         this.searchNotesCommand({ ancestorNoteId: noteId });
     }
@@ -254,7 +254,7 @@ export default class RootCommandExecutor extends Component {
 
             const result = await noteCreateService.createNote(
                 {
-                    parentNoteUrl: rootNoteId,
+                    parentNoteLink: rootNoteId,
                     target: "into",
                     title: "New AI Chat",
                     type: "aiChat",

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -2,7 +2,7 @@ import dateNoteService from "../services/date_notes.js";
 import froca from "../services/froca.js";
 import openService from "../services/open.js";
 import options from "../services/options.js";
-import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../services/note_create.js";
+import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../services/note_create.js";
 import protectedSessionService from "../services/protected_session.js";
 import treeService from "../services/tree.js";
 import utils, { openInReusableSplit } from "../services/utils.js";
@@ -261,7 +261,7 @@ export default class RootCommandExecutor extends Component {
                         messages: [],
                         title: "New AI Chat"
                     }),
-                } as CreateNoteIntoURLOpts
+                } as CreateNoteIntoUrlOpts
             );
 
             if (!result.note) {

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -2,12 +2,13 @@ import dateNoteService from "../services/date_notes.js";
 import froca from "../services/froca.js";
 import openService from "../services/open.js";
 import options from "../services/options.js";
-import noteCreateService, { CreateNoteIntoUrlOpts } from "../services/note_create.js";
+import noteCreateService from "../services/note_create.js";
 import protectedSessionService from "../services/protected_session.js";
 import utils, { openInReusableSplit } from "../services/utils.js";
 import appContext, { type CommandListenerData } from "./app_context.js";
 import Component from "./component.js";
 import treeService from "../services/tree.js";
+import toastService from "../services/toast.js";
 
 export default class RootCommandExecutor extends Component {
     editReadOnlyNoteCommand() {

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -253,8 +253,8 @@ export default class RootCommandExecutor extends Component {
             const rootNoteId = "root";
 
             const result = await noteCreateService.createNote(
-                CreateNoteTarget.IntoNoteURL,
                 {
+                    target: CreateNoteTarget.IntoNoteURL,
                     title: "New AI Chat",
                     type: "aiChat",
                     content: JSON.stringify({

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -2,6 +2,7 @@ import dateNoteService from "../services/date_notes.js";
 import froca from "../services/froca.js";
 import openService from "../services/open.js";
 import options from "../services/options.js";
+import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../services/note_create.js";
 import protectedSessionService from "../services/protected_session.js";
 import treeService from "../services/tree.js";
 import utils, { openInReusableSplit } from "../services/utils.js";
@@ -246,4 +247,37 @@ export default class RootCommandExecutor extends Component {
         }
     }
 
+    async createAiChatCommand() {
+        try {
+            // Create a new AI Chat note at the root level
+            const rootNoteId = "root";
+
+            const result = await noteCreateService.createNote(
+                CreateNoteTarget.IntoNoteURL,
+                {
+                    title: "New AI Chat",
+                    type: "aiChat",
+                    content: JSON.stringify({
+                        messages: [],
+                        title: "New AI Chat"
+                    }),
+                } as CreateNoteIntoURLOpts
+            );
+
+            if (!result.note) {
+                toastService.showError("Failed to create AI Chat note");
+                return;
+            }
+
+            await appContext.tabManager.openTabWithNoteWithHoisting(result.note.noteId, {
+                activate: true
+            });
+
+            toastService.showMessage("Created new AI Chat note");
+        }
+        catch (e) {
+            console.error("Error creating AI Chat note:", e);
+            toastService.showError("Failed to create AI Chat note: " + (e as Error).message);
+        }
+    }
 }

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -2,12 +2,12 @@ import dateNoteService from "../services/date_notes.js";
 import froca from "../services/froca.js";
 import openService from "../services/open.js";
 import options from "../services/options.js";
-import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../services/note_create.js";
+import noteCreateService, { CreateNoteIntoUrlOpts } from "../services/note_create.js";
 import protectedSessionService from "../services/protected_session.js";
-import treeService from "../services/tree.js";
 import utils, { openInReusableSplit } from "../services/utils.js";
 import appContext, { type CommandListenerData } from "./app_context.js";
 import Component from "./component.js";
+import treeService from "../services/tree.js";
 
 export default class RootCommandExecutor extends Component {
     editReadOnlyNoteCommand() {
@@ -254,7 +254,7 @@ export default class RootCommandExecutor extends Component {
 
             const result = await noteCreateService.createNote(
                 {
-                    target: CreateNoteTarget.IntoNoteURL,
+                    target: "into",
                     title: "New AI Chat",
                     type: "aiChat",
                     content: JSON.stringify({

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -254,6 +254,7 @@ export default class RootCommandExecutor extends Component {
 
             const result = await noteCreateService.createNote(
                 {
+                    parentNoteUrl: rootNoteId,
                     target: "into",
                     title: "New AI Chat",
                     type: "aiChat",

--- a/apps/client/src/components/tab_manager.ts
+++ b/apps/client/src/components/tab_manager.ts
@@ -74,10 +74,10 @@ export default class TabManager extends Component {
 
             // preload all notes at once
             await froca.getNotes([...noteContextsToOpen.flatMap((tab: NoteContextState) =>
-                [treeService.getNoteIdFromUrl(tab.notePath), tab.hoistedNoteId])], true);
+                [treeService.getNoteIdFromLink(tab.notePath), tab.hoistedNoteId])], true);
 
             const filteredNoteContexts = noteContextsToOpen.filter((openTab: NoteContextState) => {
-                const noteId = treeService.getNoteIdFromUrl(openTab.notePath);
+                const noteId = treeService.getNoteIdFromLink(openTab.notePath);
                 if (!noteId || !(noteId in froca.notes)) {
                     // note doesn't exist so don't try to open tab for it
                     return false;

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -307,7 +307,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             noteCreateService.createNote(
                 {
                     target: "after",
-                    parentNoteUrl: parentNotePath,
+                    parentNoteLink: parentNotePath,
                     targetBranchId: this.node.data.branchId,
                     type: type,
                     isProtected: isProtected,
@@ -321,7 +321,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             noteCreateService.createNote(
                 {
                     target: "into",
-                    parentNoteUrl: parentNotePath,
+                    parentNoteLink: parentNotePath,
                     type: type,
                     isProtected: this.node.data.isProtected,
                     templateNoteId: templateNoteId,

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -305,7 +305,9 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
 
 
             noteCreateService.createNote(
-                CreateNoteTarget.AfterNoteURL,
+                {
+                    target: CreateNoteTarget.AfterNoteURL,
+                    parentNoteUrl: parentNotePath,
                     targetBranchId: this.node.data.branchId,
                     type: type,
                     isProtected: isProtected,
@@ -315,14 +317,13 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             const parentNotePath = treeService.getNotePath(this.node);
 
             noteCreateService.createNote(
-                CreateNoteTarget.IntoNoteURL,
                 {
+                    target: CreateNoteTarget.IntoNoteURL,
                     parentNoteUrl: parentNotePath,
                     type: type,
                     isProtected: this.node.data.isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                    placement:
                 } as CreateNoteIntoURLOpts
             );
         } else if (command === "openNoteInSplit") {

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -301,7 +301,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             const parentNotePath = treeService.getNotePath(this.node.getParent());
             const isProtected = treeService.getParentProtectedStatus(this.node);
 
-            noteCreateService.createNote(parentNotePath, {
+            noteCreateService.createNoteIntoPath(parentNotePath, {
                 target: "after",
                 targetBranchId: this.node.data.branchId,
                 type,

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -313,7 +313,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     isProtected: isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                } as CreateNoteAfterUrlOpts
+                } as CreateNoteWithUrlOpts
             );
         } else if (command === "insertChildNote") {
             const parentNotePath = treeService.getNotePath(this.node);
@@ -326,7 +326,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     isProtected: this.node.data.isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                } as CreateNoteIntoUrlOpts
+                } as CreateNoteWithUrlOpts
             );
         } else if (command === "openNoteInSplit") {
             const subContexts = appContext.tabManager.getActiveContext()?.getSubContexts();

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -306,7 +306,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
 
             noteCreateService.createNote(
                 {
-                    target: CreateNoteTarget.AfterNoteURL,
+                    target: "after",
                     parentNoteUrl: parentNotePath,
                     targetBranchId: this.node.data.branchId,
                     type: type,
@@ -320,7 +320,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
 
             noteCreateService.createNote(
                 {
-                    target: CreateNoteTarget.IntoNoteURL,
+                    target: "into",
                     parentNoteUrl: parentNotePath,
                     type: type,
                     isProtected: this.node.data.isProtected,

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -13,11 +13,9 @@ import noteCreateService from "../services/note_create.js";
 import noteTypesService from "../services/note_types.js";
 import server from "../services/server.js";
 import toastService from "../services/toast.js";
-import treeService from "../services/tree.js";
 import utils from "../services/utils.js";
 import type NoteTreeWidget from "../widgets/note_tree.js";
 import contextMenu, { type MenuCommandItem, type MenuItem } from "./context_menu.js";
-import NoteColorPicker from "./custom-items/NoteColorPicker.jsx";
 
 // TODO: Deduplicate once client/server is well split.
 interface ConvertToAttachmentResponse {

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -313,7 +313,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     isProtected: isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                } as CreateNoteWithUrlOpts
+                }
             );
         } else if (command === "insertChildNote") {
             const parentNotePath = treeService.getNotePath(this.node);
@@ -326,7 +326,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     isProtected: this.node.data.isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                } as CreateNoteWithUrlOpts
+                }
             );
         } else if (command === "openNoteInSplit") {
             const subContexts = appContext.tabManager.getActiveContext()?.getSubContexts();

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -312,6 +312,8 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     type: type,
                     isProtected: isProtected,
                     templateNoteId: templateNoteId,
+                    promptForType: false,
+                } as CreateNoteAfterUrlOpts
             );
         } else if (command === "insertChildNote") {
             const parentNotePath = treeService.getNotePath(this.node);
@@ -324,7 +326,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     isProtected: this.node.data.isProtected,
                     templateNoteId: templateNoteId,
                     promptForType: false,
-                } as CreateNoteIntoURLOpts
+                } as CreateNoteIntoUrlOpts
             );
         } else if (command === "openNoteInSplit") {
             const subContexts = appContext.tabManager.getActiveContext()?.getSubContexts();

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -1,3 +1,5 @@
+import NoteColorPicker from "./custom-items/NoteColorPicker.jsx";
+import treeService from "../services/tree.js";
 import appContext, { type ContextMenuCommandData, type FilteredCommandNames } from "../components/app_context.js";
 import type { SelectMenuItemEventListener } from "../components/events.js";
 import type FAttachment from "../entities/fattachment.js";
@@ -301,21 +303,28 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             const parentNotePath = treeService.getNotePath(this.node.getParent());
             const isProtected = treeService.getParentProtectedStatus(this.node);
 
-            noteCreateService.createNoteIntoPath(parentNotePath, {
-                target: "after",
-                targetBranchId: this.node.data.branchId,
-                type,
-                isProtected,
-                templateNoteId
-            });
+
+            noteCreateService.createNote(
+                CreateNoteTarget.AfterNoteURL,
+                    targetBranchId: this.node.data.branchId,
+                    type: type,
+                    isProtected: isProtected,
+                    templateNoteId: templateNoteId,
+            );
         } else if (command === "insertChildNote") {
             const parentNotePath = treeService.getNotePath(this.node);
 
-            noteCreateService.createNote(parentNotePath, {
-                type,
-                isProtected: this.node.data.isProtected,
-                templateNoteId
-            });
+            noteCreateService.createNote(
+                CreateNoteTarget.IntoNoteURL,
+                {
+                    parentNoteUrl: parentNotePath,
+                    type: type,
+                    isProtected: this.node.data.isProtected,
+                    templateNoteId: templateNoteId,
+                    promptForType: false,
+                    placement:
+                } as CreateNoteIntoURLOpts
+            );
         } else if (command === "openNoteInSplit") {
             const subContexts = appContext.tabManager.getActiveContext()?.getSubContexts();
             const { ntxId } = subContexts?.[subContexts.length - 1] ?? {};

--- a/apps/client/src/services/content_renderer_text.ts
+++ b/apps/client/src/services/content_renderer_text.ts
@@ -28,7 +28,7 @@ export default async function renderText(note: FNote | FAttachment, $renderedCon
             renderMathInElement($renderedContent[0], { trust: true });
         }
 
-        const getNoteIdFromLink = (el: HTMLElement) => tree.getNoteIdFromUrl($(el).attr("href") || "");
+        const getNoteIdFromLink = (el: HTMLElement) => tree.getNoteIdFromLink($(el).attr("href") || "");
         const referenceLinks = $renderedContent.find<HTMLAnchorElement>("a.reference-link");
         const noteIdsToPrefetch = referenceLinks.map((i, el) => getNoteIdFromLink(el));
         await froca.getNotes(noteIdsToPrefetch);

--- a/apps/client/src/services/hoisted_note.ts
+++ b/apps/client/src/services/hoisted_note.ts
@@ -50,7 +50,7 @@ async function checkNoteAccess(notePath: string, noteContext: NoteContext) {
     const hoistedNoteId = noteContext.hoistedNoteId;
 
     if (!resolvedNotePath.includes(hoistedNoteId) && (!resolvedNotePath.includes("_hidden") || resolvedNotePath.includes("_lbBookmarks"))) {
-        const noteId = treeService.getNoteIdFromUrl(resolvedNotePath);
+        const noteId = treeService.getNoteIdFromLink(resolvedNotePath);
         if (!noteId) {
             return false;
         }

--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -262,7 +262,7 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
 
     return {
         notePath,
-        noteId: treeService.getNoteIdFromUrl(notePath),
+        noteId: treeService.getNoteIdFromLink(notePath),
         ntxId,
         hoistedNoteId,
         viewScope,

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -46,10 +46,10 @@ export enum SuggestionAction {
     // This overlap ensures that when a suggestion triggers a note creation callback,
     // the receiving features (e.g. note creation handlers, CKEditor mentions) can interpret
     // the action type consistently
-    CreateNoteIntoInbox = CreateNoteAction.CreateNoteIntoInbox,
-    CreateNoteIntoPath = CreateNoteAction.CreateNoteIntoPath,
-    CreateAndLinkNoteIntoInbox = CreateNoteAction.CreateAndLinkNoteIntoInbox,
-    CreateAndLinkNoteIntoPath = CreateNoteAction.CreateAndLinkNoteIntoPath,
+    CreateNote = CreateNoteAction.CreateNote,
+    CreateChildNote = CreateNoteAction.CreateChildNote,
+    CreateAndLinkNote = CreateNoteAction.CreateAndLinkNote,
+    CreateAndLinkChildNote = CreateNoteAction.CreateAndLinkChildNote,
 
     SearchNotes = "search-notes",
     ExternalLink = "external-link",
@@ -182,16 +182,16 @@ async function autocompleteSource(
             case CreateMode.CreateOnly: {
                 results = [
                     {
-                        action: SuggestionAction.CreateNoteIntoInbox,
+                        action: SuggestionAction.CreateNote,
                         noteTitle: trimmedTerm,
                         parentNoteId: "inbox",
-                        highlightedNotePathTitle: t("note_autocomplete.create-note-into-inbox", { term: trimmedTerm }),
+                        highlightedNotePathTitle: t("note_autocomplete.create-note", { term: trimmedTerm }),
                     },
                     {
-                        action: SuggestionAction.CreateNoteIntoPath,
+                        action: SuggestionAction.CreateChildNote,
                         noteTitle: trimmedTerm,
                         parentNoteId: activeNoteId || "root",
-                        highlightedNotePathTitle: t("note_autocomplete.create-note-into-path", { term: trimmedTerm }),
+                        highlightedNotePathTitle: t("note_autocomplete.create-child-note", { term: trimmedTerm }),
                     },
                     ...results,
                 ];
@@ -201,16 +201,16 @@ async function autocompleteSource(
             case CreateMode.CreateAndLink: {
                 results = [
                     {
-                        action: SuggestionAction.CreateAndLinkNoteIntoInbox,
+                        action: SuggestionAction.CreateAndLinkNote,
                         noteTitle: trimmedTerm,
                         parentNoteId: "inbox",
-                        highlightedNotePathTitle: t("note_autocomplete.create-and-link-note-into-inbox", { term: trimmedTerm }),
+                        highlightedNotePathTitle: t("note_autocomplete.create-and-link-note", { term: trimmedTerm }),
                     },
                     {
-                        action: SuggestionAction.CreateAndLinkNoteIntoPath,
+                        action: SuggestionAction.CreateAndLinkChildNote,
                         noteTitle: trimmedTerm,
                         parentNoteId: activeNoteId || "root",
-                        highlightedNotePathTitle: t("note_autocomplete.create-and-link-note-into-path", { term: trimmedTerm }),
+                        highlightedNotePathTitle: t("note_autocomplete.create-and-link-child-note", { term: trimmedTerm }),
                     },
                     ...results,
                 ];
@@ -316,11 +316,11 @@ function renderNoteSuggestion(s: Suggestion): string {
         switch (s.action) {
             case SuggestionAction.SearchNotes:
                 return "bx bx-search";
-            case SuggestionAction.CreateAndLinkNoteIntoInbox:
-            case SuggestionAction.CreateNoteIntoInbox:
+            case SuggestionAction.CreateAndLinkNote:
+            case SuggestionAction.CreateNote:
                 return "bx bx-plus";
-            case SuggestionAction.CreateAndLinkNoteIntoPath:
-            case SuggestionAction.CreateNoteIntoPath:
+            case SuggestionAction.CreateAndLinkChildNote:
+            case SuggestionAction.CreateChildNote:
                 return "bx bx-plus";
             case SuggestionAction.ExternalLink:
                 return "bx bx-link-external";
@@ -477,7 +477,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             }
 
             // --- CREATE NOTE INTO INBOX ---
-            case SuggestionAction.CreateNoteIntoInbox: {
+            case SuggestionAction.CreateNote: {
                 const { note } = await noteCreateService.createNote(
                     {
                         target: "inbox",
@@ -495,7 +495,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            case SuggestionAction.CreateAndLinkNoteIntoInbox: {
+            case SuggestionAction.CreateAndLinkNote: {
                 const { note } = await noteCreateService.createNote(
                     {
                         target: "inbox",
@@ -516,7 +516,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 return;
             }
 
-            case SuggestionAction.CreateNoteIntoPath: {
+            case SuggestionAction.CreateChildNote: {
                 if (!suggestion.parentNoteId) {
                     console.warn("Missing parentNoteId for CreateNoteIntoPath");
                     return;
@@ -538,7 +538,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            case SuggestionAction.CreateAndLinkNoteIntoPath: {
+            case SuggestionAction.CreateAndLinkChildNote: {
                 if (!suggestion.parentNoteId) {
                     console.warn("Missing parentNoteId for CreateNoteIntoPath");
                     return;

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -5,7 +5,7 @@ import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
 import type { MentionFeedObjectItem } from "@triliumnext/ckeditor5";
-import { MentionAction } from "@triliumnext/ckeditor5/src/augmentation.js";
+import { CreateNoteAction } from "@triliumnext/commons"
 
 /**
  * Extends CKEditor's MentionFeedObjectItem with extra fields used by Trilium.
@@ -42,14 +42,14 @@ let searchDelay = getSearchDelay(notesCount);
 
 // String values ensure stable, human-readable identifiers across serialization (JSON, CKEditor, logs).
 export enum SuggestionAction {
-    // These values intentionally mirror MentionAction string values 1:1.
+    // These values intentionally mirror CreateNoteAction string values 1:1.
     // This overlap ensures that when a suggestion triggers a note creation callback,
     // the receiving features (e.g. note creation handlers, CKEditor mentions) can interpret
     // the action type consistently
-    CreateNoteIntoInbox = MentionAction.CreateNoteIntoInbox,
-    CreateNoteIntoPath = MentionAction.CreateNoteIntoPath,
-    CreateAndLinkNoteIntoInbox = MentionAction.CreateAndLinkNoteIntoInbox,
-    CreateAndLinkNoteIntoPath = MentionAction.CreateAndLinkNoteIntoPath,
+    CreateNoteIntoInbox = CreateNoteAction.CreateNoteIntoInbox,
+    CreateNoteIntoPath = CreateNoteAction.CreateNoteIntoPath,
+    CreateAndLinkNoteIntoInbox = CreateNoteAction.CreateAndLinkNoteIntoInbox,
+    CreateAndLinkNoteIntoPath = CreateNoteAction.CreateAndLinkNoteIntoPath,
 
     SearchNotes = "search-notes",
     ExternalLink = "external-link",

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteTarget, CreateNoteIntoInboxOpts } from "./note_create.js";
+import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteIntoInboxOpts } from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
@@ -483,7 +483,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             case SuggestionAction.CreateNoteIntoInbox: {
                 const { note } = await noteCreateService.createNote(
                     {
-                        target: CreateNoteTarget.IntoInbox,
+                        target: "inbox",
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
@@ -503,7 +503,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             case SuggestionAction.CreateAndLinkNoteIntoInbox: {
                 const { note } = await noteCreateService.createNote(
                     {
-                        target: CreateNoteTarget.IntoInbox,
+                        target: "inbox",
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
@@ -523,7 +523,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             case SuggestionAction.CreateNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
                     {
-                        target: CreateNoteTarget.IntoNoteURL,
+                        target: "into",
                         parentNoteUrl: suggestion.parentNoteId,
                         title: suggestion.noteTitle,
                         activate: true,
@@ -544,7 +544,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             case SuggestionAction.CreateAndLinkNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
                     {
-                        target: CreateNoteTarget.IntoNoteURL,
+                        target: "into",
                         parentNoteUrl: suggestion.parentNoteId,
                         title: suggestion.noteTitle,
                         activate: false,

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService, { CreateNoteIntoInboxOpts, CreateNoteWithUrlOpts } from "./note_create.js";
+import noteCreateService from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget, CreateNoteIntoInboxURLOpts } from "./note_create.js";
+import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteTarget, CreateNoteIntoInboxOpts } from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
@@ -487,7 +487,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
-                    } as CreateNoteIntoInboxURLOpts
+                    } as CreateNoteIntoInboxOpts
                 );
 
                 if (!note) return;
@@ -507,7 +507,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
-                    } as CreateNoteIntoInboxURLOpts,
+                    } as CreateNoteIntoInboxOpts,
                 );
 
                 if (!note) return;
@@ -528,7 +528,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
-                    } as CreateNoteIntoURLOpts,
+                    } as CreateNoteIntoUrlOpts,
                 );
 
                 if (!note) return;
@@ -549,7 +549,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
-                    } as CreateNoteIntoURLOpts
+                    } as CreateNoteIntoUrlOpts
                 );
 
                 if (!note) return;

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget, InboxNoteOpts } from "./note_create.js";
+import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget, CreateNoteIntoInboxURLOpts } from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
@@ -482,12 +482,12 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             // --- CREATE NOTE INTO INBOX ---
             case SuggestionAction.CreateNoteIntoInbox: {
                 const { note } = await noteCreateService.createNote(
-                    CreateNoteTarget.IntoInbox,
                     {
+                        target: CreateNoteTarget.IntoInbox,
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
-                    } as InboxNoteOpts
+                    } as CreateNoteIntoInboxURLOpts
                 );
 
                 if (!note) return;
@@ -503,12 +503,12 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             // --- CREATE AND LINK NOTE INTO INBOX ---
             case SuggestionAction.CreateAndLinkNoteIntoInbox: {
                 const { note } = await noteCreateService.createNote(
-                    CreateNoteTarget.IntoInbox,
                     {
+                        target: CreateNoteTarget.IntoInbox,
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
-                    } as InboxNoteOpts,
+                    } as CreateNoteIntoInboxURLOpts,
                 );
 
                 if (!note) return;
@@ -524,14 +524,14 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             // --- CREATE NOTE INTO PATH ---
             case SuggestionAction.CreateNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
-                    CreateNoteTarget.IntoNoteURL,
                     {
+                        target: CreateNoteTarget.IntoNoteURL,
                         parentNoteUrl: suggestion.parentNoteId,
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
-                    } as CreateNoteIntoURLOpts
-                )
+                    } as CreateNoteIntoURLOpts,
+                );
 
                 if (!note) return;
 
@@ -546,15 +546,16 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             // --- CREATE AND LINK NOTE INTO PATH ---
             case SuggestionAction.CreateAndLinkNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
-                    CreateNoteTarget.IntoNoteURL,
                     {
+                        target: CreateNoteTarget.IntoNoteURL,
+                        parentNoteUrl: suggestion.parentNoteId,
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
                     } as CreateNoteIntoURLOpts
                 );
 
-                if (!note) return
+                if (!note) return;
 
                 const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
                 suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -57,10 +57,10 @@ export enum SuggestionAction {
     Command = "command",
 }
 
-export enum CreateMode {
-    None = "none",
-    CreateOnly = "create-only",
-    CreateAndLink = "create-and-link"
+export enum SuggestionMode {
+    SuggestNothing = "nothing",
+    SuggestCreateOnly = "create-only",
+    SuggestCreateAndLink = "create-and-link"
 }
 
 // NOTE: Previously marked for deduplication with a server-side type,
@@ -86,7 +86,7 @@ export interface Suggestion {
 export interface Options {
     container?: HTMLElement | null;
     fastSearch?: boolean;
-    createMode?: CreateMode;
+    suggestionMode?: SuggestionMode;
     allowJumpToSearchNotes?: boolean;
     allowExternalLinks?: boolean;
     /** If set, hides the right-side button corresponding to go to selected note. */
@@ -99,7 +99,7 @@ export interface Options {
 
 async function autocompleteSourceForCKEditor(
     queryText: string,
-    createMode: CreateMode
+    suggestionMode: SuggestionMode
 ): Promise<MentionFeedObjectItem[]> {
     // Wrap the callback-based autocompleteSource in a Promise for async/await
     const rows = await new Promise<Suggestion[]>((resolve) => {
@@ -107,7 +107,7 @@ async function autocompleteSourceForCKEditor(
             queryText,
             (suggestions) => resolve(suggestions),
             {
-                createMode,
+                suggestionMode,
             }
         );
     });
@@ -179,8 +179,8 @@ async function autocompleteSource(
 
     // --- Create Note suggestions ---
     if (trimmedTerm.length >= 1) {
-        switch (options.createMode) {
-            case CreateMode.CreateOnly: {
+        switch (options.suggestionMode) {
+            case SuggestionMode.SuggestCreateOnly: {
                 results = [
                     {
                         action: SuggestionAction.CreateNote,
@@ -199,7 +199,7 @@ async function autocompleteSource(
                 break;
             }
 
-            case CreateMode.CreateAndLink: {
+            case SuggestionMode.SuggestCreateAndLink: {
                 results = [
                     {
                         action: SuggestionAction.CreateAndLinkNote,

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService from "./note_create.js";
+import noteCreateService, { CreateNoteIntoURLOpts, CreateNoteTarget, InboxNoteOpts } from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
@@ -481,15 +481,16 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
 
             // --- CREATE NOTE INTO INBOX ---
             case SuggestionAction.CreateNoteIntoInbox: {
-                const { success, noteType, templateNoteId } = await noteCreateService.chooseNoteType();
-                if (!success) return;
+                const { note } = await noteCreateService.createNote(
+                    CreateNoteTarget.IntoInbox,
+                    {
+                        title: suggestion.noteTitle,
+                        activate: true,
+                        promptForType: true,
+                    } as InboxNoteOpts
+                );
 
-                const { note } = await noteCreateService.createNoteIntoInbox({
-                    title: suggestion.noteTitle,
-                    activate: true,
-                    type: noteType,
-                    templateNoteId,
-                });
+                if (!note) return;
 
                 const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
                 suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
@@ -501,15 +502,16 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
 
             // --- CREATE AND LINK NOTE INTO INBOX ---
             case SuggestionAction.CreateAndLinkNoteIntoInbox: {
-                const { success, noteType, templateNoteId } = await noteCreateService.chooseNoteType();
-                if (!success) return;
+                const { note } = await noteCreateService.createNote(
+                    CreateNoteTarget.IntoInbox,
+                    {
+                        title: suggestion.noteTitle,
+                        activate: false,
+                        promptForType: true,
+                    } as InboxNoteOpts,
+                );
 
-                const { note } = await noteCreateService.createNoteIntoInbox({
-                    title: suggestion.noteTitle,
-                    activate: false,
-                    type: noteType,
-                    templateNoteId,
-                });
+                if (!note) return;
 
                 const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
                 suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
@@ -521,15 +523,17 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
 
             // --- CREATE NOTE INTO PATH ---
             case SuggestionAction.CreateNoteIntoPath: {
-                const { success, noteType, templateNoteId, notePath } = await noteCreateService.chooseNoteType();
-                if (!success) return;
+                const { note } = await noteCreateService.createNote(
+                    CreateNoteTarget.IntoNoteURL,
+                    {
+                        parentNoteUrl: suggestion.parentNoteId,
+                        title: suggestion.noteTitle,
+                        activate: true,
+                        promptForType: true,
+                    } as CreateNoteIntoURLOpts
+                )
 
-                const { note } = await noteCreateService.createNoteIntoPath(notePath || suggestion.parentNoteId, {
-                    title: suggestion.noteTitle,
-                    activate: true,
-                    type: noteType,
-                    templateNoteId,
-                });
+                if (!note) return;
 
                 const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
                 suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
@@ -541,15 +545,16 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
 
             // --- CREATE AND LINK NOTE INTO PATH ---
             case SuggestionAction.CreateAndLinkNoteIntoPath: {
-                const { success, noteType, templateNoteId, notePath } = await noteCreateService.chooseNoteType();
-                if (!success) return;
+                const { note } = await noteCreateService.createNote(
+                    CreateNoteTarget.IntoNoteURL,
+                    {
+                        title: suggestion.noteTitle,
+                        activate: false,
+                        promptForType: true,
+                    } as CreateNoteIntoURLOpts
+                );
 
-                const { note } = await noteCreateService.createNoteIntoPath(notePath || suggestion.parentNoteId, {
-                    title: suggestion.noteTitle,
-                    activate: false,
-                    type: noteType,
-                    templateNoteId,
-                });
+                if (!note) return
 
                 const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
                 suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,6 +1,6 @@
 import server from "./server.js";
 import appContext from "../components/app_context.js";
-import noteCreateService, { CreateNoteIntoUrlOpts, CreateNoteIntoInboxOpts } from "./note_create.js";
+import noteCreateService, { CreateNoteIntoInboxOpts, CreateNoteWithUrlOpts } from "./note_create.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import commandRegistry from "./command_registry.js";
@@ -528,7 +528,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
-                    } as CreateNoteIntoUrlOpts,
+                    } as CreateNoteWithUrlOpts,
                 );
 
                 if (!note) return;
@@ -549,7 +549,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         title: suggestion.noteTitle,
                         activate: false,
                         promptForType: true,
-                    } as CreateNoteIntoUrlOpts
+                    } as CreateNoteWithUrlOpts
                 );
 
                 if (!note) return;

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -479,77 +479,25 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            // --- CREATE NOTE INTO INBOX ---
-            case SuggestionAction.CreateNoteIntoInbox: {
+            case SuggestionAction.CreateNoteIntoInbox:
+            case SuggestionAction.CreateAndLinkNoteIntoInbox:
+            case SuggestionAction.CreateNoteIntoPath:
+            case SuggestionAction.CreateAndLinkNoteIntoPath: {
+                let target = "inbox";
+                if (
+                    suggestion.action === SuggestionAction.CreateNoteIntoPath ||
+                    suggestion.action === SuggestionAction.CreateAndLinkNoteIntoPath
+                ) {
+                    target = "path";
+                }
+
                 const { note } = await noteCreateService.createNote(
                     {
-                        target: "inbox",
+                        target: target,
                         title: suggestion.noteTitle,
                         activate: true,
                         promptForType: true,
                     } as CreateNoteIntoInboxOpts
-                );
-
-                if (!note) return;
-
-                const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
-                suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
-
-                $el.trigger("autocomplete:noteselected", [suggestion]);
-                $el.autocomplete("close");
-                break;
-            }
-
-            case SuggestionAction.CreateAndLinkNoteIntoInbox: {
-                const { note } = await noteCreateService.createNote(
-                    {
-                        target: "inbox",
-                        title: suggestion.noteTitle,
-                        activate: false,
-                        promptForType: true,
-                    } as CreateNoteIntoInboxOpts,
-                );
-
-                if (!note) return;
-
-                const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
-                suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
-
-                $el.trigger("autocomplete:noteselected", [suggestion]);
-                $el.autocomplete("close");
-                break;
-            }
-
-            case SuggestionAction.CreateNoteIntoPath: {
-                const { note } = await noteCreateService.createNote(
-                    {
-                        target: "into",
-                        parentNoteUrl: suggestion.parentNoteId,
-                        title: suggestion.noteTitle,
-                        activate: true,
-                        promptForType: true,
-                    } as CreateNoteWithUrlOpts,
-                );
-
-                if (!note) return;
-
-                const hoistedNoteId = appContext.tabManager.getActiveContext()?.hoistedNoteId;
-                suggestion.notePath = note?.getBestNotePathString(hoistedNoteId);
-
-                $el.trigger("autocomplete:noteselected", [suggestion]);
-                $el.autocomplete("close");
-                break;
-            }
-
-            case SuggestionAction.CreateAndLinkNoteIntoPath: {
-                const { note } = await noteCreateService.createNote(
-                    {
-                        target: "into",
-                        parentNoteUrl: suggestion.parentNoteId,
-                        title: suggestion.noteTitle,
-                        activate: false,
-                        promptForType: true,
-                    } as CreateNoteWithUrlOpts
                 );
 
                 if (!note) return;

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -500,7 +500,6 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            // --- CREATE AND LINK NOTE INTO INBOX ---
             case SuggestionAction.CreateAndLinkNoteIntoInbox: {
                 const { note } = await noteCreateService.createNote(
                     {
@@ -521,7 +520,6 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            // --- CREATE NOTE INTO PATH ---
             case SuggestionAction.CreateNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
                     {
@@ -543,7 +541,6 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                 break;
             }
 
-            // --- CREATE AND LINK NOTE INTO PATH ---
             case SuggestionAction.CreateAndLinkNoteIntoPath: {
                 const { note } = await noteCreateService.createNote(
                     {

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -488,7 +488,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                     suggestion.action === SuggestionAction.CreateNoteIntoPath ||
                     suggestion.action === SuggestionAction.CreateAndLinkNoteIntoPath
                 ) {
-                    target = "path";
+                    target = "into";
                 }
 
                 const { note } = await noteCreateService.createNote(

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -15,13 +15,13 @@ import dateNoteService from "../services/date_notes.js";
 /**
  * Creating notes through note_create can have multiple kinds of valid
  * arguments. This type hierchary is checking if the arguments are correct.
- * Later the functions are overloaded based on an enum, to fixate the argument
- * type and through the type system the legal arguments.
+ * Later the functions of note_create are overloaded based to reflect these types,
+ * which define valid arguments.
  *
  * Theoretically: If the typechecking returns no errors, then the inputs
- * create a valid state, but only if the types are defined correctly.
- * Through the Curry–Howard correspondence, this kinda acts as a proof system
- * for correctness of the arguments (I believe that this is the connection here):
+ * create a valid state, given that the types are defined correctly.
+ * Through the Curry–Howard correspondence, this acts as a proof system
+ * proving that the arguments will produce a correct state at compile time.
  * that just means that if the code type-checks, then the provided options
  * represent a valid state. To represent the theoretical bases `type` is
  * used instead of `interface`

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -176,7 +176,7 @@ async function createNoteFromAction(
         }
         case CreateNoteAction.CreateChildNote: {
             if (!parentNoteLink) {
-                console.warn("Missing parentNoteLink in createNoteFromCkEditor()");
+                console.warn("createNoteFromAction: Missing parentNoteLink");
                 return { note: null, branch: undefined };
             }
 
@@ -193,7 +193,7 @@ async function createNoteFromAction(
         }
         case CreateNoteAction.CreateAndLinkChildNote: {
             if (!parentNoteLink) {
-                console.warn("Missing parentNoteLink in createNoteFromCkEditor()");
+                console.warn("createNoteFromAction: Missing parentNoteLink");
                 return { note: null, branch: undefined };
             }
             const resp = await createNote(

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -83,7 +83,7 @@ export type CreateNoteWithUrlOpts = CreateNoteOpts & {
     parentNoteUrl: string;
 
     // Disambiguates the position for cloned notes.
-    targetBranchId: string;
+    targetBranchId?: string;
 }
 
 type NeverDefineParentNoteUrlRule = {

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -78,10 +78,10 @@ export type CreateNoteOpts = {
 
 /*
  * Defines options for creating a note at a specific path.
- * Serves as a base (not exported) for "into", "before", and "after" variants,
+ * Serves as a base for "into", "before", and "after" variants,
  * sharing common URL-related fields.
  */
-type CreateNoteAtUrlOpts = CreateNoteOpts & {
+type CreateNoteWithUrlOpts = CreateNoteOpts & {
     // `Url` may refer to either parentNotePath or parentNoteId.
     // The vocabulary is inspired by existing function getNoteIdFromUrl.
     parentNoteUrl: string;
@@ -90,9 +90,9 @@ type CreateNoteAtUrlOpts = CreateNoteOpts & {
     targetBranchId: string;
 }
 
-export type CreateNoteIntoUrlOpts = CreateNoteAtUrlOpts;
-export type CreateNoteBeforeUrlOpts = CreateNoteAtUrlOpts;
-export type CreateNoteAfterUrlOpts = CreateNoteAtUrlOpts;
+export type CreateNoteIntoUrlOpts = CreateNoteWithUrlOpts;
+export type CreateNoteBeforeUrlOpts = CreateNoteWithUrlOpts;
+export type CreateNoteAfterUrlOpts = CreateNoteWithUrlOpts;
 
 type NeverDefineParentNoteUrlRule = {
     parentNoteUrl?: never;
@@ -132,9 +132,9 @@ async function createNote(
         return createNoteIntoInbox(resolvedOptions as CreateNoteIntoInboxOpts);
     }
 
-    return createNoteAtNote(
+    return createNoteWithUrl(
         resolvedOptions.target as "into" | "after" | "before",
-        resolvedOptions as CreateNoteAtUrlOpts
+        resolvedOptions as CreateNoteWithUrlOpts
     );
 }
 
@@ -173,9 +173,9 @@ async function promptForType(
  * @param options - Note creation options
  * @returns A promise resolving with the created note and its branch.
  */
-async function createNoteAtNote(
+async function createNoteWithUrl(
     target: "into" | "after" | "before",
-    options: CreateNoteAtUrlOpts
+    options: CreateNoteWithUrlOpts
 ): Promise<{ note: FNote | null; branch: FBranch | undefined }> {
     options = Object.assign(
         {
@@ -270,7 +270,7 @@ async function createNoteIntoInbox(
             inboxNote.isProtected && protectedSessionHolder.isProtectedSessionAvailable();
     }
 
-    const result = await createNoteAtNote("into",
+    const result = await createNoteWithUrl("into",
         {
             ...options,
             parentNoteUrl: inboxNote.noteId,

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -48,7 +48,14 @@ type PromptingRule = {
   type?: never;
 } | {
   promptForType?: false;
-  type: string;
+  /**
+   * The note type (e.g. "text", "code", "image", "mermaid", etc.).
+   *
+   * If omitted, the server will automatically default to `"text"`.
+   * TypeScript still enforces explicit typing unless `promptForType` is true,
+   * to encourage clarity at the call site.
+   */
+  type?: string;
 };
 
 
@@ -120,16 +127,15 @@ async function createNote(
         resolvedOptions = maybeResolvedOptions;
     }
 
-    if (resolvedOptions.target === "inbox") {
-        return createNoteIntoInbox(resolvedOptions);
-    }
 
-    // Only "into" | "before" | "after". the possibility of "inbox" was resolved
-    // a line above
-    return createNoteWithUrl(
-        resolvedOptions.target as "into" | "before" | "after",
-        resolvedOptions
-    );
+    switch(resolvedOptions.target) {
+        case "inbox":
+            return createNoteIntoInbox(resolvedOptions);
+        case "into":
+        case "before":
+        case "after":
+            return createNoteWithUrl(resolvedOptions.target, resolvedOptions);
+    }
 }
 
 async function promptForType(
@@ -141,12 +147,12 @@ async function promptForType(
         return null;
     }
 
-    let resolvedOptions = {
+    let resolvedOptions: CreateNoteOpts = {
         ...options,
         promptForType: false,
         type: noteType,
         templateNoteId,
-    } as CreateNoteOpts;
+    };
 
     if (notePath) {
         resolvedOptions = resolvedOptions as CreateNoteWithUrlOpts;
@@ -154,7 +160,7 @@ async function promptForType(
             ...resolvedOptions,
             target: "into",
             parentNoteUrl: notePath,
-        } as CreateNoteWithUrlOpts;
+        };
     }
 
     return resolvedOptions;
@@ -269,7 +275,7 @@ async function createNoteIntoInbox(
             ...options,
             target: "into",
             parentNoteUrl: inboxNote.noteId,
-        } as CreateNoteWithUrlOpts
+        }
     );
 
     return result;

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -37,7 +37,7 @@ import { CreateNoteAction } from "@triliumnext/commons";
  * Hierarchy (general → specific):
  * - CreateNoteOpts
  *   - CreateNoteWithUrlOpts
- *   - CreateNoteIntoInboxOpts
+ *   - CreateNoteIntoDefaultOpts
  */
 
 /** enforces a truth rule:
@@ -97,12 +97,12 @@ export type CreateNoteWithUrlOpts =
           targetBranchId: string;
       });
 
-export type CreateNoteIntoInboxOpts = CreateNoteBase & {
-    target: "inbox";
+export type CreateNoteIntoDefaultOpts = CreateNoteBase & {
+    target: "default";
     parentNoteUrl?: never;
 };
 
-export type CreateNoteOpts = CreateNoteWithUrlOpts | CreateNoteIntoInboxOpts;
+export type CreateNoteOpts = CreateNoteWithUrlOpts | CreateNoteIntoDefaultOpts;
 
 interface Response {
     // TODO: Deduplicate with server once we have client/server architecture.
@@ -134,8 +134,8 @@ async function createNote(
 
 
     switch(resolvedOptions.target) {
-        case "inbox":
-            return createNoteIntoInbox(resolvedOptions);
+        case "default":
+            return createNoteIntoDefaultLocation(resolvedOptions);
         case "into":
         case "before":
         case "after":
@@ -154,7 +154,7 @@ async function createNoteFromAction(
         case CreateNoteAction.CreateNote: {
             const resp = await createNote(
                 {
-                    target: "inbox",
+                    target: "default",
                     title: title,
                     activate: true,
                     promptForType: promptForType,
@@ -165,7 +165,7 @@ async function createNoteFromAction(
         case CreateNoteAction.CreateAndLinkNote: {
             const resp = await createNote(
                 {
-                    target: "inbox",
+                    target: "default",
                     title,
                     activate: false,
                     promptForType: promptForType,
@@ -329,12 +329,12 @@ async function createNoteWithUrl(
 /**
  * Creates a new note inside the user's Inbox.
  *
- * @param {CreateNoteIntoInboxOpts} [options] - Optional settings such as title, type, template, or content.
+ * @param {CreateNoteIntoDefaultOpts} [options] - Optional settings such as title, type, template, or content.
  * @returns {Promise<{ note: FNote | null; branch: FBranch | undefined }>}
  * Resolves with the created note and its branch, or `{ note: null, branch: undefined }` if the inbox is missing.
  */
-async function createNoteIntoInbox(
-    options: CreateNoteIntoInboxOpts
+async function createNoteIntoDefaultLocation(
+    options: CreateNoteIntoDefaultOpts
 ): Promise<{ note: FNote | null; branch: FBranch | undefined }> {
     const inboxNote = await dateNoteService.getInboxNote();
     if (!inboxNote) {

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -25,20 +25,24 @@ import dateNoteService from "../services/date_notes.js";
  * that just means that if the code type-checks, then the provided options
  * represent a valid state. To represent the theoretical bases `type` is
  * used instead of `interface`
+ *
+ * * Hierarchy of general to specific categories(hypernyms -> hyponyms):
+ *
+ * BaseCreateNoteSharedOpts
+ * |
+ * \-- BaseCreateNoteOpts
+ *     |
+ *     +-- CreateNoteAtUrlOpts
+ *     |   +-- CreateNoteIntoURLOpts
+ *     |   +-- CreateNoteBeforeURLOpts
+ *     |   \-- CreateNoteAfterURLOpts
+ *     |
+ *     \-- CreateNoteIntoInboxURLOpts
  */
-export type BaseCreateNoteOpts =
-  | ({
-      promptForType: true;
-      type?: never;
-    } & BaseCreateNoteSharedOpts)
-  | ({
-      promptForType?: false;
-      type?: string;
-    } & BaseCreateNoteSharedOpts);
 
 /**
- * this is the shared basis for all types, but since BaseCreateNoteOpts is can
- * have multiple different type systems
+ * this is the shared basis for all types. Every other type is child (hyponym)
+ * of it (domain hypernym).
  */
 type BaseCreateNoteSharedOpts = {
     target: CreateNoteTarget;
@@ -55,12 +59,22 @@ type BaseCreateNoteSharedOpts = {
     textEditor?: CKTextEditor;
 }
 
+export type BaseCreateNoteOpts =
+  | (BaseCreateNoteSharedOpts & {
+      promptForType: true;
+      type?: never;
+    })
+  | (BaseCreateNoteSharedOpts & {
+      promptForType?: false;
+      type?: string;
+    });
+
 /*
  * For creating a note in a specific path. At is the broader category (hypernym)
  * of "into" and "as siblings". It is not exported because it only exists, to
  * have its legal values propagated to its children (types inheriting from it).
  */
-type CreateNoteAtUrlOpts = BaseCreateNoteSharedOpts & {
+type CreateNoteAtUrlOpts = BaseCreateNoteOpts & {
     // `Url` means either parentNotePath or parentNoteId.
     // The vocabulary  is inspired by its loose semantics of getNoteIdFromUrl.
     parentNoteUrl: string;
@@ -78,7 +92,7 @@ type CreateNoteSiblingURLOpts = Omit<CreateNoteAtUrlOpts, "targetBranchId"> & {
 export type CreateNoteBeforeURLOpts = CreateNoteSiblingURLOpts;
 export type CreateNoteAfterURLOpts = CreateNoteSiblingURLOpts;
 
-export type CreateNoteIntoInboxURLOpts = BaseCreateNoteSharedOpts & {
+export type CreateNoteIntoInboxURLOpts = BaseCreateNoteOpts & {
     parentNoteUrl?: never;
 }
 

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -17,9 +17,8 @@ import dateNoteService from "../services/date_notes.js";
  * accepted by `note_create`.
  *
  * ## Overview
- * Each variant (e.g. `CreateNoteIntoUrlOpts`, `CreateNoteBeforeUrlOpts`, etc.)
- * extends `CreateNoteOpts` and enforces specific constraints to ensure only
- * valid note creation options are allowed at compile time.
+ * Each variant extends `CreateNoteOpts` and enforces specific constraints to
+ * ensure only valid note creation options are allowed at compile time.
  *
  * ## Type Safety
  * The `PromptingRule` ensures that `promptForType` and `type` stay mutually
@@ -36,10 +35,7 @@ import dateNoteService from "../services/date_notes.js";
  *
  * Hierarchy (general → specific):
  * - CreateNoteOpts
- *   - CreateNoteAtUrlOpts
- *     - CreateNoteIntoUrlOpts
- *     - CreateNoteBeforeUrlOpts
- *     - CreateNoteAfterUrlOpts
+ *   - CreateNoteWithUrlOpts
  *   - CreateNoteIntoInboxOpts
  */
 
@@ -81,7 +77,7 @@ export type CreateNoteOpts = {
  * Serves as a base for "into", "before", and "after" variants,
  * sharing common URL-related fields.
  */
-type CreateNoteWithUrlOpts = CreateNoteOpts & {
+export type CreateNoteWithUrlOpts = CreateNoteOpts & {
     // `Url` may refer to either parentNotePath or parentNoteId.
     // The vocabulary is inspired by existing function getNoteIdFromUrl.
     parentNoteUrl: string;
@@ -89,10 +85,6 @@ type CreateNoteWithUrlOpts = CreateNoteOpts & {
     // Disambiguates the position for cloned notes.
     targetBranchId: string;
 }
-
-export type CreateNoteIntoUrlOpts = CreateNoteWithUrlOpts;
-export type CreateNoteBeforeUrlOpts = CreateNoteWithUrlOpts;
-export type CreateNoteAfterUrlOpts = CreateNoteWithUrlOpts;
 
 type NeverDefineParentNoteUrlRule = {
     parentNoteUrl?: never;
@@ -155,12 +147,12 @@ async function promptForType(
     } as CreateNoteOpts;
 
     if (notePath) {
-        resolvedOptions = resolvedOptions as CreateNoteIntoUrlOpts;
+        resolvedOptions = resolvedOptions as CreateNoteWithUrlOpts;
         resolvedOptions = {
             ...resolvedOptions,
             target: "into",
             parentNoteUrl: notePath,
-        } as CreateNoteIntoUrlOpts;
+        } as CreateNoteWithUrlOpts;
     }
 
     return resolvedOptions;
@@ -274,7 +266,7 @@ async function createNoteIntoInbox(
         {
             ...options,
             parentNoteUrl: inboxNote.noteId,
-        } as CreateNoteIntoUrlOpts
+        } as CreateNoteWithUrlOpts
     );
 
     return result;

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -125,7 +125,7 @@ async function createNote(
     }
 
     return createNoteWithUrl(
-        resolvedOptions.target as "into" | "after" | "before",
+        resolvedOptions.target,
         resolvedOptions as CreateNoteWithUrlOpts
     );
 }

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -21,6 +21,29 @@ export enum CreateNoteTarget {
     IntoInbox,
 }
 
+/**
+ * validation of note creation options through type checking.
+ *
+ * If the typechecking returns no errors, then the inputs create a valid state,
+ * but only if the types are defined semantically correct.
+ *
+ * These definitions use discriminated unions (`BaseCreateNoteOpts`) built from composable
+ * `type` aliases (not `interface`) to ensure that only *logically valid* configurations
+ * of creation parameters can exist at compile time.
+ *
+ * Through the Curry–Howard correspondence, this acts as a lightweight proof system:
+ * if the code type-checks, then the provided options represent a valid state
+ * for note creation — i.e. the combination of fields cannot express an invalid
+ * or contradictory configuration.
+ *
+ * In other words:
+ *   - Each variant of `BaseCreateNoteOpts` encodes one valid semantic path.
+ *   - The type system statically eliminates impossible states.
+ *   - The runtime logic can therefore assume the input is internally consistent.
+ *
+ * This is why `type` is used instead of `interface`: the goal is type-level proof
+ * of validity.
+ */
 export type BaseCreateNoteOpts =
   | ({
       promptForType: true;
@@ -31,7 +54,7 @@ export type BaseCreateNoteOpts =
       type?: string;
     } & BaseCreateNoteSharedOpts);
 
-export interface BaseCreateNoteSharedOpts {
+export type BaseCreateNoteSharedOpts = {
     target: CreateNoteTarget;
     isProtected?: boolean;
     saveSelection?: boolean;
@@ -63,7 +86,6 @@ type CreateNoteSiblingURLOpts = Omit<CreateNoteAtURLOpts, "targetBranchId"> & {
 export type CreateNoteBeforeURLOpts = CreateNoteSiblingURLOpts;
 export type CreateNoteAfterURLOpts = CreateNoteSiblingURLOpts;
 
-// For creating *in the inbox*
 export type CreateNoteIntoInboxURLOpts = BaseCreateNoteSharedOpts & {
     // disallowed
     parentNoteUrl?: never;

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -29,14 +29,15 @@ import dateNoteService from "../services/date_notes.js";
  *
  * * Hierarchy of general to specific categories(hypernyms -> hyponyms):
  *
- * BaseCreateNoteSharedOpts
+ * * BaseCreateNoteSharedOpts
  * |
  * \-- BaseCreateNoteOpts
  *     |
  *     +-- CreateNoteAtUrlOpts
  *     |   +-- CreateNoteIntoURLOpts
- *     |   +-- CreateNoteBeforeURLOpts
- *     |   \-- CreateNoteAfterURLOpts
+ *     |   \-- CreateNoteSiblingURLOpts
+ *     |       +-- CreateNoteBeforeURLOpts
+ *     |       \-- CreateNoteAfterURLOpts
  *     |
  *     \-- CreateNoteIntoInboxURLOpts
  */
@@ -56,7 +57,6 @@ type BaseCreateNoteSharedOpts = {
     templateNoteId?: string;
     activate?: boolean;
     focus?: "title" | "content";
-    targetBranchId?: string;
     textEditor?: CKTextEditor;
 }
 
@@ -79,17 +79,16 @@ type CreateNoteAtUrlOpts = BaseCreateNoteOpts & {
     // `Url` means either parentNotePath or parentNoteId.
     // The vocabulary  is inspired by its loose semantics of getNoteIdFromUrl.
     parentNoteUrl: string;
+    /*
+     * targetBranchId disambiguates the position for cloned notes. This is a
+     * concern whenever we are given a note URL.
+     */
+    targetBranchId: string;
 }
 
 export type CreateNoteIntoURLOpts = CreateNoteAtUrlOpts;
 
-/*
- * targetBranchId disambiguates the position for cloned notes. This is only a
- * concern for siblings. The reason for that is specified in the backend.
- */
-type CreateNoteSiblingURLOpts = Omit<CreateNoteAtUrlOpts, "targetBranchId"> & {
-    targetBranchId: string;
-};
+type CreateNoteSiblingURLOpts = CreateNoteAtUrlOpts;
 export type CreateNoteBeforeURLOpts = CreateNoteSiblingURLOpts;
 export type CreateNoteAfterURLOpts = CreateNoteSiblingURLOpts;
 

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -29,9 +29,9 @@ import dateNoteService from "../services/date_notes.js";
  *
  * * Hierarchy of general to specific categories(hypernyms -> hyponyms):
  *
- * * BaseCreateNoteSharedOpts
+ * * CreateNoteEntity
  * |
- * \-- BaseCreateNoteOpts
+ * \-- CreateNoteOpts
  *     |
  *     +-- CreateNoteAtUrlOpts
  *     |   +-- CreateNoteIntoURLOpts
@@ -46,7 +46,7 @@ import dateNoteService from "../services/date_notes.js";
  * this is the shared basis for all types. Every other type is child (hyponym)
  * of it (domain hypernym).
  */
-type BaseCreateNoteSharedOpts = {
+type CreateNoteEntity = {
     target: CreateNoteTarget;
     isProtected?: boolean;
     saveSelection?: boolean;
@@ -60,12 +60,12 @@ type BaseCreateNoteSharedOpts = {
     textEditor?: CKTextEditor;
 }
 
-export type BaseCreateNoteOpts =
-  | (BaseCreateNoteSharedOpts & {
+export type CreateNoteOpts =
+  | (CreateNoteEntity & {
       promptForType: true;
       type?: never;
     })
-  | (BaseCreateNoteSharedOpts & {
+  | (CreateNoteEntity & {
       promptForType?: false;
       type?: string;
     });
@@ -75,7 +75,7 @@ export type BaseCreateNoteOpts =
  * of "into" and "as siblings". It is not exported because it only exists, to
  * have its legal values propagated to its children (types inheriting from it).
  */
-type CreateNoteAtUrlOpts = BaseCreateNoteOpts & {
+type CreateNoteAtUrlOpts = CreateNoteOpts & {
     // `Url` means either parentNotePath or parentNoteId.
     // The vocabulary  is inspired by its loose semantics of getNoteIdFromUrl.
     parentNoteUrl: string;
@@ -92,7 +92,7 @@ type CreateNoteSiblingURLOpts = CreateNoteAtUrlOpts;
 export type CreateNoteBeforeURLOpts = CreateNoteSiblingURLOpts;
 export type CreateNoteAfterURLOpts = CreateNoteSiblingURLOpts;
 
-export type CreateNoteIntoInboxURLOpts = BaseCreateNoteOpts & {
+export type CreateNoteIntoInboxURLOpts = CreateNoteOpts & {
     parentNoteUrl?: never;
 }
 
@@ -132,7 +132,7 @@ async function createNote(
 ): Promise<{ note: FNote | null; branch: FBranch | undefined }>;
 
 async function createNote(
-  options: BaseCreateNoteOpts
+  options: CreateNoteOpts
 ): Promise<{ note: FNote | null; branch: FBranch | undefined }> {
 
     let resolvedOptions = { ...options };
@@ -150,7 +150,7 @@ async function createNote(
             promptForType: false,
             type: noteType,
             templateNoteId,
-        } as BaseCreateNoteOpts;
+        } as CreateNoteOpts;
 
         if (notePath) {
             resolvedOptions = resolvedOptions as CreateNoteIntoURLOpts;
@@ -187,7 +187,7 @@ async function createNote(
  * Core function that creates a new note under the specified parent note path.
  *
  * @param target - Duplicates apps/server/src/routes/api/notes.ts createNote
- * @param {BaseCreateNoteSharedOpts} [options] - Options controlling note creation (title, content, type, template, focus, etc.).
+ * @param {CreateNoteEntity} [options] - Options controlling note creation (title, content, type, template, focus, etc.).
  * with parentNotePath - The parent note path where the new note will be created.
  * @returns {Promise<{ note: FNote | null; branch: FBranch | undefined }>}
  * Resolves with the created note and branch entities.
@@ -290,7 +290,7 @@ async function createNoteAfterNote(
 /**
  * Creates a new note inside the user's Inbox.
  *
- * @param {BaseCreateNoteSharedOpts} [options] - Optional settings such as title, type, template, or content.
+ * @param {CreateNoteEntity} [options] - Optional settings such as title, type, template, or content.
  * @returns {Promise<{ note: FNote | null; branch: FBranch | undefined }>}
  * Resolves with the created note and its branch, or `{ note: null, branch: undefined }` if the inbox is missing.
  */

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -63,7 +63,7 @@ type PromptingRule = {
  * Combine with `&` to ensure valid logical combinations.
  */
 export type CreateNoteOpts = {
-    target: CreateNoteTarget;
+    target: "into" | "after" | "before" | "inbox";
     isProtected?: boolean;
     saveSelection?: boolean;
     title?: string | null;
@@ -99,13 +99,6 @@ type NeverDefineParentNoteUrlRule = {
 };
 export type CreateNoteIntoInboxOpts = CreateNoteOpts & NeverDefineParentNoteUrlRule;
 
-export enum CreateNoteTarget {
-    IntoNoteURL,
-    AfterNoteURL,
-    BeforeNoteURL,
-    IntoInbox,
-}
-
 interface Response {
     // TODO: Deduplicate with server once we have client/server architecture.
     note: FNote;
@@ -136,16 +129,16 @@ async function createNote(
     }
 
     switch (resolvedOptions.target) {
-        case CreateNoteTarget.IntoNoteURL:
+        case "into":
             return await createNoteAtNote("into", {...options} as CreateNoteAtUrlOpts);
 
-        case CreateNoteTarget.BeforeNoteURL:
+        case "before":
             return await createNoteAtNote("before", resolvedOptions as CreateNoteBeforeUrlOpts);
 
-        case CreateNoteTarget.AfterNoteURL:
+        case "after":
             return await createNoteAtNote("after", resolvedOptions as CreateNoteAfterUrlOpts);
 
-        case CreateNoteTarget.IntoInbox:
+        case "inbox":
             return await createNoteIntoInbox(resolvedOptions as CreateNoteIntoInboxOpts);
 
         default: {
@@ -176,7 +169,7 @@ async function promptForType(
         resolvedOptions = resolvedOptions as CreateNoteIntoUrlOpts;
         resolvedOptions = {
             ...resolvedOptions,
-            target: CreateNoteTarget.IntoNoteURL,
+            target: "into",
             parentNoteUrl: notePath,
         } as CreateNoteIntoUrlOpts;
     }

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -155,7 +155,6 @@ async function promptForType(
     };
 
     if (notePath) {
-        resolvedOptions = resolvedOptions as CreateNoteWithUrlOpts;
         resolvedOptions = {
             ...resolvedOptions,
             target: "into",

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -13,19 +13,23 @@ import type { CKTextEditor } from "@triliumnext/ckeditor5";
 import dateNoteService from "../services/date_notes.js";
 
 /**
- * Creating notes through note_create can have multiple kinds of valid
- * arguments. This type hierarchy is checking if the arguments are correct.
- * Later the functions of note_create are overloaded based to reflect these types,
- * which define valid arguments.
+ * The `note_create` function can be called with multiple valid combinations
+ * of arguments. This type hierarchy defines and enforces which combinations
+ * are valid at compile time.
  *
- * Theoretically: If the typechecking returns no errors, then the inputs
- * create a valid state, given that the types are defined correctly.
- * Through the Curry–Howard correspondence, this acts as a proof system
- * proving that the arguments will produce a correct state at compile time.
- * That means when typescript does type-checks, then the arguments will
- * definitely represent a valid state.
+ * The function overloads later in `note_create` correspond to these types,
+ * ensuring that each variant of note creation accepts only the correct
+ * set of arguments.
  *
- * To represent the theoretical bases `type` is used instead of `interface`
+ * Theoretically: If type checking produces no errors, then the provided
+ * arguments represent a valid state — assuming the types below are defined
+ * correctly. Through the Curry–Howard correspondence, this type system
+ * effectively acts as a proof system: a successful type check serves as a
+ * compile-time proof that the arguments of `create_note` can only produce
+ * a valid state.
+ *
+ * To align with its theoretical foundation in type theory (via the
+ * Curry–Howard correspondence), `type` is used instead of `interface`
  *
  * * Hierarchy of general to specific categories(hypernyms -> hyponyms):
  *
@@ -44,7 +48,7 @@ import dateNoteService from "../services/date_notes.js";
 
 /**
  * this is the shared basis for all types. Every other type is child (hyponym)
- * of it (domain hypernym).
+ * of it (Its the domain hypernym).
  */
 type CreateNoteEntity = {
     target: CreateNoteTarget;

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -353,7 +353,7 @@ async function createNoteIntoDefaultLocation(
         {
             ...options,
             target: "into",
-            parentNoteLink: inboxNote.noteId,
+            parentNoteLink: inboxNote.getBestNotePathString(),
         }
     );
 

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -14,7 +14,7 @@ import dateNoteService from "../services/date_notes.js";
 
 /**
  * Creating notes through note_create can have multiple kinds of valid
- * arguments. This type hierchary is checking if the arguments are correct.
+ * arguments. This type hierarchy is checking if the arguments are correct.
  * Later the functions of note_create are overloaded based to reflect these types,
  * which define valid arguments.
  *
@@ -22,9 +22,10 @@ import dateNoteService from "../services/date_notes.js";
  * create a valid state, given that the types are defined correctly.
  * Through the Curry–Howard correspondence, this acts as a proof system
  * proving that the arguments will produce a correct state at compile time.
- * that just means that if the code type-checks, then the provided options
- * represent a valid state. To represent the theoretical bases `type` is
- * used instead of `interface`
+ * That means when typescript does type-checks, then the arguments will
+ * definitely represent a valid state.
+ *
+ * To represent the theoretical bases `type` is used instead of `interface`
  *
  * * Hierarchy of general to specific categories(hypernyms -> hyponyms):
  *

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -176,7 +176,7 @@ async function createNoteFromAction(
         }
         case CreateNoteAction.CreateChildNote: {
             if (!parentNoteLink) {
-                console.warn("Missing parentNotePath in createNoteFromCkEditor()");
+                console.warn("Missing parentNoteLink in createNoteFromCkEditor()");
                 return { note: null, branch: undefined };
             }
 
@@ -193,7 +193,7 @@ async function createNoteFromAction(
         }
         case CreateNoteAction.CreateAndLinkChildNote: {
             if (!parentNoteLink) {
-                console.warn("Missing parentNotePath in createNoteFromCkEditor()");
+                console.warn("Missing parentNoteLink in createNoteFromCkEditor()");
                 return { note: null, branch: undefined };
             }
             const resp = await createNote(

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -158,7 +158,7 @@ async function createNoteFromAction(
                     target: "default",
                     title: title,
                     activate: true,
-                    promptForType: promptForType,
+                    promptForType,
                 }
             );
             return resp;
@@ -169,7 +169,7 @@ async function createNoteFromAction(
                     target: "default",
                     title,
                     activate: false,
-                    promptForType: promptForType,
+                    promptForType,
                 }
             );
             return resp;
@@ -186,7 +186,7 @@ async function createNoteFromAction(
                     parentNoteLink,
                     title,
                     activate: true,
-                    promptForType: true,
+                    promptForType,
                 },
             );
             return resp
@@ -202,7 +202,7 @@ async function createNoteFromAction(
                     parentNoteLink: parentNoteLink,
                     title,
                     activate: false,
-                    promptForType: promptForType,
+                    promptForType,
                 },
             )
             return resp;

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -13,13 +13,7 @@ import type { CKTextEditor } from "@triliumnext/ckeditor5";
 import dateNoteService from "../services/date_notes.js";
 import { CreateChildrenResponse } from "@triliumnext/commons";
 
-// // Creating a note at a path creates ambiguity, do we want it created Into or
-// // Next to as sibling?
-// // TODO: where the heck is this defined
-// export enum NotePlacement {
-//     Into = "into",
-//     After = "after"
-// }
+// build around functionality of @see createNoteAtNote
 export enum CreateNoteTarget {
     IntoNoteURL,
     AfterNoteURL,

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -11,7 +11,6 @@ import type FBranch from "../entities/fbranch.js";
 import type { ChooseNoteTypeResponse } from "../widgets/dialogs/note_type_chooser.js";
 import type { CKTextEditor } from "@triliumnext/ckeditor5";
 import dateNoteService from "../services/date_notes.js";
-import { CreateChildrenResponse } from "@triliumnext/commons";
 
 /**
  * Creating notes through note_create can have multiple kinds of valid

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -124,8 +124,12 @@ async function createNote(
         return createNoteIntoInbox(resolvedOptions);
     }
 
-    // Only "into" | "before" | "after" reach here
-    return createNoteWithUrl(resolvedOptions.target, resolvedOptions);
+    // Only "into" | "before" | "after". the possibility of "inbox" was resolved
+    // a line above
+    return createNoteWithUrl(
+        resolvedOptions.target as "into" | "before" | "after",
+        resolvedOptions
+    );
 }
 
 async function promptForType(

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -40,35 +40,6 @@ interface DuplicateResponse {
 }
 
 /**
- * Creates a new note inside the user's Inbox.
- *
- * @param {CreateNoteOpts} [options] - Optional settings such as title, type, template, or content.
- * @returns {Promise<{ note: FNote | null; branch: FBranch | undefined }>}
- * Resolves with the created note and its branch, or `{ note: null, branch: undefined }` if the inbox is missing.
- */
-async function createNoteIntoInbox(
-    options: CreateNoteOpts = {}
-): Promise<{ note: FNote | null; branch: FBranch | undefined }> {
-    const inboxNote = await dateNoteService.getInboxNote();
-    if (!inboxNote) {
-        console.warn("Missing inbox note.");
-        // always return a defined object
-        return { note: null, branch: undefined };
-    }
-
-    if (options.isProtected === undefined) {
-        options.isProtected =
-            inboxNote.isProtected && protectedSessionHolder.isProtectedSessionAvailable();
-    }
-
-    const result = await createNoteIntoPath(inboxNote.noteId, {
-        ...options,
-        target: "into",
-    });
-
-    return result;
-}
-/**
  * Core function that creates a new note under the specified parent note path.
  *
  * @param {string | undefined} parentNotePath - The parent note path where the new note will be created.
@@ -147,6 +118,36 @@ async function createNoteIntoPath(
         note: noteEntity,
         branch: branchEntity
     };
+}
+
+/**
+ * Creates a new note inside the user's Inbox.
+ *
+ * @param {CreateNoteOpts} [options] - Optional settings such as title, type, template, or content.
+ * @returns {Promise<{ note: FNote | null; branch: FBranch | undefined }>}
+ * Resolves with the created note and its branch, or `{ note: null, branch: undefined }` if the inbox is missing.
+ */
+async function createNoteIntoInbox(
+    options: CreateNoteOpts = {}
+): Promise<{ note: FNote | null; branch: FBranch | undefined }> {
+    const inboxNote = await dateNoteService.getInboxNote();
+    if (!inboxNote) {
+        console.warn("Missing inbox note.");
+        // always return a defined object
+        return { note: null, branch: undefined };
+    }
+
+    if (options.isProtected === undefined) {
+        options.isProtected =
+            inboxNote.isProtected && protectedSessionHolder.isProtectedSessionAvailable();
+    }
+
+    const result = await createNoteIntoPath(inboxNote.noteId, {
+        ...options,
+        target: "into",
+    });
+
+    return result;
 }
 
 async function chooseNoteType() {

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -128,25 +128,14 @@ async function createNote(
         resolvedOptions = maybeResolvedOptions;
     }
 
-    switch (resolvedOptions.target) {
-        case "into":
-            return await createNoteAtNote("into", {...options} as CreateNoteAtUrlOpts);
-
-        case "before":
-            return await createNoteAtNote("before", resolvedOptions as CreateNoteBeforeUrlOpts);
-
-        case "after":
-            return await createNoteAtNote("after", resolvedOptions as CreateNoteAfterUrlOpts);
-
-        case "inbox":
-            return await createNoteIntoInbox(resolvedOptions as CreateNoteIntoInboxOpts);
-
-        default: {
-            console.warn("[createNote] Unknown target:", options.target, resolvedOptions);
-            toastService.showMessage("Unknown note creation target."); // optional
-            return { note: null, branch: undefined };
-        }
+    if (resolvedOptions.target === "inbox") {
+        return createNoteIntoInbox(resolvedOptions as CreateNoteIntoInboxOpts);
     }
+
+    return createNoteAtNote(
+        resolvedOptions.target as "into" | "after" | "before",
+        resolvedOptions as CreateNoteAtUrlOpts
+    );
 }
 
 async function promptForType(

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -263,6 +263,7 @@ async function createNoteIntoInbox(
     const result = await createNoteWithUrl("into",
         {
             ...options,
+            target: "into",
             parentNoteUrl: inboxNote.noteId,
         } as CreateNoteWithUrlOpts
     );

--- a/apps/client/src/services/tree.ts
+++ b/apps/client/src/services/tree.ts
@@ -94,7 +94,7 @@ async function resolveNotePathToSegments(notePath: string, hoistedNoteId = "root
     if (effectivePathSegments.includes(hoistedNoteId) && effectivePathSegments.includes('root')) {
         return effectivePathSegments;
     } else {
-        const noteId = getNoteIdFromUrl(notePath);
+        const noteId = getNoteIdFromLink(notePath);
         if (!noteId) {
             throw new Error(`Unable to find note with ID: ${noteId}.`);
         }
@@ -131,7 +131,7 @@ function getParentProtectedStatus(node: Fancytree.FancytreeNode) {
     return hoistedNoteService.isHoistedNode(node) ? false : node.getParent().data.isProtected;
 }
 
-function getNoteIdFromUrl(urlOrNotePath: string | null | undefined) {
+function getNoteIdFromLink(urlOrNotePath: string | null | undefined) {
     if (!urlOrNotePath) {
         return null;
     }
@@ -308,7 +308,7 @@ export default {
     getParentProtectedStatus,
     getNotePath,
     getNotePathTitleComponents,
-    getNoteIdFromUrl,
+    getNoteIdFromLink,
     getNoteIdAndParentIdFromUrl,
     getBranchIdFromUrl,
     getNoteTitle,

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1838,14 +1838,13 @@
   },
   "note_autocomplete": {
     "search-for": "Search for \"{{term}}\"",
-    "create-note-into-path": "Create child note \"{{term}}\"",
-    "create-note-into-inbox": "Create in Inbox note \"{{term}}\"",
-    "create-and-link-note-into-path": "Create and link child note \"{{term}}\"",
-    "create-and-link-note-into-inbox": "Create in Inbox and link note \"{{term}}\"",
+    "create-child-note": "Create child note \"{{term}}\"",
+    "create-note": "Create note \"{{term}}\"",
+    "create-and-link-child-note": "Create and link child note \"{{term}}\"",
+    "create-and-link-note": "Create and link note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",
-    "show-recent-notes": "Show recent notes",
-    "full-text-search": "Full text search"
+    "show-recent-notes": "Show recent notes"
   },
   "note_tooltip": {
     "note-has-been-deleted": "Note has been deleted.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1844,7 +1844,7 @@
     "create-and-link-note": "Create and link note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",
-    "show-recent-notes": "Show recent notes"
+    "show-recent-notes": "Show recent notes",
     "full-text-search": "Full text search"
   },
   "note_tooltip": {

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1845,6 +1845,7 @@
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",
     "show-recent-notes": "Show recent notes"
+    "full-text-search": "Full text search"
   },
   "note_tooltip": {
     "note-has-been-deleted": "Note has been deleted.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1838,7 +1838,10 @@
   },
   "note_autocomplete": {
     "search-for": "Search for \"{{term}}\"",
-    "create-note": "Create and link child note \"{{term}}\"",
+    "create-note-into-path": "Create child note \"{{term}}\"",
+    "create-note-into-inbox": "Create in Inbox note \"{{term}}\"",
+    "create-and-link-note-into-path": "Create and link child note \"{{term}}\"",
+    "create-and-link-note-into-inbox": "Create in Inbox and link note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",
     "show-recent-notes": "Show recent notes",

--- a/apps/client/src/widgets/attribute_widgets/attribute_detail.ts
+++ b/apps/client/src/widgets/attribute_widgets/attribute_detail.ts
@@ -3,7 +3,7 @@ import server from "../../services/server.js";
 import froca from "../../services/froca.js";
 import linkService from "../../services/link.js";
 import attributeAutocompleteService from "../../services/attribute_autocomplete.js";
-import noteAutocompleteService from "../../services/note_autocomplete.js";
+import noteAutocompleteService, { CreateMode } from "../../services/note_autocomplete.js";
 import promotedAttributeDefinitionParser from "../../services/promoted_attribute_definition_parser.js";
 import NoteContextAwareWidget from "../note_context_aware_widget.js";
 import SpacedUpdate from "../../services/spaced_update.js";
@@ -432,7 +432,7 @@ export default class AttributeDetailWidget extends NoteContextAwareWidget {
         this.$rowTargetNote = this.$widget.find(".attr-row-target-note");
         this.$inputTargetNote = this.$widget.find(".attr-input-target-note");
 
-        noteAutocompleteService.initNoteAutocomplete(this.$inputTargetNote, { allowCreatingNotes: true }).on("autocomplete:noteselected", (event, suggestion, dataset) => {
+        noteAutocompleteService.initNoteAutocomplete(this.$inputTargetNote, { createMode: CreateMode.CreateAndLink }).on("autocomplete:noteselected", (event, suggestion, dataset) => {
             if (!suggestion.notePath) {
                 return false;
             }

--- a/apps/client/src/widgets/attribute_widgets/attribute_detail.ts
+++ b/apps/client/src/widgets/attribute_widgets/attribute_detail.ts
@@ -3,7 +3,7 @@ import server from "../../services/server.js";
 import froca from "../../services/froca.js";
 import linkService from "../../services/link.js";
 import attributeAutocompleteService from "../../services/attribute_autocomplete.js";
-import noteAutocompleteService, { CreateMode } from "../../services/note_autocomplete.js";
+import noteAutocompleteService, { SuggestionMode } from "../../services/note_autocomplete.js";
 import promotedAttributeDefinitionParser from "../../services/promoted_attribute_definition_parser.js";
 import NoteContextAwareWidget from "../note_context_aware_widget.js";
 import SpacedUpdate from "../../services/spaced_update.js";
@@ -432,7 +432,7 @@ export default class AttributeDetailWidget extends NoteContextAwareWidget {
         this.$rowTargetNote = this.$widget.find(".attr-row-target-note");
         this.$inputTargetNote = this.$widget.find(".attr-input-target-note");
 
-        noteAutocompleteService.initNoteAutocomplete(this.$inputTargetNote, { createMode: CreateMode.CreateAndLink }).on("autocomplete:noteselected", (event, suggestion, dataset) => {
+        noteAutocompleteService.initNoteAutocomplete(this.$inputTargetNote, { suggestionMode: SuggestionMode.SuggestCreateAndLink }).on("autocomplete:noteselected", (event, suggestion, dataset) => {
             if (!suggestion.notePath) {
                 return false;
             }

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -39,7 +39,8 @@ export default class BoardApi {
             const parentNotePath = this.parentNote.noteId;
 
             // Create a new note as a child of the parent note
-            const { note: newNote, branch: newBranch } = await note_create.createNote(CreateNoteTarget.IntoNoteURL, {
+            const { note: newNote, branch: newBranch } = await note_create.createNote({
+                target: CreateNoteTarget.IntoNoteURL,
                 parentNoteUrl: parentNotePath,
                 activate: false,
                 title,
@@ -140,14 +141,14 @@ export default class BoardApi {
     async insertRowAtPosition(
             column: string,
             relativeToBranchId: string,
-            direction: "before" | "after") {
+            direction: CreateNoteTarget.BeforeNoteURL | CreateNoteTarget.AfterNoteURL
+    ) {
         const { note, branch } = await note_create.createNote(
-            CreateNoteTarget.IntoNoteURL,
             {
+                target: direction,
                 parentNoteUrl: this.parentNote.noteId,
                 activate: false,
                 targetBranchId: relativeToBranchId,
-                target: direction,
                 title: t("board_view.new-item"),
             } as CreateNoteIntoURLOpts
         );

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create from "../../../services/note_create";
+import note_create from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create.js";
+import note_create, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 
@@ -44,7 +44,7 @@ export default class BoardApi {
                 parentNoteUrl: parentNotePath,
                 activate: false,
                 title,
-            } as CreateNoteIntoURLOpts);
+            } as CreateNoteIntoUrlOpts);
 
             if (newNote && newBranch) {
                 await this.changeColumn(newNote.noteId, column);
@@ -150,7 +150,7 @@ export default class BoardApi {
                 activate: false,
                 targetBranchId: relativeToBranchId,
                 title: t("board_view.new-item"),
-            } as CreateNoteIntoURLOpts
+            } as CreateNoteIntoUrlOpts
         );
 
         if (!note || !branch) {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create, { CreateNoteWithUrlOpts } from "../../../services/note_create.js";
+import note_create from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -44,7 +44,7 @@ export default class BoardApi {
                 parentNoteUrl: parentNotePath,
                 activate: false,
                 title,
-            } as CreateNoteWithUrlOpts);
+            });
 
             if (newNote && newBranch) {
                 await this.changeColumn(newNote.noteId, column);
@@ -150,7 +150,7 @@ export default class BoardApi {
                 activate: false,
                 targetBranchId: relativeToBranchId,
                 title: t("board_view.new-item"),
-            } as CreateNoteWithUrlOpts
+            }
         );
 
         if (!note || !branch) {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create from "../../../services/note_create.js";
+import note_create, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 
@@ -39,10 +39,11 @@ export default class BoardApi {
             const parentNotePath = this.parentNote.noteId;
 
             // Create a new note as a child of the parent note
-            const { note: newNote, branch: newBranch } = await note_create.createNoteIntoPath(parentNotePath, {
+            const { note: newNote, branch: newBranch } = await note_create.createNote(CreateNoteTarget.IntoNoteURL, {
+                parentNoteUrl: parentNotePath,
                 activate: false,
-                title
-            });
+                title,
+            } as CreateNoteIntoURLOpts);
 
             if (newNote && newBranch) {
                 await this.changeColumn(newNote.noteId, column);
@@ -140,12 +141,16 @@ export default class BoardApi {
             column: string,
             relativeToBranchId: string,
             direction: "before" | "after") {
-        const { note, branch } = await note_create.createNoteIntoPath(this.parentNote.noteId, {
-            activate: false,
-            targetBranchId: relativeToBranchId,
-            target: direction,
-            title: t("board_view.new-item")
-        });
+        const { note, branch } = await note_create.createNote(
+            CreateNoteTarget.IntoNoteURL,
+            {
+                parentNoteUrl: this.parentNote.noteId,
+                activate: false,
+                targetBranchId: relativeToBranchId,
+                target: direction,
+                title: t("board_view.new-item"),
+            } as CreateNoteIntoURLOpts
+        );
 
         if (!note || !branch) {
             throw new Error("Failed to create note");

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../../services/note_create.js";
+import note_create, { CreateNoteIntoUrlOpts } from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 
@@ -40,7 +40,7 @@ export default class BoardApi {
 
             // Create a new note as a child of the parent note
             const { note: newNote, branch: newBranch } = await note_create.createNote({
-                target: CreateNoteTarget.IntoNoteURL,
+                target: "into",
                 parentNoteUrl: parentNotePath,
                 activate: false,
                 title,
@@ -141,7 +141,7 @@ export default class BoardApi {
     async insertRowAtPosition(
             column: string,
             relativeToBranchId: string,
-            direction: CreateNoteTarget.BeforeNoteURL | CreateNoteTarget.AfterNoteURL
+            direction: "before" | "after"
     ) {
         const { note, branch } = await note_create.createNote(
             {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -39,7 +39,7 @@ export default class BoardApi {
             const parentNotePath = this.parentNote.noteId;
 
             // Create a new note as a child of the parent note
-            const { note: newNote, branch: newBranch } = await note_create.createNote(parentNotePath, {
+            const { note: newNote, branch: newBranch } = await note_create.createNoteIntoPath(parentNotePath, {
                 activate: false,
                 title
             });
@@ -140,7 +140,7 @@ export default class BoardApi {
             column: string,
             relativeToBranchId: string,
             direction: "before" | "after") {
-        const { note, branch } = await note_create.createNote(this.parentNote.noteId, {
+        const { note, branch } = await note_create.createNoteIntoPath(this.parentNote.noteId, {
             activate: false,
             targetBranchId: relativeToBranchId,
             target: direction,

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -41,7 +41,7 @@ export default class BoardApi {
             // Create a new note as a child of the parent note
             const { note: newNote, branch: newBranch } = await note_create.createNote({
                 target: "into",
-                parentNoteUrl: parentNotePath,
+                parentNoteLink: parentNotePath,
                 activate: false,
                 title,
             });
@@ -146,7 +146,7 @@ export default class BoardApi {
         const { note, branch } = await note_create.createNote(
             {
                 target: direction,
-                parentNoteUrl: this.parentNote.noteId,
+                parentNoteLink: this.parentNote.noteId,
                 activate: false,
                 targetBranchId: relativeToBranchId,
                 title: t("board_view.new-item"),

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -7,7 +7,7 @@ import branches from "../../../services/branches";
 import { executeBulkActions } from "../../../services/bulk_action";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
-import note_create, { CreateNoteIntoUrlOpts } from "../../../services/note_create.js";
+import note_create, { CreateNoteWithUrlOpts } from "../../../services/note_create.js";
 import server from "../../../services/server";
 import { ColumnMap } from "./data";
 
@@ -44,7 +44,7 @@ export default class BoardApi {
                 parentNoteUrl: parentNotePath,
                 activate: false,
                 title,
-            } as CreateNoteIntoUrlOpts);
+            } as CreateNoteWithUrlOpts);
 
             if (newNote && newBranch) {
                 await this.changeColumn(newNote.noteId, column);
@@ -150,7 +150,7 @@ export default class BoardApi {
                 activate: false,
                 targetBranchId: relativeToBranchId,
                 title: t("board_view.new-item"),
-            } as CreateNoteIntoUrlOpts
+            } as CreateNoteWithUrlOpts
         );
 
         if (!note || !branch) {

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -6,7 +6,6 @@ import branches from "../../../services/branches";
 import dialog from "../../../services/dialog";
 import { getArchiveMenuItem } from "../../../menus/context_menu_utils";
 import { t } from "../../../services/i18n";
-import { CreateNoteTarget } from "../../../services/note_create";
 import Api from "./api";
 
 export function openColumnContextMenu(api: Api, event: ContextMenuEvent, column: string) {
@@ -50,7 +49,7 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, note: FNo
                 handler: () => api.insertRowAtPosition(
                     column,
                     branchId,
-                    CreateNoteTarget.BeforeNoteURL)
+                    "before")
             },
             {
                 title: t("board_view.insert-below"),
@@ -58,7 +57,7 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, note: FNo
                 handler: () => api.insertRowAtPosition(
                     column,
                     branchId,
-                    CreateNoteTarget.AfterNoteURL)
+                    "after")
             },
             { kind: "separator" },
             {

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -6,6 +6,7 @@ import branches from "../../../services/branches";
 import dialog from "../../../services/dialog";
 import { getArchiveMenuItem } from "../../../menus/context_menu_utils";
 import { t } from "../../../services/i18n";
+import { CreateNoteTarget } from "../../../services/note_create";
 import Api from "./api";
 
 export function openColumnContextMenu(api: Api, event: ContextMenuEvent, column: string) {
@@ -46,12 +47,18 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, note: FNo
             {
                 title: t("board_view.insert-above"),
                 uiIcon: "bx bx-list-plus",
-                handler: () => api.insertRowAtPosition(column, branchId, "before")
+                handler: () => api.insertRowAtPosition(
+                    column,
+                    branchId,
+                    CreateNoteTarget.BeforeNoteURL)
             },
             {
                 title: t("board_view.insert-below"),
                 uiIcon: "bx bx-empty",
-                handler: () => api.insertRowAtPosition(column, branchId, "after")
+                handler: () => api.insertRowAtPosition(
+                    column,
+                    branchId,
+                    CreateNoteTarget.AfterNoteURL)
             },
             { kind: "separator" },
             {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -310,8 +310,7 @@ export function TitleEditor({ currentValue, placeholder, save, dismiss, mode, is
             inputRef={inputRef}
             noteId={currentValue ?? ""}
             opts={{
-                hideAllButtons: true,
-                allowCreatingNotes: true
+                hideAllButtons: true
             }}
             onKeyDown={(e) => {
                 if (e.key === "Escape") {

--- a/apps/client/src/widgets/collections/table/columns.tsx
+++ b/apps/client/src/widgets/collections/table/columns.tsx
@@ -6,7 +6,7 @@ import Icon from "../../react/Icon.jsx";
 import { useEffect, useRef, useState } from "preact/hooks";
 import froca from "../../../services/froca.js";
 import NoteAutocomplete from "../../react/NoteAutocomplete.jsx";
-import { CreateMode } from "../../../services/note_autocomplete.js";
+import { SuggestionMode } from "../../../services/note_autocomplete.js";
 
 type ColumnType = LabelType | "relation";
 
@@ -228,7 +228,7 @@ function RelationEditor({ cell, success }: EditorOpts) {
         inputRef={inputRef}
         noteId={cell.getValue()}
         opts={{
-            createMode: CreateMode.CreateAndLink,
+            suggestionMode: SuggestionMode.SuggestCreateAndLink,
             hideAllButtons: true
         }}
         noteIdChanged={success}

--- a/apps/client/src/widgets/collections/table/columns.tsx
+++ b/apps/client/src/widgets/collections/table/columns.tsx
@@ -6,6 +6,7 @@ import Icon from "../../react/Icon.jsx";
 import { useEffect, useRef, useState } from "preact/hooks";
 import froca from "../../../services/froca.js";
 import NoteAutocomplete from "../../react/NoteAutocomplete.jsx";
+import { CreateMode } from "../../../services/note_autocomplete.js";
 
 type ColumnType = LabelType | "relation";
 
@@ -227,7 +228,7 @@ function RelationEditor({ cell, success }: EditorOpts) {
         inputRef={inputRef}
         noteId={cell.getValue()}
         opts={{
-            allowCreatingNotes: true,
+            createMode: CreateMode.CreateAndLink,
             hideAllButtons: true
         }}
         noteIdChanged={success}

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -184,9 +184,10 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
+                        parentNoteUrl: parentNoteId,
                         target: "before",
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteWithUrlOpts
+                    }
                 })
             },
             {
@@ -195,12 +196,16 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: async () => {
                     const branchId = row.getData().branchId;
                     const note = await froca.getBranch(branchId)?.getNote();
+                    if (!note) {
+                        return;
+                    }
                     parentComponent?.triggerCommand("addNewRow", {
-                        parentNotePath: note?.noteId,
+                        parentNotePath: note.noteId,
                         customOpts: {
+                            parentNoteUrl: note.noteId,
                             target: "after",
                             targetBranchId: branchId,
-                        } as CreateNoteWithUrlOpts
+                        }
                     });
                 }
             },
@@ -211,9 +216,10 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
+                        parentNoteUrl: parentNoteId,
                         target: "after",
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteWithUrlOpts
+                    }
                 })
             },
             { kind: "separator" },

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -182,7 +182,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 enabled: !sorters.length,
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     customOpts: {
-                        parentNoteUrl: parentNoteId,
+                        parentNoteLink: parentNoteId,
                         target: "before",
                         targetBranchId: rowData.branchId,
                     }
@@ -199,7 +199,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     }
                     parentComponent?.triggerCommand("addNewRow", {
                         customOpts: {
-                            parentNoteUrl: note.noteId,
+                            parentNoteLink: note.noteId,
                             target: "after",
                             targetBranchId: branchId,
                         }
@@ -212,7 +212,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 enabled: !sorters.length,
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     customOpts: {
-                        parentNoteUrl: parentNoteId,
+                        parentNoteLink: parentNoteId,
                         target: "after",
                         targetBranchId: rowData.branchId,
                     }

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,7 +9,7 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
-import { CreateNoteAfterURLOpts, CreateNoteBeforeURLOpts, CreateNoteTarget } from "../../../services/note_create.js";
+import { CreateNoteAfterUrlOpts, CreateNoteBeforeUrlOpts, CreateNoteTarget } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};
@@ -186,7 +186,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: CreateNoteTarget.BeforeNoteURL,
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteBeforeURLOpts
+                    } as CreateNoteBeforeUrlOpts
                 })
             },
             {
@@ -200,7 +200,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                         customOpts: {
                             target: CreateNoteTarget.AfterNoteURL,
                             targetBranchId: branchId,
-                        } as CreateNoteAfterURLOpts
+                        } as CreateNoteAfterUrlOpts
                     });
                 }
             },
@@ -213,7 +213,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: CreateNoteTarget.AfterNoteURL,
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteAfterURLOpts
+                    } as CreateNoteAfterUrlOpts
                 })
             },
             { kind: "separator" },

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,7 +9,7 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
-import { CreateNoteAfterUrlOpts, CreateNoteBeforeUrlOpts } from "../../../services/note_create.js";
+import { CreateNoteWithUrlOpts } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};
@@ -186,7 +186,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: "before",
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteBeforeUrlOpts
+                    } as CreateNoteWithUrlOpts
                 })
             },
             {
@@ -200,7 +200,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                         customOpts: {
                             target: "after",
                             targetBranchId: branchId,
-                        } as CreateNoteAfterUrlOpts
+                        } as CreateNoteWithUrlOpts
                     });
                 }
             },
@@ -213,7 +213,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: "after",
                         targetBranchId: rowData.branchId,
-                    } as CreateNoteAfterUrlOpts
+                    } as CreateNoteWithUrlOpts
                 })
             },
             { kind: "separator" },

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,7 +9,6 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
-import { CreateNoteWithUrlOpts } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,6 +9,7 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
+import { CreateNoteTarget } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};
@@ -183,7 +184,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
-                        target: "before",
+                        target: CreateNoteTarget.BeforeNoteURL,
                         targetBranchId: rowData.branchId,
                     }
                 })
@@ -197,7 +198,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     parentComponent?.triggerCommand("addNewRow", {
                         parentNotePath: note?.noteId,
                         customOpts: {
-                            target: "after",
+                            target: CreateNoteTarget.AfterNoteURL,
                             targetBranchId: branchId,
                         }
                     });
@@ -210,7 +211,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
-                        target: "after",
+                        target: CreateNoteTarget.AfterNoteURL,
                         targetBranchId: rowData.branchId,
                     }
                 })

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -182,7 +182,6 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 uiIcon: "bx bx-horizontal-left bx-rotate-90",
                 enabled: !sorters.length,
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
-                    parentNotePath: parentNoteId,
                     customOpts: {
                         parentNoteUrl: parentNoteId,
                         target: "before",
@@ -200,7 +199,6 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                         return;
                     }
                     parentComponent?.triggerCommand("addNewRow", {
-                        parentNotePath: note.noteId,
                         customOpts: {
                             parentNoteUrl: note.noteId,
                             target: "after",
@@ -214,7 +212,6 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 uiIcon: "bx bx-horizontal-left bx-rotate-270",
                 enabled: !sorters.length,
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
-                    parentNotePath: parentNoteId,
                     customOpts: {
                         parentNoteUrl: parentNoteId,
                         target: "after",

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,7 +9,7 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
-import { CreateNoteAfterUrlOpts, CreateNoteBeforeUrlOpts, CreateNoteTarget } from "../../../services/note_create.js";
+import { CreateNoteAfterUrlOpts, CreateNoteBeforeUrlOpts } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};
@@ -184,7 +184,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
-                        target: CreateNoteTarget.BeforeNoteURL,
+                        target: "before",
                         targetBranchId: rowData.branchId,
                     } as CreateNoteBeforeUrlOpts
                 })
@@ -198,7 +198,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     parentComponent?.triggerCommand("addNewRow", {
                         parentNotePath: note?.noteId,
                         customOpts: {
-                            target: CreateNoteTarget.AfterNoteURL,
+                            target: "after",
                             targetBranchId: branchId,
                         } as CreateNoteAfterUrlOpts
                     });
@@ -211,7 +211,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                 handler: () => parentComponent?.triggerCommand("addNewRow", {
                     parentNotePath: parentNoteId,
                     customOpts: {
-                        target: CreateNoteTarget.AfterNoteURL,
+                        target: "after",
                         targetBranchId: rowData.branchId,
                     } as CreateNoteAfterUrlOpts
                 })

--- a/apps/client/src/widgets/collections/table/context_menu.ts
+++ b/apps/client/src/widgets/collections/table/context_menu.ts
@@ -9,7 +9,7 @@ import branches from "../../../services/branches.js";
 import Component from "../../../components/component.js";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker.jsx";
 import { RefObject } from "preact";
-import { CreateNoteTarget } from "../../../services/note_create.js";
+import { CreateNoteAfterURLOpts, CreateNoteBeforeURLOpts, CreateNoteTarget } from "../../../services/note_create.js";
 
 export function useContextMenu(parentNote: FNote, parentComponent: Component | null | undefined, tabulator: RefObject<Tabulator>): Partial<EventCallBackMethods> {
     const events: Partial<EventCallBackMethods> = {};
@@ -186,7 +186,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: CreateNoteTarget.BeforeNoteURL,
                         targetBranchId: rowData.branchId,
-                    }
+                    } as CreateNoteBeforeURLOpts
                 })
             },
             {
@@ -200,7 +200,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                         customOpts: {
                             target: CreateNoteTarget.AfterNoteURL,
                             targetBranchId: branchId,
-                        }
+                        } as CreateNoteAfterURLOpts
                     });
                 }
             },
@@ -213,7 +213,7 @@ export function showRowContextMenu(parentComponent: Component, e: MouseEvent, ro
                     customOpts: {
                         target: CreateNoteTarget.AfterNoteURL,
                         targetBranchId: rowData.branchId,
-                    }
+                    } as CreateNoteAfterURLOpts
                 })
             },
             { kind: "separator" },

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -21,9 +21,9 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                 };
             }
 
-            const noteUrl = customOpts.parentNoteUrl ?? parentNotePath;
+            const noteUrl = customOpts.parentNoteLink ?? parentNotePath;
             if (noteUrl) {
-                customOpts.parentNoteUrl = noteUrl;
+                customOpts.parentNoteLink = noteUrl;
                 customOpts.activate = false;
                 note_create.createNote(customOpts).then(({ branch }) => {
                     if (branch) {

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { CreateNoteOpts, CreateNoteIntoURLOpts as CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create";
+import note_create, { CreateNoteOpts, CreateNoteIntoUrlOpts as CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";
@@ -23,7 +23,7 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                     {
                         parentNoteUrl: notePath,
                         ...opts
-                    } as CreateNoteIntoURLOpts
+                    } as CreateNoteIntoUrlOpts
                 ).then(({ branch }) => {
                     if (branch) {
                         setTimeout(() => {

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -19,11 +19,18 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                     activate: false,
                     ...customOpts
                 }
+
+                // Normalize "inbox" targets into standard path-based creation.
+                // When adding a new row, we always have a concrete parent path (`notePath`),
+                // so even if the originating command requested an "inbox" creation,
+                // it should instead behave as "into" under the current note.
+                const normalizedOpts: CreateNoteWithUrlOpts =
+                    opts.target === "inbox"
+                        ? { ...opts, target: "into", parentNoteUrl: notePath }
+                        : { ...opts, parentNoteUrl: notePath };
+
                 note_create.createNote(
-                    {
-                        parentNoteUrl: notePath,
-                        ...opts
-                    } as CreateNoteWithUrlOpts
+                    normalizedOpts
                 ).then(({ branch }) => {
                     if (branch) {
                         setTimeout(() => {

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -19,7 +19,7 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                     activate: false,
                     ...customOpts
                 }
-                note_create.createNote(notePath, opts).then(({ branch }) => {
+                note_create.createNoteIntoPath(notePath, opts).then(({ branch }) => {
                     if (branch) {
                         setTimeout(() => {
                             if (!api.current) return;

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { BaseCreateNoteOpts, CreateNoteIntoURLOpts as CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create";
+import note_create, { CreateNoteOpts, CreateNoteIntoURLOpts as CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";
@@ -15,7 +15,7 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
         addNewRowCommand({ customOpts, parentNotePath: customNotePath }: CommandListenerData<"addNewRow">) {
             const notePath = customNotePath ?? parentNotePath;
             if (notePath) {
-                const opts: BaseCreateNoteOpts = {
+                const opts: CreateNoteOpts = {
                     activate: false,
                     ...customOpts
                 }

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -9,7 +9,10 @@ import server from "../../../services/server";
 import branches from "../../../services/branches";
 import AttributeDetailWidget from "../../attribute_widgets/attribute_detail";
 
-export default function useRowTableEditing(api: RefObject<Tabulator>, attributeDetailWidget: AttributeDetailWidget, parentNotePath: string): Partial<EventCallBackMethods> { // Adding new rows
+/**
+ * Hook for handling row table editing, including adding new rows.
+ */
+export default function useRowTableEditing(api: RefObject<Tabulator>, attributeDetailWidget: AttributeDetailWidget, parentNotePath: string): Partial<EventCallBackMethods> {
     useLegacyImperativeHandlers({
         addNewRowCommand({ customOpts }: CommandListenerData<"addNewRow">) {
             if (!customOpts) {

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -20,7 +20,6 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                     ...customOpts
                 }
                 note_create.createNote(
-                    CreateNoteTarget.IntoNoteURL,
                     {
                         parentNoteUrl: notePath,
                         ...opts

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { CreateNoteOpts, CreateNoteIntoUrlOpts as CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../../services/note_create";
+import note_create, { CreateNoteOpts, CreateNoteIntoUrlOpts as CreateNoteIntoUrlOpts } from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { CreateNoteOpts } from "../../../services/note_create";
+import note_create, { BaseCreateNoteOpts, CreateNoteIntoURLOpts as CreateNoteIntoURLOpts, CreateNoteTarget } from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";
@@ -15,11 +15,17 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
         addNewRowCommand({ customOpts, parentNotePath: customNotePath }: CommandListenerData<"addNewRow">) {
             const notePath = customNotePath ?? parentNotePath;
             if (notePath) {
-                const opts: CreateNoteOpts = {
+                const opts: BaseCreateNoteOpts = {
                     activate: false,
                     ...customOpts
                 }
-                note_create.createNoteIntoPath(notePath, opts).then(({ branch }) => {
+                note_create.createNote(
+                    CreateNoteTarget.IntoNoteURL,
+                    {
+                        parentNoteUrl: notePath,
+                        ...opts
+                    } as CreateNoteIntoURLOpts
+                ).then(({ branch }) => {
                     if (branch) {
                         setTimeout(() => {
                             if (!api.current) return;

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { CreateNoteOpts, CreateNoteIntoUrlOpts as CreateNoteIntoUrlOpts } from "../../../services/note_create";
+import note_create, { CreateNoteOpts, CreateNoteWithUrlOpts } from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";
@@ -23,7 +23,7 @@ export default function useRowTableEditing(api: RefObject<Tabulator>, attributeD
                     {
                         parentNoteUrl: notePath,
                         ...opts
-                    } as CreateNoteIntoUrlOpts
+                    } as CreateNoteWithUrlOpts
                 ).then(({ branch }) => {
                     if (branch) {
                         setTimeout(() => {

--- a/apps/client/src/widgets/collections/table/row_editing.ts
+++ b/apps/client/src/widgets/collections/table/row_editing.ts
@@ -1,6 +1,6 @@
 import { EventCallBackMethods, RowComponent, Tabulator } from "tabulator-tables";
 import { CommandListenerData } from "../../../components/app_context";
-import note_create, { CreateNoteOpts, CreateNoteWithUrlOpts } from "../../../services/note_create";
+import note_create from "../../../services/note_create";
 import { useLegacyImperativeHandlers } from "../../react/hooks";
 import { RefObject } from "preact";
 import { setAttribute, setLabel } from "../../../services/attributes";

--- a/apps/client/src/widgets/dialogs/add_link.tsx
+++ b/apps/client/src/widgets/dialogs/add_link.tsx
@@ -5,7 +5,7 @@ import FormRadioGroup from "../react/FormRadioGroup";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import { useRef, useState, useEffect } from "preact/hooks";
 import tree from "../../services/tree";
-import note_autocomplete, { Suggestion } from "../../services/note_autocomplete";
+import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete";
 import { logError } from "../../services/ws";
 import FormGroup from "../react/FormGroup.js";
 import { refToJQuerySelector } from "../react/react_utils";
@@ -133,7 +133,7 @@ export default function AddLinkDialog() {
                     onChange={setSuggestion}
                     opts={{
                         allowExternalLinks: true,
-                        allowCreatingNotes: true
+                        createMode: CreateMode.CreateAndLink,
                     }}
                 />
             </FormGroup>

--- a/apps/client/src/widgets/dialogs/add_link.tsx
+++ b/apps/client/src/widgets/dialogs/add_link.tsx
@@ -5,7 +5,7 @@ import FormRadioGroup from "../react/FormRadioGroup";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import { useRef, useState, useEffect } from "preact/hooks";
 import tree from "../../services/tree";
-import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete";
+import note_autocomplete, { SuggestionMode, Suggestion } from "../../services/note_autocomplete";
 import { logError } from "../../services/ws";
 import FormGroup from "../react/FormGroup.js";
 import { refToJQuerySelector } from "../react/react_utils";
@@ -133,7 +133,7 @@ export default function AddLinkDialog() {
                     onChange={setSuggestion}
                     opts={{
                         allowExternalLinks: true,
-                        createMode: CreateMode.CreateAndLink,
+                        suggestionMode: SuggestionMode.SuggestCreateAndLink,
                     }}
                 />
             </FormGroup>

--- a/apps/client/src/widgets/dialogs/add_link.tsx
+++ b/apps/client/src/widgets/dialogs/add_link.tsx
@@ -58,7 +58,7 @@ export default function AddLinkDialog() {
         }
 
         if (suggestion.notePath) {
-            const noteId = tree.getNoteIdFromUrl(suggestion.notePath);
+            const noteId = tree.getNoteIdFromLink(suggestion.notePath);
             if (noteId) {
                 setDefaultLinkTitle(noteId);
             }

--- a/apps/client/src/widgets/dialogs/include_note.tsx
+++ b/apps/client/src/widgets/dialogs/include_note.tsx
@@ -5,7 +5,7 @@ import FormRadioGroup from "../react/FormRadioGroup";
 import Modal from "../react/Modal";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import Button from "../react/Button";
-import { Suggestion, triggerRecentNotes } from "../../services/note_autocomplete";
+import { CreateMode, Suggestion, triggerRecentNotes } from "../../services/note_autocomplete";
 import tree from "../../services/tree";
 import froca from "../../services/froca";
 import { useTriliumEvent } from "../react/hooks";
@@ -50,7 +50,7 @@ export default function IncludeNoteDialog() {
                     inputRef={autoCompleteRef}
                     opts={{
                         hideGoToSelectedNoteButton: true,
-                        allowCreatingNotes: true
+                        createMode: CreateMode.CreateOnly,
                     }}
                 />
             </FormGroup>

--- a/apps/client/src/widgets/dialogs/include_note.tsx
+++ b/apps/client/src/widgets/dialogs/include_note.tsx
@@ -5,7 +5,7 @@ import FormRadioGroup from "../react/FormRadioGroup";
 import Modal from "../react/Modal";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import Button from "../react/Button";
-import { CreateMode, Suggestion, triggerRecentNotes } from "../../services/note_autocomplete.js";
+import { SuggestionMode, Suggestion, triggerRecentNotes } from "../../services/note_autocomplete.js";
 import tree from "../../services/tree";
 import froca from "../../services/froca";
 import { useTriliumEvent } from "../react/hooks";
@@ -50,7 +50,7 @@ export default function IncludeNoteDialog() {
                     inputRef={autoCompleteRef}
                     opts={{
                         hideGoToSelectedNoteButton: true,
-                        createMode: CreateMode.CreateOnly,
+                        suggestionMode: SuggestionMode.SuggestCreateOnly,
                     }}
                 />
             </FormGroup>

--- a/apps/client/src/widgets/dialogs/include_note.tsx
+++ b/apps/client/src/widgets/dialogs/include_note.tsx
@@ -5,7 +5,7 @@ import FormRadioGroup from "../react/FormRadioGroup";
 import Modal from "../react/Modal";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import Button from "../react/Button";
-import { CreateMode, Suggestion, triggerRecentNotes } from "../../services/note_autocomplete";
+import { CreateMode, Suggestion, triggerRecentNotes } from "../../services/note_autocomplete.js";
 import tree from "../../services/tree";
 import froca from "../../services/froca";
 import { useTriliumEvent } from "../react/hooks";

--- a/apps/client/src/widgets/dialogs/include_note.tsx
+++ b/apps/client/src/widgets/dialogs/include_note.tsx
@@ -70,7 +70,7 @@ export default function IncludeNoteDialog() {
     )
 }
 
-async function includeNote(notePath: string, textTypeWidget: EditableTextTypeWidget, boxSize: BoxSize) {
+async function includeNote(notePath: string, editorApi: CKEditorApi, boxSize: BoxSize) {
     const noteId = tree.getNoteIdFromLink(notePath);
     if (!noteId) {
         return;

--- a/apps/client/src/widgets/dialogs/include_note.tsx
+++ b/apps/client/src/widgets/dialogs/include_note.tsx
@@ -70,8 +70,8 @@ export default function IncludeNoteDialog() {
     )
 }
 
-async function includeNote(notePath: string, editorApi: CKEditorApi, boxSize: BoxSize) {
-    const noteId = tree.getNoteIdFromUrl(notePath);
+async function includeNote(notePath: string, textTypeWidget: EditableTextTypeWidget, boxSize: BoxSize) {
+    const noteId = tree.getNoteIdFromLink(notePath);
     if (!noteId) {
         return;
     }

--- a/apps/client/src/widgets/dialogs/jump_to_note.tsx
+++ b/apps/client/src/widgets/dialogs/jump_to_note.tsx
@@ -51,10 +51,6 @@ export default function JumpToNoteDialogComponent() {
                 }
                 break;
 
-            // Mode.RecentNotes intentionally falls through to default:
-            // both represent the "normal open" behavior, where we decide between
-            // showing recent notes or restoring the last search depending on timing.
-            case Mode.RecentNotes:
             default:
                 if (Date.now() - lastOpenedTs <= KEEP_LAST_SEARCH_FOR_X_SECONDS * 1000 && actualText.current) {
                     newMode = Mode.LastSearch;

--- a/apps/client/src/widgets/dialogs/jump_to_note.tsx
+++ b/apps/client/src/widgets/dialogs/jump_to_note.tsx
@@ -3,7 +3,7 @@ import Button from "../react/Button";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import { t } from "../../services/i18n";
 import { useRef, useState } from "preact/hooks";
-import note_autocomplete, { Suggestion } from "../../services/note_autocomplete";
+import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete";
 import appContext from "../../components/app_context";
 import commandRegistry from "../../services/command_registry";
 import { refToJQuerySelector } from "../react/react_utils";
@@ -12,34 +12,57 @@ import shortcutService from "../../services/shortcuts";
 
 const KEEP_LAST_SEARCH_FOR_X_SECONDS = 120;
 
-type Mode = "last-search" | "recent-notes" | "commands";
+enum Mode {
+    LastSearch,
+    RecentNotes,
+    Commands,
+}
 
 export default function JumpToNoteDialogComponent() {
     const [ mode, setMode ] = useState<Mode>();
     const [ lastOpenedTs, setLastOpenedTs ] = useState<number>(0);
     const containerRef = useRef<HTMLDivElement>(null);
     const autocompleteRef = useRef<HTMLInputElement>(null);
-    const [ isCommandMode, setIsCommandMode ] = useState(mode === "commands");
+    const [ isCommandMode, setIsCommandMode ] = useState(mode === Mode.Commands);
     const [ initialText, setInitialText ] = useState(isCommandMode ? "> " : "");
     const actualText = useRef<string>(initialText);
     const [ shown, setShown ] = useState(false);
-    
-    async function openDialog(commandMode: boolean) {        
+
+    async function openDialog(requestedMode: Mode) {
         let newMode: Mode;
         let initialText = "";
 
-        if (commandMode) {
-            newMode = "commands";
-            initialText = ">";            
-        } else if (Date.now() - lastOpenedTs <= KEEP_LAST_SEARCH_FOR_X_SECONDS * 1000 && actualText.current) {
-            // if you open the Jump To dialog soon after using it previously, it can often mean that you
-            // actually want to search for the same thing (e.g., you opened the wrong note at first try)
-            // so we'll keep the content.
-            // if it's outside of this time limit, then we assume it's a completely new search and show recent notes instead.
-            newMode = "last-search";
-            initialText = actualText.current;
-        } else {
-            newMode = "recent-notes";
+        switch (requestedMode) {
+            case Mode.Commands:
+                newMode = Mode.Commands;
+                initialText = ">";
+                break;
+
+            case Mode.LastSearch:
+                // if you open the Jump To dialog soon after using it previously, it can often mean that you
+                // actually want to search for the same thing (e.g., you opened the wrong note at first try)
+                // so we'll keep the content.
+                // if it's outside of this time limit, then we assume it's a completely new search and show recent notes instead.
+                if (Date.now() - lastOpenedTs <= KEEP_LAST_SEARCH_FOR_X_SECONDS * 1000 && actualText.current) {
+                    newMode = Mode.LastSearch;
+                    initialText = actualText.current;
+                } else {
+                    newMode = Mode.RecentNotes;
+                }
+                break;
+
+            // Mode.RecentNotes intentionally falls through to default:
+            // both represent the "normal open" behavior, where we decide between
+            // showing recent notes or restoring the last search depending on timing.
+            case Mode.RecentNotes:
+            default:
+                if (Date.now() - lastOpenedTs <= KEEP_LAST_SEARCH_FOR_X_SECONDS * 1000 && actualText.current) {
+                    newMode = Mode.LastSearch;
+                    initialText = actualText.current;
+                } else {
+                    newMode = Mode.RecentNotes;
+                }
+                break;
         }
 
         if (mode !== newMode) {
@@ -51,14 +74,14 @@ export default function JumpToNoteDialogComponent() {
         setLastOpenedTs(Date.now());
     }
 
-    useTriliumEvent("jumpToNote", () => openDialog(false));
-    useTriliumEvent("commandPalette", () => openDialog(true));
+    useTriliumEvent("jumpToNote", () => openDialog(Mode.RecentNotes));
+    useTriliumEvent("commandPalette", () => openDialog(Mode.Commands));
 
     async function onItemSelected(suggestion?: Suggestion | null) {
         if (!suggestion) {
             return;
         }
-        
+
         setShown(false);
         if (suggestion.notePath) {
             appContext.tabManager.getActiveContext()?.setNote(suggestion.notePath);
@@ -83,7 +106,7 @@ export default function JumpToNoteDialogComponent() {
         $autoComplete
             .trigger("focus")
             .trigger("select");
-            
+
         // Add keyboard shortcut for full search
         shortcutService.bindElShortcut($autoComplete, "ctrl+return", () => {
             if (!isCommandMode) {
@@ -91,7 +114,7 @@ export default function JumpToNoteDialogComponent() {
             }
         });
     }
-    
+
     async function showInFullSearch() {
         try {
             setShown(false);
@@ -116,7 +139,7 @@ export default function JumpToNoteDialogComponent() {
                 container={containerRef}
                 text={initialText}
                 opts={{
-                    allowCreatingNotes: true,
+                    createMode: CreateMode.CreateOnly,
                     hideGoToSelectedNoteButton: true,
                     allowJumpToSearchNotes: true,
                     isCommandPalette: true
@@ -129,9 +152,9 @@ export default function JumpToNoteDialogComponent() {
                 />}
             onShown={onShown}
             onHidden={() => setShown(false)}
-            footer={!isCommandMode && <Button 
-                className="show-in-full-text-button" 
-                text={t("jump_to_note.search_button")} 
+            footer={!isCommandMode && <Button
+                className="show-in-full-text-button"
+                text={t("jump_to_note.search_button")}
                 keyboardShortcut="Ctrl+Enter"
                 onClick={showInFullSearch}
             />}

--- a/apps/client/src/widgets/dialogs/jump_to_note.tsx
+++ b/apps/client/src/widgets/dialogs/jump_to_note.tsx
@@ -3,7 +3,7 @@ import Button from "../react/Button";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import { t } from "../../services/i18n";
 import { useRef, useState } from "preact/hooks";
-import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete";
+import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete.js";
 import appContext from "../../components/app_context";
 import commandRegistry from "../../services/command_registry";
 import { refToJQuerySelector } from "../react/react_utils";

--- a/apps/client/src/widgets/dialogs/jump_to_note.tsx
+++ b/apps/client/src/widgets/dialogs/jump_to_note.tsx
@@ -3,7 +3,7 @@ import Button from "../react/Button";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import { t } from "../../services/i18n";
 import { useRef, useState } from "preact/hooks";
-import note_autocomplete, { CreateMode, Suggestion } from "../../services/note_autocomplete.js";
+import note_autocomplete, { SuggestionMode, Suggestion } from "../../services/note_autocomplete.js";
 import appContext from "../../components/app_context";
 import commandRegistry from "../../services/command_registry";
 import { refToJQuerySelector } from "../react/react_utils";
@@ -135,7 +135,7 @@ export default function JumpToNoteDialogComponent() {
                 container={containerRef}
                 text={initialText}
                 opts={{
-                    createMode: CreateMode.CreateOnly,
+                    suggestionMode: SuggestionMode.SuggestCreateOnly,
                     hideGoToSelectedNoteButton: true,
                     allowJumpToSearchNotes: true,
                     isCommandPalette: true

--- a/apps/client/src/widgets/dialogs/jump_to_note.tsx
+++ b/apps/client/src/widgets/dialogs/jump_to_note.tsx
@@ -93,12 +93,12 @@ export default function JumpToNoteDialogComponent() {
     function onShown() {
         const $autoComplete = refToJQuerySelector(autocompleteRef);
         switch (mode) {
-            case "last-search":
+            case Mode.LastSearch:
                 break;
-            case "recent-notes":
+            case Mode.RecentNotes:
                 note_autocomplete.showRecentNotes($autoComplete);
                 break;
-            case "commands":
+            case Mode.Commands:
                 note_autocomplete.showAllCommands($autoComplete);
                 break;
         }

--- a/apps/client/src/widgets/dialogs/note_type_chooser.tsx
+++ b/apps/client/src/widgets/dialogs/note_type_chooser.tsx
@@ -76,6 +76,7 @@ export default function NoteTypeChooserDialogComponent() {
             onHidden={() => {
                 callback?.({ success: false });
                 setShown(false);
+                setParentNote(null);
             }}
             show={shown}
             stackable

--- a/apps/client/src/widgets/dialogs/note_type_chooser.tsx
+++ b/apps/client/src/widgets/dialogs/note_type_chooser.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "preact/hooks";
 import note_types from "../../services/note_types";
 import { MenuCommandItem, MenuItem } from "../../menus/context_menu";
 import { TreeCommandNames } from "../../menus/tree_context_menu";
-import { Suggestion } from "../../services/note_autocomplete";
+import { Suggestion, SuggestionMode } from "../../services/note_autocomplete";
 import SimpleBadge from "../react/Badge";
 import { useTriliumEvent } from "../react/hooks";
 

--- a/apps/client/src/widgets/dialogs/note_type_chooser.tsx
+++ b/apps/client/src/widgets/dialogs/note_type_chooser.tsx
@@ -86,7 +86,7 @@ export default function NoteTypeChooserDialogComponent() {
                     onChange={setParentNote}
                     placeholder={t("note_type_chooser.search_placeholder")}
                     opts={{
-                        createMode: CreateMode.None,
+                        suggestionMode: SuggestionMode.SuggestNothing,
                         hideGoToSelectedNoteButton: true,
                         allowJumpToSearchNotes: false,
                     }}

--- a/apps/client/src/widgets/dialogs/note_type_chooser.tsx
+++ b/apps/client/src/widgets/dialogs/note_type_chooser.tsx
@@ -85,7 +85,7 @@ export default function NoteTypeChooserDialogComponent() {
                     onChange={setParentNote}
                     placeholder={t("note_type_chooser.search_placeholder")}
                     opts={{
-                        allowCreatingNotes: false,
+                        createMode: CreateMode.None,
                         hideGoToSelectedNoteButton: true,
                         allowJumpToSearchNotes: false,
                     }}

--- a/apps/client/src/widgets/layout/Breadcrumb.tsx
+++ b/apps/client/src/widgets/layout/Breadcrumb.tsx
@@ -229,7 +229,12 @@ function BreadcrumbSeparatorDropdownContent({ notePath, noteContext, activeNoteP
             {childNotes.length > 0 && <FormDropdownDivider />}
             <FormListItem
                 icon="bx bx-plus"
-                onClick={() => note_create.createNote(notePath, { activate: true })}
+                onClick={() => note_create.createNote(
+                    {
+                        target: "into",
+                        parentNoteLink: notePath,
+                        activate: true
+                    })}
             >{t("breadcrumb.create_new_note")}</FormListItem>
         </>
     );

--- a/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
+++ b/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
@@ -5,7 +5,7 @@ import { createPortal, useRef, useState } from "preact/compat";
 
 import FNote, { NotePathRecord } from "../../entities/fnote";
 import { t } from "../../services/i18n";
-import note_create, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../services/note_create";
+import note_create from "../../services/note_create";
 import server from "../../services/server";
 import { BacklinksList, useBacklinkCount } from "../FloatingButtonsDefinitions";
 import { getLocaleName, NoteInfoContent } from "../layout/StatusBar";
@@ -67,7 +67,10 @@ export default function MobileDetailMenu() {
 
                         {noteContext && ntxId && <NoteActionsCustom note={note} noteContext={noteContext} ntxId={ntxId} />}
                         <FormListItem
-                            onClick={() => noteContext?.notePath && note_create.createNote(noteContext.notePath)}
+                            onClick={() => noteContext?.notePath && note_create.createNote({
+                                target: "into",
+                                parentNoteLink: noteContext.notePath
+                            })}
                             icon="bx bx-plus"
                         >{t("mobile_detail_menu.insert_child_note")}</FormListItem>
                         {subContexts.length < 2 && <>

--- a/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
+++ b/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
@@ -5,7 +5,7 @@ import { createPortal, useRef, useState } from "preact/compat";
 
 import FNote, { NotePathRecord } from "../../entities/fnote";
 import { t } from "../../services/i18n";
-import note_create from "../../services/note_create";
+import note_create, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../../services/note_create";
 import server from "../../services/server";
 import { BacklinksList, useBacklinkCount } from "../FloatingButtonsDefinitions";
 import { getLocaleName, NoteInfoContent } from "../layout/StatusBar";

--- a/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
+++ b/apps/client/src/widgets/mobile_widgets/mobile_detail_menu.tsx
@@ -5,7 +5,7 @@ import { createPortal, useRef, useState } from "preact/compat";
 
 import FNote, { NotePathRecord } from "../../entities/fnote";
 import { t } from "../../services/i18n";
-import note_create, { CreateNoteIntoURLOpts, CreateNoteTarget } from "../../services/note_create";
+import note_create, { CreateNoteIntoUrlOpts, CreateNoteTarget } from "../../services/note_create";
 import server from "../../services/server";
 import { BacklinksList, useBacklinkCount } from "../FloatingButtonsDefinitions";
 import { getLocaleName, NoteInfoContent } from "../layout/StatusBar";

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -232,7 +232,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                 const parentNotePath = treeService.getNotePath(node);
                 noteCreateService.createNote(
                     {
-                        target: CreateNoteTarget.IntoNoteURL,
+                        target: "into",
                         parentNoteUrl: parentNotePath,
                         isProtected: node.data.isProtected
                     } as CreateNoteIntoUrlOpts,
@@ -1881,7 +1881,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     const notePath = treeService.getNotePath(node);
                     noteCreateService.createNote(
                         {
-                            target: CreateNoteTarget.IntoNoteURL,
+                            target: "into",
                             parentNoteUrl: notePath,
                             isProtected: node.data.isProtected
                         } as CreateNoteIntoUrlOpts

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -230,7 +230,13 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
             } else if (target.classList.contains("add-note-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
                 const parentNotePath = treeService.getNotePath(node);
-                noteCreateService.createNoteIntoPath(parentNotePath, { isProtected: node.data.isProtected });
+                noteCreateService.createNote(
+                    CreateNoteTarget.IntoNoteURL,
+                    {
+                        parentNoteUrl: parentNotePath,
+                        isProtected: node.data.isProtected
+                    } as CreateNoteIntoURLOpts,
+                );
             } else if (target.classList.contains("enter-workspace-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
                 this.triggerCommand("hoistNote", { noteId: node.data.noteId });
@@ -1873,9 +1879,13 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     const node = this.getActiveNode();
                     if (!node) return;
                     const notePath = treeService.getNotePath(node);
-                    noteCreateService.createNoteIntoPath(notePath, {
-                        isProtected: node.data.isProtected
-                    });
+                    noteCreateService.createNote(
+                        CreateNoteTarget.IntoNoteURL,
+                        {
+                            parentNoteUrl: notePath,
+                            isProtected: node.data.isProtected
+                        } as CreateNoteIntoURLOpts
+                    )
                 }
             }),
             new TouchBar.TouchBarButton({

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -235,7 +235,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                         target: "into",
                         parentNoteUrl: parentNotePath,
                         isProtected: node.data.isProtected
-                    } as CreateNoteWithUrlOpts,
+                    },
                 );
             } else if (target.classList.contains("enter-workspace-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
@@ -1884,7 +1884,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                             target: "into",
                             parentNoteUrl: notePath,
                             isProtected: node.data.isProtected
-                        } as CreateNoteWithUrlOpts
+                        }
                     )
                 }
             }),

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -235,7 +235,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                         target: CreateNoteTarget.IntoNoteURL,
                         parentNoteUrl: parentNotePath,
                         isProtected: node.data.isProtected
-                    } as CreateNoteIntoURLOpts,
+                    } as CreateNoteIntoUrlOpts,
                 );
             } else if (target.classList.contains("enter-workspace-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
@@ -1884,7 +1884,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                             target: CreateNoteTarget.IntoNoteURL,
                             parentNoteUrl: notePath,
                             isProtected: node.data.isProtected
-                        } as CreateNoteIntoURLOpts
+                        } as CreateNoteIntoUrlOpts
                     )
                 }
             }),

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -233,7 +233,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                 noteCreateService.createNote(
                     {
                         target: "into",
-                        parentNoteUrl: parentNotePath,
+                        parentNoteLink: parentNotePath,
                         isProtected: node.data.isProtected
                     },
                 );
@@ -1446,10 +1446,10 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
 
         let node: Fancytree.FancytreeNode | null | undefined = await this.expandToNote(activeNotePath, false);
 
-        if (node && node.data.noteId !== treeService.getNoteIdFromUrl(activeNotePath)) {
+        if (node && node.data.noteId !== treeService.getNoteIdFromLink(activeNotePath)) {
             // if the active note has been moved elsewhere then it won't be found by the path,
             // so we switch to the alternative of trying to find it by noteId
-            const noteId = treeService.getNoteIdFromUrl(activeNotePath);
+            const noteId = treeService.getNoteIdFromLink(activeNotePath);
 
             if (noteId) {
                 const notesById = this.getNodesByNoteId(noteId);
@@ -1882,7 +1882,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     noteCreateService.createNote(
                         {
                             target: "into",
-                            parentNoteUrl: notePath,
+                            parentNoteLink: notePath,
                             isProtected: node.data.isProtected
                         }
                     )

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -230,7 +230,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
             } else if (target.classList.contains("add-note-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
                 const parentNotePath = treeService.getNotePath(node);
-                noteCreateService.createNote(parentNotePath, { isProtected: node.data.isProtected });
+                noteCreateService.createNoteIntoPath(parentNotePath, { isProtected: node.data.isProtected });
             } else if (target.classList.contains("enter-workspace-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
                 this.triggerCommand("hoistNote", { noteId: node.data.noteId });
@@ -1873,7 +1873,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     const node = this.getActiveNode();
                     if (!node) return;
                     const notePath = treeService.getNotePath(node);
-                    noteCreateService.createNote(notePath, {
+                    noteCreateService.createNoteIntoPath(notePath, {
                         isProtected: node.data.isProtected
                     });
                 }

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -231,8 +231,8 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
                 const parentNotePath = treeService.getNotePath(node);
                 noteCreateService.createNote(
-                    CreateNoteTarget.IntoNoteURL,
                     {
+                        target: CreateNoteTarget.IntoNoteURL,
                         parentNoteUrl: parentNotePath,
                         isProtected: node.data.isProtected
                     } as CreateNoteIntoURLOpts,
@@ -1880,8 +1880,8 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     if (!node) return;
                     const notePath = treeService.getNotePath(node);
                     noteCreateService.createNote(
-                        CreateNoteTarget.IntoNoteURL,
                         {
+                            target: CreateNoteTarget.IntoNoteURL,
                             parentNoteUrl: notePath,
                             isProtected: node.data.isProtected
                         } as CreateNoteIntoURLOpts

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -235,7 +235,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                         target: "into",
                         parentNoteUrl: parentNotePath,
                         isProtected: node.data.isProtected
-                    } as CreateNoteIntoUrlOpts,
+                    } as CreateNoteWithUrlOpts,
                 );
             } else if (target.classList.contains("enter-workspace-button")) {
                 const node = $.ui.fancytree.getNode(e as unknown as Event);
@@ -1884,7 +1884,7 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                             target: "into",
                             parentNoteUrl: notePath,
                             isProtected: node.data.isProtected
-                        } as CreateNoteIntoUrlOpts
+                        } as CreateNoteWithUrlOpts
                     )
                 }
             }),

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -21,12 +21,6 @@ import AttributeDetailWidget from "../../attribute_widgets/attribute_detail";
 import ActionButton from "../../react/ActionButton";
 import CKEditor, { CKEditorApi } from "../../react/CKEditor";
 import { useLegacyImperativeHandlers, useLegacyWidget, useTooltip, useTriliumEvent, useTriliumOption } from "../../react/hooks";
-import froca from "../../../services/froca";
-import contextMenu from "../../../menus/context_menu";
-import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
-import { AttributeType } from "@triliumnext/commons";
-import attributes from "../../../services/attributes";
-import note_create from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -252,7 +252,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
         createNoteFromCkEditor: async (
             title: string,
             parentNotePath: string | undefined,
-            action: MentionAction
+            action: CreateNoteAction
         ): Promise<string> => {
             if (!parentNotePath) {
                 console.warn("Missing parentNotePath in createNoteFromCkEditor()");
@@ -260,8 +260,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             }
 
             switch (action) {
-                case MentionAction.CreateNoteIntoInbox:
-                case MentionAction.CreateAndLinkNoteIntoInbox: {
+                case CreateNoteAction.CreateNoteIntoInbox:
+                case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
                     const { note } = await note_create.createNoteIntoInbox({
                         title,
                         activate: false
@@ -269,8 +269,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                     return note?.getBestNotePathString() ?? "";
                 }
 
-                case MentionAction.CreateNoteIntoPath:
-                case MentionAction.CreateAndLinkNoteIntoPath: {
+                case CreateNoteAction.CreateNoteIntoPath:
+                case CreateNoteAction.CreateAndLinkNoteIntoPath: {
                     const resp = await note_create.createNoteIntoPathWithTypePrompt(parentNotePath, {
                         title,
                         activate: false
@@ -279,7 +279,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                 }
 
                 default:
-                    console.warn("Unknown MentionAction:", action);
+                    console.warn("Unknown CreateNoteAction:", action);
                     return "";
         }
             }

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -26,7 +26,7 @@ import contextMenu from "../../../menus/context_menu";
 import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
 import { AttributeType } from "@triliumnext/commons";
 import attributes from "../../../services/attributes";
-import note_create, { CreateNoteAfterUrlOpts, CreateNoteIntoUrlOpts, CreateNoteTarget, CreateNoteIntoInboxOpts } from "../../../services/note_create";
+import note_create, { CreateNoteAfterUrlOpts, CreateNoteIntoUrlOpts, CreateNoteIntoInboxOpts } from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;
@@ -271,7 +271,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                 case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
                     const { note } = await note_create.createNote(
                         {
-                            target: CreateNoteTarget.IntoInbox,
+                            target: "inbox",
                             title,
                             activate: false
                         } as CreateNoteIntoInboxOpts
@@ -283,7 +283,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                 case CreateNoteAction.CreateAndLinkNoteIntoPath: {
                     const resp = await note_create.createNote(
                         {
-                            target: CreateNoteTarget.IntoNoteURL,
+                            target: "into",
                             parentNoteUrl: parentNotePath,
                             title,
                             activate: false,

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -12,7 +12,7 @@ import attributes from "../../../services/attributes";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
 import link from "../../../services/link";
-import note_autocomplete, { Suggestion } from "../../../services/note_autocomplete";
+import note_autocomplete, { Suggestion, SuggestionMode } from "../../../services/note_autocomplete";
 import note_create from "../../../services/note_create";
 import server from "../../../services/server";
 import { isIMEComposing } from "../../../services/shortcuts";

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -21,6 +21,13 @@ import AttributeDetailWidget from "../../attribute_widgets/attribute_detail";
 import ActionButton from "../../react/ActionButton";
 import CKEditor, { CKEditorApi } from "../../react/CKEditor";
 import { useLegacyImperativeHandlers, useLegacyWidget, useTooltip, useTriliumEvent, useTriliumOption } from "../../react/hooks";
+import froca from "../../../services/froca";
+import contextMenu from "../../../menus/context_menu";
+import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
+import { AttributeType } from "@triliumnext/commons";
+import attributes from "../../../services/attributes";
+import note_create, { CreateNoteAfterURLOpts, CreateNoteIntoURLOpts, CreateNoteTarget, InboxNoteOpts } from "../../../services/note_create";
+import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;
 
@@ -262,19 +269,27 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             switch (action) {
                 case CreateNoteAction.CreateNoteIntoInbox:
                 case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
-                    const { note } = await note_create.createNoteIntoInbox({
-                        title,
-                        activate: false
-                    });
+                    const { note } = await note_create.createNote(
+                        CreateNoteTarget.IntoInbox,
+                        {
+                            title,
+                            activate: false
+                        } as InboxNoteOpts
+                    );
                     return note?.getBestNotePathString() ?? "";
                 }
 
                 case CreateNoteAction.CreateNoteIntoPath:
                 case CreateNoteAction.CreateAndLinkNoteIntoPath: {
-                    const resp = await note_create.createNoteIntoPathWithTypePrompt(parentNotePath, {
-                        title,
-                        activate: false
-                    });
+                    const resp = await note_create.createNote(
+                        CreateNoteTarget.IntoNoteURL,
+                        {
+                            parentNoteUrl: parentNotePath,
+                            title,
+                            activate: false,
+                            promptForType: true,
+                        } as CreateNoteIntoURLOpts,
+                    )
                     return resp?.note?.getBestNotePathString() ?? "";
                 }
 

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -261,43 +261,14 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             parentNotePath: string | undefined,
             action: CreateNoteAction
         ): Promise<string> => {
-            switch (action) {
-                case CreateNoteAction.CreateNote:
-                case CreateNoteAction.CreateAndLinkNote: {
-                    const { note } = await note_create.createNote(
-                        {
-                            target: "inbox",
-                            title,
-                            activate: false,
-                            promptForType: true,
-                        }
-                    );
-                    return note?.getBestNotePathString() ?? "";
-                }
-
-                case CreateNoteAction.CreateChildNote:
-                case CreateNoteAction.CreateAndLinkChildNote: {
-                    if (!parentNotePath) {
-                        console.warn("Missing parentNotePath in createNoteFromCkEditor()");
-                        return "";
-                    }
-                    const resp = await note_create.createNote(
-                        {
-                            target: "into",
-                            parentNoteUrl: parentNotePath,
-                            title,
-                            activate: false,
-                            promptForType: true,
-                        },
-                    )
-                    return resp?.note?.getBestNotePathString() ?? "";
-                }
-
-                default:
-                    console.warn("Unknown CreateNoteAction:", action);
-                    return "";
+            const { note } = await note_create.createNoteFromAction(
+                action,
+                true,
+                parentNotePath,
+                title,
+            );
+            return note?.getBestNotePathString() ?? "";
         }
-            }
     }), [ notePath ]));
 
     // Keyboard shortcuts

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -26,7 +26,7 @@ import contextMenu from "../../../menus/context_menu";
 import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
 import { AttributeType } from "@triliumnext/commons";
 import attributes from "../../../services/attributes";
-import note_create, { CreateNoteAfterUrlOpts, CreateNoteIntoUrlOpts, CreateNoteIntoInboxOpts } from "../../../services/note_create";
+import note_create, { CreateNoteWithUrlOpts, CreateNoteIntoInboxOpts } from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;
@@ -288,7 +288,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                             title,
                             activate: false,
                             promptForType: true,
-                        } as CreateNoteIntoUrlOpts,
+                        } as CreateNoteWithUrlOpts,
                     )
                     return resp?.note?.getBestNotePathString() ?? "";
                 }

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -261,11 +261,6 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             parentNotePath: string | undefined,
             action: CreateNoteAction
         ): Promise<string> => {
-            if (!parentNotePath) {
-                console.warn("Missing parentNotePath in createNoteFromCkEditor()");
-                return "";
-            }
-
             switch (action) {
                 case CreateNoteAction.CreateNoteIntoInbox:
                 case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
@@ -273,7 +268,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                         {
                             target: "inbox",
                             title,
-                            activate: false
+                            activate: false,
+                            promptForType: true,
                         }
                     );
                     return note?.getBestNotePathString() ?? "";
@@ -281,6 +277,10 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
 
                 case CreateNoteAction.CreateNoteIntoPath:
                 case CreateNoteAction.CreateAndLinkNoteIntoPath: {
+                    if (!parentNotePath) {
+                        console.warn("Missing parentNotePath in createNoteFromCkEditor()");
+                        return "";
+                    }
                     const resp = await note_create.createNote(
                         {
                             target: "into",

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -262,8 +262,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             action: CreateNoteAction
         ): Promise<string> => {
             switch (action) {
-                case CreateNoteAction.CreateNoteIntoInbox:
-                case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
+                case CreateNoteAction.CreateNote:
+                case CreateNoteAction.CreateAndLinkNote: {
                     const { note } = await note_create.createNote(
                         {
                             target: "inbox",
@@ -275,8 +275,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                     return note?.getBestNotePathString() ?? "";
                 }
 
-                case CreateNoteAction.CreateNoteIntoPath:
-                case CreateNoteAction.CreateAndLinkNoteIntoPath: {
+                case CreateNoteAction.CreateChildNote:
+                case CreateNoteAction.CreateAndLinkChildNote: {
                     if (!parentNotePath) {
                         console.warn("Missing parentNotePath in createNoteFromCkEditor()");
                         return "";

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -264,8 +264,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
             const { note } = await note_create.createNoteFromAction(
                 action,
                 true,
-                parentNotePath,
                 title,
+                parentNotePath,
             );
             return note?.getBestNotePathString() ?? "";
         }

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -26,7 +26,7 @@ import contextMenu from "../../../menus/context_menu";
 import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
 import { AttributeType } from "@triliumnext/commons";
 import attributes from "../../../services/attributes";
-import note_create, { CreateNoteWithUrlOpts, CreateNoteIntoInboxOpts } from "../../../services/note_create";
+import note_create from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -34,7 +34,7 @@ const HELP_TEXT = `
 const mentionSetup: MentionFeed[] = [
     {
         marker: "@",
-        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText),
+        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText, CreateMode.CreateAndLink),
         itemRenderer: (_item) => {
             const item = _item as Suggestion;
             const itemElement = document.createElement("button");
@@ -249,17 +249,40 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
 
             $el.text(title);
         },
-        createNoteForReferenceLink: async (title: string) => {
-            let result;
-            if (notePath) {
-                result = await note_create.createNoteWithTypePrompt(notePath, {
-                    activate: false,
-                    title
-                });
+        createNoteFromCkEditor: async (
+            title: string,
+            parentNotePath: string | undefined,
+            action: MentionAction
+        ): Promise<string> => {
+            if (!parentNotePath) {
+                console.warn("Missing parentNotePath in createNoteFromCkEditor()");
+                return "";
             }
 
-            return result?.note?.getBestNotePathString();
+            switch (action) {
+                case MentionAction.CreateNoteIntoInbox:
+                case MentionAction.CreateAndLinkNoteIntoInbox: {
+                    const { note } = await note_create.createNoteIntoInbox({
+                        title,
+                        activate: false
+                    });
+                    return note?.getBestNotePathString() ?? "";
+                }
+
+                case MentionAction.CreateNoteIntoPath:
+                case MentionAction.CreateAndLinkNoteIntoPath: {
+                    const resp = await note_create.createNoteIntoPathWithTypePrompt(parentNotePath, {
+                        title,
+                        activate: false
+                    });
+                    return resp?.note?.getBestNotePathString() ?? "";
+                }
+
+                default:
+                    console.warn("Unknown MentionAction:", action);
+                    return "";
         }
+            }
     }), [ notePath ]));
 
     // Keyboard shortcuts

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -26,7 +26,7 @@ import contextMenu from "../../../menus/context_menu";
 import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
 import { AttributeType } from "@triliumnext/commons";
 import attributes from "../../../services/attributes";
-import note_create, { CreateNoteAfterURLOpts, CreateNoteIntoURLOpts, CreateNoteTarget, CreateNoteIntoInboxURLOpts } from "../../../services/note_create";
+import note_create, { CreateNoteAfterUrlOpts, CreateNoteIntoUrlOpts, CreateNoteTarget, CreateNoteIntoInboxOpts } from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;
@@ -274,7 +274,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                             target: CreateNoteTarget.IntoInbox,
                             title,
                             activate: false
-                        } as CreateNoteIntoInboxURLOpts
+                        } as CreateNoteIntoInboxOpts
                     );
                     return note?.getBestNotePathString() ?? "";
                 }
@@ -288,7 +288,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                             title,
                             activate: false,
                             promptForType: true,
-                        } as CreateNoteIntoURLOpts,
+                        } as CreateNoteIntoUrlOpts,
                     )
                     return resp?.note?.getBestNotePathString() ?? "";
                 }

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -41,7 +41,7 @@ const HELP_TEXT = `
 const mentionSetup: MentionFeed[] = [
     {
         marker: "@",
-        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText, CreateMode.CreateAndLink),
+        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText, SuggestionMode.SuggestCreateAndLink),
         itemRenderer: (_item) => {
             const item = _item as Suggestion;
             const itemElement = document.createElement("button");

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -274,7 +274,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                             target: "inbox",
                             title,
                             activate: false
-                        } as CreateNoteIntoInboxOpts
+                        }
                     );
                     return note?.getBestNotePathString() ?? "";
                 }
@@ -288,7 +288,7 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                             title,
                             activate: false,
                             promptForType: true,
-                        } as CreateNoteWithUrlOpts,
+                        },
                     )
                     return resp?.note?.getBestNotePathString() ?? "";
                 }

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -26,7 +26,7 @@ import contextMenu from "../../../menus/context_menu";
 import type { CommandData, FilteredCommandNames } from "../../../components/app_context";
 import { AttributeType } from "@triliumnext/commons";
 import attributes from "../../../services/attributes";
-import note_create, { CreateNoteAfterURLOpts, CreateNoteIntoURLOpts, CreateNoteTarget, InboxNoteOpts } from "../../../services/note_create";
+import note_create, { CreateNoteAfterURLOpts, CreateNoteIntoURLOpts, CreateNoteTarget, CreateNoteIntoInboxURLOpts } from "../../../services/note_create";
 import { CreateNoteAction } from "@triliumnext/commons";
 
 type AttributeCommandNames = FilteredCommandNames<CommandData>;
@@ -270,11 +270,11 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                 case CreateNoteAction.CreateNoteIntoInbox:
                 case CreateNoteAction.CreateAndLinkNoteIntoInbox: {
                     const { note } = await note_create.createNote(
-                        CreateNoteTarget.IntoInbox,
                         {
+                            target: CreateNoteTarget.IntoInbox,
                             title,
                             activate: false
-                        } as InboxNoteOpts
+                        } as CreateNoteIntoInboxURLOpts
                     );
                     return note?.getBestNotePathString() ?? "";
                 }
@@ -282,8 +282,8 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
                 case CreateNoteAction.CreateNoteIntoPath:
                 case CreateNoteAction.CreateAndLinkNoteIntoPath: {
                     const resp = await note_create.createNote(
-                        CreateNoteTarget.IntoNoteURL,
                         {
+                            target: CreateNoteTarget.IntoNoteURL,
                             parentNoteUrl: parentNotePath,
                             title,
                             activate: false,

--- a/apps/client/src/widgets/type_widgets/Empty.tsx
+++ b/apps/client/src/widgets/type_widgets/Empty.tsx
@@ -4,7 +4,7 @@ import FormGroup from "../react/FormGroup";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import "./Empty.css";
 import { ParentComponent, refToJQuerySelector } from "../react/react_utils";
-import note_autocomplete, { CreateMode } from "../../services/note_autocomplete";
+import note_autocomplete, { SuggestionMode } from "../../services/note_autocomplete";
 import appContext from "../../components/app_context";
 import FNote from "../../entities/fnote";
 import search from "../../services/search";
@@ -38,7 +38,7 @@ function NoteSearch({ ntxId }: { ntxId: string | null }) {
                     inputRef={autocompleteRef}
                     opts={{
                         hideGoToSelectedNoteButton: true,
-                        createMode: CreateMode.CreateOnly,
+                        suggestionMode: SuggestionMode.SuggestCreateOnly,
                         allowJumpToSearchNotes: true,
                     }}
                     onChange={suggestion => {

--- a/apps/client/src/widgets/type_widgets/Empty.tsx
+++ b/apps/client/src/widgets/type_widgets/Empty.tsx
@@ -4,7 +4,7 @@ import FormGroup from "../react/FormGroup";
 import NoteAutocomplete from "../react/NoteAutocomplete";
 import "./Empty.css";
 import { ParentComponent, refToJQuerySelector } from "../react/react_utils";
-import note_autocomplete from "../../services/note_autocomplete";
+import note_autocomplete, { CreateMode } from "../../services/note_autocomplete";
 import appContext from "../../components/app_context";
 import FNote from "../../entities/fnote";
 import search from "../../services/search";
@@ -38,7 +38,7 @@ function NoteSearch({ ntxId }: { ntxId: string | null }) {
                     inputRef={autocompleteRef}
                     opts={{
                         hideGoToSelectedNoteButton: true,
-                        allowCreatingNotes: true,
+                        createMode: CreateMode.CreateOnly,
                         allowJumpToSearchNotes: true,
                     }}
                     onChange={suggestion => {

--- a/apps/client/src/widgets/type_widgets/Render.tsx
+++ b/apps/client/src/widgets/type_widgets/Render.tsx
@@ -145,7 +145,9 @@ async function setRenderNote(note: FNote, targetNoteUrl: string) {
 }
 
 async function setupSampleNote(parentNote: FNote, mime: string, content: string) {
-    const { note: codeNote } = await note_create.createNote(parentNote.noteId, {
+    const { note: codeNote } = await note_create.createNote({
+        target: "into",
+        parentNoteLink: parentNote.noteId,
         type: "code",
         mime,
         content,

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -122,17 +122,18 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
         },
         loadIncludedNote,
         // Creating notes in @-completion
-        async createNoteForReferenceLink(title: string) {
-            const notePath = noteContext?.notePath;
-            if (!notePath) return;
-
-            const resp = await note_create.createNoteWithTypePrompt(notePath, {
-                activate: false,
-                title
-            });
-
-            if (!resp || !resp.note) return;
-            return resp.note.getBestNotePathString();
+        async createNoteFromCkEditor (
+            title: string,
+            parentNotePath: string | undefined,
+            action: CreateNoteAction
+        ): Promise<string> {
+            const { note }= await note_create.createNoteFromAction(
+                action,
+                true,
+                title,
+                parentNotePath,
+            )
+            return note?.getBestNotePathString() ?? "";
         },
         // Keyboard shortcut
         async followLinkUnderCursorCommand() {

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -1,7 +1,7 @@
 import "./EditableText.css";
 
 import { CKTextEditor, EditorWatchdog, TemplateDefinition } from "@triliumnext/ckeditor5";
-import { deferred } from "@triliumnext/commons";
+import { CreateNoteAction, deferred } from "@triliumnext/commons";
 import { RefObject } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
@@ -125,7 +125,7 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
         async createNoteFromCkEditor (
             title: string,
             parentNotePath: string | undefined,
-            action: CreateNoteAction
+            action: CreateNoteAction.CreateChildNote
         ): Promise<string> {
             const { note }= await note_create.createNoteFromAction(
                 action,

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -170,7 +170,9 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
             // without await as this otherwise causes deadlock through component mutex
             const parentNotePath = appContext.tabManager.getActiveContextNotePath();
             if (noteContext && parentNotePath) {
-                note_create.createNote(parentNotePath, {
+                note_create.createNote({
+                    parentNoteLink: parentNotePath,
+                    target: "into",
                     isProtected: note.isProtected,
                     saveSelection: true,
                     textEditor: await noteContext?.getTextEditor()

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -6,7 +6,7 @@ import { copyTextWithToast } from "../../../services/clipboard_ext.js";
 import { t } from "../../../services/i18n.js";
 import { getMermaidConfig } from "../../../services/mermaid.js";
 import { default as mimeTypesService, getHighlightJsNameForMime } from "../../../services/mime_types.js";
-import noteAutocompleteService, { type Suggestion } from "../../../services/note_autocomplete.js";
+import noteAutocompleteService, { SuggestionMode, type Suggestion } from "../../../services/note_autocomplete.js";
 import options from "../../../services/options.js";
 import { ensureMimeTypesForHighlighting, isSyntaxHighlightEnabled } from "../../../services/syntax_highlight.js";
 import { buildToolbarConfig } from "./toolbar.js";

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -180,7 +180,7 @@ export async function buildConfig(opts: BuildEditorOptions): Promise<EditorConfi
             feeds: [
                 {
                     marker: "@",
-                    feed: (queryText: string) => noteAutocompleteService.autocompleteSourceForCKEditor(queryText),
+                    feed: (queryText: string) => noteAutocompleteService.autocompleteSourceForCKEditor(queryText, CreateMode.CreateAndLink),
                     itemRenderer: (item) => {
                         const itemElement = document.createElement("button");
 

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -180,7 +180,7 @@ export async function buildConfig(opts: BuildEditorOptions): Promise<EditorConfi
             feeds: [
                 {
                     marker: "@",
-                    feed: (queryText: string) => noteAutocompleteService.autocompleteSourceForCKEditor(queryText, CreateMode.CreateAndLink),
+                    feed: (queryText: string) => noteAutocompleteService.autocompleteSourceForCKEditor(queryText, SuggestionMode.SuggestCreateAndLink),
                     itemRenderer: (item) => {
                         const itemElement = document.createElement("button");
 

--- a/apps/server-e2e/src/support/app.ts
+++ b/apps/server-e2e/src/support/app.ts
@@ -8,6 +8,7 @@ interface GotoOpts {
 }
 
 const BASE_URL = "http://127.0.0.1:8082";
+const NUM_OF_CREATE_NOTE_OPTIONS = 2;
 
 interface DropdownLocator extends Locator {
     selectOptionByText: (text: string) => Promise<void>;
@@ -76,8 +77,10 @@ export default class App {
 
         const resultsSelector = this.currentNoteSplit.locator(".note-detail-empty-results");
         await expect(resultsSelector).toContainText(noteTitle);
-        const suggestionSelector = resultsSelector.locator(".aa-suggestion")
-            .nth(1); // Select the second one (best candidate), as the first one is "Create a new note"
+        await resultsSelector.locator(".aa-suggestion", { hasText: noteTitle })
+            // Select the n+1 one, as the first one is "Create a new note"
+            .nth(NUM_OF_CREATE_NOTE_OPTIONS)
+            .click();
         await expect(suggestionSelector).toContainText(noteTitle);
         await suggestionSelector.click();
     }

--- a/apps/server-e2e/src/support/app.ts
+++ b/apps/server-e2e/src/support/app.ts
@@ -77,10 +77,9 @@ export default class App {
 
         const resultsSelector = this.currentNoteSplit.locator(".note-detail-empty-results");
         await expect(resultsSelector).toContainText(noteTitle);
-        await resultsSelector.locator(".aa-suggestion", { hasText: noteTitle })
-            // Select the n+1 one, as the first one is "Create a new note"
-            .nth(NUM_OF_CREATE_NOTE_OPTIONS)
-            .click();
+        // The first n are note options.
+        const suggestionSelector = resultsSelector.locator(".aa-suggestion")
+            .nth(NUM_OF_CREATE_NOTE_OPTIONS);
         await expect(suggestionSelector).toContainText(noteTitle);
         await suggestionSelector.click();
     }

--- a/packages/ckeditor5/src/augmentation.ts
+++ b/packages/ckeditor5/src/augmentation.ts
@@ -1,12 +1,5 @@
 import "ckeditor5";
-import { CKTextEditor } from "src";
-
-export enum MentionAction {
-    CreateNoteIntoInbox = "create-note-into-inbox",
-    CreateNoteIntoPath = "create-note-into-path",
-    CreateAndLinkNoteIntoInbox = "create-and-link-note-into-inbox",
-    CreateAndLinkNoteIntoPath = "create-and-link-note-into-path"
-}
+import { type CreateNoteAction } from "@triliumnext/commons"
 
 declare global {
     interface Component {
@@ -16,7 +9,7 @@ declare global {
     interface EditorComponent extends Component {
         loadReferenceLinkTitle($el: JQuery<HTMLElement>, href: string): Promise<void>;
         // Must Return Note Path
-        createNoteFromCkEditor(title: string, parentNotePath: string | undefined, action: MentionAction): Promise<string>;
+        createNoteFromCkEditor(title: string, parentNotePath: string | undefined, action: CreateNoteAction): Promise<string>;
         loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>): void;
     }
 

--- a/packages/ckeditor5/src/augmentation.ts
+++ b/packages/ckeditor5/src/augmentation.ts
@@ -1,4 +1,12 @@
 import "ckeditor5";
+import { CKTextEditor } from "src";
+
+export enum MentionAction {
+    CreateNoteIntoInbox = "create-note-into-inbox",
+    CreateNoteIntoPath = "create-note-into-path",
+    CreateAndLinkNoteIntoInbox = "create-and-link-note-into-inbox",
+    CreateAndLinkNoteIntoPath = "create-and-link-note-into-path"
+}
 
 declare global {
     interface Component {
@@ -7,7 +15,8 @@ declare global {
 
     interface EditorComponent extends Component {
         loadReferenceLinkTitle($el: JQuery<HTMLElement>, href: string): Promise<void>;
-        createNoteForReferenceLink(title: string): Promise<string>;
+        // Must Return Note Path
+        createNoteFromCkEditor(title: string, parentNotePath: string | undefined, action: MentionAction): Promise<string>;
         loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>): void;
     }
 

--- a/packages/ckeditor5/src/plugins/mention_customization.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.ts
@@ -1,5 +1,5 @@
 import { Command, Mention, Plugin, ModelRange, type ModelSelectable } from "ckeditor5";
-import { MentionAction } from "../augmentation";
+import { type CreateNoteAction } from "@triliumnext/commons"
 
 /**
  * Overrides the actions taken by the Mentions plugin (triggered by `@` in the text editor, or `~` & `#` in the attribute editor):
@@ -37,7 +37,7 @@ interface MentionOpts {
 
 interface MentionAttribute {
 	id: string;
-	action?: MentionAction;
+	action?: CreateNoteAction;
 	noteTitle: string;
 	notePath: string;
 	parentNoteId?: string;
@@ -59,10 +59,10 @@ class CustomMentionCommand extends Command {
 			});
 		}
 	    else if (
-	        mention.action === MentionAction.CreateNoteIntoInbox ||
-	            mention.action === MentionAction.CreateNoteIntoPath ||
-	            mention.action === MentionAction.CreateAndLinkNoteIntoInbox ||
-	            mention.action === MentionAction.CreateAndLinkNoteIntoPath
+	        mention.action === CreateNoteAction.CreateNoteIntoInbox ||
+	            mention.action === CreateNoteAction.CreateNoteIntoPath ||
+	            mention.action === CreateNoteAction.CreateAndLinkNoteIntoInbox ||
+	            mention.action === CreateNoteAction.CreateAndLinkNoteIntoPath
 	    ) {
 	        const editorEl = this.editor.editing.view.getDomRoot();
 	        const component = glob.getComponentByEl<EditorComponent>(editorEl);

--- a/packages/ckeditor5/src/plugins/mention_customization.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.ts
@@ -1,5 +1,5 @@
 import { Command, Mention, Plugin, ModelRange, type ModelSelectable } from "ckeditor5";
-import { type CreateNoteAction } from "@triliumnext/commons"
+import { CreateNoteAction } from "@triliumnext/commons"
 
 /**
  * Overrides the actions taken by the Mentions plugin (triggered by `@` in the text editor, or `~` & `#` in the attribute editor):

--- a/packages/ckeditor5/src/plugins/mention_customization.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.ts
@@ -59,10 +59,10 @@ class CustomMentionCommand extends Command {
 			});
 		}
 	    else if (
-	        mention.action === CreateNoteAction.CreateNoteIntoInbox ||
-	            mention.action === CreateNoteAction.CreateNoteIntoPath ||
-	            mention.action === CreateNoteAction.CreateAndLinkNoteIntoInbox ||
-	            mention.action === CreateNoteAction.CreateAndLinkNoteIntoPath
+	        mention.action === CreateNoteAction.CreateNote ||
+	            mention.action === CreateNoteAction.CreateChildNote ||
+	            mention.action === CreateNoteAction.CreateAndLinkNote ||
+	            mention.action === CreateNoteAction.CreateAndLinkChildNote
 	    ) {
 	        const editorEl = this.editor.editing.view.getDomRoot();
 	        const component = glob.getComponentByEl<EditorComponent>(editorEl);

--- a/packages/ckeditor5/src/plugins/mention_customization.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.ts
@@ -1,4 +1,5 @@
 import { Command, Mention, Plugin, ModelRange, type ModelSelectable } from "ckeditor5";
+import { MentionAction } from "../augmentation";
 
 /**
  * Overrides the actions taken by the Mentions plugin (triggered by `@` in the text editor, or `~` & `#` in the attribute editor):
@@ -9,11 +10,11 @@ import { Command, Mention, Plugin, ModelRange, type ModelSelectable } from "cked
  */
 export default class MentionCustomization extends Plugin {
 
-    static get requires() {
+	static get requires() {
 		return [ Mention ];
 	}
 
-    public static get pluginName() {
+	public static get pluginName() {
 		return "MentionCustomization" as const;
 	}
 
@@ -25,20 +26,21 @@ export default class MentionCustomization extends Plugin {
 }
 
 interface MentionOpts {
-    mention: string | {
-        id: string;
-        [key: string]: unknown;
-    };
-    marker: string;
-    text?: string;
-    range?: ModelRange;
+	mention: string | {
+	    id: string;
+	    [key: string]: unknown;
+	};
+	marker: string;
+	text?: string;
+	range?: ModelRange;
 }
 
 interface MentionAttribute {
-    id: string;
-    action?: "create-note";
-    noteTitle: string;
-    notePath: string;
+	id: string;
+	action?: MentionAction;
+	noteTitle: string;
+	notePath: string;
+	parentNoteId?: string;
 }
 
 class CustomMentionCommand extends Command {
@@ -56,14 +58,27 @@ class CustomMentionCommand extends Command {
 				model.insertContent( writer.createText( mention.id, {} ), range );
 			});
 		}
-		else if (mention.action === 'create-note') {
-			const editorEl = this.editor.editing.view.getDomRoot();
-			const component = glob.getComponentByEl<EditorComponent>(editorEl);
+	    else if (
+	        mention.action === MentionAction.CreateNoteIntoInbox ||
+	            mention.action === MentionAction.CreateNoteIntoPath ||
+	            mention.action === MentionAction.CreateAndLinkNoteIntoInbox ||
+	            mention.action === MentionAction.CreateAndLinkNoteIntoPath
+	    ) {
+	        const editorEl = this.editor.editing.view.getDomRoot();
+	        const component = glob.getComponentByEl<EditorComponent>(editorEl);
 
-			component.createNoteForReferenceLink(mention.noteTitle).then(notePath => {
-				this.insertReference(range, notePath);
-			});
-		}
+	        // use parentNoteId as fallback when notePath is missing
+	        const parentNotePath = mention.notePath || mention.parentNoteId;
+
+	        component
+	            .createNoteFromCkEditor(mention.noteTitle, parentNotePath, mention.action)
+	            .then(notePath => {
+	                if (notePath) {
+	                    this.insertReference(range, notePath);
+	                }
+	            })
+	            .catch(err => console.error("Error creating note from CKEditor mention:", err));
+	    }
 		else {
 			this.insertReference(range, mention.notePath);
 		}

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -10,6 +10,7 @@ export * from "./lib/server_api.js";
 export * from "./lib/shared_constants.js";
 export * from "./lib/ws_api.js";
 export * from "./lib/attribute_names.js";
+export * from "./lib/create_note_actions.js";
 export * from "./lib/utils.js";
 export * from "./lib/dayjs.js";
 export * from "./lib/notes.js";

--- a/packages/commons/src/lib/create_note_actions.ts
+++ b/packages/commons/src/lib/create_note_actions.ts
@@ -1,6 +1,6 @@
 export enum CreateNoteAction {
-    CreateNoteIntoInbox = "create-note-into-inbox",
-    CreateNoteIntoPath = "create-note-into-path",
-    CreateAndLinkNoteIntoInbox = "create-and-link-note-into-inbox",
-    CreateAndLinkNoteIntoPath = "create-and-link-note-into-path"
+    CreateNote = "create-note",
+    CreateChildNote = "create-child-note",
+    CreateAndLinkNote = "create-and-link-note",
+    CreateAndLinkChildNote = "create-and-link-child-note"
 }

--- a/packages/commons/src/lib/create_note_actions.ts
+++ b/packages/commons/src/lib/create_note_actions.ts
@@ -1,6 +1,6 @@
 export enum CreateNoteAction {
-    CreateNoteIntoInbox,
-    CreateNoteIntoPath,
-    CreateAndLinkNoteIntoInbox,
-    CreateAndLinkNoteIntoPath
+    CreateNoteIntoInbox = "create-note-into-inbox",
+    CreateNoteIntoPath = "create-note-into-path",
+    CreateAndLinkNoteIntoInbox = "create-and-link-note-into-inbox",
+    CreateAndLinkNoteIntoPath = "create-and-link-note-into-path"
 }

--- a/packages/commons/src/lib/create_note_actions.ts
+++ b/packages/commons/src/lib/create_note_actions.ts
@@ -1,0 +1,6 @@
+export enum CreateNoteAction {
+    CreateNoteIntoInbox,
+    CreateNoteIntoPath,
+    CreateAndLinkNoteIntoInbox,
+    CreateAndLinkNoteIntoPath
+}


### PR DESCRIPTION
**Solves**: https://github.com/TriliumNext/Trilium/issues/6817
<table align="center">
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/2656e276-de6d-4cdd-b654-b2f706f47dc7" width="300" />
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/057c3439-5769-466c-8677-afb55700fd7d" width="300" />
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/c6b6cce3-c5e3-4065-bce3-af47386bf1a1" width="300" />
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/86f09f1e-3cfd-4e20-8ec2-3d030ad38557" width="300" />
    </td>
  </tr>
</table>


**State:** Workes. waiting for Review
**TODO**:
- [ ] Resolve the debate at https://github.com/TriliumNext/Trilium/issues/6817, and fit the solution to the resolution (also solved through review)

**Done**:
- [X] Replaced scattered `createNote` calls with unified `createNoteIntoPath` / `createNoteIntoInbox`
- [X] Added `CreateMode` to autocomplete system
- [X] Introduced `MentionAction` enum for CKEditor mentions
- [X] Updated translations for new creation strings
- [X] Refactored `note_autocomplete.ts` and related widgets for consistency
- [X] Hopefully improved code structure for creating Notes

**PS**
Yes I had to put my hands on many files, because the logic of creating notes was handled by a lot of different files. After this PR managing the code for creating notes should becomes easier.