### PR TITLE
docs: add comprehensive AI coding agent instructions for copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -197,7 +197,7 @@ When adding query parameters to ETAPI endpoints (`apps/server/src/etapi/`), main
 
 2. **Protected notes require session check** - Before accessing `note.title` or `note.getContent()` on protected notes, check `note.isContentAvailable()` or use `note.getTitleOrProtected()` which handles this automatically.
 
-3. **Widget lifecycle matters** - Override `refreshWithNote()` for note changes, `doRenderBody()` for initial render, `entitiesReloadedEvent()` for entity updates. Widgets use jQuery (`this.$body`) - don't mix React patterns.
+3. **Widget lifecycle matters** - Override `refreshWithNote()` for note changes, `doRenderBody()` for initial render, `entitiesReloadedEvent()` for entity updates. Widgets use jQuery (`this.$widget`) - don't mix React patterns.
 
 4. **Tests run differently** - Server tests must run sequentially (shared database state), client tests can run in parallel. Use `pnpm test:sequential` for backend, `pnpm test:parallel` for frontend.
 


### PR DESCRIPTION
I noticed there’s a Claude.md but not a copilot-instructions file. With AI becoming an increasingly common tool for programming and engaging people, it’s important to ensure agents have a general understanding of the application. Since VSCode comes with GitHub Copilot built in, I’d imagine it’s the most widely used or easiest for some to access. I’ve also seen more editors adopting the .github folder as the standard location for AI agent files. I used the Claude.md as a base and leveraged some AI to update and organize it.