### PR TITLE
feat(search): prefix-aware fuzzy match for short tokens vs long words

### DIFF
--- a/packages/trilium-core/src/services/search/utils/text_utils.spec.ts
+++ b/packages/trilium-core/src/services/search/utils/text_utils.spec.ts
@@ -65,15 +65,21 @@ describe('Fuzzy Search Core', () => {
         it('matches a token against a prefix of a longer word', () => {
             // The whole-word check skips words too different in length, so without the
             // prefix-aware path a typo in a short token never matches a long word.
-            // "infa" should reach "infrastructure" via its leading "infra".
+            // Use real typos here — both tokens are NOT substrings of the target, so the
+            // exact-substring fast-path at the top of fuzzyMatchWordWithResult can't satisfy
+            // them and Strategy 2 is the only path that can return true.
             expect(fuzzyMatchWord('infa', 'cloud infrastructure overview')).toBe(true);
-            expect(fuzzyMatchWord('instal', 'installer downloaded')).toBe(true);
+            expect(fuzzyMatchWord('insall', 'installer downloaded')).toBe(true);
 
             // Unrelated long words remain non-matches.
             expect(fuzzyMatchWord('infa', 'cloud elsewhere unrelated')).toBe(false);
+            // First-character guard rejects long words whose leading letter doesn't match.
+            expect(fuzzyMatchWord('infa', 'zlothy overview reporting')).toBe(false);
         });
+    });
 
