### PR TITLE
Print collection - add missing links

### DIFF
--- a/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
+++ b/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
@@ -132,15 +132,24 @@ async function rewriteLinks(contentEl: HTMLElement, noteIdsSet: Set<string>) {
 
             if (!noteId) continue;
 
-            const note = await froca.getNote(noteId);
-            const noteTitle = note?.title || "";
+            let noteTitle = "";
+            if (linkEl.classList.contains("reference-link")) {
+                const note = await froca.getNote(noteId);
+                noteTitle = note?.title || "";
+            }
             if (noteIdsSet.has(noteId)) {
-                linkEl.textContent = noteTitle;
+                if (noteTitle) {
+                    linkEl.textContent = noteTitle;
+                }
                 linkEl.setAttribute("href", `#note-${noteId}`);
             } else {
                 // Link to note not in the print view, remove link but keep text
                 const spanEl = document.createElement("span");
-                spanEl.textContent = noteTitle;
+                if (noteTitle) {
+                    spanEl.textContent = noteTitle;
+                } else {
+                    spanEl.textContent = linkEl.textContent;
+                }
                 linkEl.replaceWith(spanEl);
             }
         }

--- a/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
+++ b/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
@@ -62,7 +62,7 @@ export function ListPrintView({ note, noteIds: unfilteredNoteIds, onReady, onPro
 
             // After all notes are processed, rewrite links
             for (const { contentEl } of notesWithContent) {
-                rewriteLinks(contentEl, noteIdsSet);
+                await rewriteLinks(contentEl, noteIdsSet);
             }
 
             setState({
@@ -123,19 +123,23 @@ function rewriteHeadings(contentEl: HTMLElement, depth: number) {
     }
 }
 
-function rewriteLinks(contentEl: HTMLElement, noteIdsSet: Set<string>) {
+async function rewriteLinks(contentEl: HTMLElement, noteIdsSet: Set<string>) {
     const linkEls = contentEl.querySelectorAll("a");
     for (const linkEl of linkEls) {
         const href = linkEl.getAttribute("href");
         if (href && href.startsWith("#root/")) {
             const noteId = href.split("/").at(-1);
 
-            if (noteId && noteIdsSet.has(noteId)) {
+            if (!noteId) continue;
+
+            const note = await froca.getNote(noteId);
+            if (noteIdsSet.has(noteId)) {
+                linkEl.textContent = note?.title || "?";
                 linkEl.setAttribute("href", `#note-${noteId}`);
             } else {
                 // Link to note not in the print view, remove link but keep text
                 const spanEl = document.createElement("span");
-                spanEl.innerHTML = linkEl.innerHTML;
+                spanEl.innerHTML = note?.title || "?";
                 linkEl.replaceWith(spanEl);
             }
         }

--- a/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
+++ b/apps/client/src/widgets/collections/legacy/ListPrintView.tsx
@@ -133,13 +133,14 @@ async function rewriteLinks(contentEl: HTMLElement, noteIdsSet: Set<string>) {
             if (!noteId) continue;
 
             const note = await froca.getNote(noteId);
+            const noteTitle = note?.title || "";
             if (noteIdsSet.has(noteId)) {
-                linkEl.textContent = note?.title || "?";
+                linkEl.textContent = noteTitle;
                 linkEl.setAttribute("href", `#note-${noteId}`);
             } else {
                 // Link to note not in the print view, remove link but keep text
                 const spanEl = document.createElement("span");
-                spanEl.innerHTML = note?.title || "?";
+                spanEl.textContent = noteTitle;
                 linkEl.replaceWith(spanEl);
             }
         }


### PR DESCRIPTION
Printed version didn't have neither links for collection notes, nor note titles for notes outside of the collection

Note:
<img width="405" height="329" alt="image" src="https://github.com/user-attachments/assets/db6d6acf-7d8c-42b4-8aa9-17a131cd75cf" />

Printed version:
<img width="498" height="371" alt="image" src="https://github.com/user-attachments/assets/0dec3e18-b166-4518-8cc1-bf76f946e02c" />


