### PR TITLE
feat(desktop): support trilium note URLs

### DIFF
--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -176,6 +176,17 @@ export default class TreeContextMenu implements SelectMenuItemEventListener<Tree
                     { kind: "separator" },
 
                     { title: t("tree-context-menu.copy-note-path-to-clipboard"), command: "copyNotePathToClipboard", uiIcon: "bx bx-directions", enabled: true },
+                    {
+                        title: t("tree-context-menu.copy-desktop-note-url-to-clipboard"),
+                        uiIcon: "bx bx-link-external",
+                        enabled: true,
+                        handler: () => {
+                            const currentNotePath = treeService.getNotePath(this.node);
+                            const encodedNotePath = currentNotePath.split("/").map(segment => encodeURIComponent(segment)).join("/");
+                            navigator.clipboard.writeText(`trilium://${encodedNotePath}`);
+                            toastService.showMessage(t("clipboard.copied"));
+                        }
+                    },
                     { title: t("tree-context-menu.recent-changes-in-subtree"), command: "recentChangesInSubtree", uiIcon: "bx bx-history", enabled: noSelectedNotes && notOptionsOrHelp }
                 ].filter(Boolean) as MenuItem<TreeCommandNames>[]
             },

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1689,6 +1689,7 @@
     "recent-changes-in-subtree": "Recent changes in subtree",
     "convert-to-attachment": "Convert to attachment",
     "copy-note-path-to-clipboard": "Copy note path to clipboard",
+    "copy-desktop-note-url-to-clipboard": "Copy desktop note URL",
     "protect-subtree": "Protect subtree",
     "unprotect-subtree": "Unprotect subtree",
     "copy-clone": "Copy / clone",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,6 +13,9 @@ import port from "@triliumnext/server/src/services/port.js";
 import { join, resolve } from "path";
 import { deferred, LOCALES } from "../../../packages/commons/src";
 
+const TRILIUM_PROTOCOL = "trilium";
+let pendingProtocolNotePath = getProtocolNotePath(process.argv);
+
 async function main() {
     const userDataPath = getUserData();
     app.setPath("userData", userDataPath);
@@ -71,7 +74,16 @@ async function main() {
 
     app.on("second-instance", (event, commandLine) => {
         const lastFocusedWindow = windowService.getLastFocusedWindow();
-        if (commandLine.includes("--new-window")) {
+        const protocolNotePath = getProtocolNotePath(commandLine);
+
+        if (protocolNotePath) {
+            const targetWindow = lastFocusedWindow ?? BrowserWindow.getAllWindows().find(win => !win.isDestroyed());
+            if (targetWindow) {
+                openProtocolNoteInWindow(targetWindow, protocolNotePath);
+            } else {
+                pendingProtocolNotePath = protocolNotePath;
+            }
+        } else if (commandLine.includes("--new-window")) {
             windowService.createExtraWindow("");
         } else if (lastFocusedWindow) {
             if (lastFocusedWindow.isMinimized()) {
@@ -115,13 +127,18 @@ function getUserData() {
 
 async function onReady() {
     //    app.setAppUserModelId('com.github.zadam.trilium');
+    registerProtocolClient();
 
     // if db is not initialized -> setup process
     // if db is initialized, then we need to wait until the migration process is finished
     if (sqlInit.isDbInitialized()) {
         await sqlInit.dbReady;
 
-        await windowService.createMainWindow(app);
+        const mainWindow = await windowService.createMainWindow(app);
+        if (pendingProtocolNotePath) {
+            openProtocolNoteInWindow(mainWindow, pendingProtocolNotePath);
+            pendingProtocolNotePath = null;
+        }
 
         if (process.platform === "darwin") {
             app.on("activate", async () => {
@@ -137,6 +154,61 @@ async function onReady() {
     }
 
     await windowService.registerGlobalShortcuts();
+}
+
+function registerProtocolClient() {
+    if (process.defaultApp && process.argv.length >= 2) {
+        app.setAsDefaultProtocolClient(TRILIUM_PROTOCOL, process.execPath, [resolve(process.argv[1])]);
+        return;
+    }
+
+    app.setAsDefaultProtocolClient(TRILIUM_PROTOCOL);
+}
+
+function getProtocolNotePath(args: string[]) {
+    const protocolArg = args.find(arg => /^trilium:/i.test(arg.trim()));
+    if (!protocolArg) {
+        return null;
+    }
+
+    return parseProtocolNotePath(protocolArg);
+}
+
+function parseProtocolNotePath(protocolUrl: string) {
+    const withoutProtocol = protocolUrl.trim().replace(/^trilium:\/*/i, "");
+    const [rawNotePath] = withoutProtocol.split(/[?#]/);
+    let notePath = rawNotePath || "";
+
+    try {
+        notePath = decodeURIComponent(notePath);
+    } catch {
+        return null;
+    }
+
+    notePath = notePath.replace(/^\/+/, "");
+
+    return notePath || null;
+}
+
+function openProtocolNoteInWindow(targetWindow: BrowserWindow, notePath: string) {
+    if (targetWindow.isDestroyed()) {
+        return;
+    }
+
+    if (targetWindow.isMinimized()) {
+        targetWindow.restore();
+    }
+
+    targetWindow.show();
+    targetWindow.focus();
+
+    const openNote = () => targetWindow.webContents.send("openInSameTab", notePath);
+
+    if (targetWindow.webContents.isLoading()) {
+        targetWindow.webContents.once("did-finish-load", openNote);
+    } else {
+        openNote();
+    }
 }
 
 function getElectronLocale() {

--- a/apps/server/src/services/window.ts
+++ b/apps/server/src/services/window.ts
@@ -136,6 +136,8 @@ async function createMainWindow(app: App) {
 
     configureWebContents(mainWindow.webContents, spellcheckEnabled);
     trackWindowFocus(mainWindow);
+
+    return mainWindow;
 }
 
 function getWindowExtraOpts() {


### PR DESCRIPTION
## Summary
- register the `trilium://` desktop protocol
- open protocol URLs in the active Trilium window on first launch or second-instance activation
- add a tree context menu action to copy `trilium://root/...` URLs for the selected note

Closes #649
IssueHunt: https://oss.issuehunt.io/r/TriliumNext/Trilium/issues/649

## Test
- `corepack pnpm typecheck`