### PR TITLE
fix share url can be broken because of extra slash

### DIFF
--- a/apps/client/src/widgets/shared_info.tsx
+++ b/apps/client/src/widgets/shared_info.tsx
@@ -24,8 +24,7 @@ export default function SharedInfo() {
         const shareId = getShareId(note);
 
         if (syncServerHost) {
-            const cleanedServerHost = syncServerHost.replace(/\/$/, "");
-            link = `${cleanedServerHost}/share/${shareId}`;
+            link = new URL(`/share/${shareId}`, syncServerHost).href;
         } else {
             let host = location.host;
             if (host.endsWith("/")) {


### PR DESCRIPTION
syncServerHost is allowed to be both `https://example.com` and `https://example.com/`


Share url generated for the latter variant was not valid and shared note could not be displayed:
<img width="430" height="94" alt="image" src="https://github.com/user-attachments/assets/8a8dd249-0ff0-4622-8c1e-36a23fa8e0c7" />
