### PR TITLE
feat(search): auto-execute saved search when note is opened

### DIFF
--- a/apps/client/src/widgets/search_result.tsx
+++ b/apps/client/src/widgets/search_result.tsx
@@ -39,11 +39,14 @@ export default function SearchResult() {
     // Auto-execute search when opening a saved search note.
     // Triggered only when the note ID changes (i.e. the user navigates to a different note),
     // not on every render. This avoids re-running while the user is editing the query.
+    const [lastExecutedNoteId, setLastExecutedNoteId] = useState<string>();
+
     useEffect(() => {
-        if (note?.type === "search" && !note?.searchResultsLoaded) {
+        if (note?.type === "search" && !note?.searchResultsLoaded && note.noteId !== lastExecutedNoteId) {
             appContext.triggerCommand("searchNotes");
+            setLastExecutedNoteId(note.noteId);
         }
-    }, [ note?.noteId ]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [note, lastExecutedNoteId]);
     useTriliumEvent("searchRefreshed", ({ ntxId: eventNtxId }) => {
         if (eventNtxId === ntxId) {
             refresh();


### PR DESCRIPTION
## Problem

When opening a saved search note, the user must manually press the "Search" button to see results. The note shows a "Search has not been executed yet" message that requires an extra interaction every time.

Fixes #5658

## Change

Added a `useEffect` in `SearchResult` that automatically triggers the `searchNotes` command when a saved search note is first opened.

```tsx
useEffect(() => {
    if (note?.type === "search" && !note?.searchResultsLoaded) {
        appContext.triggerCommand("searchNotes");
    }
}, [ note?.noteId ]);
```

**Why `note?.noteId` as dependency?**
Using the noteId (rather than the full note object) ensures the auto-execute fires once per navigation, not on every re-render or search update. It will not re-run while the user edits the search query on the same note.

## Behaviour
- Navigating to a saved search note → search executes immediately.
- If the note has already been loaded in this session (`searchResultsLoaded === true`), the effect does nothing.
- No config option needed — this matches the expected UX for a note type whose entire purpose is to display search results.