### PR TITLE
better ide navigation and encapsulation for max migration version

### DIFF
--- a/packages/trilium-core/src/migrations/migrations.spec.ts
+++ b/packages/trilium-core/src/migrations/migrations.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import MIGRATIONS from "./migrations.js";
+import { MIGRATIONS } from "./migrations.js";
 
 describe("migrations", () => {
     it("should have unique version numbers", () => {

--- a/packages/trilium-core/src/migrations/migrations.ts
+++ b/packages/trilium-core/src/migrations/migrations.ts
@@ -3,9 +3,12 @@
  *
  * Contains all the migrations that are run on the database.
  */
+export function getMaxMigrationVersion() {
+    return MIGRATIONS[0].version;
+}
 
 // Migrations should be kept in descending order, so the latest migration is first.
-const MIGRATIONS: (SqlMigration | JsMigration)[] = [
+export const MIGRATIONS: (SqlMigration | JsMigration)[] = [
     // Add description column to revisions table for manual revision comments
     {
         version: 238,
@@ -350,10 +353,6 @@ const MIGRATIONS: (SqlMigration | JsMigration)[] = [
         `
     }
 ];
-
-export default MIGRATIONS;
-
-export const MAX_MIGRATION_VERSION = MIGRATIONS[0].version;
 
 interface Migration {
     version: number;

--- a/packages/trilium-core/src/services/app_info.ts
+++ b/packages/trilium-core/src/services/app_info.ts
@@ -1,14 +1,14 @@
 import build from "./build.js";
 import packageJson from "../../package.json" with { type: "json" };
 import { AppInfo } from "@triliumnext/commons";
-import { MAX_MIGRATION_VERSION } from "../migrations/migrations.js";
+import { getMaxMigrationVersion } from "../migrations/migrations.js";
 
 const SYNC_VERSION = 39;
 const CLIPPER_PROTOCOL_VERSION = "1.0";
 
 const appInfo: AppInfo = {
     appVersion: packageJson.version,
-    dbVersion: MAX_MIGRATION_VERSION,
+    dbVersion: getMaxMigrationVersion(),
     syncVersion: SYNC_VERSION,
     buildDate: build.buildDate,
     buildRevision: build.buildRevision,

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -5,7 +5,7 @@ import { getPlatform } from "./platform.js";
 import appInfo from "./app_info.js";
 import * as cls from "./context.js";
 import { t } from "i18next";
-import MIGRATIONS from "../migrations/migrations.js";
+import { MIGRATIONS } from "../migrations/migrations.js";
 
 interface MigrationInfo {
     dbVersion: number;


### PR DESCRIPTION
Main motivation is better IDE navigation towards max migration value. Now, when you navigate to max version from AppInfo it goes as close as possible to actual version number. Previously, you had to do additional clicking and scrolling to view the value.

As a bonus, getMaxMigrationVersion is better API that hides implementation details of migration definitions.