### PR TITLE
feat(i18n): add Indonesian (id) as a selectable display language

### DIFF
--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -79,6 +79,7 @@ export const LOCALE_MAPPINGS: Record<DISPLAYABLE_LOCALE_IDS, (() => Promise<{ de
     fr: () => import("@fullcalendar/core/locales/fr"),
     it: () => import("@fullcalendar/core/locales/it"),
     hi: () => import("@fullcalendar/core/locales/hi"),
+    id: () => import("@fullcalendar/core/locales/id"),
     ga: null,
     cn: () => import("@fullcalendar/core/locales/zh-cn"),
     cs: () => import("@fullcalendar/core/locales/cs"),

--- a/apps/client/src/widgets/type_widgets/canvas/i18n.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/i18n.ts
@@ -12,6 +12,7 @@ export const LANGUAGE_MAPPINGS: Record<DISPLAYABLE_LOCALE_IDS, Language["code"] 
     es: "es-ES",
     fr: "fr-FR",
     ga: null,
+    id: "id-ID",
     it: "it-IT",
     hi: "hi-IN",
     ja: "ja-JP",

--- a/packages/ckeditor5/src/i18n.ts
+++ b/packages/ckeditor5/src/i18n.ts
@@ -46,6 +46,11 @@ const LOCALE_MAPPINGS: Record<DISPLAYABLE_LOCALE_IDS, LocaleMapping | null> = {
         premiumFeaturesTranslation: () => import("ckeditor5-premium-features/translations/fr.js"),
     },
     ga: null,
+    id: {
+        languageCode: "id",
+        coreTranslation: () => import("ckeditor5/translations/id.js"),
+        premiumFeaturesTranslation: () => import("ckeditor5-premium-features/translations/id.js"),
+    },
     it: {
         languageCode: "it",
         coreTranslation: () => import("ckeditor5/translations/it.js"),

--- a/packages/commons/src/lib/dayjs.ts
+++ b/packages/commons/src/lib/dayjs.ts
@@ -45,6 +45,7 @@ export const DAYJS_LOADER: Record<DISPLAYABLE_LOCALE_IDS, () => Promise<typeof i
     "es": () => import("dayjs/locale/es.js"),
     "fr": () => import("dayjs/locale/fr.js"),
     "ga": () => import("dayjs/locale/ga.js"),
+    "id": () => import("dayjs/locale/id.js"),
     "it": () => import("dayjs/locale/it.js"),
     "hi": () => import("dayjs/locale/hi.js"),
     "ja": () => import("dayjs/locale/ja.js"),

--- a/packages/commons/src/lib/i18n.ts
+++ b/packages/commons/src/lib/i18n.ts
@@ -10,7 +10,7 @@ export interface Locale {
     /** The value to pass to `--lang` for the Electron instance in order to set it as a locale. Not setting it will hide it from the list of supported locales. */
     electronLocale?: "en" | "de" | "es" | "fr" | "zh_CN" | "zh_TW" | "ro" | "af" | "am" | "ar" | "bg" | "bn" | "ca" | "cs" | "da" | "el" | "en_GB" | "es_419" | "et" | "fa" | "fi" | "fil" | "gu" | "he" | "hi" | "hr" | "hu" | "id" | "it" | "ja" | "kn" | "ko" | "lt" | "lv" | "ml" | "mr" | "ms" | "nb" | "nl" | "pl" | "pt_BR" | "pt_PT" | "ru" | "sk" | "sl" | "sr" | "sv" | "sw" | "ta" | "te" | "th" | "tr" | "uk" | "ur" | "vi";
     /** The Tesseract OCR language code for this locale (e.g. "eng", "fra", "deu"). See https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html */
-    tesseractCode?: "eng" | "deu" | "spa" | "fra" | "gle" | "ita" | "hin" | "jpn" | "por" | "pol" | "ron" | "rus" | "chi_sim" | "chi_tra" | "ukr" | "ara" | "heb" | "kur" | "fas" | "kor" | "ces" | "uig";
+    tesseractCode?: "eng" | "deu" | "spa" | "fra" | "gle" | "ita" | "hin" | "ind" | "jpn" | "por" | "pol" | "ron" | "rus" | "chi_sim" | "chi_tra" | "ukr" | "ara" | "heb" | "kur" | "fas" | "kor" | "ces" | "uig";
 }
 
 // When adding a new locale, prefer the version with hyphen instead of underscore.
@@ -23,6 +23,7 @@ const UNSORTED_LOCALES = [
     { id: "es", name: "Español", electronLocale: "es", tesseractCode: "spa" },
     { id: "fr", name: "Français", electronLocale: "fr", tesseractCode: "fra" },
     { id: "ga", name: "Gaeilge", electronLocale: "en", tesseractCode: "gle" },
+    { id: "id", name: "Bahasa Indonesia", electronLocale: "id", tesseractCode: "ind" },
     { id: "it", name: "Italiano", electronLocale: "it", tesseractCode: "ita" },
     { id: "hi", name: "हिन्दी", electronLocale: "hi", tesseractCode: "hin" },
     { id: "ja", name: "日本語", electronLocale: "ja", tesseractCode: "jpn" },


### PR DESCRIPTION
## Summary

Indonesian (`id`) translations have reached sufficient coverage on Weblate (**~93% client**, ~21% server) and are already present in the repo. This PR registers Indonesian as a selectable **display language** across the application, following the steps in `docs/Developer Guide/.../Adding a new locale.md`.

## Changes

| Area | File | Change |
|---|---|---|
| Locale registry | `packages/commons/src/lib/i18n.ts` | Add `{ id: "id", name: "Bahasa Indonesia", electronLocale: "id", tesseractCode: "ind" }`; add `"ind"` to the Tesseract code union |
| Date formatting | `packages/commons/src/lib/dayjs.ts` | Map `id` → `dayjs/locale/id` |
| Calendar | `apps/client/src/widgets/collections/calendar/index.tsx` | Map `id` → FullCalendar `id` locale |
| Canvas (Excalidraw) | `apps/client/src/widgets/type_widgets/canvas/i18n.ts` | Map `id` → `id-ID` |
| Rich text (CKEditor 5) | `packages/ckeditor5/src/i18n.ts` | Wire `id` → bundled core + premium translations |

**pdf.js** needs no change — the build's default locale mapping (`electronLocale.replace("_","-")` = `id`) already resolves to the existing `packages/pdfjs-viewer/viewer/locale/id/viewer.ftl`.

The `translation.json` / `server.json` files were already added by Weblate and are loaded dynamically by locale id (the client build copies the whole `translations/` directory), so no extra registration is needed for the strings themselves.

## Verification

- `pnpm typecheck` — clean (the `Record<DISPLAYABLE_LOCALE_IDS, …>` maps are exhaustive, so every map is forced to include `id`)
- Canvas i18n test (`id-ID` is a supported Excalidraw locale) — pass
- Client `i18n.spec.ts` + Commons `i18n.spec.ts` / `dayjs.spec.ts` — pass
- Confirmed every external `id` locale resolves: dayjs, FullCalendar, CKEditor core + premium, Excalidraw (`id-ID`), pdf.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)