### PR TITLE
add logseq to supported protocols

### DIFF
--- a/packages/commons/src/lib/shared_constants.ts
+++ b/packages/commons/src/lib/shared_constants.ts
@@ -18,5 +18,5 @@ export const ALLOWED_PROTOCOLS = [
     'gopher', 'imap', 'irc', 'irc6', 'jabber', 'jar', 'lastfm', 'ldap', 'ldaps', 'magnet', 'message',
     'mumble', 'nfs', 'onenote', 'pop', 'rmi', 's3', 'sftp', 'skype', 'sms', 'spotify', 'steam', 'svn', 'udp',
     'view-source', 'vlc', 'vnc', 'ws', 'wss', 'xmpp', 'jdbc', 'slack', 'tel', 'smb', 'zotero', 'geo',
-    'mid', 'obsidian'
+    'logseq', 'mid', 'obsidian'
 ];


### PR DESCRIPTION
allows cross-links to logsec pages from a trilium note (logseq://graph/folder?page=2026-01-08) 