### PR TITLE
fix(breadcrumb): note title update

### DIFF
--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -1215,11 +1215,11 @@ export function useNoteTitle(noteId: string | undefined, parentNoteId: string | 
     });
 
     // React to external changes.
-    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
-        if (loadResults.isNoteReloaded(noteId)) {
+    useTriliumEvent("entitiesReloaded", useCallback(({ loadResults }) => {
+        if (loadResults.isNoteReloaded(noteId) || (parentNoteId && loadResults.getBranchRows().some(b => b.noteId === noteId && b.parentNoteId === parentNoteId))) {
             refresh();
         }
-    });
+    }, [noteId, parentNoteId, refresh]));
     return title;
 }
 


### PR DESCRIPTION
Before: The note title in the breadcrumbs did not reflect the updated title without opening other note.

After: The note title reflects live in the breadcrumb.
![breadcrubms](https://github.com/user-attachments/assets/8bf91826-73bc-40ec-ac0b-3d1fc939cddb)
