### PR TITLE
fix(client): notes being overwritten with another note's content

### DIFF
--- a/apps/client/src/components/component.ts
+++ b/apps/client/src/components/component.ts
@@ -1,7 +1,7 @@
 import utils from "../services/utils.js";
 import type { CommandMappings, CommandNames, EventData, EventNames } from "./app_context.js";
 
-type EventHandler = ((data: any) => void);
+type EventHandler = ((data: any) => unknown);
 
 /**
  * Abstract class for all components in the Trilium's frontend.
@@ -91,10 +91,20 @@ export class TypedComponent<ChildT extends TypedComponent<ChildT>> {
     handleEventInChildren<T extends EventNames>(name: T, data: EventData<T>): Promise<unknown[] | unknown> | null {
         const promises: Promise<unknown>[] = [];
 
-        // Handle React children.
+        // Handle React children. Iterate over a copy: a listener can cause handlers to be
+        // (un)registered while the event is being distributed.
         if (this.listeners?.[name]) {
-            for (const listener of this.listeners[name]) {
-                listener(data);
+            for (const listener of [ ...this.listeners[name] ]) {
+                const ret = listener(data);
+
+                // Collect the promise so that awaiting triggerEvent() waits for async React
+                // listeners too (the contract documented on this class). Failures are logged
+                // rather than propagated, so one broken listener cannot abort the operation
+                // (e.g. a note switch) for everyone else.
+                if (ret instanceof Promise) {
+                    promises.push(ret.catch((e) =>
+                        console.error(`Handling of event '${name}' failed in a React listener with error`, e)));
+                }
             }
         }
 

--- a/apps/client/src/components/note_context.ts
+++ b/apps/client/src/components/note_context.ts
@@ -60,6 +60,13 @@ export interface NoteContextDataMap {
     saveState: {
         state: SaveState;
     };
+    /** Published by content widgets (via `useNoteBlob`) while the note's content is being fetched,
+     * so the note detail can show a loading state instead of the previous note's content. */
+    contentLoad: {
+        state: "loading" | "loaded" | "error";
+        /** Re-attempts the content fetch (e.g. from a "Retry" button after an error). */
+        retry: () => void;
+    };
 }
 
 type ContextDataKey = keyof NoteContextDataMap;

--- a/apps/client/src/services/spaced_update.spec.ts
+++ b/apps/client/src/services/spaced_update.spec.ts
@@ -232,6 +232,116 @@ describe("SpacedUpdate", () => {
         });
     });
 
