### PR TITLE
Fix toggle tray wont restore from tray

### DIFF
--- a/apps/server/src/services/window.ts
+++ b/apps/server/src/services/window.ts
@@ -6,7 +6,6 @@ import optionService from "./options.js";
 import log from "./log.js";
 import sqlInit from "./sql_init.js";
 import cls from "./cls.js";
-import { KeyboardActionNames } from "@triliumnext/commons";
 import keyboardActionsService from "./keyboard_actions.js";
 import electron from "electron";
 import type { App, BrowserWindowConstructorOptions, BrowserWindow, WebContents, IpcMainEvent } from "electron";
@@ -320,7 +319,6 @@ function closeSetupWindow() {
 }
 
 async function registerGlobalShortcuts() {
-    const toggleTrayAction: KeyboardActionNames = "toggleTray";
     const { globalShortcut } = await import("electron");
 
     await sqlInit.dbReady;
@@ -344,7 +342,7 @@ async function registerGlobalShortcuts() {
                             return;
                         }
 
-                        if (action.actionName === toggleTrayAction) {
+                        if (action.actionName === "toggleTray") {
                             targetWindow.focus();
                         } else {
                             showAndFocusWindow(targetWindow);


### PR DESCRIPTION
resolves  #7730

Now, when the app is minimized to tray, global shortcuts:

- restore from tray: work (fixed in the PR)
- create new note (global:Ctrl+Alt+P): works
- search (custom global shortcut): works (opens in active window or restores last active window from tray)
