### PR TITLE
chore: prevent error in .envrc for non nix systems

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,3 @@
-if command -v nix > /dev/null 2>&1; then
+if has nix; then
     use flake
 fi


### PR DESCRIPTION
Prevents `direnv` error non nix system:
```
direnv: loading ~/trilium/.envrc
direnv: using flake
environment:1330: nix: command not found
environment:1331: nix: command not found
```