### PR TITLE
Add desktop app links for notes

### DIFF
--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -4,6 +4,7 @@ import type FAttachment from "../entities/fattachment.js";
 import attributes from "../services/attributes.js";
 import { executeBulkActions } from "../services/bulk_action.js";
 import clipboard from "../services/clipboard.js";
+import { copyTextWithToast } from "../services/clipboard_ext.js";
 import dialogService from "../services/dialog.js";
 import froca from "../services/froca.js";
 import { t } from "../services/i18n.js";
@@ -26,7 +27,7 @@ let lastTargetNode: HTMLElement | null = null;
 
 // This will include all commands that implement ContextMenuCommandData, but it will not work if it additional options are added via the `|` operator,
 // so they need to be added manually.
-export type TreeCommandNames = FilteredCommandNames<ContextMenuCommandData> | "openBulkActionsDialog" | "searchInSubtree";
+export type TreeCommandNames = FilteredCommandNames<ContextMenuCommandData> | "openBulkActionsDialog" | "searchInSubtree" | "copyAppLinkToClipboard";
 
 export default class TreeContextMenu implements SelectMenuItemEventListener<TreeCommandNames> {
     private treeWidget: NoteTreeWidget;
@@ -176,6 +177,7 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     { kind: "separator" },
 
                     { title: t("tree-context-menu.copy-note-path-to-clipboard"), command: "copyNotePathToClipboard", uiIcon: "bx bx-directions", enabled: true },
+                    { title: t("tree-context-menu.copy-app-link-to-clipboard"), command: "copyAppLinkToClipboard", uiIcon: "bx bx-link", enabled: isNotRoot },
                     { title: t("tree-context-menu.recent-changes-in-subtree"), command: "recentChangesInSubtree", uiIcon: "bx bx-history", enabled: noSelectedNotes && notOptionsOrHelp }
                 ].filter(Boolean) as MenuItem<TreeCommandNames>[]
             },
