### PR TITLE
docs(readme): fix broken Repology badge for Linux distributions (#9608)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Download the binary release for your platform from the [latest release page](htt
 
 If your distribution is listed in the table below, use your distribution's package.
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/triliumnext.svg)](https://repology.org/project/triliumnext/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/trilium.svg)](https://repology.org/project/trilium/versions)
 
 You may also download the binary release for your platform from the [latest release page](https://github.com/TriliumNext/Trilium/releases/latest), unzip the package and run the `trilium` executable.
 


### PR DESCRIPTION
Closes #9608.

## What

The Linux-distribution badge in the README currently renders as **"No known packages"** because it points to a non-existent Repology project (`triliumnext`):

```
https://repology.org/badge/vertical-allrepos/triliumnext.svg
```

Repology tracks this project under the unified `trilium` identifier, which already includes the `trilium-next` package entries across AUR, Chocolatey, Homebrew, NixOS, and the other distros. There is no separate `triliumnext` project.

## Fix

Single character swap in `README.md`:

- `https://repology.org/badge/vertical-allrepos/triliumnext.svg` → `…/trilium.svg`
- `https://repology.org/project/triliumnext/versions` → `…/trilium/versions`

## Verification

- `https://repology.org/badge/vertical-allrepos/trilium.svg` returns a populated SVG listing AUR / Chocolatey / Homebrew / NixOS / nixpkgs / pkgsrc / etc. with the current TriliumNext versions.
- `https://repology.org/project/trilium/versions` resolves to the project page with the full per-repo version matrix.