### PR TITLE
fix NoteLink component is unable to display path for root note

### DIFF
--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -150,11 +150,16 @@ async function createLink(notePath: string | undefined, options: CreateLinkOptio
     $container.append($noteLink);
 
     if (showNotePath) {
-        const resolvedPathSegments = (await treeService.resolveNotePathToSegments(notePath)) || [];
-        resolvedPathSegments.pop(); // Remove last element
+        let pathSegments: string[];
+        if (notePath == "root") {
+            pathSegments = ["⌂"];
+        } else {
+            const resolvedPathSegments = (await treeService.resolveNotePathToSegments(notePath)) || [];
+            resolvedPathSegments.pop(); // Remove last element
 
-        const resolvedPath = resolvedPathSegments.join("/");
-        const pathSegments = await treeService.getNotePathTitleComponents(resolvedPath);
+            const resolvedPath = resolvedPathSegments.join("/");
+            pathSegments = await treeService.getNotePathTitleComponents(resolvedPath);
+        }
 
         if (pathSegments) {
             if (pathSegments.length) {


### PR DESCRIPTION
This fixes `<NoteLink />` react component error in console and “not found” in UI when it tries to display root note:

<img width="985" height="383" alt="image" src="https://github.com/user-attachments/assets/ac0bdf41-60e5-4460-848b-6c90b489e8ed" />

To reproduce the problem:
- edit root note
- go to Today Journal Note (Edited Notes)


This PR fixes the error and displays path for root note like this:

<img width="534" height="118" alt="image" src="https://github.com/user-attachments/assets/ce85bd32-159b-4cc6-ad94-9fa7552f72f4" />