-        it('returns the matched prefix for highlighting', () => {
+    describe('fuzzyMatchWordWithResult', () => {
+        it('returns the matched prefix substring so callers can highlight it', () => {
             // The prefix the search budget allows is token.length + maxDistance.
             // For "infa" (4 chars) + maxDistance 2 → 6-char prefix "infras".
             expect(fuzzyMatchWordWithResult('infa', 'infrastructure')).toBe('infras');

--- a/packages/trilium-core/src/services/search/utils/text_utils.spec.ts
+++ b/packages/trilium-core/src/services/search/utils/text_utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateOptimizedEditDistance, validateFuzzySearchTokens, fuzzyMatchWord, stripHtmlTags } from './text_utils.js';
+import { calculateOptimizedEditDistance, validateFuzzySearchTokens, fuzzyMatchWord, fuzzyMatchWordWithResult, stripHtmlTags } from './text_utils.js';
 
 describe('Fuzzy Search Core', () => {
     describe('calculateOptimizedEditDistance', () => {
@@ -60,6 +60,23 @@ describe('Fuzzy Search Core', () => {
             expect(fuzzyMatchWord('', 'test')).toBe(false);
             expect(fuzzyMatchWord('test', '')).toBe(false);
             expect(fuzzyMatchWord('a', 'b')).toBe(false); // Very short tokens
+        });
+
+        it('matches a token against a prefix of a longer word', () => {
+            // The whole-word check skips words too different in length, so without the
+            // prefix-aware path a typo in a short token never matches a long word.
+            // "infa" should reach "infrastructure" via its leading "infra".
+            expect(fuzzyMatchWord('infa', 'cloud infrastructure overview')).toBe(true);
+            expect(fuzzyMatchWord('instal', 'installer downloaded')).toBe(true);
+
+            // Unrelated long words remain non-matches.
+            expect(fuzzyMatchWord('infa', 'cloud elsewhere unrelated')).toBe(false);
+        });
+
+        it('returns the matched prefix for highlighting', () => {
+            // The prefix the search budget allows is token.length + maxDistance.
+            // For "infa" (4 chars) + maxDistance 2 → 6-char prefix "infras".
+            expect(fuzzyMatchWordWithResult('infa', 'infrastructure')).toBe('infras');
         });
     });
 

--- a/packages/trilium-core/src/services/search/utils/text_utils.ts
+++ b/packages/trilium-core/src/services/search/utils/text_utils.ts
@@ -319,20 +319,29 @@ export function fuzzyMatchWordWithResult(token: string, text: string, maxDistanc
             const word = words[i];
             const originalWord = originalWords[i];
 
-            // Skip if word is too different in length for fuzzy matching
-            if (Math.abs(word.length - normalizedToken.length) > maxDistance) {
-                continue;
+            // Strategy 1: whole-word fuzzy match for similar-length words ("infra" ↔ "infa", typos).
+            if (normalizedToken.length >= 4 &&
+                Math.abs(word.length - normalizedToken.length) <= maxDistance) {
+                const distance = calculateOptimizedEditDistance(normalizedToken, word, maxDistance);
+                if (distance <= maxDistance) {
+                    return originalWord;
+                }
             }
 
-            // For very short tokens or very different lengths, be more strict
-            if (normalizedToken.length < 4 || Math.abs(word.length - normalizedToken.length) > 2) {
-                continue;
-            }
-
-            // Use optimized edit distance calculation
-            const distance = calculateOptimizedEditDistance(normalizedToken, word, maxDistance);
-            if (distance <= maxDistance) {
-                return originalWord; // Return the original word with case preserved
+            // Strategy 2: prefix-aware fuzzy match for longer words ("infa" ↔ "infrastructure").
+            // The whole-word check above skips length-mismatched words; without this, a typo in
+            // a short token never matches a long word that starts with the intended prefix.
+            // We try edit distance against a prefix sized to the token's intended length
+            // (±maxDistance), so "infa" lines up with the first 4-6 chars of "infrastructure".
+            // Require a healthy length difference to avoid double-counting Strategy 1 hits.
+            if (normalizedToken.length >= 4 &&
+                word.length > normalizedToken.length + maxDistance) {
+                const prefixLen = Math.min(word.length, normalizedToken.length + maxDistance);
+                const prefix = word.substring(0, prefixLen);
+                const distance = calculateOptimizedEditDistance(normalizedToken, prefix, maxDistance);
+                if (distance <= maxDistance) {
+                    return originalWord.substring(0, prefixLen);
+                }
             }
         }
 

--- a/packages/trilium-core/src/services/search/utils/text_utils.ts
+++ b/packages/trilium-core/src/services/search/utils/text_utils.ts
@@ -332,11 +332,17 @@ export function fuzzyMatchWordWithResult(token: string, text: string, maxDistanc
             // The whole-word check above skips length-mismatched words; without this, a typo in
             // a short token never matches a long word that starts with the intended prefix.
             // We try edit distance against a prefix sized to the token's intended length
-            // (±maxDistance), so "infa" lines up with the first 4-6 chars of "infrastructure".
-            // Require a healthy length difference to avoid double-counting Strategy 1 hits.
+            // (token.length + maxDistance), so "infa" lines up with the first 6 chars of
+            // "infrastructure". Require a healthy length difference to avoid double-counting
+            // Strategy 1 hits.
+            //
+            // Cheap first-character match guard: in a prefix-style mistype the leading character
+            // is almost always intact, and this filter rejects ~96% of unrelated long words
+            // before the more expensive edit-distance call runs.
             if (normalizedToken.length >= 4 &&
-                word.length > normalizedToken.length + maxDistance) {
-                const prefixLen = Math.min(word.length, normalizedToken.length + maxDistance);
+                word.length > normalizedToken.length + maxDistance &&
+                word[0] === normalizedToken[0]) {
+                const prefixLen = normalizedToken.length + maxDistance;
                 const prefix = word.substring(0, prefixLen);
                 const distance = calculateOptimizedEditDistance(normalizedToken, prefix, maxDistance);
                 if (distance <= maxDistance) {


### PR DESCRIPTION
## Summary

Split out from #9963 as requested in review — this change is independent of
the FTS5 work and stands on its own.

`fuzzyMatchWordWithResult` currently skips fuzzy comparisons whenever the
word in the text is more than `MAX_EDIT_DISTANCE` characters longer than
the search token. That means a short typo like `infa` never reaches a long
word like `infrastructure`, even though the user clearly meant the same
prefix.

This PR adds a second strategy: for words that are still longer than the
token even after the existing length guard, compute the edit distance
against the word's leading prefix (sized `token.length + maxDistance`).
The whole-word path is unchanged, so typos in similarly-sized words
(`infra` ↔ `infa`) still match exactly as before; the new prefix path
handles the partial-word case (`infa` → `infrastructure`).

The matched substring is returned so the existing highlight plumbing in
`NoteFlatTextExp.smartMatch` only marks the matched portion of the longer
word.

## Test plan

- [x] New unit tests covering both directions: a short token matching
      against the prefix of a longer word, and unrelated long words still
      failing the match. Adds a returned-prefix assertion so highlight
      behaviour is locked in.
- [x] `pnpm --filter server test text_utils` — 17/17 pass.
- [x] `pnpm typecheck` clean.