### PR TITLE
fix markdown headings are rendered with extra character

### DIFF
--- a/apps/client/src/widgets/type_widgets/text/EditableText.css
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.css
@@ -32,11 +32,11 @@ body.mobile .note-detail-editable-text {
 .note-detail-editable-text h5 { font-size: 1.1em; }
 .note-detail-editable-text h6 { font-size: 1.0em; }
 
-body.heading-style-markdown .note-detail-editable-text h2::before { content: "##\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-editable-text h3::before { content: "###\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-editable-text h4:not(.include-note-title)::before { content: "####\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-editable-text h5::before { content: "#####\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-editable-text h6::before { content: "######\\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-editable-text h2::before { content: "##\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-editable-text h3::before { content: "###\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-editable-text h4:not(.include-note-title)::before { content: "####\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-editable-text h5::before { content: "#####\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-editable-text h6::before { content: "######\2004"; color: var(--muted-text-color); }
 
 body.heading-style-underline .note-detail-editable-text h2 { border-bottom: 1px solid var(--main-border-color); }
 body.heading-style-underline .note-detail-editable-text h3 { border-bottom: 1px solid var(--main-border-color); }

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.css
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.css
@@ -6,12 +6,12 @@
 .note-detail-readonly-text h5 { font-size: 1.1em; }
 .note-detail-readonly-text h6 { font-size: 1.0em; }
 
-body.heading-style-markdown .note-detail-readonly-text h1::before { content: "#\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-readonly-text h2::before { content: "##\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-readonly-text h3::before { content: "###\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-readonly-text h4:not(.include-note-title)::before { content: "####\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-readonly-text h5::before { content: "#####\\2004"; color: var(--muted-text-color); }
-body.heading-style-markdown .note-detail-readonly-text h6::before { content: "######\\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h1::before { content: "#\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h2::before { content: "##\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h3::before { content: "###\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h4:not(.include-note-title)::before { content: "####\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h5::before { content: "#####\2004"; color: var(--muted-text-color); }
+body.heading-style-markdown .note-detail-readonly-text h6::before { content: "######\2004"; color: var(--muted-text-color); }
 
 body.heading-style-underline .note-detail-readonly-text h1 { border-bottom: 1px solid var(--main-border-color); }
 body.heading-style-underline .note-detail-readonly-text h2 { border-bottom: 1px solid var(--main-border-color); }


### PR DESCRIPTION
Fixes markdown headings displays 2004 literally:

<img width="343" height="190" alt="image" src="https://github.com/user-attachments/assets/5a13c985-8dd3-4498-abaf-17a885a7e719" />


