### PR TITLE
fix: add "latex" alias for math command

### DIFF
--- a/packages/ckeditor5/src/extra_slash_commands.ts
+++ b/packages/ckeditor5/src/extra_slash_commands.ts
@@ -54,6 +54,7 @@ export default function buildExtraCommands(): SlashCommandDefinition[] {
             id: "math",
             title: "Math equation",
             description: "Insert a math equation",
+            aliases: [ "latex", "equation" ],
             icon: mathIcons.ckeditor,
             execute: (editor: Editor) => editor.plugins.get(MathUI)._showUI()
         },


### PR DESCRIPTION
Adds another option to quickly pull up the math equation slash command in the editor.