### PR TITLE
Send global shortcut to current window

### DIFF
--- a/apps/server/src/services/window.ts
+++ b/apps/server/src/services/window.ts
@@ -343,11 +343,7 @@ async function registerGlobalShortcuts() {
                         }
 
                         // window may be hidden / not in focus
-                        if (targetWindow.isMinimized()) {
-                            targetWindow.restore();
-                        }
-                        targetWindow.show();
-                        targetWindow.focus();
+                        showAndFocusWindow(targetWindow);
 
                         targetWindow.webContents.send("globalShortcut", action.actionName);
                     })
@@ -361,6 +357,17 @@ async function registerGlobalShortcuts() {
             }
         }
     }
+}
+
+function showAndFocusWindow(window: BrowserWindow) {
+    if (!window) return;
+
+    if (window.isMinimized()) {
+        window.restore();
+    }
+
+    window.show();
+    window.focus();
 }
 
 function getMainWindow() {


### PR DESCRIPTION
This fixes two problems:
- annoying bug when you trigger search using `global:` keyboard shortcut in the second window, but the search is always opened in the first window.
- global shortcuts didn't work at all when app is minimized to system tray