### PR TITLE
feat: Open specific note via command line argument

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -116,17 +116,20 @@ function getUserData() {
 async function onReady() {
     //    app.setAppUserModelId('com.github.zadam.trilium');
 
+    const noteIdArg = process.argv.find(arg => arg.startsWith("--open-note="));
+    const noteId = noteIdArg ? noteIdArg.split("=")[1] : undefined;
+
     // if db is not initialized -> setup process
     // if db is initialized, then we need to wait until the migration process is finished
     if (sqlInit.isDbInitialized()) {
         await sqlInit.dbReady;
 
-        await windowService.createMainWindow(app);
+        await windowService.createMainWindow(app, noteId);
 
         if (process.platform === "darwin") {
             app.on("activate", async () => {
                 if (BrowserWindow.getAllWindows().length === 0) {
-                    await windowService.createMainWindow(app);
+                    await windowService.createMainWindow(app, noteId);
                 }
             });
         }
@@ -138,6 +141,7 @@ async function onReady() {
 
     await windowService.registerGlobalShortcuts();
 }
+
 
 function getElectronLocale() {
     const uiLocale = options.getOptionOrNull("locale");

--- a/apps/server/src/services/window.ts
+++ b/apps/server/src/services/window.ts
@@ -84,7 +84,7 @@ electron.ipcMain.on("add-word-to-dictionary", (event, word: string) => {
 
 initPrintingHandlers();
 
-async function createMainWindow(app: App) {
+async function createMainWindow(app: App, noteId?: string) {
     if ("setUserTasks" in app) {
         app.setUserTasks([
             {
@@ -131,12 +131,19 @@ async function createMainWindow(app: App) {
     mainWindowState.manage(mainWindow);
 
     mainWindow.setMenuBarVisibility(false);
-    mainWindow.loadURL(`http://127.0.0.1:${port}`);
+    
+    let url = `http://127.0.0.1:${port}`;
+    if (noteId) {
+        url += `#${noteId}`;
+    }
+    
+    mainWindow.loadURL(url);
     mainWindow.on("closed", () => (mainWindow = null));
 
     configureWebContents(mainWindow.webContents, spellcheckEnabled);
     trackWindowFocus(mainWindow);
 }
+
 
 function getWindowExtraOpts() {
     const extraOpts: Partial<BrowserWindowConstructorOptions> = {};


### PR DESCRIPTION
Adds support for --open-note=ID flag to open specific notes on startup. Solves Issue #649. Implemented in apps/desktop/src/main.ts and apps/server/src/services/window.ts.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#649: Open/focus a note from command line / desktop URL handler (Trilium URL protocol)](https://oss.issuehunt.io/repos/92111509/issues/649)
---
</details>
<!-- /Issuehunt content-->