+    describe("keyed bindings (prepare/commit)", () => {
+        function setupKeyedHarness() {
+            // Stand-in for a reused editor: holds whichever note's content was last loaded.
+            const editor = { content: "A content" };
+            const commits: { key: string; data: string }[] = [];
+            const makeBinding = (key: string) => ({
+                key,
+                prepare: () => editor.content,
+                commit: async (data: string) => {
+                    commits.push({ key, data });
+                }
+            });
+            return { editor, commits, makeBinding };
+        }
+
+        it("commits a pending change under the binding that scheduled it, even after rebinding", async () => {
+            const { editor, commits, makeBinding } = setupKeyedHarness();
+            const spacedUpdate = new SpacedUpdate<string>(makeBinding("A"), 50);
+
+            // A change is pending against A when the consumer rebinds to B; the snapshot is
+            // taken with A's binding before the swap, so it can never be saved under B.
+            spacedUpdate.scheduleUpdate();
+            const b = makeBinding("B");
+            spacedUpdate.rebind(b.key, b.prepare, b.commit);
+            editor.content = "B content"; // B's content arrives only after the rebind
+
+            await vi.runAllTimersAsync();
+            expect(commits).toEqual([{ key: "A", data: "A content" }]);
+
+            // A change made after the rebind saves under the new binding.
+            spacedUpdate.scheduleUpdate();
+            await vi.runAllTimersAsync();
+            expect(commits).toEqual([
+                { key: "A", data: "A content" },
+                { key: "B", data: "B content" }
+            ]);
+        });
+
+        it("retries a failed commit with the frozen snapshot, not the live state", async () => {
+            const editor = { content: "typed into A" };
+            const commits: string[] = [];
+            let failuresLeft = 1;
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => editor.content,
+                commit: async (data) => {
+                    if (failuresLeft > 0) {
+                        failuresLeft--;
+                        throw new Error("offline");
+                    }
+                    commits.push(data);
+                }
+            }, 50);
+
+            spacedUpdate.scheduleUpdate();
+            await vi.advanceTimersByTimeAsync(60); // first attempt fails
+
+            // The live state moves on (e.g. another note's content is loaded into the editor),
+            // but the retry must persist the snapshot taken when the change was flushed.
+            editor.content = "now showing B";
+            await vi.advanceTimersByTimeAsync(200); // backoff retry fires
+
+            expect(commits).toEqual(["typed into A"]);
+        });
+
+        it("supersedes a queued failed snapshot with a newer one for the same key", async () => {
+            const editor = { content: "v1" };
+            const commits: string[] = [];
+            let failuresLeft = 1;
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => editor.content,
+                commit: async (data) => {
+                    if (failuresLeft > 0) {
+                        failuresLeft--;
+                        throw new Error("offline");
+                    }
+                    commits.push(data);
+                }
+            }, 50);
+
+            spacedUpdate.scheduleUpdate();
+            await vi.advanceTimersByTimeAsync(60); // "v1" fails and stays queued
+
+            editor.content = "v2";
+            spacedUpdate.scheduleUpdate();
+            await vi.advanceTimersByTimeAsync(300);
+
+            // The newer snapshot replaced the queued one: a single save with the latest data,
+            // not a stale "v1" overwriting "v2".
+            expect(commits).toEqual(["v2"]);
+        });
+
+        it("supports an asynchronous prepare", async () => {
+            const commits: string[] = [];
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => Promise.resolve("async snapshot"),
+                commit: async (data) => {
+                    commits.push(data);
+                }
+            }, 50);
+
+            spacedUpdate.scheduleUpdate();
+            await spacedUpdate.updateNowIfNecessary();
+
+            expect(commits).toEqual(["async snapshot"]);
+        });
+    });
+
     describe("allowUpdateWithoutChange", () => {
         it("suppresses scheduleUpdate while the callback runs and re-enables it afterwards", async () => {
             const updater = vi.fn(async () => {});

--- a/apps/client/src/services/spaced_update.spec.ts
+++ b/apps/client/src/services/spaced_update.spec.ts
@@ -325,6 +325,34 @@ describe("SpacedUpdate", () => {
             expect(commits).toEqual(["v2"]);
         });
 
+        it("does not report all-saved while an asynchronous snapshot from rebind is still being captured", async () => {
+            let resolvePrepare: (value: string) => void = () => {};
+            const commits: { key: string; data: string }[] = [];
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => new Promise<string>((resolve) => {
+                    resolvePrepare = resolve;
+                }),
+                commit: async (data) => {
+                    commits.push({ key: "A", data });
+                }
+            }, 50);
+
+            spacedUpdate.scheduleUpdate();
+            spacedUpdate.rebind("B", () => "B content", async (data) => {
+                commits.push({ key: "B", data });
+            });
+
+            // The old binding's snapshot is still being captured, so nothing may be
+            // reported as saved yet (relevant for the beforeunload warning).
+            expect(spacedUpdate.isAllSavedAndTriggerUpdate()).toBe(false);
+
+            resolvePrepare("typed into A");
+            await spacedUpdate.updateNowIfNecessary();
+
+            expect(commits).toEqual([{ key: "A", data: "typed into A" }]);
+        });
+
         it("supports an asynchronous prepare", async () => {
             const commits: string[] = [];
             const spacedUpdate = new SpacedUpdate<string>({

--- a/apps/client/src/services/spaced_update.ts
+++ b/apps/client/src/services/spaced_update.ts
@@ -5,8 +5,37 @@ type Callback = () => Promise<void> | void;
 
 export type StateCallback = (state: SaveState) => void;
 
-export default class SpacedUpdate {
-    private updater: Callback;
+type PrepareCallback<T> = () => T | Promise<T>;
+type CommitCallback<T> = (data: T) => Promise<void> | void;
+
+/**
+ * Binds pending changes to the target they belong to (see #9614).
+ *
+ * A change scheduled while one binding is active is always *snapshotted* (via {@link SpacedUpdateBinding.prepare})
+ * before the binding can be swapped to a different key, and the snapshot is committed together with the
+ * `commit` closure that was current when it was taken. This makes it impossible for a pending change to be
+ * persisted under a different target than the one it was made against, no matter when the save fires.
+ */
+export interface SpacedUpdateBinding<T> {
+    /** Identity of the save target (e.g. a noteId). Pending changes never cross a key change. */
+    key: string | null;
+    /** Snapshots the live state that should be saved. May refuse by returning a value `commit` treats as a no-op. */
+    prepare: PrepareCallback<T>;
+    /** Persists a snapshot. Retries always reuse the closure that was current when the snapshot was taken. */
+    commit: CommitCallback<T>;
+}
+
+interface PendingCommit<T> {
+    data: T;
+    commit: CommitCallback<T>;
+}
+
+const MAX_RETRY_DELAY = 60_000;
+
+export default class SpacedUpdate<T = void> {
+    private bindingKey: string | null;
+    private prepare: PrepareCallback<T>;
+    private commit: CommitCallback<T>;
     private lastUpdated: number;
     private changed: boolean;
     private updateInterval: number;
@@ -14,8 +43,30 @@ export default class SpacedUpdate {
     private stateCallback?: StateCallback;
     private lastState: SaveState = "saved";
 
-    constructor(updater: Callback, updateInterval = 1000, stateCallback?: StateCallback) {
-        this.updater = updater;
+    /**
+     * Snapshots that have been taken but not successfully persisted yet, by binding key.
+     * A newer snapshot for the same key supersedes the queued one. Entries survive failed
+     * commits and are retried (with backoff) until they land — they are never dropped.
+     */
+    private pendingCommits = new Map<string | null, PendingCommit<T>>();
+    private drainPromise: Promise<void> | null = null;
+    private debounceTimer?: ReturnType<typeof setTimeout>;
+    private retryTimer?: ReturnType<typeof setTimeout>;
+    private retryCount = 0;
+
+    constructor(updaterOrBinding: Callback | SpacedUpdateBinding<T>, updateInterval = 1000, stateCallback?: StateCallback) {
+        if (typeof updaterOrBinding === "function") {
+            // Legacy single-callback mode: the updater reads live state and persists it in one
+            // step, so there is nothing to snapshot and the binding key never changes.
+            this.bindingKey = null;
+            this.prepare = () => undefined as T;
+            this.commit = () => updaterOrBinding();
+        } else {
+            this.bindingKey = updaterOrBinding.key;
+            this.prepare = updaterOrBinding.prepare;
+            this.commit = updaterOrBinding.commit;
+        }
+
         this.lastUpdated = Date.now();
         this.changed = false;
         this.updateInterval = updateInterval;
@@ -26,38 +77,56 @@ export default class SpacedUpdate {
         if (!this.changeForbidden) {
             this.changed = true;
             this.onStateChanged("unsaved");
-            setTimeout(() => this.triggerUpdate());
+            this.armDebounceTimer();
         }
     }
 
-    async updateNowIfNecessary() {
-        if (this.changed) {
-            this.changed = false; // optimistic...
+    /**
+     * Swaps the binding to a new target. If the key changes while a change is still pending,
+     * the change is first snapshotted with the *previous* binding (and committed in the
+     * background, addressed to the previous key), so it can never be saved under the new key.
+     */
+    rebind(key: string | null, prepare: PrepareCallback<T>, commit: CommitCallback<T>) {
+        if (key !== this.bindingKey && this.changed) {
+            const snapshotted = this.snapshotPending();
+            const drainInBackground = () => {
+                this.drain().catch(() => {
+                    // Failures are logged in runDrain and retried; the snapshot stays addressed to the old key.
+                });
+            };
 
-            try {
-                this.onStateChanged("saving");
-                await this.updater();
-                this.onStateChanged("saved");
-            } catch (e) {
-                this.changed = true;
-                this.onStateChanged("error");
-                logError(getErrorMessage(e));
-                throw e;
+            if (snapshotted instanceof Promise) {
+                // The old prepare() was already invoked synchronously, so swapping the binding
+                // below cannot leak the pending change to the new key.
+                snapshotted.then(drainInBackground, () => {});
+            } else {
+                drainInBackground();
             }
         }
+
+        this.bindingKey = key;
+        this.prepare = prepare;
+        this.commit = commit;
+    }
+
+    /** Flushes the pending change (if any) and waits until all queued snapshots are persisted. */
+    updateNowIfNecessary(): Promise<void> {
+        return this.drain();
     }
 
     isAllSavedAndTriggerUpdate() {
-        const allSaved = !this.changed;
+        const allSaved = !this.changed && this.pendingCommits.size === 0 && !this.drainPromise;
 
-        this.updateNowIfNecessary();
+        this.updateNowIfNecessary().catch(() => {
+            // Failures are logged in runDrain and retried.
+        });
 
         return allSaved;
     }
 
     /**
      * Normally {@link scheduleUpdate()} would actually trigger the update only once per {@link updateInterval}. If the method is called 200 times within 20s, it will execute only 20 times.
-     * Sometimes, if the updates are continuous this would cause a performance impact. Resetting the time ensures that the calls to {@link triggerUpdate} have stopped before actually triggering an update.
+     * Sometimes, if the updates are continuous this would cause a performance impact. Resetting the time ensures that the calls to the update have stopped before actually triggering an update.
      */
     resetUpdateTimer() {
         this.lastUpdated = Date.now();
@@ -69,34 +138,6 @@ export default class SpacedUpdate {
      */
     setUpdateInterval(interval: number) {
         this.updateInterval = interval;
-    }
-
-    async triggerUpdate() {
-        if (!this.changed) {
-            return;
-        }
-
-        if (Date.now() - this.lastUpdated > this.updateInterval) {
-            // Update these BEFORE the async call to prevent race conditions.
-            // Multiple setTimeout callbacks may be pending from recursive scheduleUpdate() calls.
-            // Without this, they would all pass the time check during the await and trigger multiple requests.
-            this.lastUpdated = Date.now();
-            this.changed = false;
-
-            this.onStateChanged("saving");
-            try {
-                await this.updater();
-                this.onStateChanged("saved");
-            } catch (e) {
-                // Restore changed flag on error so a retry can happen
-                this.changed = true;
-                this.onStateChanged("error");
-                logError(getErrorMessage(e));
-            }
-        } else {
-            // update isn't triggered but changes are still pending, so we need to schedule another check
-            this.scheduleUpdate();
-        }
     }
 
     onStateChanged(state: SaveState) {
@@ -114,5 +155,155 @@ export default class SpacedUpdate {
         } finally {
             this.changeForbidden = false;
         }
+    }
+
+    /**
+     * Single debounce timer replacing the old 0-ms self-rescheduling loop: armed with the time
+     * remaining until the interval elapses, re-armed if {@link resetUpdateTimer} pushed it back.
+     */
+    private armDebounceTimer() {
+        if (this.debounceTimer) {
+            return;
+        }
+
+        const delay = Math.max(1, this.updateInterval - (Date.now() - this.lastUpdated));
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = undefined;
+
+            if (!this.changed) {
+                return;
+            }
+
+            if (Date.now() - this.lastUpdated >= this.updateInterval) {
+                this.drain().catch(() => {
+                    // Failures are logged in runDrain and retried.
+                });
+            } else {
+                this.armDebounceTimer();
+            }
+        }, delay);
+    }
+
+    /**
+     * Snapshots the pending change with the *current* binding and queues it for commit.
+     * Returns a promise only when `prepare` is asynchronous; in the synchronous case the
+     * snapshot is queued before this method returns, so callers (notably the `beforeunload`
+     * path) can rely on the commit starting synchronously within {@link drain}.
+     */
+    private snapshotPending(): void | Promise<void> {
+        if (!this.changed) {
+            return;
+        }
+
+        this.changed = false;
+        this.lastUpdated = Date.now();
+
+        const { bindingKey, commit } = this;
+        const restoreOnError = (e: unknown): never => {
+            this.changed = true;
+            this.onStateChanged("error");
+            throw e;
+        };
+
+        let result: T | Promise<T>;
+        try {
+            result = this.prepare();
+        } catch (e) {
+            return restoreOnError(e);
+        }
+
+        if (result instanceof Promise) {
+            return result.then(
+                (data) => {
+                    this.pendingCommits.set(bindingKey, { data, commit });
+                },
+                restoreOnError
+            );
+        }
+
+        this.pendingCommits.set(bindingKey, { data: result, commit });
+    }
+
+    private drain(): Promise<void> {
+        if (this.drainPromise) {
+            return this.drainPromise;
+        }
+
+        if (!this.changed && this.pendingCommits.size === 0) {
+            return Promise.resolve();
+        }
+
+        this.drainPromise = this.runDrain().finally(() => {
+            this.drainPromise = null;
+        });
+
+        return this.drainPromise;
+    }
+
+    private async runDrain(): Promise<void> {
+        while (true) {
+            // Fold any pending change into the queue first, so a queued snapshot and a newer
+            // pending change for the same key result in a single save, not two.
+            const snapshotted = this.snapshotPending();
+            if (snapshotted instanceof Promise) {
+                await snapshotted;
+            }
+
+            if (this.pendingCommits.size === 0) {
+                break;
+            }
+
+            this.onStateChanged("saving");
+
+            let failed = false;
+            let firstError: unknown;
+
+            for (const key of [ ...this.pendingCommits.keys() ]) {
+                const entry = this.pendingCommits.get(key);
+                if (!entry) {
+                    continue;
+                }
+
+                try {
+                    await entry.commit(entry.data);
+                    this.retryCount = 0;
+
+                    // Delete only if the entry was not superseded by a newer snapshot during the await.
+                    if (this.pendingCommits.get(key) === entry) {
+                        this.pendingCommits.delete(key);
+                    }
+                } catch (e) {
+                    if (!failed) {
+                        failed = true;
+                        firstError = e;
+                    }
+                    logError(getErrorMessage(e));
+                }
+            }
+
+            if (failed) {
+                this.onStateChanged("error");
+                this.scheduleRetry();
+                throw firstError;
+            }
+        }
+
+        this.onStateChanged(this.changed ? "unsaved" : "saved");
+    }
+
+    private scheduleRetry() {
+        if (this.retryTimer) {
+            return;
+        }
+
+        const delay = Math.min(this.updateInterval * 2 ** this.retryCount, MAX_RETRY_DELAY);
+        this.retryCount++;
+
+        this.retryTimer = setTimeout(() => {
+            this.retryTimer = undefined;
+            this.drain().catch(() => {
+                // Failures are logged in runDrain and will be retried again.
+            });
+        }, delay);
     }
 }

--- a/apps/client/src/services/spaced_update.ts
+++ b/apps/client/src/services/spaced_update.ts
@@ -49,6 +49,8 @@ export default class SpacedUpdate<T = void> {
      * commits and are retried (with backoff) until they land — they are never dropped.
      */
     private pendingCommits = new Map<string | null, PendingCommit<T>>();
+    /** Snapshots whose asynchronous `prepare` is still running — captured but not yet queued. */
+    private pendingSnapshots = new Set<Promise<void>>();
     private drainPromise: Promise<void> | null = null;
     private debounceTimer?: ReturnType<typeof setTimeout>;
     private retryTimer?: ReturnType<typeof setTimeout>;
@@ -115,7 +117,10 @@ export default class SpacedUpdate<T = void> {
     }
 
     isAllSavedAndTriggerUpdate() {
-        const allSaved = !this.changed && this.pendingCommits.size === 0 && !this.drainPromise;
+        const allSaved = !this.changed
+            && this.pendingCommits.size === 0
+            && this.pendingSnapshots.size === 0
+            && !this.drainPromise;
 
         this.updateNowIfNecessary().catch(() => {
             // Failures are logged in runDrain and retried.
@@ -213,12 +218,20 @@ export default class SpacedUpdate<T = void> {
         }
 
         if (result instanceof Promise) {
-            return result.then(
-                (data) => {
-                    this.pendingCommits.set(bindingKey, { data, commit });
-                },
-                restoreOnError
-            );
+            // Track the in-flight snapshot so drain() and isAllSavedAndTriggerUpdate() don't
+            // consider everything saved before the snapshot has been queued for commit.
+            const snapshot: Promise<void> = result
+                .then(
+                    (data) => {
+                        this.pendingCommits.set(bindingKey, { data, commit });
+                    },
+                    restoreOnError
+                )
+                .finally(() => {
+                    this.pendingSnapshots.delete(snapshot);
+                });
+            this.pendingSnapshots.add(snapshot);
+            return snapshot;
         }
 
         this.pendingCommits.set(bindingKey, { data: result, commit });
@@ -229,7 +242,7 @@ export default class SpacedUpdate<T = void> {
             return this.drainPromise;
         }
 
-        if (!this.changed && this.pendingCommits.size === 0) {
+        if (!this.changed && this.pendingCommits.size === 0 && this.pendingSnapshots.size === 0) {
             return Promise.resolve();
         }
 
@@ -242,6 +255,12 @@ export default class SpacedUpdate<T = void> {
 
     private async runDrain(): Promise<void> {
         while (true) {
+            // Wait for snapshots that were started elsewhere (e.g. by rebind) to be queued.
+            // Their failures restore the `changed` flag and are handled by the fold below.
+            while (this.pendingSnapshots.size > 0) {
+                await Promise.allSettled([ ...this.pendingSnapshots ]);
+            }
+
             // Fold any pending change into the queue first, so a queued snapshot and a newer
             // pending change for the same key result in a single save, not two.
             const snapshotted = this.snapshotPending();

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1980,6 +1980,9 @@
     "window-on-top": "Keep Window on Top"
   },
   "note_detail": {
+    "content_load_error": "The note's content could not be loaded.",
+    "content_load_retry": "Retry",
+    "content_load_stalled": "Still loading the note's content…",
     "could_not_find_typewidget": "Could not find typeWidget for type '{{type}}'",
     "printing": "Printing in progress...",
     "printing_pdf": "Preparing print preview...",

--- a/apps/client/src/widgets/NoteDetail.css
+++ b/apps/client/src/widgets/NoteDetail.css
@@ -3,6 +3,7 @@
     font-family: var(--detail-font-family);
     font-size: var(--detail-font-size);
     contain: none;
+    position: relative; /* anchor for the content-loading overlay */
 
     &.fixed-tree {
         display: flex;
@@ -36,4 +37,37 @@ body.prefers-centered-content .note-detail {
 
 .note-detail > * {
     contain: none;
+}
+
+.note-detail-loading-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: var(--main-background-color);
+    animation: note-detail-loading-overlay-fade-in 100ms ease-in;
+
+    > .bx-loader-alt {
+        font-size: 2em;
+        color: var(--muted-text-color);
+    }
+}
+
+/* Dialogs (e.g. the quick-edit popup) paint their content area with the modal background,
+   so the overlay must match it there instead of the main background. */
+.modal .note-detail-loading-overlay {
+    background: var(--modal-background-color);
+}
+
+@keyframes note-detail-loading-overlay-fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
 }

--- a/apps/client/src/widgets/NoteDetail.tsx
+++ b/apps/client/src/widgets/NoteDetail.tsx
@@ -16,7 +16,10 @@ import toast from "../services/toast.js";
 import { isElectron, isMobile } from "../services/utils";
 import NoteTreeWidget from "./note_tree";
 import { ExtendedNoteType, TYPE_MAPPINGS, TypeWidget } from "./note_types";
-import { useLegacyWidget, useNoteContext, useTriliumEvent } from "./react/hooks";
+import Button from "./react/Button";
+import { useDelayedVisibility, useGetContextDataFrom, useLegacyWidget, useNoteContext, useTriliumEvent } from "./react/hooks";
+import Icon from "./react/Icon";
+import NoItems from "./react/NoItems";
 import { NoteListWithLinks } from "./react/NoteList";
 import { TypeWidgetProps } from "./type_widgets/type_widget";
 
@@ -234,6 +237,8 @@ export default function NoteDetail() {
                     props={props}
                 />;
             })}
+
+            <NoteDetailLoadingOverlay noteContext={noteContext} />
         </div>
     );
 }
@@ -284,6 +289,42 @@ function NoteDetailWrapper({ Element, type, isVisible, isFullHeight, props }: { 
     );
 }
 
+/**
+ * Covers the note detail while the note's content is being fetched, so the user is not left
+ * looking at (and typing into) the previous note's content when the blob is slow to arrive.
+ *
+ * Driven by the `contentLoad` context data published from `useNoteInfo` (type resolution,
+ * which fetches the content for the auto-readonly check) and `useNoteBlob` (the editors'
+ * own content fetch), and paced by {@link useDelayedVisibility}: fast loads never flash it,
+ * slow loads fade it in, and loads stuck past the stall threshold (or failed outright)
+ * offer a retry.
+ */
+function NoteDetailLoadingOverlay({ noteContext }: { noteContext: NoteContext | null | undefined }) {
+    const contentLoad = useGetContextDataFrom(noteContext, "contentLoad");
+    const phase = useDelayedVisibility(contentLoad?.state === "loading");
+    const isError = contentLoad?.state === "error";
+
+    if (!isError && phase === "hidden") {
+        return null;
+    }
+
+    return (
+        <div className="note-detail-loading-overlay">
+            {isError ? (
+                <NoItems icon="bx bx-error-circle" text={t("note_detail.content_load_error")}>
+                    <Button text={t("note_detail.content_load_retry")} onClick={() => contentLoad?.retry()} />
+                </NoItems>
+            ) : phase === "stalled" ? (
+                <NoItems icon="bx bx-loader-alt bx-spin" text={t("note_detail.content_load_stalled")}>
+                    <Button text={t("note_detail.content_load_retry")} onClick={() => contentLoad?.retry()} />
+                </NoItems>
+            ) : (
+                <Icon icon="bx bx-loader-alt bx-spin" />
+            )}
+        </div>
+    );
+}
+
 /** Manages both note changes and changes to the widget type, which are asynchronous. */
 function useNoteInfo() {
     const { note: actualNote, noteContext, parentComponent } = useNoteContext();
@@ -295,11 +336,21 @@ function useNoteInfo() {
     function refresh() {
         const refreshId = ++refreshIdRef.current;
 
+        // The type resolution below can take a while (the auto-readonly check of
+        // getExtendedWidgetType fetches the note's content), during which the previously
+        // rendered note stays visible — cover it with the content-loading overlay.
+        if (actualNote) {
+            noteContext?.setContextData("contentLoad", { state: "loading", retry: refresh });
+        }
+
         getExtendedWidgetType(actualNote, noteContext).then(type => {
             if (refreshId !== refreshIdRef.current) return;
             setNote(actualNote);
             setType(type);
             setMime(actualNote?.mime);
+            if (actualNote) {
+                noteContext?.setContextData("contentLoad", { state: "loaded", retry: refresh });
+            }
         });
     }
 

--- a/apps/client/src/widgets/containers/split_note_container.ts
+++ b/apps/client/src/widgets/containers/split_note_container.ts
@@ -250,7 +250,9 @@ export default class SplitNoteContainer extends FlexContainer<SplitNoteWidget> {
             if (widget.hasBeenAlreadyShown || name === "noteSwitchedAndActivated" || appContext.tabManager.getActiveMainContext() === noteSwitchedContext.noteContext.getMainContext()) {
                 widget.hasBeenAlreadyShown = true;
 
-                return [widget.handleEvent("noteSwitched", noteSwitchedContext), this.refreshNotShown(noteSwitchedContext)];
+                // Promise.all (not a bare array) so that awaiting triggerEvent("noteSwitched")
+                // genuinely waits for the tab's widgets to process the switch.
+                return Promise.all([ widget.handleEvent("noteSwitched", noteSwitchedContext), this.refreshNotShown(noteSwitchedContext) ]);
             }
             return Promise.resolve();
 

--- a/apps/client/src/widgets/react/editor_save_race.spec.tsx
+++ b/apps/client/src/widgets/react/editor_save_race.spec.tsx
@@ -1,0 +1,206 @@
+/**
+ * Synthetic reproduction of https://github.com/TriliumNext/Trilium/issues/9614
+ * ("Notes being overwritten with another note").
+ *
+ * The save pipeline in `useEditorSpacedUpdate` does not bind the content snapshot
+ * (`getData()`, which reads the live editor) to the note it was loaded from. Editor
+ * components are reused across note switches (NoteDetailWrapper is keyed by note
+ * *type*), and the new note's content arrives only after an async blob fetch. Any
+ * save that fires in that window writes the previous note's content under the new
+ * note's id.
+ *
+ * These tests assert the *correct* behavior, so they are red while the bug exists
+ * and become the regression suite once it is fixed. The fake "editor" is a plain
+ * content holder standing in for CKEditor; note B's blob is a controllable deferred
+ * standing in for a slow blob fetch (remote server / PWA).
+ */
+import { deferred } from "@triliumnext/commons";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Component from "../../components/component";
+import NoteContext from "../../components/note_context";
+import FBlob from "../../entities/fblob";
+import type FNote from "../../entities/fnote";
+import server from "../../services/server";
+import type SpacedUpdate from "../../services/spaced_update";
+import { buildNote } from "../../test/easy-froca";
+import { useEditorSpacedUpdate } from "./hooks";
+import { ParentComponent } from "./react_utils";
+
+vi.stubGlobal("logError", vi.fn());
+vi.stubGlobal("logInfo", vi.fn());
+
+let currentSpacedUpdate: SpacedUpdate | undefined;
+
+/** Stand-in for EditableText: `editor.content` plays the role of the live CKEditor document. */
+function FakeEditor({ note, noteContext, editor }: {
+    note: FNote;
+    noteContext: NoteContext | null;
+    editor: { content: string };
+}) {
+    currentSpacedUpdate = useEditorSpacedUpdate({
+        note,
+        noteContext,
+        noteType: "text",
+        getData: () => ({ content: editor.content }),
+        onContentChange(newContent) {
+            editor.content = newContent;
+        }
+    });
+    return null;
+}
+
+function getSpacedUpdate(): SpacedUpdate {
+    if (!currentSpacedUpdate) {
+        throw new Error("Harness was not rendered yet");
+    }
+    return currentSpacedUpdate;
+}
+
+function setupEditorHarness({ withParent = false } = {}) {
+    const noteA = buildNote({ title: "Note A", type: "text", content: "AAA" });
+    const noteB = buildNote({ title: "Note B", type: "text", content: "BBB" });
+
+    // Note B's content stays "in flight" (slow server) until the test resolves it.
+    const blobB = new FBlob({
+        blobId: `blob-${noteB.noteId}`,
+        content: "BBB",
+        contentLength: 3,
+        dateModified: new Date().toISOString(),
+        utcDateModified: new Date().toISOString()
+    });
+    const pendingBlobB = deferred<FBlob>();
+    noteB.getBlob = () => pendingBlobB;
+
+    const editor = { content: "" };
+    const puts: { url: string; content: string }[] = [];
+    server.put = vi.fn(async (url: string, data: { content: string }) => {
+        puts.push({ url, content: data.content });
+        return {};
+    }) as typeof server.put;
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const parent = withParent ? new Component() : null;
+    const noteContext = withParent ? new NoteContext("test-ntx") : null;
+
+    async function show(note: FNote) {
+        await act(async () => {
+            const editorEl = <FakeEditor note={note} noteContext={noteContext} editor={editor} />;
+            render(
+                parent ? <ParentComponent.Provider value={parent}>{editorEl}</ParentComponent.Provider> : editorEl,
+                container
+            );
+        });
+        // Let the blob-load effect's `allowUpdateWithoutChange` settle (it re-enables
+        // scheduling on a microtask), without crossing the 1s save debounce.
+        await vi.advanceTimersByTimeAsync(20);
+    }
+
+    function putsTo(note: FNote) {
+        return puts.filter((p) => p.url === `notes/${note.noteId}/data`);
+    }
+
+    return { noteA, noteB, pendingBlobB, blobB, editor, puts, putsTo, container, parent, noteContext, show };
+}
+
+describe("note switch save race (#9614)", () => {
+    let cleanupContainer: HTMLElement | undefined;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        currentSpacedUpdate = undefined;
+    });
+
+    afterEach(() => {
+        if (cleanupContainer) {
+            render(null, cleanupContainer);
+            cleanupContainer.remove();
+            cleanupContainer = undefined;
+        }
+        vi.useRealTimers();
+    });
+
+    it("does not save the previous note's content under the next note when switching while an edit is pending (quick-edit popup path)", async () => {
+        const harness = setupEditorHarness();
+        cleanupContainer = harness.container;
+        const { noteA, noteB, editor, putsTo, show } = harness;
+
+        await show(noteA);
+        expect(editor.content).toBe("AAA"); // sanity: note A's content reached the editor
+
+        // The user types into note A; the save is debounced by SpacedUpdate (1s).
+        editor.content = "AAA edited";
+        getSpacedUpdate().scheduleUpdate();
+
+        // Within the debounce window, the quick-edit popup swaps to note B
+        // (PopupEditor creates a fresh NoteContext whose beforeNoteSwitch event
+        // reaches no listeners, so nothing flushes or clears the pending change).
+        // B's blob fetch is still in flight, so the editor still holds A's content.
+        await show(noteB);
+
+        // The debounce elapses while note B's content is still loading.
+        await vi.advanceTimersByTimeAsync(1500);
+
+        // Note B must never receive note A's content.
+        expect(putsTo(noteB)).toEqual([]);
+
+        // The pending edit belongs to note A and must not be lost.
+        expect(putsTo(noteA)).toContainEqual({ url: `notes/${noteA.noteId}/data`, content: "AAA edited" });
+    });
+
+    it("does not attribute keystrokes typed right after an in-tab switch to the new note while the editor still shows the old note's content", async () => {
+        const harness = setupEditorHarness({ withParent: true });
+        cleanupContainer = harness.container;
+        const { noteA, noteB, editor, putsTo, parent, noteContext, show } = harness;
+        if (!parent || !noteContext) {
+            throw new Error("Harness misconfigured");
+        }
+
+        await show(noteA);
+        expect(editor.content).toBe("AAA");
+
+        // The user types into note A...
+        editor.content = "AAA edited";
+        getSpacedUpdate().scheduleUpdate();
+
+        // ...then clicks note B in the tree. NoteContext.setNote fires beforeNoteSwitch
+        // (which the editor hook handles by flushing), then proceeds with the switch.
+        await parent.handleEvent("beforeNoteSwitch", { noteContext });
+        await show(noteB);
+
+        // The flush saved note A correctly — that part works.
+        expect(putsTo(noteA)).toContainEqual({ url: `notes/${noteA.noteId}/data`, content: "AAA edited" });
+
+        // The user starts typing immediately, while the editor still displays note A's
+        // content under note B's title (B's blob fetch is still in flight).
+        editor.content = "AAA edited plus keystrokes meant for B";
+        getSpacedUpdate().scheduleUpdate();
+        await vi.advanceTimersByTimeAsync(1500);
+
+        // Note B must not be overwritten with note A's content + the new keystrokes.
+        expect(putsTo(noteB)).toEqual([]);
+    });
+
+    it("awaits async event handlers registered by React components (the contract NoteContext.setNote relies on)", async () => {
+        const parent = new Component();
+        let flushed = false;
+        parent.registerHandler("beforeNoteSwitch", async () => {
+            // The real handler (the editor's save flush) suspends across a full network
+            // round trip; two chained awaits are the minimal stand-in for "takes longer
+            // than the single microtask that `await handleEvent(...)` burns".
+            await Promise.resolve();
+            await Promise.resolve();
+            flushed = true;
+        });
+
+        // NoteContext.setNote does `await this.triggerEvent("beforeNoteSwitch", ...)`
+        // expecting all handlers (including the editor's save flush) to have completed.
+        await parent.handleEvent("beforeNoteSwitch", { noteContext: new NoteContext("contract-ntx") });
+
+        expect(flushed).toBe(true);
+    });
+});

--- a/apps/client/src/widgets/react/editor_save_race.spec.tsx
+++ b/apps/client/src/widgets/react/editor_save_race.spec.tsx
@@ -26,13 +26,13 @@ import type FNote from "../../entities/fnote";
 import server from "../../services/server";
 import type SpacedUpdate from "../../services/spaced_update";
 import { buildNote } from "../../test/easy-froca";
-import { useEditorSpacedUpdate } from "./hooks";
+import { type SavedData, useEditorSpacedUpdate } from "./hooks";
 import { ParentComponent } from "./react_utils";
 
 vi.stubGlobal("logError", vi.fn());
 vi.stubGlobal("logInfo", vi.fn());
 
-let currentSpacedUpdate: SpacedUpdate | undefined;
+let currentSpacedUpdate: SpacedUpdate<SavedData | undefined> | undefined;
 
 /** Stand-in for EditableText: `editor.content` plays the role of the live CKEditor document. */
 function FakeEditor({ note, noteContext, editor }: {
@@ -52,7 +52,7 @@ function FakeEditor({ note, noteContext, editor }: {
     return null;
 }
 
-function getSpacedUpdate(): SpacedUpdate {
+function getSpacedUpdate(): SpacedUpdate<SavedData | undefined> {
     if (!currentSpacedUpdate) {
         throw new Error("Harness was not rendered yet");
     }

--- a/apps/client/src/widgets/react/hooks.spec.tsx
+++ b/apps/client/src/widgets/react/hooks.spec.tsx
@@ -1,0 +1,83 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type DelayedVisibilityPhase, useDelayedVisibility } from "./hooks";
+
+let currentPhase: DelayedVisibilityPhase | undefined;
+
+function Probe({ active }: { active: boolean }) {
+    currentPhase = useDelayedVisibility(active, { graceMs: 150, minVisibleMs: 280, stalledMs: 8000 });
+    return null;
+}
+
+describe("useDelayedVisibility", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        currentPhase = undefined;
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+        vi.useRealTimers();
+    });
+
+    async function show(active: boolean) {
+        await act(async () => {
+            render(<Probe active={active} />, container);
+        });
+    }
+
+    async function advance(ms: number) {
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(ms);
+        });
+    }
+
+    it("never shows when loading finishes within the grace period", async () => {
+        await show(true);
+        expect(currentPhase).toBe("hidden");
+
+        await advance(100); // still within the 150ms grace window
+        await show(false);
+        await advance(1000);
+
+        expect(currentPhase).toBe("hidden");
+    });
+
+    it("shows after the grace period and stays for the minimum visible time", async () => {
+        await show(true);
+        await advance(150);
+        expect(currentPhase).toBe("visible");
+
+        // Loading finishes shortly after the indicator appeared...
+        await advance(10);
+        await show(false);
+
+        // ...but the indicator must not flicker away before the minimum visible time.
+        await advance(200);
+        expect(currentPhase).toBe("visible");
+
+        await advance(100);
+        expect(currentPhase).toBe("hidden");
+    });
+
+    it("escalates to stalled after continuous loading, then hides immediately once loading ends", async () => {
+        await show(true);
+        await advance(150);
+        expect(currentPhase).toBe("visible");
+
+        await advance(8000);
+        expect(currentPhase).toBe("stalled");
+
+        // The minimum visible time has long passed, so deactivation hides without further delay.
+        await show(false);
+        await advance(0);
+        expect(currentPhase).toBe("hidden");
+    });
+});

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -115,33 +115,61 @@ export function useEditorSpacedUpdate({ note, noteType, noteContext, getData, on
     const parentComponent = useContext(ParentComponent);
     const blob = useNoteBlob(note, parentComponent?.componentId);
 
-    const callback = useMemo(() => {
-        return async () => {
-            const data = await getData();
+    // The note whose content is currently loaded in the editor. Editor instances are reused
+    // across note switches, so until the new note's blob arrives the editor still holds the
+    // previous note's content — content that must never be saved under the new noteId (#9614).
+    const loadedNoteIdRef = useRef<string>();
 
-            // for read only notes, or if note is not yet available (e.g. lazy creation)
-            if (data === undefined || !note || note.type !== noteType) return;
+    const prepare = useCallback(() => {
+        if (!note || loadedNoteIdRef.current !== note.noteId) return undefined;
+        return getData();
+    }, [ note, getData ]);
 
-            protected_session_holder.touchProtectedSessionIfNecessary(note);
+    const commit = useCallback(async (data: SavedData | undefined) => {
+        // for read only notes, or if note is not yet available (e.g. lazy creation)
+        if (data === undefined || !note || note.type !== noteType) return;
 
-            await server.put(`notes/${note.noteId}/data`, data, parentComponent?.componentId);
+        protected_session_holder.touchProtectedSessionIfNecessary(note);
 
-            noteSavedDataStore.set(note.noteId, data.content);
-            dataSaved?.(data);
-        };
-    }, [ note, getData, dataSaved, noteType, parentComponent ]);
+        await server.put(`notes/${note.noteId}/data`, data, parentComponent?.componentId);
+
+        noteSavedDataStore.set(note.noteId, data.content);
+        dataSaved?.(data);
+    }, [ note, dataSaved, noteType, parentComponent ]);
+
     const stateCallback = useCallback<StateCallback>((state) => {
         noteContext?.setContextData("saveState", {
             state
         });
     }, [ noteContext ]);
-    const spacedUpdate = useSpacedUpdate(callback, updateInterval, stateCallback);
+    const stateCallbackRef = useRef(stateCallback);
+    useEffect(() => {
+        stateCallbackRef.current = stateCallback;
+    }, [ stateCallback ]);
+
+    const spacedUpdateRef = useRef<SpacedUpdate<SavedData | undefined>>();
+    if (!spacedUpdateRef.current) {
+        spacedUpdateRef.current = new SpacedUpdate<SavedData | undefined>(
+            { key: note?.noteId ?? null, prepare, commit },
+            updateInterval,
+            (state) => stateCallbackRef.current(state)
+        );
+    }
+    const spacedUpdate = spacedUpdateRef.current;
+
+    // Rebind to the current note on every render. When the note changes while a change is
+    // still pending, rebind() snapshots it with the previous binding first, so it is saved
+    // under the note it was typed into rather than the note the component now displays.
+    useEffect(() => {
+        spacedUpdate.rebind(note?.noteId ?? null, prepare, commit);
+    });
 
     // React to note/blob changes.
     useEffect(() => {
         if (!blob || !note) return;
         noteSavedDataStore.set(note.noteId, blob.content);
         spacedUpdate.allowUpdateWithoutChange(() => onContentChange(blob.content));
+        loadedNoteIdRef.current = note.noteId;
     }, [ blob ]);
 
     // React to update interval changes.
@@ -186,29 +214,55 @@ export function useBlobEditorSpacedUpdate({ note, noteType, noteContext, getData
     const parentComponent = useContext(ParentComponent);
     const blob = useNoteBlob(note, parentComponent?.componentId);
 
-    const callback = useMemo(() => {
-        return async () => {
-            const data = await getData();
+    // Same provenance guard as useEditorSpacedUpdate: never save content under a note it
+    // was not loaded from (#9614).
+    const loadedNoteIdRef = useRef<string>();
 
-            // for read only notes
-            if (data === undefined || note.type !== noteType) return;
+    const prepare = useCallback(() => {
+        if (loadedNoteIdRef.current !== note.noteId) return undefined;
+        return getData();
+    }, [ note, getData ]);
 
-            protected_session_holder.touchProtectedSessionIfNecessary(note);
-            await server.upload(`notes/${note.noteId}/file?replace=${replaceWithoutRevision ? "1" : "0"}`, new File([ data ], note.title, { type: note.mime }), parentComponent?.componentId);
-            dataSaved?.(data);
-        };
-    }, [ note, getData, dataSaved, noteType, parentComponent, replaceWithoutRevision ]);
+    const commit = useCallback(async (data: Blob | undefined) => {
+        // for read only notes
+        if (data === undefined || note.type !== noteType) return;
+
+        protected_session_holder.touchProtectedSessionIfNecessary(note);
+        await server.upload(`notes/${note.noteId}/file?replace=${replaceWithoutRevision ? "1" : "0"}`, new File([ data ], note.title, { type: note.mime }), parentComponent?.componentId);
+        dataSaved?.(data);
+    }, [ note, dataSaved, noteType, parentComponent, replaceWithoutRevision ]);
+
     const stateCallback = useCallback<StateCallback>((state) => {
         noteContext?.setContextData("saveState", {
             state
         });
     }, [ noteContext ]);
-    const spacedUpdate = useSpacedUpdate(callback, updateInterval, stateCallback);
+    const stateCallbackRef = useRef(stateCallback);
+    useEffect(() => {
+        stateCallbackRef.current = stateCallback;
+    }, [ stateCallback ]);
+
+    const spacedUpdateRef = useRef<SpacedUpdate<Blob | undefined>>();
+    if (!spacedUpdateRef.current) {
+        spacedUpdateRef.current = new SpacedUpdate<Blob | undefined>(
+            { key: note.noteId, prepare, commit },
+            updateInterval,
+            (state) => stateCallbackRef.current(state)
+        );
+    }
+    const spacedUpdate = spacedUpdateRef.current;
+
+    // Rebind to the current note on every render; flushes a pending change with the previous
+    // binding when the note changes (see useEditorSpacedUpdate).
+    useEffect(() => {
+        spacedUpdate.rebind(note.noteId, prepare, commit);
+    });
 
     // React to note/blob changes.
     useEffect(() => {
         if (!blob) return;
         spacedUpdate.allowUpdateWithoutChange(() => onContentChange(blob));
+        loadedNoteIdRef.current = note.noteId;
     }, [ blob ]);
 
     // React to update interval changes.

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -112,7 +112,7 @@ export function useEditorSpacedUpdate({ note, noteType, noteContext, getData, on
     updateInterval?: number;
 }) {
     const parentComponent = useContext(ParentComponent);
-    const blob = useNoteBlob(note, parentComponent?.componentId);
+    const blob = useNoteBlob(note, parentComponent?.componentId, { reportLoadStateTo: noteContext });
 
     // The note whose content is currently loaded in the editor. Editor instances are reused
     // across note switches, so until the new note's blob arrives the editor still holds the
@@ -211,7 +211,7 @@ export function useBlobEditorSpacedUpdate({ note, noteType, noteContext, getData
     replaceWithoutRevision?: boolean;
 }) {
     const parentComponent = useContext(ParentComponent);
-    const blob = useNoteBlob(note, parentComponent?.componentId);
+    const blob = useNoteBlob(note, parentComponent?.componentId, { reportLoadStateTo: noteContext });
 
     // Same provenance guard as useEditorSpacedUpdate: never save content under a note it
     // was not loaded from (#9614).
@@ -752,17 +752,34 @@ export function useNoteLabelInt(note: FNote | undefined | null, labelName: Filte
     ];
 }
 
-export function useNoteBlob(note: FNote | null | undefined, componentId?: string): FBlob | null | undefined {
+export function useNoteBlob(note: FNote | null | undefined, componentId?: string, opts?: {
+    /** Publish the fetch progress as `contentLoad` context data on the given note context, so
+     * the note detail can show a loading state instead of the previous note's content. Should
+     * only be set by widgets whose main content display is gated on this blob. (Passed
+     * explicitly because NoteContextContext is only provided in dialogs, not the main window.) */
+    reportLoadStateTo?: NoteContext | null;
+}): FBlob | null | undefined {
     const [ blob, setBlob ] = useState<FBlob | null>();
     const requestIdRef = useRef(0);
 
+    function reportLoadState(state: "loading" | "loaded" | "error") {
+        opts?.reportLoadStateTo?.setContextData("contentLoad", { state, retry: () => refresh() });
+    }
+
     async function refresh() {
         const requestId = ++requestIdRef.current;
+        if (note) {
+            reportLoadState("loading");
+        }
         const newBlob = await note?.getBlob();
 
         // Only update if this is the latest request.
         if (requestId === requestIdRef.current) {
             setBlob(newBlob);
+            if (note) {
+                // froca.getBlob() resolves to null when the fetch failed.
+                reportLoadState(newBlob ? "loaded" : "error");
+            }
         }
     }
 
@@ -1697,4 +1714,58 @@ export function useContainedLinkNavigation(
         container.addEventListener("click", onClick, true);
         return () => container.removeEventListener("click", onClick, true);
     }, [ containerRef, onNavigate ]);
+}
+
+export type DelayedVisibilityPhase = "hidden" | "visible" | "stalled";
+
+export interface DelayedVisibilityOpts {
+    /** The indicator is never shown if `active` clears within this window (fast loads never flash). */
+    graceMs?: number;
+    /** Once shown, the indicator stays at least this long, even if `active` clears sooner (no two-frame flicker). */
+    minVisibleMs?: number;
+    /** After this much continuous activity the phase escalates to "stalled" so the UI can offer a retry. */
+    stalledMs?: number;
+}
+
+/**
+ * Drives a flicker-free loading indicator from a boolean "is loading" signal:
+ *
+ * - **grace period**: nothing is shown if loading finishes within {@link DelayedVisibilityOpts.graceMs},
+ *   so fast loads never flash a loading state;
+ * - **minimum visibility**: once shown, the indicator stays for at least
+ *   {@link DelayedVisibilityOpts.minVisibleMs}, preventing a skeleton that appears for two frames;
+ * - **escalation**: after {@link DelayedVisibilityOpts.stalledMs} of continuous loading the phase
+ *   becomes `"stalled"`, letting the UI switch to a "still loading / retry" presentation.
+ */
+export function useDelayedVisibility(active: boolean, { graceMs = 150, minVisibleMs = 280, stalledMs = 8000 }: DelayedVisibilityOpts = {}): DelayedVisibilityPhase {
+    const [ phase, setPhase ] = useState<DelayedVisibilityPhase>("hidden");
+    const shownAtRef = useRef(0);
+
+    useEffect(() => {
+        if (active) {
+            if (phase === "hidden") {
+                const graceTimer = setTimeout(() => {
+                    shownAtRef.current = Date.now();
+                    setPhase("visible");
+                }, graceMs);
+                return () => clearTimeout(graceTimer);
+            }
+
+            if (phase === "visible") {
+                const stalledTimer = setTimeout(
+                    () => setPhase("stalled"),
+                    Math.max(0, shownAtRef.current + stalledMs - Date.now())
+                );
+                return () => clearTimeout(stalledTimer);
+            }
+        } else if (phase !== "hidden") {
+            const hideTimer = setTimeout(
+                () => setPhase("hidden"),
+                Math.max(0, shownAtRef.current + minVisibleMs - Date.now())
+            );
+            return () => clearTimeout(hideTimer);
+        }
+    }, [ active, phase, graceMs, minVisibleMs, stalledMs ]);
+
+    return phase;
 }

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -44,11 +44,10 @@ export function useTriliumEvents<T extends EventNames>(eventNames: T[], handler:
     const parentComponent = useContext(ParentComponent);
 
     useLayoutEffect(() => {
-        const handlers: ({ eventName: T, callback: (data: EventData<T>) => void })[] = [];
+        const handlers: ({ eventName: T, callback: (data: EventData<T>) => unknown })[] = [];
         for (const eventName of eventNames) {
-            handlers.push({ eventName, callback: (data) => {
-                handler(data, eventName);
-            }});
+            // Return the handler's result so async handlers stay awaitable through triggerEvent().
+            handlers.push({ eventName, callback: (data) => handler(data, eventName) });
         }
 
         for (const { eventName, callback } of handlers) {

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
@@ -22,7 +22,7 @@ import { applyReferenceLinks } from "./read_only_helper";
 import { loadIncludedNote, refreshIncludedNote, setupImageOpening } from "./utils";
 
 export default function ReadOnlyText({ note, noteContext, ntxId }: TypeWidgetProps) {
-    const blob = useNoteBlob(note);
+    const blob = useNoteBlob(note, undefined, { reportLoadStateTo: noteContext });
     const { isRtl } = useNoteLanguage(note);
     const readOnlyContentRef = usePreactRef<HTMLDivElement>(null);
 

--- a/apps/desktop/src/ipc_messaging_provider.spec.ts
+++ b/apps/desktop/src/ipc_messaging_provider.spec.ts
@@ -102,13 +102,15 @@ describe("IpcMessagingProvider", () => {
             ]);
         });
 
-        it("still delivers noisy log-filtered message types (sync-failed / api-log-messages)", () => {
+        it("still delivers noisy log-filtered message types (frontend-update / sync-failed / api-log-messages)", () => {
             const w = newWindow();
 
+            provider.sendMessageToAllClients({ type: "frontend-update" } as any);
             provider.sendMessageToAllClients({ type: "sync-failed" } as any);
             provider.sendMessageToAllClients({ type: "api-log-messages" } as any);
 
             expect(sends).toEqual([
+                { windowId: w.id, channel: "trilium-ws-message", payload: { type: "frontend-update" } },
                 { windowId: w.id, channel: "trilium-ws-message", payload: { type: "sync-failed" } },
                 { windowId: w.id, channel: "trilium-ws-message", payload: { type: "api-log-messages" } }
             ]);

--- a/apps/desktop/src/ipc_messaging_provider.ts
+++ b/apps/desktop/src/ipc_messaging_provider.ts
@@ -1,5 +1,5 @@
 import type { WebSocketMessage } from "@triliumnext/commons";
-import { getLog, type ClientMessageHandler, type MessagingProvider } from "@triliumnext/core";
+import { getLog, shouldLogMessage, type ClientMessageHandler, type MessagingProvider } from "@triliumnext/core";
 import electron from "electron";
 
 /**
@@ -48,9 +48,7 @@ export default class IpcMessagingProvider implements MessagingProvider {
     }
 
     sendMessageToAllClients(message: WebSocketMessage): void {
-        // Match the WS provider's log-filtering so noisy sync-failed /
-        // api-log-messages traffic doesn't flood the log.
-        if (message.type !== "sync-failed" && message.type !== "api-log-messages") {
+        if (shouldLogMessage(message)) {
             getLog().info(`Sending message to all windows: ${JSON.stringify(message)}`);
         }
 

--- a/apps/server/playwright.config.ts
+++ b/apps/server/playwright.config.ts
@@ -10,10 +10,16 @@ const baseURL = process.env["BASE_URL"] || `http://127.0.0.1:${port}`;
 // server finds it as a regular file-backed database. In CI the workflow
 // handles this, but for local runs we do it here.
 if (!process.env.TRILIUM_DOCKER) {
-    cpSync(
-        join(__dirname, "../../packages/trilium-core/src/test/fixtures/document.db"),
-        join(__dirname, "spec/db/document.db")
-    );
+    try {
+        cpSync(
+            join(__dirname, "../../packages/trilium-core/src/test/fixtures/document.db"),
+            join(__dirname, "spec/db/document.db")
+        );
+    } catch (e) {
+        // The config is re-evaluated in every worker process; by then the webServer already
+        // holds the database open, which makes the (redundant) copy fail on Windows.
+        console.warn("Skipping test database copy:", (e as Error).message);
+    }
 }
 
 export default createBaseConfig({

--- a/apps/server/src/services/ws_messaging_provider.spec.ts
+++ b/apps/server/src/services/ws_messaging_provider.spec.ts
@@ -46,7 +46,13 @@ vi.mock("ws", () => ({
 }));
 vi.mock("./config.js", () => ({ default: configMock }));
 vi.mock("./utils.js", () => ({ randomString: randomStringMock }));
-vi.mock("@triliumnext/core", () => ({ getLog: () => getLogMock }));
+vi.mock("@triliumnext/core", async () => {
+    // use the real shouldLogMessage so the suppression tests cover the actual filter
+    const { shouldLogMessage } = await vi.importActual<typeof import("@triliumnext/core/src/services/messaging/index.js")>(
+        "@triliumnext/core/src/services/messaging/index.js"
+    );
+    return { getLog: () => getLogMock, shouldLogMessage };
+});
 
 import WebSocketMessagingProvider from "./ws_messaging_provider.js";
 
@@ -171,17 +177,24 @@ describe("WebSocketMessagingProvider", () => {
             server.clients.add(open);
             server.clients.add(closed);
 
-            provider.sendMessageToAllClients({ type: "frontend-update" } as WebSocketMessage);
+            provider.sendMessageToAllClients({ type: "sync-finished" } as WebSocketMessage);
             expect(open.sent).toHaveLength(1);
             expect(closed.sent).toHaveLength(0);
             expect(getLogMock.info).toHaveBeenCalled();
         });
 
         it("does not log for suppressed message types", () => {
-            init();
+            const { server } = init();
+            const open = makeSocket(OPEN);
+            server.clients.add(open);
+
+            provider.sendMessageToAllClients({ type: "frontend-update" } as WebSocketMessage);
             provider.sendMessageToAllClients({ type: "sync-failed" } as WebSocketMessage);
             provider.sendMessageToAllClients({ type: "api-log-messages" } as WebSocketMessage);
+
             expect(getLogMock.info).not.toHaveBeenCalled();
+            // suppressing the log must not suppress delivery
+            expect(open.sent).toHaveLength(3);
         });
 
         it("is a no-op when the server is not initialized", () => {

--- a/apps/server/src/services/ws_messaging_provider.ts
+++ b/apps/server/src/services/ws_messaging_provider.ts
@@ -1,11 +1,10 @@
 import type { WebSocketMessage } from "@triliumnext/commons";
-import type { ClientMessageHandler, MessagingProvider } from "@triliumnext/core";
+import { getLog, shouldLogMessage, type ClientMessageHandler, type MessagingProvider } from "@triliumnext/core";
 import type { IncomingMessage, Server as HttpServer } from "http";
 import type express from "express";
 import { WebSocket, WebSocketServer } from "ws";
 
 import config from "./config.js";
-import { getLog } from "@triliumnext/core";
 import { randomString } from "./utils.js";
 
 type SessionParser = (req: IncomingMessage, params: {}, cb: () => void) => void;
@@ -86,7 +85,7 @@ export default class WebSocketMessagingProvider implements MessagingProvider {
         const jsonStr = JSON.stringify(message);
 
         if (this.webSocketServer) {
-            if (message.type !== "sync-failed" && message.type !== "api-log-messages") {
+            if (shouldLogMessage(message)) {
                 getLog().info(`Sending message to all clients: ${jsonStr}`);
             }
 

--- a/packages/trilium-core/src/services/messaging/index.spec.ts
+++ b/packages/trilium-core/src/services/messaging/index.spec.ts
@@ -5,7 +5,8 @@ import {
     getMessagingProvider,
     initMessaging,
     isMessagingInitialized,
-    sendMessageToAllClients
+    sendMessageToAllClients,
+    shouldLogMessage
 } from "./index.js";
 import type { ClientMessageHandler, MessagingProvider } from "./types.js";
 
@@ -45,5 +46,15 @@ describe("messaging provider (core)", () => {
         sendMessageToAllClients({ type: "ping" });
         expect(fake.sendMessageToAllClients).toHaveBeenCalledWith({ type: "ping" });
         expect(fake.sent).toEqual([{ type: "ping" }]);
+    });
+
+    it("excludes frequent/noisy message types from broadcast logging", () => {
+        expect(shouldLogMessage({ type: "frontend-update" } as WebSocketMessage)).toBe(false);
+        expect(shouldLogMessage({ type: "sync-failed" } as WebSocketMessage)).toBe(false);
+        expect(shouldLogMessage({ type: "api-log-messages" } as WebSocketMessage)).toBe(false);
+
+        expect(shouldLogMessage({ type: "ping" } as WebSocketMessage)).toBe(true);
+        expect(shouldLogMessage({ type: "sync-finished" } as WebSocketMessage)).toBe(true);
+        expect(shouldLogMessage({ type: "reload-frontend" } as WebSocketMessage)).toBe(true);
     });
 });

--- a/packages/trilium-core/src/services/messaging/index.spec.ts
+++ b/packages/trilium-core/src/services/messaging/index.spec.ts
@@ -50,10 +50,10 @@ describe("messaging provider (core)", () => {
 
     it("excludes frequent/noisy message types from broadcast logging", () => {
         expect(shouldLogMessage({ type: "frontend-update" } as WebSocketMessage)).toBe(false);
+        expect(shouldLogMessage({ type: "ping" } as WebSocketMessage)).toBe(false);
         expect(shouldLogMessage({ type: "sync-failed" } as WebSocketMessage)).toBe(false);
         expect(shouldLogMessage({ type: "api-log-messages" } as WebSocketMessage)).toBe(false);
 
-        expect(shouldLogMessage({ type: "ping" } as WebSocketMessage)).toBe(true);
         expect(shouldLogMessage({ type: "sync-finished" } as WebSocketMessage)).toBe(true);
         expect(shouldLogMessage({ type: "reload-frontend" } as WebSocketMessage)).toBe(true);
     });

--- a/packages/trilium-core/src/services/messaging/index.ts
+++ b/packages/trilium-core/src/services/messaging/index.ts
@@ -44,11 +44,12 @@ export function sendMessageToAllClients(message: WebSocketMessage): void {
 
 /**
  * Message types excluded from broadcast logging: "frontend-update" fires on
- * every write transaction and embeds full entity payloads, "api-log-messages"
- * would recursively log API log output, and "sync-failed" repeats on every
- * failed sync attempt.
+ * every write transaction and embeds full entity payloads, "ping" fires on
+ * every no-change transaction and carries no data, "api-log-messages" would
+ * recursively log API log output, and "sync-failed" repeats on every failed
+ * sync attempt.
  */
-const UNLOGGED_MESSAGE_TYPES = new Set<WebSocketMessage["type"]>(["frontend-update", "sync-failed", "api-log-messages"]);
+const UNLOGGED_MESSAGE_TYPES = new Set<WebSocketMessage["type"]>(["frontend-update", "ping", "sync-failed", "api-log-messages"]);
 
 /**
  * Whether a broadcast message should be logged by the messaging provider,

--- a/packages/trilium-core/src/services/messaging/index.ts
+++ b/packages/trilium-core/src/services/messaging/index.ts
@@ -42,5 +42,21 @@ export function sendMessageToAllClients(message: WebSocketMessage): void {
     messagingProvider.sendMessageToAllClients(message);
 }
 
+/**
+ * Message types excluded from broadcast logging: "frontend-update" fires on
+ * every write transaction and embeds full entity payloads, "api-log-messages"
+ * would recursively log API log output, and "sync-failed" repeats on every
+ * failed sync attempt.
+ */
+const UNLOGGED_MESSAGE_TYPES = new Set<WebSocketMessage["type"]>(["frontend-update", "sync-failed", "api-log-messages"]);
+
+/**
+ * Whether a broadcast message should be logged by the messaging provider,
+ * filtering out types that are too frequent or noisy to log in full.
+ */
+export function shouldLogMessage(message: WebSocketMessage): boolean {
+    return !UNLOGGED_MESSAGE_TYPES.has(message.type);
+}
+
 // Re-export types
 export * from "./types.js";


### PR DESCRIPTION
Closes #9614.

## Root cause

The client's save pipeline had no binding between the content snapshot and the note it belongs to. The save callback read whatever was currently in the (reused) editor and PUT it to whatever note the component was currently bound to. The new note's content arrives via an async blob fetch, so any save firing inside that window wrote note A's content under note B's noteId. Two defects made the window reachable:

1. The quick-edit popup creates a fresh `NoteContext` and calls `setNote()` before wiring it, so its `beforeNoteSwitch` flush event reaches nobody — the pending change survives the rebind to the next card (near-deterministic corruption in Kanban triage).
2. `Component.handleEventInChildren` discarded promises returned by React-hook listeners, so the `await triggerEvent("beforeNoteSwitch")` contract was fake — a failed save re-armed the pending flag *after* the component had been rebound to the new note.

## Fixes

- **`SpacedUpdate` rewritten around keyed bindings** (`af1e4b2e`): pending changes are snapshotted (`prepare`) with the binding that scheduled them before the binding can be swapped (`rebind`), and committed as frozen `(key, data, commit)` triples that retry with backoff until they land — saves can never cross note boundaries and are never silently dropped. The editor hooks add a provenance guard: content is only ever saved under the note it was loaded from. The legacy single-updater API is unchanged for existing consumers.
- **Real event awaits for React listeners** (`6a0f311b`): `handleEventInChildren` collects listener promises into the existing `Promise.all` (restoring the contract documented on the class), and the `useTriliumEvents` wrapper stops swallowing handler results. This also restores read-your-writes on note switches.
- **Real event awaits for legacy widgets** (`d947bc41`): restores the `Promise.all` around the per-tab `noteSwitched` dispatch in `SplitNoteContainer` that was accidentally turned into a bare array literal in 67f39e8bde.

## UX: loading indicator (`26bddd01`)

With slow content loads the editor used to keep showing the previous note's content under the new note's title (the confusing state from the issue's screenshot). The note detail now covers itself with a loading overlay driven by `contentLoad` context data published from the type resolution and the editors' blob fetch, paced to never flash: 150ms grace (fast loads show nothing), fade-in, 280ms minimum visibility, "still loading / retry" after 8s, and fetch errors as their own retryable state.

## Testing

- `editor_save_race.spec.tsx` reproduces both corruption triggers and the event-await contract; red before the fixes, green after.
- New `SpacedUpdate` keyed-binding tests (rebind flush, frozen-snapshot retry, supersession, async prepare); all 13 pre-existing `SpacedUpdate` specs pass unmodified.
- `useDelayedVisibility` timing tests (grace/min-visible/stall) under fake timers.
- Manually reproduced the corruption with an artificially delayed blob route (both quick-edit popup and in-tab paths), and verified the fix saves the pending edit to the *old* note while the new note receives nothing; verified the overlay on the same setup in tabs and the quick-edit popup across themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)