### PR TITLE
fix(etapi): correct calendar year/month endpoint descriptions and year pattern; docs: add trilium-fastmcp integration

### DIFF
--- a/apps/server/etapi.openapi.yaml
+++ b/apps/server/etapi.openapi.yaml
@@ -870,7 +870,7 @@ paths:
                                 $ref: "#/components/schemas/Error"
     /calendar/months/{month}:
         get:
-            description: returns a week note for a given date. Gets created if doesn't exist.
+            description: returns a month note for a given month. Gets created if doesn't exist.
             operationId: getMonthNote
             parameters:
                 - name: month
@@ -895,7 +895,7 @@ paths:
                                 $ref: "#/components/schemas/Error"
     /calendar/years/{year}:
         get:
-            description: returns a week note for a given date. Gets created if doesn't exist.
+            description: returns a year note for a given year. Gets created if doesn't exist.
             operationId: getYearNote
             parameters:
                 - name: year
@@ -903,8 +903,8 @@ paths:
                   required: true
                   schema:
                       type: string
-                      pattern: "[0-9]{4}-[0-9]{2}"
-                  example: 2022-02
+                      pattern: "[0-9]{4}"
+                  example: "2022"
             responses:
                 "200":
                     description: year note

--- a/apps/server/etapi.openapi.yaml
+++ b/apps/server/etapi.openapi.yaml
@@ -870,7 +870,8 @@ paths:
                                 $ref: "#/components/schemas/Error"
     /calendar/months/{month}:
         get:
-            description: returns a month note for a given month. Gets created if doesn't exist.
+            summary: Get a month note
+            description: Returns a month note for a given month (format YYYY-MM, e.g., 2022-02). The note is created if it doesn't exist.
             operationId: getMonthNote
             parameters:
                 - name: month
@@ -895,7 +896,8 @@ paths:
                                 $ref: "#/components/schemas/Error"
     /calendar/years/{year}:
         get:
-            description: returns a year note for a given year. Gets created if doesn't exist.
+            summary: Get a year note
+            description: Returns a year note for a given year (format YYYY, e.g., 2022). The note is created if it doesn't exist.
             operationId: getYearNote
             parameters:
                 - name: year
@@ -903,7 +905,7 @@ paths:
                   required: true
                   schema:
                       type: string
-                      pattern: "[0-9]{4}"
+                      pattern: "^[0-9]{4}$"
                   example: "2022"
             responses:
                 "200":

--- a/docs/User Guide/User Guide/AI.md
+++ b/docs/User Guide/User Guide/AI.md
@@ -13,6 +13,7 @@ As such, there are third-party solutions that integrate an MCP server that can b
 
 *   [tan-yong-sheng/triliumnext-mcp](https://github.com/tan-yong-sheng/triliumnext-mcp)
 *   [perfectra1n/triliumnext-mcp](https://github.com/perfectra1n/triliumnext-mcp)
+*   [eliassoares/trilium-fastmcp](https://github.com/eliassoares/trilium-fastmcp)
 
 > [!IMPORTANT]
 > These solutions are third-party and thus not endorsed or supported directly by the Trilium Notes team. Please address questions and issues on their corresponding repository instead.


### PR DESCRIPTION
# Summary
- Fix incorrect descriptions in ETAPI calendar endpoints: /calendar/months/{month} and /calendar/years/{year} were both describing "a week note for a given date" (copy-paste from the week endpoint)
- Fix year parameter pattern in /calendar/years/{year}: was incorrectly using [0-9]{4}-[0-9]{2} (month format) instead of [0-9]{4}
- Add [eliassoares/trilium-fastmcp](https://github.com/eliassoares/trilium-fastmcp) to the list of third-party MCP integrations in the User Guide