### PR TITLE
always show Note Paths in Status Bar

### DIFF
--- a/apps/client/src/widgets/layout/StatusBar.tsx
+++ b/apps/client/src/widgets/layout/StatusBar.tsx
@@ -414,7 +414,7 @@ function NotePaths({ note, hoistedNoteId, notePath }: StatusBarContext) {
     const dropdownRef = useRef<BootstrapDropdown>(null);
     const sortedNotePaths = useSortedNotePaths(note, hoistedNoteId);
     const count = sortedNotePaths?.length ?? 0;
-    const enabled = count > 1;
+    const enabled = true;
 
     // Keyboard shortcut.
     useTriliumEvent("toggleRibbonTabNotePaths", () => enabled && dropdownRef.current?.show());


### PR DESCRIPTION
This is useful if a note is opened from a saved search (no other way to find out note's path).

In old layout it works ok (you can see the paths in search result), but in new layout this is one the things that was not done right.

Note: I left `enabled` flag in use. In the future visibility of status bar items may be controlled through options.


