### PR TITLE
edited notes: remove comma for flexible styling

### DIFF
--- a/apps/client/src/widgets/ribbon/EditedNotesTab.tsx
+++ b/apps/client/src/widgets/ribbon/EditedNotesTab.tsx
@@ -13,8 +13,8 @@ export default function EditedNotesTab({ note }: TabContext) {
     useEffect(() => {
         if (!note) return;
         server.get<EditedNotesResponse>(`edited-notes/${note.getLabelValue("dateNote")}`).then(async editedNotes => {
-            editedNotes = editedNotes.filter((n) => n.noteId !== note.noteId);        
-            const noteIds = editedNotes.flatMap((n) => n.noteId);            
+            editedNotes = editedNotes.filter((n) => n.noteId !== note.noteId);
+            const noteIds = editedNotes.flatMap((n) => n.noteId);
             await froca.getNotes(noteIds, true); // preload all at once
             setEditedNotes(editedNotes);
         });
@@ -41,11 +41,11 @@ export default function EditedNotesTab({ note }: TabContext) {
                                 )}
                             </span>
                         )
-                    }))}
+                    }), " ")}
                 </div>
             ) : (
                 <div className="no-edited-notes-found">{t("edited_notes.no_edited_notes_found")}</div>
             )}
         </div>
-    )    
+    )
 }


### PR DESCRIPTION
Currently, edited notes ribbon separates notes by with comma. This PR replaces comma with a space.

Advantages:
- if you use custom css, space provide way better opportunities for custom styling  
- default style almost identical visually (probably cleaner without comma). If someone still need the comma, this could be solved using ::after pseudo-element in appCss or theme.

Screenshots to contrast comma/space views:

With comma (default style):
<img width="599" height="155" alt="image" src="https://github.com/user-attachments/assets/2978e301-1b07-41a4-8281-680e8476a637" />

With space (default style):
<img width="620" height="155" alt="image-1" src="https://github.com/user-attachments/assets/ed64a88a-659b-4560-9b55-4ea08b387609" />

With comma (custom css):
<img width="520" height="233" alt="image" src="https://github.com/user-attachments/assets/b381f35a-046c-4b1b-910c-3f0dbd64770a" />

With space (custom css):
<img width="604" height="234" alt="image-1" src="https://github.com/user-attachments/assets/116b1f1c-d91f-462b-a56b-557190cc360d" />






