### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ apps/*/coverage
 scripts/translation/.language*.json
 
 .claude
+.pnpm-store


### PR DESCRIPTION
Skipping `.pnpm-store` is useful, if using a work environment container for trilium builds.
pnpm places `.pnpm-store` in the mount root, which becomes Trilium project root dir, when this directory has been shared from host to container.