### PR TITLE
fix revisions dialog shows translation keys instead of values

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1341,7 +1341,7 @@
     "erase_deleted_notes_now": "Erase deleted notes now",
     "deleted_notes_erased": "Deleted notes have been erased."
   },
-  "revisions": {
+  "revisions_snapshot": {
     "title": "Note Revisions"
   },
   "revisions_snapshot_interval": {

--- a/apps/client/src/widgets/type_widgets/options/other.tsx
+++ b/apps/client/src/widgets/type_widgets/options/other.tsx
@@ -177,7 +177,7 @@ function RevisionSettings() {
     const [ revisionSnapshotNumberLimit, setRevisionSnapshotNumberLimit ] = useTriliumOption("revisionSnapshotNumberLimit");
 
     return (
-        <OptionsSection title={t("revisions.title")}>
+        <OptionsSection title={t("revisions_snapshot.title")}>
             <OptionsRow name="revision-snapshot-time-interval" label={t("revisions_snapshot_interval.snapshot_time_interval_label")} description={t("revisions_snapshot_interval.note_revisions_snapshot_description_short")}>
                 <TimeSelector
                     name="revision-snapshot-time-interval"


### PR DESCRIPTION

<img width="738" height="97" alt="image" src="https://github.com/user-attachments/assets/27736fc8-6a5e-4809-a8ec-ac3953f58a73" />