@@ -353,6 +355,8 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
             toastService.showMessage(t("tree-context-menu.converted-to-attachments", { count: converted }));
         } else if (command === "copyNotePathToClipboard") {
             navigator.clipboard.writeText(`#${  notePath}`);
+        } else if (command === "copyAppLinkToClipboard") {
+            copyTextWithToast(`trilium://note/${encodeURIComponent(this.node.data.noteId)}`);
         } else if (command) {
             this.treeWidget.triggerCommand<TreeCommandNames>(command, {
                 node: this.node,

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1689,6 +1689,7 @@
     "recent-changes-in-subtree": "Recent changes in subtree",
     "convert-to-attachment": "Convert to attachment",
     "copy-note-path-to-clipboard": "Copy note path to clipboard",
+    "copy-app-link-to-clipboard": "Copy app link to clipboard",
     "protect-subtree": "Protect subtree",
     "unprotect-subtree": "Unprotect subtree",
     "copy-clone": "Copy / clone",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,6 +13,9 @@ import port from "@triliumnext/server/src/services/port.js";
 import { join, resolve } from "path";
 import { deferred, LOCALES } from "../../../packages/commons/src";
 
+const APP_PROTOCOL = "trilium";
+let pendingAppLinkNoteId: string | null = null;
+
 async function main() {
     const userDataPath = getUserData();
     app.setPath("userData", userDataPath);
@@ -27,6 +30,9 @@ async function main() {
     // Adds debug features like hotkeys for triggering dev tools and reload
     electronDebug();
     electronDl({ saveAs: true });
+
+    registerAppProtocol();
+    pendingAppLinkNoteId = getNoteIdFromAppLinkArgs(process.argv);
 
     // needed for excalidraw export https://github.com/zadam/trilium/issues/4271
     app.commandLine.appendSwitch("enable-experimental-web-platform-features");
@@ -69,7 +75,18 @@ async function main() {
         globalShortcut.unregisterAll();
     });
 
+    app.on("open-url", (event, appLink) => {
+        event.preventDefault();
+        openAppLink(appLink);
+    });
+
     app.on("second-instance", (event, commandLine) => {
+        const noteId = getNoteIdFromAppLinkArgs(commandLine);
+        if (noteId) {
+            openNoteById(noteId);
+            return;
+        }
+
         const lastFocusedWindow = windowService.getLastFocusedWindow();
         if (commandLine.includes("--new-window")) {
             windowService.createExtraWindow("");
@@ -99,6 +116,64 @@ async function main() {
     serverInitializedPromise.resolve();
 }
 
+function registerAppProtocol() {
+    if (process.defaultApp && process.argv.length >= 2) {
+        app.setAsDefaultProtocolClient(APP_PROTOCOL, process.execPath, [resolve(process.argv[1])]);
+        return;
+    }
+
+    app.setAsDefaultProtocolClient(APP_PROTOCOL);
+}
+
+function getNoteIdFromAppLinkArgs(commandLine: string[]) {
+    return commandLine.map(getNoteIdFromAppLink).find(Boolean) ?? null;
+}
+
+function getNoteIdFromAppLink(appLink: string) {
+    try {
+        const parsedUrl = new URL(appLink);
+        if (parsedUrl.protocol !== `${APP_PROTOCOL}:`) {
+            return null;
+        }
+
+        if (parsedUrl.hostname === "note") {
+            return decodeURIComponent(parsedUrl.pathname.replace(/^\/+/, ""));
+        }
+
+        const notePath = parsedUrl.pathname.replace(/^\/+/, "");
+        if (notePath.startsWith("note/")) {
+            return decodeURIComponent(notePath.slice("note/".length));
+        }
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+function openAppLink(appLink: string) {
+    const noteId = getNoteIdFromAppLink(appLink);
+    if (noteId) {
+        openNoteById(noteId);
+    }
+}
+
+function openNoteById(noteId: string) {
+    const targetWindow = windowService.getLastFocusedWindow() ?? windowService.getMainWindow();
+    if (!targetWindow || targetWindow.isDestroyed()) {
+        pendingAppLinkNoteId = noteId;
+        return;
+    }
+
+    if (targetWindow.isMinimized()) {
+        targetWindow.restore();
+    }
+
+    targetWindow.show();
+    targetWindow.focus();
+    targetWindow.loadURL(`http://127.0.0.1:${port}/#root/${encodeURIComponent(noteId)}`);
+}
+
 /**
  * Returns a unique user data directory for Electron so that single instance locks between legitimately different instances such as different port or data directory can still act independently, but we are focusing the main window otherwise.
  *
@@ -122,6 +197,11 @@ async function onReady() {
         await sqlInit.dbReady;
 
         await windowService.createMainWindow(app);
+
+        if (pendingAppLinkNoteId) {
+            openNoteById(pendingAppLinkNoteId);
+            pendingAppLinkNoteId = null;
+        }
 
         if (process.platform === "darwin") {
             app.on("activate", async () => {


### PR DESCRIPTION
## Summary
- register the desktop app as the `trilium://` protocol handler
- handle `trilium://note/<noteId>` links on cold start, macOS `open-url`, and Electron `second-instance` flows
- focus the existing window and navigate to the target note when an app link is opened
- add a note tree context menu item to copy `trilium://note/<noteId>` links

IssueHunt bounty: #649

## Verification
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('apps/client/src/translations/en/translation.json','utf8')); console.log('translation json ok')"`
- `npx --yes esbuild@0.24.2 apps/desktop/src/main.ts --bundle --platform=node --packages=external --format=esm --outfile=/tmp/trilium-main-check.js`
- `npx --yes esbuild@0.24.2 apps/client/src/menus/tree_context_menu.ts --bundle --platform=browser --packages=external --format=esm --loader:.png=dataurl --loader:.ttf=file --outfile=/tmp/trilium-tree-menu-check.js`

Note: I could not run the full pnpm workspace test/build in this checkout because dependencies were not installed and the local machine is low on disk. The esbuild checks above parse and bundle the touched TypeScript entry points with external packages left external.