### PR TITLE
fix(windows script): add -command flag

### DIFF
--- a/apps/desktop/electron-forge/trilium-no-cert-check.bat
+++ b/apps/desktop/electron-forge/trilium-no-cert-check.bat
@@ -6,7 +6,7 @@ WHERE powershell.exe > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
 
 :POWERSHELL
-powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:NODE_TLS_REJECT_UNAUTHORIZED -Value 0; ./trilium.exe"
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo -Command "Set-Item -Path Env:NODE_TLS_REJECT_UNAUTHORIZED -Value 0; ./trilium.exe"
 GOTO END
 
 :BATCH

--- a/apps/desktop/electron-forge/trilium-portable.bat
+++ b/apps/desktop/electron-forge/trilium-portable.bat
@@ -6,7 +6,7 @@ WHERE powershell.exe > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
 
 :POWERSHELL
-powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:TRILIUM_DATA_DIR -Value './trilium-data'; ./trilium.exe"
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo -Command "Set-Item -Path Env:TRILIUM_DATA_DIR -Value './trilium-data'; ./trilium.exe"
 GOTO END
 
 :BATCH

--- a/apps/desktop/electron-forge/trilium-safe-mode.bat
+++ b/apps/desktop/electron-forge/trilium-safe-mode.bat
@@ -6,7 +6,7 @@ WHERE powershell.exe > NUL 2>&1
 IF %ERRORLEVEL% NEQ 0 GOTO BATCH ELSE GOTO POWERSHELL
 
 :POWERSHELL
-powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo "Set-Item -Path Env:TRILIUM_SAFE_MODE -Value 1; ./trilium.exe --disable-gpu"
+powershell -ExecutionPolicy Bypass -NonInteractive -NoLogo -Command "Set-Item -Path Env:TRILIUM_SAFE_MODE -Value 1; ./trilium.exe --disable-gpu"
 GOTO END
 
 :BATCH


### PR DESCRIPTION
I don't know why if I replace old, system builtin powershell executable with powershell 7, scripts fail with this error:

The argument 'Set-Item -Path ...' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Adding -Command at the end of flags just fixed it.