### PR TITLE
Theming: color scheme selectors

### DIFF
--- a/apps/client/src/widgets/containers/root_container.ts
+++ b/apps/client/src/widgets/containers/root_container.ts
@@ -13,6 +13,8 @@ import FlexContainer from "./flex_container.js";
  *
  * For convenience, the root container has a few class selectors that can be used to target some global state:
  *
+ * - `#root-container.light-theme`, indicates whether the current color scheme is light.
+ * - `#root-container.dark-theme`, indicates whether the current color scheme is dark.
  * - `#root-container.virtual-keyboard-opened`, on mobile devices if the virtual keyboard is open.
  * - `#root-container.horizontal-layout`, if the current layout is horizontal.
  * - `#root-container.vertical-layout`, if the current layout is horizontal.


### PR DESCRIPTION
Now the current color scheme is indicated by a class on the body element: `light-theme` or `dark-theme`. It will be updated automatically according to the system preference if needed. This makes it easier for custom CSS to define colors correctly based on the active color scheme.

Here is an example:

```css
#trilium-app.light-theme {
    --launcher-pane-vert-background-color: white;
}

#trilium-app.dark-theme {
    --launcher-pane-vert-background-color: black;
}
```