### PR TITLE
chore(etapi): Add missing share format

### DIFF
--- a/apps/server/etapi.openapi.yaml
+++ b/apps/server/etapi.openapi.yaml
@@ -268,6 +268,7 @@ paths:
                   enum:
                       - html
                       - markdown
+                      - share
                   default: html
         get:
             description: Exports ZIP file export of a given note subtree. To export whole document, use "root" for noteId


### PR DESCRIPTION
The export accepts the share format but is not documented.

NOTE: I added this manually, please let me know if it must be done in a different way.