### PR TITLE
feat(desktop): add trilium:// custom protocol handler and --open-note CLI arg

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -141,13 +141,21 @@ async function main() {
 
         // Handle protocol URL passed when this is the *first* instance
         // (Windows / Linux deliver the URL as a command-line argument).
-        const protocolUrl = extractTriliumUrlFromArgs(process.argv);
-        if (protocolUrl) {
-            const noteId = parseTriliumUrl(protocolUrl);
-            if (noteId) {
-                // Wait a short moment for the renderer to finish initialising
-                // before sending the navigation request.
-                setTimeout(() => navigateToNote(noteId), 1500);
+        // Only handle process.argv on non-macOS; macOS delivers protocol URLs via the open-url event.
+        if (process.platform !== "darwin") {
+            const protocolUrl = extractTriliumUrlFromArgs(process.argv);
+            if (protocolUrl) {
+                const noteId = parseTriliumUrl(protocolUrl);
+                if (noteId) {
+                    const win = windowService.getLastFocusedWindow() ?? windowService.getMainWindow();
+                    if (win && !win.isDestroyed()) {
+                        if (win.webContents.isLoading()) {
+                            win.webContents.once("did-finish-load", () => navigateToNote(noteId));
+                        } else {
+                            navigateToNote(noteId);
+                        }
+                    }
+                }
             }
         }
     });
@@ -165,8 +173,14 @@ async function main() {
             if (navigateToNote(noteId)) {
                 return;
             }
-            // Window not ready yet – retry after the ready event fires.
-            app.once("ready", () => setTimeout(() => navigateToNote(noteId), 1500));
+            // Window not ready yet — wait for it to be created and finish loading.
+            app.once("browser-window-created", (_event, win) => {
+                if (win.webContents.isLoading()) {
+                    win.webContents.once("did-finish-load", () => navigateToNote(noteId));
+                } else {
+                    navigateToNote(noteId);
+                }
+            });
         }
     });
 


### PR DESCRIPTION
## Summary

Implements a custom URI scheme (	rilium://) so that external apps, scripts, and OS integrations can launch TriliumNext and navigate directly to a specific note.

Closes #649

## Supported formats

| Format | Example |
|---|---|
| 	rilium://note/<noteId> | 	rilium://note/abc123def456 |
| 	rilium://<noteId> | 	rilium://abc123def456 |
| --open-note=<noteId> CLI flag | 	rilium --open-note=abc123def456 |

## How it works

1. **Protocol registration** - pp.setAsDefaultProtocolClient('trilium') is called before the single-instance lock so the OS registers the scheme.

2. **New instance** - when TriliumNext is *not* running and is launched via 	rilium://note/NOTEID (Windows / Linux pass the URL as a command-line argument; macOS fires open-url), the app starts normally and navigates to the note ~1.5 s after the window is ready.

3. **Running instance** - when TriliumNext *is* already running the second-instance event receives the command line. The protocol URL (or --open-note flag) is parsed, the existing window is focused, and openInSameTab IPC is sent to the renderer.

4. **macOS** - protocol activations for a *running* instance arrive via the open-url event and are handled identically.

## Implementation detail

Navigation is performed by sending the pre-existing openInSameTab IPC message to the renderer, which calls ppContext.tabManager.openInSameTab(noteId). No renderer changes are required.

## Files changed

- pps/desktop/src/main.ts - added parseTriliumUrl(), extractTriliumUrlFromArgs(), 
avigateToNote() helpers; wired up open-url event handler; updated second-instance handler; added pp.setAsDefaultProtocolClient('trilium') call.