### PR TITLE
fix(share): Prevent crashing if candidate note is null

### DIFF
--- a/packages/share-theme/src/templates/prev_next.ejs
+++ b/packages/share-theme/src/templates/prev_next.ejs
@@ -16,8 +16,13 @@
         // should go to the end of the previous tree
         let candidate = children[index - 1];
         while (candidate?.hasVisibleChildren()) {
-            const children = candidate.getVisibleChildNotes();
-            candidate = children[children.length - 1];
+            const visibleChildren = candidate.getVisibleChildNotes();
+
+            if (visibleChildren.length === 0) {
+                break;
+            }
+
+            candidate = visibleChildren[visibleChildren.length - 1];
         }
 
         return candidate ?? null;


### PR DESCRIPTION
When a note is not visible, attempting to export it ends up crashing the server with this error:

```
TypeError: ejs:193
    191|
    192|                 <% if (hasTree) { %>
 >> 193|                     <%- include("prev_next", { note: note, subRoot: subRoot }) %>
    194|                 <% } %>
    195|             </footer>
    196|         </div>
ejs:1
 >> 1| <%
    2|     // TODO: code cleanup + putting this behind a toggle/attribute
    3|     const previousNote = (() => {
    4|         // If we are at the subRoot, there is no previous
Cannot read properties of undefined (reading 'hasVisibleChildren')
    at eval (eval at compile (/usr/src/app/main.cjs:553:203), <anonymous>:27:26)
    at eval (eval at compile (/usr/src/app/main.cjs:553:203), <anonymous>:34:7)
    at d (/usr/src/app/main.cjs:557:265)
    at g (/usr/src/app/main.cjs:557:251)
    at eval (eval at compile (/usr/src/app/main.cjs:553:203), <anonymous>:293:17)
    at d (/usr/src/app/main.cjs:557:265)
    at as.render (/usr/src/app/main.cjs:532:458)
    at Omr (/usr/src/app/main.cjs:581:109552)
    at Rmr (/usr/src/app/main.cjs:581:107637)
    at $W.prepareContent (/usr/src/app/main.cjs:653:28) {
  path: ''
```

fixes #8002
fixes #8162