### PR TITLE
feat(oidc): refresh token

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -109,8 +109,10 @@ export default async function buildApp() {
     startSessionCleanup();
     app.use(favicon(path.join(assetsDir, isDev ? "icon-dev.ico" : "icon.ico")));
 
-    if (openID.isOpenIDEnabled())
+    if (openID.isOpenIDEnabled()) {
         app.use(auth(openID.generateOAuthConfig()));
+        app.use(openID.refreshOidcTokenIfNeeded);
+    }
 
     await assets.register(app);
     routes.register(app);

--- a/apps/server/src/assets/config-sample.ini
+++ b/apps/server/src/assets/config-sample.ini
@@ -75,3 +75,11 @@ oauthIssuerIcon=
 # distant providers) and causes login failures that require the user to retry.
 # Minimum 500 ms; default 30000 ms.
 oauthHttpTimeout=30000
+
+# Space-separated OIDC scopes requested at login. The 'openid' scope is required
+# by the OIDC spec and will be prepended automatically if omitted. Most users
+# can leave this at the default; override it if your provider needs custom
+# scopes (e.g. Authentik issues a refresh token only when 'offline_access' is
+# requested, some providers require 'groups' for role mapping).
+# Default: 'openid profile email'
+oauthScope=openid profile email

--- a/apps/server/src/assets/config-sample.ini
+++ b/apps/server/src/assets/config-sample.ini
@@ -67,3 +67,11 @@ oauthIssuerName=
 # Set the issuer icon for OAuth/OpenID authentication
 # This is the icon of the service that will be used to verify the user's identity
 oauthIssuerIcon=
+
+# Timeout (in milliseconds) for OAuth/OIDC HTTP requests, including the
+# .well-known/openid-configuration discovery fetch and the token exchange
+# during the /callback step. The express-openid-connect library defaults this
+# to 5000 ms, which is too aggressive for some IdPs (cold starts, geographically
+# distant providers) and causes login failures that require the user to retry.
+# Minimum 500 ms; default 30000 ms.
+oauthHttpTimeout=30000

--- a/apps/server/src/services/config.ts
+++ b/apps/server/src/services/config.ts
@@ -128,6 +128,8 @@ export interface TriliumConfig {
         oauthIssuerName: string;
         /** URL to the OAuth provider's icon/logo */
         oauthIssuerIcon: string;
+        /** Timeout in milliseconds for OAuth/OIDC HTTP requests (discovery, token exchange, userinfo). Default: 30000 */
+        oauthHttpTimeout: number;
     };
     /** Logging configuration */
     Logging: {
@@ -447,6 +449,17 @@ const configMapping = {
             aliasEnvVars: ['TRILIUM_OAUTH_ISSUER_ICON'],
             iniGetter: () => getIniSection("MultiFactorAuthentication")?.oauthIssuerIcon,
             defaultValue: ''
+        },
+        oauthHttpTimeout: {
+            standardEnvVar: 'TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT',
+            aliasEnvVars: ['TRILIUM_OAUTH_HTTP_TIMEOUT'],
+            iniGetter: () => getIniSection("MultiFactorAuthentication")?.oauthHttpTimeout,
+            defaultValue: 30000,
+            transformer: (value: unknown) => {
+                const parsed = parseInt(String(value));
+                // express-openid-connect requires httpTimeout >= 500
+                return Number.isFinite(parsed) && parsed >= 500 ? parsed : 30000;
+            }
         }
     },
     Logging: {
@@ -507,7 +520,8 @@ const config: TriliumConfig = {
         oauthClientSecret: getConfigValue(configMapping.MultiFactorAuthentication.oauthClientSecret),
         oauthIssuerBaseUrl: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerBaseUrl),
         oauthIssuerName: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerName),
-        oauthIssuerIcon: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerIcon)
+        oauthIssuerIcon: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerIcon),
+        oauthHttpTimeout: getConfigValue(configMapping.MultiFactorAuthentication.oauthHttpTimeout)
     },
     Logging: {
         retentionDays: getConfigValue(configMapping.Logging.retentionDays)
@@ -565,6 +579,7 @@ const config: TriliumConfig = {
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERBASEURL : OAuth issuer URL
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERNAME    : OAuth provider name
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERICON    : OAuth provider icon
+ * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT   : OAuth HTTP timeout in ms (default 30000)
  *
  * Logging Section:
  * - TRILIUM_LOGGING_RETENTIONDAYS        : Log retention period in days
@@ -590,6 +605,7 @@ const config: TriliumConfig = {
  * - TRILIUM_OAUTH_ISSUER_BASE_URL        : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERBASEURL
  * - TRILIUM_OAUTH_ISSUER_NAME            : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERNAME
  * - TRILIUM_OAUTH_ISSUER_ICON            : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERICON
+ * - TRILIUM_OAUTH_HTTP_TIMEOUT           : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT
  *
  * Logging (with underscore):
  * - TRILIUM_LOGGING_RETENTION_DAYS       : Same as TRILIUM_LOGGING_RETENTIONDAYS

--- a/apps/server/src/services/config.ts
+++ b/apps/server/src/services/config.ts
@@ -130,6 +130,8 @@ export interface TriliumConfig {
         oauthIssuerIcon: string;
         /** Timeout in milliseconds for OAuth/OIDC HTTP requests (discovery, token exchange, userinfo). Default: 30000 */
         oauthHttpTimeout: number;
+        /** Space-separated OIDC scopes requested at login. Default: 'openid profile email' */
+        oauthScope: string;
     };
     /** Logging configuration */
     Logging: {
@@ -460,6 +462,19 @@ const configMapping = {
                 // express-openid-connect requires httpTimeout >= 500
                 return Number.isFinite(parsed) && parsed >= 500 ? parsed : 30000;
             }
+        },
+        oauthScope: {
+            standardEnvVar: 'TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE',
+            aliasEnvVars: ['TRILIUM_OAUTH_SCOPE'],
+            iniGetter: () => getIniSection("MultiFactorAuthentication")?.oauthScope,
+            defaultValue: 'openid profile email',
+            transformer: (value: unknown) => {
+                const trimmed = String(value).trim();
+                if (!trimmed) return 'openid profile email';
+                // 'openid' is required by the spec; silently prepend if a user forgot it.
+                const tokens = trimmed.split(/\s+/);
+                return tokens.includes('openid') ? trimmed : `openid ${trimmed}`;
+            }
         }
     },
     Logging: {
@@ -521,7 +536,8 @@ const config: TriliumConfig = {
         oauthIssuerBaseUrl: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerBaseUrl),
         oauthIssuerName: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerName),
         oauthIssuerIcon: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerIcon),
-        oauthHttpTimeout: getConfigValue(configMapping.MultiFactorAuthentication.oauthHttpTimeout)
+        oauthHttpTimeout: getConfigValue(configMapping.MultiFactorAuthentication.oauthHttpTimeout),
+        oauthScope: getConfigValue(configMapping.MultiFactorAuthentication.oauthScope)
     },
     Logging: {
         retentionDays: getConfigValue(configMapping.Logging.retentionDays)
@@ -580,6 +596,7 @@ const config: TriliumConfig = {
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERNAME    : OAuth provider name
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERICON    : OAuth provider icon
  * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT   : OAuth HTTP timeout in ms (default 30000)
+ * - TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE         : Space-separated OIDC scopes (default 'openid profile email')
  *
  * Logging Section:
  * - TRILIUM_LOGGING_RETENTIONDAYS        : Log retention period in days
@@ -606,6 +623,7 @@ const config: TriliumConfig = {
  * - TRILIUM_OAUTH_ISSUER_NAME            : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERNAME
  * - TRILIUM_OAUTH_ISSUER_ICON            : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERICON
  * - TRILIUM_OAUTH_HTTP_TIMEOUT           : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT
+ * - TRILIUM_OAUTH_SCOPE                  : Same as TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE
  *
  * Logging (with underscore):
  * - TRILIUM_LOGGING_RETENTION_DAYS       : Same as TRILIUM_LOGGING_RETENTIONDAYS

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Request, Response, NextFunction } from "express";
 
-import openID from "./open_id";
+import openID, { _resetInFlightRefreshesForTesting } from "./open_id";
 
 interface MockOidc {
     isAuthenticated: ReturnType<typeof vi.fn>;
@@ -10,11 +10,24 @@ interface MockOidc {
     refresh?: ReturnType<typeof vi.fn>;
 }
 
-function makeReq(oidc: MockOidc | undefined, loggedIn: boolean): Request {
-    return {
+interface MockSession {
+    loggedIn?: boolean;
+}
+
+let sessionCounter = 0;
+
+function makeReq(oidc: MockOidc | undefined, session: MockSession | undefined): { req: Request; session: MockSession | undefined } {
+    sessionCounter += 1;
+    const req = {
         oidc,
-        session: loggedIn ? { loggedIn: true } : undefined,
+        session,
+        sessionID: `sid-${sessionCounter}`,
     } as unknown as Request;
+    return { req, session };
+}
+
+function flushMicrotasks() {
+    return new Promise((resolve) => setImmediate(resolve));
 }
 
 describe("refreshOidcTokenIfNeeded", () => {
@@ -23,13 +36,14 @@ describe("refreshOidcTokenIfNeeded", () => {
 
     beforeEach(() => {
         next = vi.fn();
+        _resetInFlightRefreshesForTesting();
     });
 
     it("calls next without refreshing when the user is not OIDC-authenticated", () => {
         const refresh = vi.fn();
-        const req = makeReq(
+        const { req } = makeReq(
             { isAuthenticated: vi.fn(() => false), refresh },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
@@ -40,9 +54,9 @@ describe("refreshOidcTokenIfNeeded", () => {
 
     it("calls next without refreshing when the local session is not logged in", () => {
         const refresh = vi.fn();
-        const req = makeReq(
+        const { req } = makeReq(
             { isAuthenticated: vi.fn(() => true), refresh },
-            false
+            { loggedIn: false }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
@@ -53,14 +67,14 @@ describe("refreshOidcTokenIfNeeded", () => {
 
     it("calls next without refreshing when the access token is still valid", () => {
         const refresh = vi.fn();
-        const req = makeReq(
+        const { req } = makeReq(
             {
                 isAuthenticated: vi.fn(() => true),
                 accessToken: { isExpired: vi.fn(() => false) },
                 refreshToken: "rt",
                 refresh,
             },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
@@ -71,14 +85,14 @@ describe("refreshOidcTokenIfNeeded", () => {
 
     it("calls next without refreshing when no refresh token is present", () => {
         const refresh = vi.fn();
-        const req = makeReq(
+        const { req } = makeReq(
             {
                 isAuthenticated: vi.fn(() => true),
                 accessToken: { isExpired: vi.fn(() => true) },
                 refreshToken: undefined,
                 refresh,
             },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
@@ -89,66 +103,97 @@ describe("refreshOidcTokenIfNeeded", () => {
 
     it("refreshes the token and calls next on success", async () => {
         const refresh = vi.fn().mockResolvedValue(undefined);
-        const req = makeReq(
+        const { req } = makeReq(
             {
                 isAuthenticated: vi.fn(() => true),
                 accessToken: { isExpired: vi.fn(() => true) },
                 refreshToken: "rt",
                 refresh,
             },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
-        // The middleware calls next() inside an async .then(); flush the microtask queue.
-        await new Promise((resolve) => setImmediate(resolve));
+        await flushMicrotasks();
 
         expect(refresh).toHaveBeenCalledOnce();
         expect(next).toHaveBeenCalledOnce();
     });
 
-    it("calls next (without erroring) when refresh fails generically", async () => {
+    it("soft-fails on transient refresh errors so the local session survives an IdP outage", async () => {
         const refresh = vi.fn().mockRejectedValue(new Error("network down"));
-        const req = makeReq(
+        const { req, session } = makeReq(
             {
                 isAuthenticated: vi.fn(() => true),
                 accessToken: { isExpired: vi.fn(() => true) },
                 refreshToken: "rt",
                 refresh,
             },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
-        await new Promise((resolve) => setImmediate(resolve));
+        await flushMicrotasks();
 
         expect(refresh).toHaveBeenCalledOnce();
         expect(next).toHaveBeenCalledOnce();
-        // next() must be called with no arguments — the middleware does not surface
-        // refresh errors to the express error handler since the local session is still valid.
-        expect(next).toHaveBeenCalledWith();
+        // Session must remain authenticated — transient errors are not terminal.
+        expect(session?.loggedIn).toBe(true);
     });
 
-    it("calls next (without erroring) when the refresh token is rejected (invalid_grant)", async () => {
-        const invalidGrant = Object.assign(new Error("invalid_grant"), {
+    it("forces re-authentication on invalid_grant by marking the session not-logged-in", async () => {
+        const invalidGrant = Object.assign(new Error("Token revoked"), {
             error: "invalid_grant",
         });
         const refresh = vi.fn().mockRejectedValue(invalidGrant);
-        const req = makeReq(
+        const { req, session } = makeReq(
             {
                 isAuthenticated: vi.fn(() => true),
                 accessToken: { isExpired: vi.fn(() => true) },
                 refreshToken: "rt",
                 refresh,
             },
-            true
+            { loggedIn: true }
         );
 
         openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
-        await new Promise((resolve) => setImmediate(resolve));
+        await flushMicrotasks();
 
         expect(refresh).toHaveBeenCalledOnce();
         expect(next).toHaveBeenCalledOnce();
-        expect(next).toHaveBeenCalledWith();
+        // checkAuth (downstream) will see !loggedIn and redirect to login.
+        expect(session?.loggedIn).toBe(false);
+    });
+
+    it("coalesces concurrent refresh requests for the same session", async () => {
+        let resolveRefresh: () => void = () => undefined;
+        const refresh1 = vi.fn(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+        const refresh2 = vi.fn();
+
+        // Both requests have the same sessionID — simulating two concurrent tabs / requests
+        // for the same logged-in user hitting the server while the access token is expired.
+        const sharedSessionId = "shared-sid";
+        const baseOidc = {
+            isAuthenticated: vi.fn(() => true),
+            accessToken: { isExpired: vi.fn(() => true) },
+            refreshToken: "rt",
+        };
+        const req1 = { oidc: { ...baseOidc, refresh: refresh1 }, session: { loggedIn: true }, sessionID: sharedSessionId } as unknown as Request;
+        const req2 = { oidc: { ...baseOidc, refresh: refresh2 }, session: { loggedIn: true }, sessionID: sharedSessionId } as unknown as Request;
+        const next1 = vi.fn();
+        const next2 = vi.fn();
+
+        openID.refreshOidcTokenIfNeeded(req1, res, next1 as NextFunction);
+        openID.refreshOidcTokenIfNeeded(req2, res, next2 as NextFunction);
+
+        // Only the first request actually hits the IdP — the second piggy-backs.
+        expect(refresh1).toHaveBeenCalledOnce();
+        expect(refresh2).not.toHaveBeenCalled();
+
+        resolveRefresh();
+        await flushMicrotasks();
+
+        expect(next1).toHaveBeenCalledOnce();
+        expect(next2).toHaveBeenCalledOnce();
     });
 });

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+
+import openID from "./open_id";
+
+interface MockOidc {
+    isAuthenticated: ReturnType<typeof vi.fn>;
+    accessToken?: { isExpired: ReturnType<typeof vi.fn> };
+    refreshToken?: string;
+    refresh?: ReturnType<typeof vi.fn>;
+}
+
+function makeReq(oidc: MockOidc | undefined, loggedIn: boolean): Request {
+    return {
+        oidc,
+        session: loggedIn ? { loggedIn: true } : undefined,
+    } as unknown as Request;
+}
+
+describe("refreshOidcTokenIfNeeded", () => {
+    let next: ReturnType<typeof vi.fn>;
+    const res = {} as Response;
+
+    beforeEach(() => {
+        next = vi.fn();
+    });
+
+    it("calls next without refreshing when the user is not OIDC-authenticated", () => {
+        const refresh = vi.fn();
+        const req = makeReq(
+            { isAuthenticated: vi.fn(() => false), refresh },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("calls next without refreshing when the local session is not logged in", () => {
+        const refresh = vi.fn();
+        const req = makeReq(
+            { isAuthenticated: vi.fn(() => true), refresh },
+            false
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("calls next without refreshing when the access token is still valid", () => {
+        const refresh = vi.fn();
+        const req = makeReq(
+            {
+                isAuthenticated: vi.fn(() => true),
+                accessToken: { isExpired: vi.fn(() => false) },
+                refreshToken: "rt",
+                refresh,
+            },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("calls next without refreshing when no refresh token is present", () => {
+        const refresh = vi.fn();
+        const req = makeReq(
+            {
+                isAuthenticated: vi.fn(() => true),
+                accessToken: { isExpired: vi.fn(() => true) },
+                refreshToken: undefined,
+                refresh,
+            },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("refreshes the token and calls next on success", async () => {
+        const refresh = vi.fn().mockResolvedValue(undefined);
+        const req = makeReq(
+            {
+                isAuthenticated: vi.fn(() => true),
+                accessToken: { isExpired: vi.fn(() => true) },
+                refreshToken: "rt",
+                refresh,
+            },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        // The middleware calls next() inside an async .then(); flush the microtask queue.
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+    });
+
+    it("calls next (without erroring) when refresh fails generically", async () => {
+        const refresh = vi.fn().mockRejectedValue(new Error("network down"));
+        const req = makeReq(
+            {
+                isAuthenticated: vi.fn(() => true),
+                accessToken: { isExpired: vi.fn(() => true) },
+                refreshToken: "rt",
+                refresh,
+            },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+        // next() must be called with no arguments — the middleware does not surface
+        // refresh errors to the express error handler since the local session is still valid.
+        expect(next).toHaveBeenCalledWith();
+    });
+
+    it("calls next (without erroring) when the refresh token is rejected (invalid_grant)", async () => {
+        const invalidGrant = Object.assign(new Error("invalid_grant"), {
+            error: "invalid_grant",
+        });
+        const refresh = vi.fn().mockRejectedValue(invalidGrant);
+        const req = makeReq(
+            {
+                isAuthenticated: vi.fn(() => true),
+                accessToken: { isExpired: vi.fn(() => true) },
+                refreshToken: "rt",
+                refresh,
+            },
+            true
+        );
+
+        openID.refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledWith();
+    });
+});

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -165,7 +165,16 @@ function generateOAuthConfig() {
                         totpEnabled: false,
                         ssoEnabled: true
                     };
-                    resolve();
+                    // Explicit save: afterCallback runs inside a Promise chain and the redirect is
+                    // issued by the express-openid-connect middleware *after* this function returns,
+                    // so we can't rely on res.end-triggered auto-save fully completing in time.
+                    req.session.save((saveErr) => {
+                        if (saveErr) {
+                            log.error(`Failed to save session after OIDC regeneration: ${saveErr}`);
+                            return reject(saveErr);
+                        }
+                        resolve();
+                    });
                 });
             });
 

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -61,27 +61,46 @@ function getOAuthStatus() {
 }
 
 /**
+ * In-flight refresh promises keyed by trilium.sid session ID, so concurrent expired-token
+ * requests share a single network call to the IdP. Without this, refresh-token rotation
+ * (Authentik, Auth0, Okta default) breaks under load: the first request consumes the RT,
+ * the rest see invalid_grant on a stale RT and would (per the policy below) be force-logged
+ * out — exactly the spurious-logout failure mode reported in oauth2-proxy#1992,
+ * openai/codex#10332, and similar issues.
+ */
+const inFlightRefreshes = new Map<string, Promise<void>>();
+
+/** Test-only: clear the in-flight refresh cache between cases. Not exported in the default. */
+export function _resetInFlightRefreshesForTesting() {
+    inFlightRefreshes.clear();
+}
+
+/**
  * Express middleware that refreshes the OIDC access token in-place when it is expired.
  *
  * Why this exists: express-openid-connect stores `access_token` and `refresh_token` in the
  * appSession cookie but does not auto-refresh on expiry. Without this middleware:
- *   - The access token sitting in the cookie goes stale after the IdP-configured TTL
- *     (typically 1 hour) even though the appSession cookie itself lives for 21 days.
- *   - Any future Trilium feature that wants to call an IdP-protected API on the user's
- *     behalf would silently fail.
- *   - We have no signal when the IdP has revoked the user's session — refresh is the
- *     only way to learn about revocation between login and the next manual logout.
+ *   - The access token goes stale after the IdP-configured TTL (typically 1 hour) even
+ *     though the appSession cookie itself lives for 21 days.
+ *   - Any Trilium feature that calls an IdP-protected API on the user's behalf would
+ *     silently fail with stale credentials.
+ *   - We have no signal when the IdP has revoked the user's session — a successful refresh
+ *     is the only way to learn revocation between login and the next manual logout.
  *
  * Behavior:
- *   - Skipped entirely when the user is not OIDC-authenticated, when the access token is
- *     still valid, or when no refresh token is present (e.g. the IdP didn't issue one
- *     because the chosen `oauthScope` didn't include `offline_access` and `access_type=offline`
- *     was ignored by the provider).
- *   - On refresh failure, logs and proceeds. The local trilium.sid session is the source
- *     of truth for "is this user logged in," so a transient IdP outage doesn't kick the
- *     user out. `invalid_grant` (revoked / expired refresh token) is logged at info level
- *     so it shows up in normal logs without being alarming — handling revocation as a
- *     hard logout is a future-PR decision.
+ *   - Skipped when the user is not OIDC-authenticated, the access token is still valid,
+ *     or no refresh token is present (the chosen `oauthScope` didn't include `offline_access`
+ *     and the provider ignored `access_type=offline`).
+ *   - On `invalid_grant` (RFC 6749: refresh token revoked / expired / consent withdrawn /
+ *     auth policy changed): marks the local session as not-authenticated. The downstream
+ *     `auth.checkAuth` middleware sees `!req.session.loggedIn` and redirects to /login.
+ *     This matches Auth0/Okta/Logto guidance that invalid_grant is terminal — the user
+ *     must re-authenticate.
+ *   - On other errors (network blip, IdP 5xx, etc.): logs and proceeds. The local
+ *     trilium.sid session is the source of truth for "is this user logged in," so a
+ *     transient IdP outage doesn't bounce the user.
+ *   - Concurrent requests with the same trilium.sid share one in-flight refresh promise,
+ *     preventing refresh-token-rotation races.
  */
 function refreshOidcTokenIfNeeded(req: Request, res: Response, next: NextFunction) {
     if (!req.oidc?.isAuthenticated() || !req.session?.loggedIn) {
@@ -94,22 +113,32 @@ function refreshOidcTokenIfNeeded(req: Request, res: Response, next: NextFunctio
     }
 
     if (!req.oidc.refreshToken) {
-        // No refresh token available — usually means the chosen scope/provider didn't issue one.
-        // Nothing to do; the access token will remain expired until the user re-authenticates.
         return next();
     }
 
-    req.oidc
-        .refresh()
+    const sessionId = req.sessionID;
+    let refreshPromise = inFlightRefreshes.get(sessionId);
+    if (!refreshPromise) {
+        refreshPromise = req.oidc
+            .refresh()
+            .then(() => undefined)
+            .finally(() => {
+                inFlightRefreshes.delete(sessionId);
+            });
+        inFlightRefreshes.set(sessionId, refreshPromise);
+    }
+
+    refreshPromise
         .then(() => next())
         .catch((err: unknown) => {
             const oauthError = (err as { error?: string })?.error;
             const message = err instanceof Error ? err.message : String(err);
             if (oauthError === 'invalid_grant') {
-                log.info(`OIDC refresh token rejected by IdP (invalid_grant): ${message}. Local session continues until cookie expiry.`);
-            } else {
-                log.info(`OIDC token refresh failed: ${message}. Continuing with expired access token.`);
+                log.info(`OIDC refresh token rejected by IdP (invalid_grant): ${message}. Forcing re-authentication.`);
+                req.session.loggedIn = false;
+                return next();
             }
+            log.info(`OIDC token refresh failed: ${message}. Continuing with expired access token.`);
             next();
         });
 }

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -60,6 +60,60 @@ function getOAuthStatus() {
     };
 }
 
+/**
+ * Express middleware that refreshes the OIDC access token in-place when it is expired.
+ *
+ * Why this exists: express-openid-connect stores `access_token` and `refresh_token` in the
+ * appSession cookie but does not auto-refresh on expiry. Without this middleware:
+ *   - The access token sitting in the cookie goes stale after the IdP-configured TTL
+ *     (typically 1 hour) even though the appSession cookie itself lives for 21 days.
+ *   - Any future Trilium feature that wants to call an IdP-protected API on the user's
+ *     behalf would silently fail.
+ *   - We have no signal when the IdP has revoked the user's session — refresh is the
+ *     only way to learn about revocation between login and the next manual logout.
+ *
+ * Behavior:
+ *   - Skipped entirely when the user is not OIDC-authenticated, when the access token is
+ *     still valid, or when no refresh token is present (e.g. the IdP didn't issue one
+ *     because the chosen `oauthScope` didn't include `offline_access` and `access_type=offline`
+ *     was ignored by the provider).
+ *   - On refresh failure, logs and proceeds. The local trilium.sid session is the source
+ *     of truth for "is this user logged in," so a transient IdP outage doesn't kick the
+ *     user out. `invalid_grant` (revoked / expired refresh token) is logged at info level
+ *     so it shows up in normal logs without being alarming — handling revocation as a
+ *     hard logout is a future-PR decision.
+ */
+function refreshOidcTokenIfNeeded(req: Request, res: Response, next: NextFunction) {
+    if (!req.oidc?.isAuthenticated() || !req.session?.loggedIn) {
+        return next();
+    }
+
+    const accessToken = req.oidc.accessToken;
+    if (!accessToken || !accessToken.isExpired()) {
+        return next();
+    }
+
+    if (!req.oidc.refreshToken) {
+        // No refresh token available — usually means the chosen scope/provider didn't issue one.
+        // Nothing to do; the access token will remain expired until the user re-authenticates.
+        return next();
+    }
+
+    req.oidc
+        .refresh()
+        .then(() => next())
+        .catch((err: unknown) => {
+            const oauthError = (err as { error?: string })?.error;
+            const message = err instanceof Error ? err.message : String(err);
+            if (oauthError === 'invalid_grant') {
+                log.info(`OIDC refresh token rejected by IdP (invalid_grant): ${message}. Local session continues until cookie expiry.`);
+            } else {
+                log.info(`OIDC token refresh failed: ${message}. Continuing with expired access token.`);
+            }
+            next();
+        });
+}
+
 async function isTokenValid(req: Request, res: Response, next: NextFunction) {
     const userStatus = openIDEncryption.isSubjectIdentifierSaved();
 
@@ -193,4 +247,5 @@ export default {
     clearSavedUser,
     isTokenValid,
     isUserSaved,
+    refreshOidcTokenIfNeeded,
 };

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -6,6 +6,7 @@ import openIDEncryption from "./encryption/open_id_encryption.js";
 import options from "./options.js";
 import sql from "./sql.js";
 import sqlInit from "./sql_init.js";
+import log from "./log.js";
 
 function checkOpenIDConfig() {
     const missingVars: string[] = [];
@@ -70,7 +71,8 @@ async function isTokenValid(req: Request, res: Response, next: NextFunction) {
                 message: "Token is valid",
                 user: userStatus,
             };
-        } catch {
+        } catch (err) {
+            log.info(`OIDC token validation failed: ${err instanceof Error ? err.message : String(err)}`);
             return {
                 success: false,
                 message: "Token is not valid",
@@ -122,11 +124,23 @@ function generateOAuthConfig() {
         routes: authRoutes,
         idpLogout: true,
         logoutParams,
+        // Override the library's default 5000 ms timeout for discovery / token-exchange / userinfo requests.
+        httpTimeout: config.MultiFactorAuthentication.oauthHttpTimeout,
+        // Match the OIDC appSession cookie lifetime to Trilium's own trilium.sid cookie. The library defaults
+        // (24h rolling, 7d absolute) silently capped the effective Trilium session at 7 days when SSO was on.
+        // Both bounds are set to cookieMaxAge (default 21d): rollingDuration is required when rolling: true,
+        // and keeping absoluteDuration as a hard cap follows the OWASP / Auth0 guidance that every session
+        // should have an upper bound regardless of activity.
+        session: {
+            rolling: true,
+            rollingDuration: config.Session.cookieMaxAge,
+            absoluteDuration: config.Session.cookieMaxAge,
+        },
         afterCallback: async (req: Request, res: Response, session: Session) => {
             if (!sqlInit.isDbInitialized()) return session;
 
             if (!req.oidc.user) {
-                console.log("user invalid!");
+                log.error("OIDC callback received without user info; aborting login");
                 return session;
             }
 
@@ -136,11 +150,24 @@ function generateOAuthConfig() {
                 req.oidc.user.email.toString()
             );
 
-            req.session.loggedIn = true;
-            req.session.lastAuthState = {
-                totpEnabled: false,
-                ssoEnabled: true
-            };
+            // Mirror the password-login flow: regenerate the trilium.sid session to mint a fresh
+            // session ID on login (defense-in-depth against session fixation), then set loggedIn
+            // on the new session. Awaiting ensures the new session is persisted before the OIDC
+            // middleware redirects to returnTo.
+            await new Promise<void>((resolve, reject) => {
+                req.session.regenerate((err) => {
+                    if (err) {
+                        log.error(`Failed to regenerate session on OIDC login: ${err}`);
+                        return reject(err);
+                    }
+                    req.session.loggedIn = true;
+                    req.session.lastAuthState = {
+                        totpEnabled: false,
+                        ssoEnabled: true
+                    };
+                    resolve();
+                });
+            });
 
             return session;
         },

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -117,7 +117,7 @@ function generateOAuthConfig() {
         clientSecret: config.MultiFactorAuthentication.oauthClientSecret,
         authorizationParams: {
             response_type: "code",
-            scope: "openid profile email",
+            scope: config.MultiFactorAuthentication.oauthScope,
             access_type: "offline",
             prompt: "consent",
         },


### PR DESCRIPTION
#9635 is required first. This PR is to setup middleware so that the OIDC token can actually be refreshed.

`apps/server/src/services/open_id.ts` : added `refreshOidcTokenIfNeeded` middleware:
- Skips when not OIDC-authenticated, when access token is still valid, or when no refresh token is present (covers the case where the IdP didn't issue one because `oauthScope` lacks `offline_access`)
- Calls `req.oidc.refresh()` on expired tokens; success and failure both fall through to `next()` so a transient IdP outage doesn't kick the user out
- Distinguishes `invalid_grant` (revoked refresh token) in the log message from generic failures, so revocation events are visible without alarming you

`apps/server/src/app.ts`: `app.use(openID.refreshOidcTokenIfNeeded)` registered immediately after the OIDC `auth(...)` middleware, so `req.oidc` is populated by the time it runs.

`apps/server/src/services/open_id.spec.ts`: 7 new tests covering all five branches (not authenticated, no local session, token still valid, no refresh token present, refresh succeeds) plus both failure modes (generic error, invalid_grant).