### PR TITLE
chore(css): fix overly narrow empty tab layout on mobile

### DIFF
--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1582,6 +1582,14 @@ body:not(.mobile) #launcher-pane.horizontal .dropdown-submenu > .dropdown-menu {
         width: 100%;
     }
 
+    .note-split.empty-note {
+        --max-content-width: var(--preferred-max-content-width);
+    }
+
+    .note-detail-empty {
+        margin: 15px;
+    }
+
     #mobile-sidebar-container.show #mobile-sidebar-wrapper {
         transform: translateX(0);
     }


### PR DESCRIPTION
Before:

<img width="320" height="712" alt="图片" src="https://github.com/user-attachments/assets/375880a3-803b-4c4c-b427-f7812343690e" />

After:

<img width="322" height="719" alt="图片" src="https://github.com/user-attachments/assets/6624a8bb-e52b-43b9-8d08-5491123302d7" />

