### PR TITLE
docs: app-link protocol notes (issue #649)

### DIFF
--- a/docs/Developer Guide/Developer Guide/IssueHunt/Issue-649-app-link-protocol-notes.md
+++ b/docs/Developer Guide/Developer Guide/IssueHunt/Issue-649-app-link-protocol-notes.md
@@ -1,0 +1,39 @@
+# Issue 649 - App Link Protocol Notes
+
+This document captures a practical implementation note for issue [#649](https://github.com/TriliumNext/Trilium/issues/649), focused on opening/focusing notes via desktop protocol links.
+
+## Target URL Shape
+
+- Canonical format: `trilium://note/<noteId>`
+- Optional query extensions for future use:
+  - `?focus=true`
+  - `?newWindow=true`
+
+## Entry Points
+
+- Cold start (desktop app not running):
+  - Parse command-line arguments and extract protocol URL.
+- Running app:
+  - Handle second-instance event and route to existing window.
+- macOS:
+  - Handle `open-url` event.
+
+## Parsing Rules
+
+- Accept only expected host/path variants.
+- Keep note ID decoding strict (safe percent-decoding).
+- Reject unsupported protocols and malformed URLs.
+
+## Routing Behavior
+
+- Resolve note ID and select note in tree.
+- Activate existing tab if already open.
+- Fallback:
+  - show non-blocking warning when note cannot be resolved.
+
+## Security Constraints
+
+- No arbitrary command execution.
+- No shell passthrough from protocol payload.
+- Length limits for parsed URL and note ID.
+

--- a/docs/Developer Guide/IssueHunt/Issue-649-app-link-protocol-notes.md
+++ b/docs/Developer Guide/IssueHunt/Issue-649-app-link-protocol-notes.md
@@ -4,12 +4,17 @@ This document captures a practical implementation note for issue [#649](https://
 
 ## Target URL Shape
 
-- Canonical format: `trilium://note/<noteId>`
+- Preferred format: `triliumnext://note/<noteId>`
+- Compatibility fallback: `trilium://note/<noteId>`
 - Optional query extensions for future use:
   - `?focus=true`
   - `?newWindow=true`
 
 ## Entry Points
+
+- Register protocol handlers with the operating system during app setup:
+  - Electron `app.setAsDefaultProtocolClient(...)`
+  - Installer registration for supported platforms
 
 - Cold start (desktop app not running):
   - Parse command-line arguments and extract protocol URL.
@@ -29,11 +34,10 @@ This document captures a practical implementation note for issue [#649](https://
 - Resolve note ID and select note in tree.
 - Activate existing tab if already open.
 - Fallback:
-  - show non-blocking warning when note cannot be resolved.
+  - Show non-blocking warning when note cannot be resolved.
 
 ## Security Constraints
 
 - No arbitrary command execution.
 - No shell passthrough from protocol payload.
 - Length limits for parsed URL and note ID.
-


### PR DESCRIPTION
Implementation notes for trilium:// note routing in issue #649.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#649: Open/focus a note from command line / desktop URL handler (Trilium URL protocol)](https://oss.issuehunt.io/repos/92111509/issues/649)
---
</details>
<!-- /Issuehunt content-->