### PR TITLE
fix: update nixpkgs to grab elector v40

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765701828,
-        "narHash": "sha256-bUqeCi+mdqXt6Ag0n+9QAqyvFiQPZdSCzTI70Nn3HhA=",
-        "owner": "nixos",
+        "lastModified": 1769184885,
+        "narHash": "sha256-wVX5Cqpz66SINNsmt3Bv/Ijzzfl8EPUISq5rKK129K0=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62996354316ef041b26c36e998a9ef193ede2864",
+        "rev": "12689597ba7a6d776c3c979f393896be095269d4",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "master",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Trilium Notes (experimental flake)";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     pnpm2nix = {
       url = "github:FliegendeWurst/pnpm2nix-nzbr";


### PR DESCRIPTION
In ccfda21413cd51712c3a20559e7ec9e6217397dd electron was updated to v40 which broke Nix. It just made it into master upstream in https://github.com/NixOS/nixpkgs/pull/482336 so update the flake to get access to it.