### PR TITLE
Space mobile launcher container evenly

### DIFF
--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1612,11 +1612,7 @@ body:not(.mobile) #launcher-pane.horizontal .dropdown-submenu > .dropdown-menu {
     }
 
     body.mobile #launcher-container {
-        justify-content: center;
-    }
-
-    body.mobile #launcher-container button {
-        margin: 0 16px;
+        justify-content: space-evenly;
     }
 
     body.mobile .modal.show {


### PR DESCRIPTION
The launcher container has been looking awkward on my phone, like this:

<img width="1080" height="336" alt="image" src="https://github.com/user-attachments/assets/49bbeb52-9747-4f84-a8f6-99437facb322" />

To fix this, instead of having a centered block with custom margins, I tried to simply rely on flexbox' space-evenly. To me the result massively improves on my phone and still seems to scale nicely on all responsive sizes until the element vanishes anyway at a certain width.

<img width="1080" height="296" alt="image" src="https://github.com/user-attachments/assets/0d21cc8e-bd3b-48a8-aab5-5abfe154efd8" />
