### PR TITLE
web-clipper: prevent cloning when clipping to an existing note + optimizations

### DIFF
--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -19,12 +19,11 @@ async function addClipping(req: Request) {
     const { title, content, images } = req.body;
     const clipType = "clippings";
 
-    const clipperInbox = await getClipperInboxNote();
-
     const pageUrl = sanitize.sanitizeUrl(req.body.pageUrl);
     let clippingNote = findClippingNote(pageUrl, clipType);
 
     if (!clippingNote) {
+        const clipperInbox = await getClipperInboxNote();
         clippingNote = noteService.createNewNote({
             parentNoteId: clipperInbox.noteId,
             title,

--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -14,9 +14,9 @@ interface Image {
 }
 
 async function addClipping(req: Request) {
-    // if a note under the clipperInbox has the same 'pageUrl' attribute,
-    // add the content to that note and clone it under today's inbox
-    // otherwise just create a new note under today's inbox
+    // if a note exists with has the same 'pageUrl' attribute,
+    // add the content to the existing note
+    // otherwise create a new note under today's inbox
     const { title, content, images } = req.body;
     const clipType = "clippings";
 

--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -47,11 +47,6 @@ async function addClipping(req: Request) {
 
     clippingNote.setContent(`${existingContent}${existingContent.trim() ? "<br>" : ""}${rewrittenContent}`);
 
-    // TODO: Is parentNoteId ever defined?
-    if ((clippingNote as any).parentNoteId !== clipperInbox.noteId) {
-        cloneService.cloneNoteToParentNote(clippingNote.noteId, clipperInbox.noteId);
-    }
-
     return {
         noteId: clippingNote.noteId
     };

--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -1,10 +1,9 @@
-import { app_info as appInfo, attribute_formatter as attributeFormatter, attributes as attributeService, type BNote, cloning as cloneService, date_notes as dateNoteService, date_utils as dateUtils, note_service as noteService, sanitize, ValidationError, ws } from "@triliumnext/core";
+import { app_info as appInfo, attribute_formatter as attributeFormatter, attributes as attributeService, type BNote, cloning as cloneService, date_notes as dateNoteService, date_utils as dateUtils, getLog, note_service as noteService, sanitize, search as searchService, ValidationError, ws } from "@triliumnext/core";
 import type { Request } from "express";
 import { parse } from "node-html-parser";
 import path from "path";
 
 import imageService from "../../services/image.js";
-import { getLog } from "@triliumnext/core";
 import utils from "../../services/utils.js";
 
 interface Image {
@@ -23,7 +22,7 @@ async function addClipping(req: Request) {
     const clipperInbox = await getClipperInboxNote();
 
     const pageUrl = sanitize.sanitizeUrl(req.body.pageUrl);
-    let clippingNote = findClippingNote(clipperInbox, pageUrl, clipType);
+    let clippingNote = findClippingNote(pageUrl, clipType);
 
     if (!clippingNote) {
         clippingNote = noteService.createNewNote({
@@ -52,12 +51,12 @@ async function addClipping(req: Request) {
     };
 }
 
-function findClippingNote(clipperInboxNote: BNote, pageUrl: string, clipType: string | null) {
+function findClippingNote(pageUrl: string, clipType: string | null) {
     if (!pageUrl) {
         return null;
     }
 
-    const notes = clipperInboxNote.searchNotesInSubtree(
+    const notes = searchService.searchNotes(
         attributeFormatter.formatAttrForSearch(
             {
                 type: "label",
@@ -91,7 +90,7 @@ async function createNote(req: Request) {
     const title = trimmedTitle || `Clipped note from ${pageUrl}`;
 
     const clipperInbox = await getClipperInboxNote();
-    let note = findClippingNote(clipperInbox, pageUrl, clipType);
+    let note = findClippingNote(pageUrl, clipType);
 
     if (!note) {
         note = noteService.createNewNote({
@@ -198,8 +197,7 @@ function handshake() {
 
 async function findNotesByUrl(req: Request<{ noteUrl: string }>) {
     const pageUrl = req.params.noteUrl;
-    const clipperInbox = await getClipperInboxNote();
-    const foundPage = findClippingNote(clipperInbox, pageUrl, null);
+    const foundPage = findClippingNote(pageUrl, null);
     return {
         noteId: foundPage ? foundPage.noteId : null
     };

--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -13,9 +13,9 @@ interface Image {
 }
 
 async function addClipping(req: Request) {
-    // if a note exists with has the same 'pageUrl' attribute,
-    // add the content to the existing note
-    // otherwise create a new note under today's inbox
+    // if a #clipType=clippings note exists with the same 'pageUrl' attribute,
+    // append the content to that note
+    // otherwise create a new note under clipperInbox (or today's note)
     const { title, content, images } = req.body;
     const clipType = "clippings";
 


### PR DESCRIPTION
This removes undesired note cloning when clipping to existing note

### Background
I noticed lot of cloned notes in clipper inbox appeared periodically. I blamed sync, but it turned out to be web clipper handler bug/feature.

The cloning was introduced in https://github.com/TriliumNext/Trilium/pull/4075/changes

But this does not works properly in my opinion:
- when clipping note is in inbox, it still tries to clone it (and siliently fails due to validation)
- when clipping note has been moved outside of inbox, it clones it to inbox (cluttering already organized inbox)

### Proposed solution

- When you clip an URL for the first time the note appears in clipper inbox (like it was before this PR)
- When you clip the same URL another time, it keeps appending to the note regardless of note location, and does not clone it ("does not clone it" part is added in this PR) 

### Additional refactoring made
Finding clipping note code is now more correct semantically (uses `searchService.searchNotes` method instead of misleading indirection via  `note.searchNotesInSubtree` method. As a bonus, it saves extra call to `getClipperInboxNote` on each click on browser extension, and in case of clipping selection to an exiting note.