### PR TITLE
fix(webview): refresh content for SPAs with "query string" in hash

### DIFF
--- a/apps/client/src/types-lib.d.ts
+++ b/apps/client/src/types-lib.d.ts
@@ -66,6 +66,7 @@ declare module "preact" {
         interface ElectronWebViewElement extends JSX.HTMLAttributes<HTMLElement> {
             src: string;
             class: string;
+            key?: string | number;
         }
 
         interface IntrinsicElements {

--- a/apps/client/src/widgets/type_widgets/WebView.tsx
+++ b/apps/client/src/widgets/type_widgets/WebView.tsx
@@ -57,6 +57,7 @@ function DesktopWebView({ src, ntxId }: { src: string, ntxId: string | null | un
     return <webview
         ref={webviewRef}
         src={src}
+        key={src}
         class="note-detail-web-view-content"
     />;
 }
@@ -80,6 +81,7 @@ function BrowserWebView({ src, ntxId }: { src: string, ntxId: string | null | un
     return <iframe
         ref={iframeRef}
         src={src}
+        key={src}
         class="note-detail-web-view-content"
         sandbox="allow-same-origin allow-scripts allow-popups" />;
 }


### PR DESCRIPTION
This fixes webview does not refresh its content if you navigate between notes of some SPA sites.

Example: emby media server

It uses pseudo query string located in URL hash, like this: `index.html#!/list/list.html?parentId=47835&serverId=abc`