### PR TITLE
ci(standalone): add Codecov bundle analysis for standalone build

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Trigger build of app
         run: pnpm --filter=standalone build
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Deploy
         uses: ./.github/actions/deploy-to-cloudflare-pages

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@types/aes-js": "3.1.4",
     "@ckeditor/ckeditor5-inspector": "5.0.0",
+    "@codecov/vite-plugin": "2.0.1",
     "@preact/preset-vite": "2.10.5",
     "@types/bootstrap": "5.2.10",
     "@types/jquery": "4.0.0",

--- a/apps/standalone/vite.config.mts
+++ b/apps/standalone/vite.config.mts
@@ -205,7 +205,7 @@ if (!isDev) {
     plugins = [
         ...plugins,
         codecovVitePlugin({
-            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
             bundleName: "standalone",
             uploadToken: process.env.CODECOV_TOKEN
         })

--- a/apps/standalone/vite.config.mts
+++ b/apps/standalone/vite.config.mts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { join, resolve, sep } from "path";
 
+import { codecovVitePlugin } from "@codecov/vite-plugin";
 import prefresh from "@prefresh/vite";
 import { defineConfig, type Plugin } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
@@ -195,6 +196,20 @@ if (process.env.TRILIUM_INTEGRATION_TEST) {
             ]
         })
     ]
+}
+
+if (!isDev) {
+    // Put the Codecov vite plugin after all other plugins.
+    // Gated on CODECOV_TOKEN so it stays a no-op locally and in the
+    // integration-test build (which sets no token).
+    plugins = [
+        ...plugins,
+        codecovVitePlugin({
+            enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
+            bundleName: "standalone",
+            uploadToken: process.env.CODECOV_TOKEN
+        })
+    ];
 }
 
 export default defineConfig(() => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1019,6 +1019,9 @@ importers:
       '@ckeditor/ckeditor5-inspector':
         specifier: 5.0.0
         version: 5.0.0
+      '@codecov/vite-plugin':
+        specifier: 2.0.1
+        version: 2.0.1(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
       '@preact/preset-vite':
         specifier: 2.10.5
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
Wire @codecov/vite-plugin into the standalone Vite build (bundleName "standalone", gated on CODECOV_TOKEN) and pass CODECOV_TOKEN to the existing deploy-app build step, mirroring the client setup.