### PR TITLE
opt-in to disable automatic DB migration 

### DIFF
--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Configuration (config.ini or e.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Configuration (config.ini or e.html
@@ -299,6 +299,28 @@
   </tbody>
 </table>
 
+<h3>Development Section</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Environment Variable</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code spellcheck="false">TRILIUM_MANUAL_DB_MIGRATION</code></td>
+      <td>boolean</td>
+      <td>false</td>
+      <td>If <code spellcheck="false">true</code>, the application will not start
+        if automatic database migrations are pending and would modify the database
+        schema.</td>
+    </tr>
+  </tbody>
+</table>
+
 <h2>Alternative Environment Variables</h2>
 <p>The following alternative environment variable names are also supported
   and work identically to their longer counterparts:</p>

--- a/apps/server/src/assets/translations/en/server.json
+++ b/apps/server/src/assets/translations/en/server.json
@@ -360,6 +360,7 @@
   "migration": {
     "old_version": "Direct migration from your current version is not supported. Please upgrade to the latest v0.60.4 first and only then to this version.",
     "error_message": "Error during migration to version {{version}}: {{stack}}",
+    "automatic_migrations_disabled": "Automatic DB migrations are disabled via environment variable TRILIUM_MANUAL_DB_MIGRATION = {{envVarValue}}",
     "wrong_db_version": "The version of the database ({{version}}) is newer than what the application expects ({{targetVersion}}), which means that it was created by a newer and incompatible version of Trilium. Upgrade to the latest version of Trilium to resolve this issue.",
     "invalid_db_version": "The database version is not a valid number. This usually indicates a corrupted 'dbVersion' option in the database. Please restore from a backup."
   },

--- a/docs/User Guide/User Guide/Advanced Usage/Configuration (config.ini or e.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Configuration (config.ini or e.md
@@ -82,6 +82,12 @@ Additionally, shorter aliases are available for common configurations (see Alter
 | --- | --- | --- | --- |
 | `TRILIUM_LOGGING_RETENTIONDAYS` | integer | 90 | Number of days to retain log files |
 
+### Development Section
+
+| Environment Variable | Type | Default | Description |
+| --- | --- | --- | --- |
+| `TRILIUM_MANUAL_DB_MIGRATION` | boolean | false | If `true`, the application will not start if automatic database migrations are pending and would modify the database schema. |
+
 ## Alternative Environment Variables
 
 The following alternative environment variable names are also supported and work identically to their longer counterparts:

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -141,6 +141,9 @@ async function migrateIfNecessary() {
     }
 
     if (!isDbUpToDate()) {
+        if (process.env.TRILIUM_MANUAL_DB_MIGRATION === "true") {
+            await crash(`Automatic DB migrations are disabled via env var TRILIUM_MANUAL_DB_MIGRATION = ${process.env.TRILIUM_MANUAL_DB_MIGRATION}`);
+        }
         await migrate();
     }
 }

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -143,6 +143,7 @@ async function migrateIfNecessary() {
     if (!isDbUpToDate()) {
         if (process.env.TRILIUM_MANUAL_DB_MIGRATION === "true") {
             await crash(`Automatic DB migrations are disabled via env var TRILIUM_MANUAL_DB_MIGRATION = ${process.env.TRILIUM_MANUAL_DB_MIGRATION}`);
+            return;
         }
         await migrate();
     }

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -142,7 +142,7 @@ async function migrateIfNecessary() {
 
     if (!isDbUpToDate()) {
         if (process.env.TRILIUM_MANUAL_DB_MIGRATION === "true") {
-            await crash(`Automatic DB migrations are disabled via env var TRILIUM_MANUAL_DB_MIGRATION = ${process.env.TRILIUM_MANUAL_DB_MIGRATION}`);
+            await crash(t("migration.automatic_migrations_disabled", { envVarValue: process.env.TRILIUM_MANUAL_DB_MIGRATION}));
             return;
         }
         await migrate();

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -142,7 +142,7 @@ async function migrateIfNecessary() {
 
     if (!isDbUpToDate()) {
         if (process.env.TRILIUM_MANUAL_DB_MIGRATION === "true") {
-            await crash(t("migration.automatic_migrations_disabled", { envVarValue: process.env.TRILIUM_MANUAL_DB_MIGRATION}));
+            await getPlatform().crash(t("migration.automatic_migrations_disabled", { envVarValue: process.env.TRILIUM_MANUAL_DB_MIGRATION}));
             return;
         }
         await migrate();


### PR DESCRIPTION
This intended mostly for developers.

If you opt-in to set TRILIUM_MANUAL_DB_MIGRATION, you won't accidentally upgrade DB when switching between branches
