### PR TITLE
fix(ckeditor): increase blockquote padding

### DIFF
--- a/packages/ckeditor5-admonition/theme/blockquote.css
+++ b/packages/ckeditor5-admonition/theme/blockquote.css
@@ -8,8 +8,7 @@
 	overflow: hidden;
 
 	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/15 */
-	padding-right: 2.0em;
-	padding-left: 2.0em;
+	padding-inline: 2em;
 
 	margin-left: 0;
 	margin-right: 0;

--- a/packages/ckeditor5-admonition/theme/blockquote.css
+++ b/packages/ckeditor5-admonition/theme/blockquote.css
@@ -8,8 +8,8 @@
 	overflow: hidden;
 
 	/* https://github.com/ckeditor/ckeditor5-block-quote/issues/15 */
-	padding-right: 1.5em;
-	padding-left: 1.5em;
+	padding-right: 2.0em;
+	padding-left: 2.0em;
 
 	margin-left: 0;
 	margin-right: 0;


### PR DESCRIPTION
Increase the padding in the block quotes for better readability.

**Previous**:

<img width="1152" height="65" alt="Screenshot 2026-05-18 at 11-04-58 test - Trilium Notes" src="https://github.com/user-attachments/assets/bd7cec81-80d9-4d06-a53d-f389f133e2a3" />

**Now**:

<img width="1152" height="65" alt="Screenshot 2026-05-18 at 11-05-38 test - Trilium Notes" src="https://github.com/user-attachments/assets/2ec3eb22-584a-4ba2-b0dc-f4efde6fd898" />
