### PR TITLE
fix(markdown): show 'import successful' when canceling markdown import

### DIFF
--- a/apps/client/src/widgets/dialogs/markdown_import.tsx
+++ b/apps/client/src/widgets/dialogs/markdown_import.tsx
@@ -36,7 +36,7 @@ export default function MarkdownImportDialog() {
 
     function submit() {
         setShown(false);
-        if (editorApiRef.current) {
+        if (editorApiRef.current && text) {
             convertMarkdownToHtml(text, editorApiRef.current);
         }
     }


### PR DESCRIPTION
When the imported markdown string is empty, return immediately to avoid displaying the "import successful" dialog.


