### PR TITLE
fix(setup): carry the chosen language over to the new document

### DIFF
--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 
 import logo from "./assets/icon-color.svg?url";
-import { initLocale, t } from "./services/i18n";
+import { getCurrentLanguage, initLocale, t } from "./services/i18n";
 import server from "./services/server";
 import { isElectron, isMobileApp, replaceHtmlEscapedSlashes } from "./services/utils";
 import ActionButton from "./widgets/react/ActionButton";
@@ -307,7 +307,7 @@ function CreateNewDocumentOptions({ setState }: { setState: (state: State) => vo
 
 function CreateNewDocumentInProgress({ withDemo = false }: { withDemo?: boolean }) {
     useEffect(() => {
-        server.post(`setup/new-document${withDemo ? "" : "?skipDemoDb"}`).then(onSetupFinished);
+        server.post(`setup/new-document${withDemo ? "" : "?skipDemoDb"}`, { locale: getCurrentLanguage() }).then(onSetupFinished);
     }, [ withDemo ]);
 
     return (

--- a/packages/commons/src/lib/i18n.spec.ts
+++ b/packages/commons/src/lib/i18n.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getTesseractCode, LOCALES } from "./i18n.js";
+import { getTesseractCode, isDisplayableLocale, LOCALES } from "./i18n.js";
 
 describe("getTesseractCode", () => {
     it("returns the Tesseract code for a mapped locale", () => {
@@ -31,5 +31,30 @@ describe("LOCALES", () => {
         const en = LOCALES.find((l) => l.id === "en");
         expect(en).toBeDefined();
         expect(en?.name).toBe("English (United States)");
+    });
+});
+
+describe("isDisplayableLocale", () => {
+    it("accepts known display locales", () => {
+        expect(isDisplayableLocale("en")).toBe(true);
+        expect(isDisplayableLocale("de")).toBe(true);
+    });
+
+    it("rejects empty, null or undefined values", () => {
+        expect(isDisplayableLocale("")).toBe(false);
+        expect(isDisplayableLocale(null)).toBe(false);
+        expect(isDisplayableLocale(undefined)).toBe(false);
+    });
+
+    it("rejects unknown locales", () => {
+        expect(isDisplayableLocale("nonexistent-locale")).toBe(false);
+    });
+
+    it("rejects content-only locales (selectable for content, not as a UI language)", () => {
+        const contentOnly = LOCALES.find((l) => l.contentOnly);
+        expect(contentOnly).toBeDefined();
+        if (contentOnly) {
+            expect(isDisplayableLocale(contentOnly.id)).toBe(false);
+        }
     });
 });

--- a/packages/commons/src/lib/i18n.ts
+++ b/packages/commons/src/lib/i18n.ts
@@ -103,3 +103,12 @@ export type DISPLAYABLE_LOCALE_IDS = Exclude<typeof UNSORTED_LOCALES[number], { 
 export function getTesseractCode(localeId: string): string | null {
     return LOCALES.find((l) => l.id === localeId)?.tesseractCode ?? null;
 }
+
+/**
+ * Returns `true` if the given locale ID corresponds to a known locale that can be used as the
+ * application's display language (i.e. it exists and is not content-only).
+ */
+export function isDisplayableLocale(localeId: string | null | undefined): localeId is DISPLAYABLE_LOCALE_IDS {
+    if (!localeId) return false;
+    return LOCALES.some((l) => l.id === localeId && !l.contentOnly);
+}

--- a/packages/trilium-core/src/routes/api/setup.spec.ts
+++ b/packages/trilium-core/src/routes/api/setup.spec.ts
@@ -37,7 +37,14 @@ describe("Setup API (core)", () => {
         const createInitial = vi.spyOn(sqlInit, "createInitialDatabase").mockResolvedValue(undefined);
         const res = await api.post("/api/setup/new-document", { query: { skipDemoDb: "1" } });
         expect(res.status).toBe(204);
-        expect(createInitial).toHaveBeenCalledWith(true);
+        expect(createInitial).toHaveBeenCalledWith(true, undefined);
+    });
+
+    it("forwards the locale chosen during setup to createInitialDatabase", async () => {
+        const createInitial = vi.spyOn(sqlInit, "createInitialDatabase").mockResolvedValue(undefined);
+        const res = await api.post("/api/setup/new-document", { query: { skipDemoDb: "1" }, body: { locale: "de" } });
+        expect(res.status).toBe(204);
+        expect(createInitial).toHaveBeenCalledWith(true, "de");
     });
 
     it("returns the sync seed shape", async () => {

--- a/packages/trilium-core/src/routes/api/setup.ts
+++ b/packages/trilium-core/src/routes/api/setup.ts
@@ -15,7 +15,8 @@ function getStatus() {
 
 async function setupNewDocument(req: Request) {
     const { skipDemoDb } = req.query;
-    await sqlInit.createInitialDatabase(skipDemoDb !== undefined);
+    const locale = req.body?.locale;
+    await sqlInit.createInitialDatabase(skipDemoDb !== undefined, locale);
 }
 
 function setupSyncFromServer(req: Request): Promise<SetupSyncFromServerResponse> {

--- a/packages/trilium-core/src/services/sql_init.ts
+++ b/packages/trilium-core/src/services/sql_init.ts
@@ -1,4 +1,4 @@
-import { deferred, OptionRow } from "@triliumnext/commons";
+import { deferred, isDisplayableLocale, OptionRow } from "@triliumnext/commons";
 import { getSql } from "./sql";
 import { getLog } from "./log";
 import { getBackup } from "./backup";
@@ -120,9 +120,10 @@ function initializeDb() {
  * Applies the database schema, creating the necessary tables and importing the demo content.
  *
  * @param skipDemoDb if set to `true`, then the demo database will not be imported, resulting in an empty root note.
+ * @param locale the display language chosen during setup; persisted as the `locale` option when it is a valid, displayable locale (otherwise the default is kept).
  * @throws {Error} if the database is already initialized.
  */
-async function createInitialDatabase(skipDemoDb?: boolean) {
+async function createInitialDatabase(skipDemoDb?: boolean, locale?: string) {
     if (isDbInitialized()) {
         throw new Error("DB is already initialized");
     }
@@ -163,6 +164,10 @@ async function createInitialDatabase(skipDemoDb?: boolean) {
         initDocumentOptions();
         initNotSyncedOptions(true, {});
         initStartupOptions();
+        // Persist the language chosen during setup, overriding the default ("en").
+        if (isDisplayableLocale(locale)) {
+            optionService.setOption("locale", locale);
+        }
         passwordService.resetPassword();
     });
 


### PR DESCRIPTION
## Problem

The language selected in the **setup wizard** is not carried over when creating a new document — the app always starts in English regardless of what was picked.

## Root cause

The wizard's language step (`apps/client/src/setup.tsx`, `SelectLanguage`) only calls `i18n.changeLanguage(locale.id)`, which switches the client's **in-memory** i18next instance. That choice is never sent to the server:

1. `CreateNewDocumentInProgress` POSTs `setup/new-document` with **no locale**.
2. `setupNewDocument` → `sqlInit.createInitialDatabase()` → `initStartupOptions()` writes the hardcoded default `locale` option:
   ```
   packages/trilium-core/src/services/options_init.ts
   { name: "locale", value: "en", isSynced: true },
   ```
3. Setup finishes → the app reloads → it reads the `locale` option (now `"en"`) → starts in English. The selection is lost.

## Fix

Carry the selected locale through to database creation and persist it:

- **Client** (`setup.tsx`): include the active locale in the new-document request body — `server.post("setup/new-document…", { locale: getCurrentLanguage() })`.
- **Route** (`routes/api/setup.ts`): read `locale` from `req.body` (via optional chaining, so a request with no body still works as before) and forward it.
- **`createInitialDatabase`** (`sql_init.ts`): after the defaults are applied, override the `locale` option when a valid, displayable locale was provided.

Validation is extracted into `isDisplayableLocale()` in `@triliumnext/commons` — it rejects unknown ids and **content-only** locales (those are selectable for note content but not as a UI language). This also covers the desktop flow, which uses the same wizard and route.

`formattingLocale` is intentionally left untouched (it auto-detects); only `locale` drives the UI language.

## Tests

- **commons** `i18n.spec.ts`: unit tests for `isDisplayableLocale` (known / empty / unknown / content-only).
- **core** `setup.spec.ts`: new case asserting the locale is forwarded to `createInitialDatabase`; the existing case updated to the new `(skipDemoDb, locale)` signature.

## Verification

- `pnpm typecheck` — clean
- Core setup spec passes under **both** the server and standalone (WASM) suites
- commons i18n spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)