### PR TITLE
fix(editor): resolve strange stuck indent when a Note has images

### DIFF
--- a/packages/ckeditor5/src/plugins/indent_block_shortcut.ts
+++ b/packages/ckeditor5/src/plugins/indent_block_shortcut.ts
@@ -2,40 +2,28 @@
  * https://github.com/zadam/trilium/issues/978
  */
 
-import { ModelDocumentFragment, ModelElement, Plugin, ModelPosition } from "ckeditor5";
+import { ModelDocumentFragment, ModelElement, Plugin, ModelPosition, ViewDocumentTabEvent, isWidget } from "ckeditor5";
 
 export default class IndentBlockShortcutPlugin extends Plugin {
 
     init() {
-        this.editor.keystrokes.set( 'Tab', ( _, cancel ) => {
+        this.listenTo<ViewDocumentTabEvent>(this.editor.editing.view.document, "tab", (ev, data) => {
             // In tables, allow default Tab behavior for cell navigation
-            if (this.isInTable()) {
-                return;
-            }
+            if (this.isInTable()) return;
 
-            const command = this.editor.commands.get( 'indentBlock' );
+            // Always cancel in non-table contexts to prevent widget navigation
+            data.preventDefault();
+            ev.stop();
+
+            const commandName = data.shiftKey ? "outdentBlock" : "indentBlock";
+            const command = this.editor.commands.get(commandName);
             if (command?.isEnabled) {
                 command.execute();
             }
-
-            // Always cancel in non-table contexts to prevent widget navigation
-            cancel();
-        } );
-
-        this.editor.keystrokes.set( 'Shift+Tab', ( _, cancel ) => {
-            // In tables, allow default Shift+Tab behavior for cell navigation
-            if (this.isInTable()) {
-                return;
-            }
-
-            const command = this.editor.commands.get( 'outdentBlock' );
-            if (command?.isEnabled) {
-                command.execute();
-            }
-
-            // Always cancel in non-table contexts to prevent widget navigation
-            cancel();
-        } );
+        }, {
+            priority: "highest",
+            context: node => isWidget( node ) || node.is( 'editableElement' ),
+        });
     }
 
     // in table TAB should switch cells


### PR DESCRIPTION
Before: Tab/Shift+Tab only called cancel() when the indent/outdent command was enabled. When at the root level of a list or in non-indentable content, the event wasn't cancelled, allowing CKEditor's widget navigation to take over.

After: Tab/Shift+Tab always calls cancel() in non-table contexts. This prevents widget navigation (jumping to images) while still:
  - Executing indent/outdent when possible
  - Allowing normal Tab behavior in tables for cell navigation


![trilium_skfnk0W6rC](https://github.com/user-attachments/assets/ae9befa8-aca3-44e1-b50d-9b639d2155ff)

---

Closes #7986
Closes #7476