### PR TITLE
fix(editor): clean up editor on noteContext removal

### DIFF
--- a/apps/client/src/widgets/type_widgets/code/Code.tsx
+++ b/apps/client/src/widgets/type_widgets/code/Code.tsx
@@ -165,7 +165,18 @@ export function CodeEditor({ parentComponent, ntxId, containerRef: externalConta
     useTriliumEvent("executeWithCodeEditor", async ({ resolve, ntxId: eventNtxId }) => {
         if (eventNtxId !== ntxId) return;
         await initialized.current.promise();
+        if (!codeEditorRef.current) return;
         resolve(codeEditorRef.current!);
+    });
+
+    useTriliumEvent("noteContextRemoved", async ({ ntxIds: eventNtxIds }) => {
+        if (!ntxId || !eventNtxIds.includes(ntxId)) return;
+
+        const cm = codeEditorRef.current;
+        if (cm) {
+            cm.destroy();
+            codeEditorRef.current = null;
+        }
     });
 
     useTriliumEvent("executeWithContentElement", async ({ resolve, ntxId: eventNtxId}) => {

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -179,6 +179,16 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
         resolve(editor);
     });
 
+    useTriliumEvent("noteContextRemoved", async ({ ntxIds: eventNtxIds }) => {
+        if (!ntxId || !eventNtxIds.includes(ntxId)) return;
+
+        const watchdog = watchdogRef.current;
+        if (!watchdog) return;
+
+        await watchdog.destroy();
+        watchdogRef.current = null;
+    });
+
     async function waitForEditor() {
         await initialized.current;
         const editor = watchdogRef.current?.editor;

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
@@ -50,6 +50,15 @@ export default function ReadOnlyText({ note, noteContext, ntxId }: TypeWidgetPro
         resolve($(contentRef.current));
     });
 
+    useTriliumEvent("noteContextRemoved", ({ ntxIds: eventNtxIds }) => {
+        if (!ntxId || !eventNtxIds.includes(ntxId)) return;
+
+        if (contentRef.current) {
+            contentRef.current.innerHTML = "";
+        }
+        contentRef.current = null;
+    });
+
     return (
         <div
             className={`note-detail-readonly-text note-detail-printable ${codeBlockWordWrap ? "word-wrap" : ""}`}


### PR DESCRIPTION
Ensure that the editor is properly destroyed when a noteContext is removed. 
This prevents issues like https://github.com/TriliumNext/Trilium/issues/5740 and 
potential memory leaks, as editors associated with removed notes would otherwise persist.

This approach seems effective, but I’m not certain if it’s the best solution.
