### PR TITLE
chore: add dev shell and direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ upload
 .rollup.cache
 *.tsbuildinfo
 
+/.direnv
 /result
 .svelte-kit
 

--- a/flake.nix
+++ b/flake.nix
@@ -258,6 +258,13 @@
         packages.server = server;
 
         packages.default = desktop;
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            nodejs
+            pnpm
+          ];
+        };
       }
     );
 }


### PR DESCRIPTION
This PR improves Nix support. We already supported using Trilium via a nix flake, and this PR further adds DevShells as well as automatic dev shell activation using Direnv. With these additions, Nix developers using this toolchain can automatically set up Node.js and pnpm upon entering the project directory (of course, the first time they’ll need to run direnv allow to grant permission).

Of course, I understand that this kind of PR is quite Nix-specific — if you think it’s not suitable, feel free to close it.

Thanks for your great work!