### PR TITLE
Allow clearing default keyboard shortcuts

### DIFF
--- a/apps/client/src/widgets/type_widgets/options/shortcuts.tsx
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts.tsx
@@ -134,7 +134,7 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
             <tbody>
                 {filteredKeyboardActions.length > 0
                  ? filteredKeyboardActions.map(action => (
-                    <tr>
+                    <tr key={"separator" in action ? `separator-${action.separator}` : action.actionName}>
                         {"separator" in action ?
                             <td class="separator" colspan={3} style={{
                                 backgroundColor: "var(--accented-background-color)",

--- a/apps/client/src/widgets/type_widgets/options/shortcuts.tsx
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts.tsx
@@ -13,6 +13,7 @@ import dialog from "../../../services/dialog";
 import { useTriliumEvent } from "../../react/hooks";
 import "./shortcuts.css";
 import NoItems from "../../react/NoItems";
+import { getShortcutOptionValue } from "./shortcuts_model";
 
 export default function ShortcutSettings() {
     const [ keyboardShortcuts, setKeyboardShortcuts ] = useState<KeyboardShortcut[]>([]);
@@ -116,7 +117,6 @@ function filterKeyboardAction(action: KeyboardShortcut, filter: string) {
 
     return action.actionName.toLowerCase().includes(filter) ||
         (action.friendlyName && action.friendlyName.toLowerCase().includes(filter)) ||
-        (action.defaultShortcuts ?? []).some((shortcut) => shortcut.toLowerCase().includes(filter)) ||
         (action.effectiveShortcuts ?? []).some((shortcut) => shortcut.toLowerCase().includes(filter)) ||
         (action.description && action.description.toLowerCase().includes(filter));
 }
@@ -128,7 +128,6 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
                 <tr class="text-nowrap">
                     <th>{t("shortcuts.action_name")}</th>
                     <th>{t("shortcuts.shortcuts")}</th>
-                    <th>{t("shortcuts.default_shortcuts")}</th>
                     <th>{t("shortcuts.description")}</th>
                 </tr>
             </thead>
@@ -137,7 +136,7 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
                  ? filteredKeyboardActions.map(action => (
                     <tr>
                         {"separator" in action ?
-                            <td class="separator" colspan={4} style={{
+                            <td class="separator" colspan={3} style={{
                                 backgroundColor: "var(--accented-background-color)",
                                 fontWeight: "bold"
                             }}>
@@ -149,7 +148,6 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
                                 <td>
                                     <ShortcutEditor keyboardShortcut={action} />
                                 </td>
-                                <td>{action.defaultShortcuts?.join(", ")}</td>
                                 <td>{action.description}</td>
                             </>
                         )}
@@ -157,7 +155,7 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
                 ))
                 : (
                     <tr>
-                        <td colspan={4} class="text-center">
+                        <td colspan={3} class="text-center">
                             <NoItems
                                 icon="bx bx-filter-alt"
                                 text={t("shortcuts.no_results", { filter })}
@@ -172,20 +170,22 @@ function KeyboardShortcutTable({ filteredKeyboardActions, filter }: { filteredKe
 
 function ShortcutEditor({ keyboardShortcut: action }: { keyboardShortcut: ActionKeyboardShortcut }) {
     const originalShortcut = (action.effectiveShortcuts ?? []).join(", ");
+    const [ shortcutInput, setShortcutInput ] = useState(originalShortcut);
+
+    useEffect(() => {
+        setShortcutInput(originalShortcut);
+    }, [ originalShortcut ]);
+
+    function saveShortcutInput(newShortcut: string) {
+        const optionName = getOptionName(action.actionName);
+        options.save(optionName, getShortcutOptionValue(newShortcut));
+    }
 
     return (
         <FormTextBox
-            currentValue={originalShortcut}
-            onBlur={(newShortcut) => {
-                const { actionName } = action;
-                const optionName = getOptionName(actionName);
-                const newShortcuts = newShortcut
-                    .replace("+,", "+Comma")
-                    .split(",")
-                    .map((shortcut) => shortcut.replace("+Comma", "+,"))
-                    .filter((shortcut) => !!shortcut);
-                options.save(optionName, JSON.stringify(newShortcuts));
-            }}
+            currentValue={shortcutInput}
+            onChange={setShortcutInput}
+            onBlur={saveShortcutInput}
         />
     )
 }

--- a/apps/client/src/widgets/type_widgets/options/shortcuts_model.spec.ts
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts_model.spec.ts
@@ -14,4 +14,8 @@ describe("shortcuts options model", () => {
             "Ctrl+,"
         ]);
     });
+
+    it("preserves comma keys when the shortcut uses whitespace around modifiers", () => {
+        expect(parseShortcutInput("Ctrl + ,")).toEqual(["Ctrl +,"]);
+    });
 });

--- a/apps/client/src/widgets/type_widgets/options/shortcuts_model.spec.ts
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts_model.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getShortcutOptionValue, parseShortcutInput } from "./shortcuts_model";
+
+describe("shortcuts options model", () => {
+    it("serializes an empty shortcut input as an empty effective shortcut override", () => {
+        expect(parseShortcutInput("")).toEqual([]);
+        expect(getShortcutOptionValue("")).toBe("[]");
+    });
+
+    it("parses comma-separated shortcuts while preserving comma keys", () => {
+        expect(parseShortcutInput("Ctrl+S, Ctrl+,")).toEqual([
+            "Ctrl+S",
+            "Ctrl+,"
+        ]);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/options/shortcuts_model.ts
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts_model.ts
@@ -1,8 +1,8 @@
 export function parseShortcutInput(shortcutInput: string) {
     return shortcutInput
-        .replaceAll("+,", "+Comma")
+        .replace(/\+\s*,/g, "+Comma")
         .split(",")
-        .map((shortcut) => shortcut.replaceAll("+Comma", "+,").trim())
+        .map((shortcut) => shortcut.replace(/\+Comma/g, "+,").trim())
         .filter((shortcut) => !!shortcut);
 }
 

--- a/apps/client/src/widgets/type_widgets/options/shortcuts_model.ts
+++ b/apps/client/src/widgets/type_widgets/options/shortcuts_model.ts
@@ -1,0 +1,11 @@
+export function parseShortcutInput(shortcutInput: string) {
+    return shortcutInput
+        .replaceAll("+,", "+Comma")
+        .split(",")
+        .map((shortcut) => shortcut.replaceAll("+Comma", "+,").trim())
+        .filter((shortcut) => !!shortcut);
+}
+
+export function getShortcutOptionValue(shortcutInput: string) {
+    return JSON.stringify(parseShortcutInput(shortcutInput));
+}


### PR DESCRIPTION
## Summary
- Allow the Shortcuts option value to be cleared and saved as an empty effective shortcut list.
- Remove the separate “Default shortcuts” column from Options → Shortcuts.
- Add focused shortcut input parsing coverage, including empty input and comma-key cases.
- Keep shortcut table rows keyed by action/separator identity so local editor state is not reused across filtered rows.

## Rationale
Keyboard shortcut configuration is easier to reason about when default and effective shortcuts have separate roles:

- `defaultShortcuts` is the built-in default configuration. It is useful for initialization and for “reset to default”.
- `effectiveShortcuts` is the user-visible, currently active configuration. It should be allowed to differ from defaults, including being an empty list.

Under this model, an empty `effectiveShortcuts` value means the shortcut is intentionally disabled. It should not fall back to `defaultShortcuts`, otherwise users cannot remove a built-in shortcut without assigning a replacement.

This also matches the behavior users are likely to expect from other note/editor tools. VS Code and Obsidian both let users remove or clear a default keybinding; after removal, the command remains available, but the shortcut is no longer active unless the user assigns one again.

Because the default value is already shown in the Shortcuts column before customization, keeping a separate “Default shortcuts” column is redundant and makes the table harder to scan. “Set all shortcuts to the default” remains the explicit way to restore defaults.

## Test Plan
- `npx vitest run apps/client/src/widgets/type_widgets/options/shortcuts_model.spec.ts --config apps/client/vite.config.mts`
- Manually verified the local Options → Shortcuts table now shows only `Action name`, `Shortcuts`, and `Description` columns.