### PR TITLE
fix(deps): unbreak nightly desktop packaging on Node 24.16 (yauzl)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,7 @@ overrides:
   hono@>=4.0.0 <=4.12.11: '>=4.12.12'
   '@hono/node-server@<1.19.13': '>=1.19.13'
   basic-ftp@=5.2.0: '>=5.2.1'
+  extract-zip>yauzl: 3.3.1
 
 patchedDependencies:
   '@ckeditor/ckeditor5-code-block': 1530be090e4f5235e197fb6208a8e8230e3355d5633fc7cad2b2e892659e9c04
@@ -23136,7 +23137,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.3.1
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -82,6 +82,9 @@ overrides:
   "hono@>=4.0.0 <=4.12.11": ">=4.12.12"
   "@hono/node-server@<1.19.13": ">=1.19.13"
   "basic-ftp@=5.2.0": ">=5.2.1"
+  # extract-zip's yauzl@2 hangs electron-forge packaging on Node >=24.16 (electron/forge#4277,
+  # electron/electron#51619). yauzl@3.3.1 is the maintainer-recommended fix.
+  "extract-zip>yauzl": "3.3.1"
 
 patchedDependencies:
   "@ckeditor/ckeditor5-mention": patches/@ckeditor__ckeditor5-mention.patch


### PR DESCRIPTION
## Problem

The nightly Electron build has been failing on **all desktop platforms** for ~10 days, plus arm64-linux for slightly longer. Root cause: **`extract-zip`'s transitive `yauzl@2` is broken on Node.js ≥ 24.16** (electron/forge#4277, electron/electron#51619).

When the CI runner toolcache rolled from Node `24.15.0` → `24.16.0`, `electron-forge make` started finishing its package phase but **never producing distributables** — so `apps/desktop/upload/` ends up empty and the downstream steps fail:

- **macOS / Windows**: `Publish release` → `Pattern 'apps/desktop/upload/*.*' does not match any files`
- **Linux**: `Build AppImage` → `Packaged app not found at .../dist/out/Trilium Notes-linux-x64`

This explains the staggered breakage: the `ubuntu-24.04-arm` runner picked up Node 24.16.0 first (arm64-linux broke ~05-23), then the x64/macOS/Windows toolcaches rolled over (~05-28, everything broke). The electron-forge 7.11.1→7.11.2 bump landing around the same time was a coincidence — arm64-linux was already failing on 7.11.1 + Node 24.16.

The last green nightly ran on Node `24.15.0`.

## Fix

Pin the affected dependency edge to `yauzl@3.3.1` (the electron-forge maintainer's recommended fix) via a scoped pnpm override:

```yaml
"extract-zip>yauzl": "3.3.1"
```

This keeps Node on the current major (no downgrade needed) and targets only the broken extraction path. `extract-zip` is the sole consumer of `yauzl` on the packaging path; `native-run` (mobile tooling) still uses `yauzl@2` and is intentionally left untouched.

## Validation

A local build can't reproduce this — it's specific to the Node 24.16.0 CI runners. This needs the nightly workflow to run on this branch (e.g. via `workflow_dispatch`) to confirm packaging produces artifacts again on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
