### PR TITLE
docs(search): fix relation shortcut to use `~` instead of `#` (#9434)

### DIFF
--- a/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.md
@@ -177,8 +177,10 @@ However, common label and relation searches have shortcut syntax:
 
 ```
 #publicationYear = 1954
-#author.title *=* Tolkien
+~author.title *=* Tolkien
 ```
+
+(Labels use the `#` prefix, relations use `~`. See the examples earlier in this page where `~author.title *=* Tolkien` is used consistently.)
 
 ### Separating Full-Text and Attribute Parts
 


### PR DESCRIPTION
Closes #9434.

## Bug

In the **Label and Relation Shortcuts** section of \`docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.md\`, the relation example mistakenly used the label prefix:

\`\`\`
#publicationYear = 1954
#author.title *=* Tolkien   ← should be \`~\` since `author.title` is a relation
\`\`\`

The "full" syntax block just above already distinguishes them correctly:

\`\`\`
note.labels.publicationYear = 1954        // → #publicationYear shortcut
note.relations.author.title *=* Tolkien   // → ~author.title shortcut
\`\`\`

…and the rest of the page already uses \`~author.title *=* Tolkien\` consistently (e.g. line 70, line 100).

## Fix

Single-character swap (\`#\` → \`~\`) on the relation example, plus a short clarifying parenthetical so the \`#\` vs \`~\` rule is explicit.