### PR TITLE
docs: clarify script API context properties (startNote, currentNote, originEntity)

### DIFF
--- a/apps/client/src/services/frontend_script_api.ts
+++ b/apps/client/src/services/frontend_script_api.ts
@@ -70,7 +70,7 @@ export interface Api {
     /**
      * Note where the script execution started — the entry point of the current script bundle
      * (in C terms, the file containing `main()`). When a script is spread across multiple code
-     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * notes (descendant code notes loaded as modules via `require()`), every note in the
      * bundle shares the same `startNote`, while {@link currentNote} differs per note.
      * Messages from `api.log()` are grouped under this note.
      */
@@ -79,7 +79,7 @@ export interface Api {
     /**
      * Note containing the source code that is currently executing (in C terms, `__FILE__`).
      * Equal to {@link startNote} unless execution has moved into a descendant module note
-     * loaded via `api.require()`. Don't confuse this with the note open in the UI — use
+     * loaded via `require()`. Don't confuse this with the note open in the UI — use
      * `api.getActiveContextNote()` for that.
      */
     currentNote: FNote;

--- a/apps/client/src/services/frontend_script_api.ts
+++ b/apps/client/src/services/frontend_script_api.ts
@@ -68,21 +68,31 @@ export interface Api {
     $container: JQuery<HTMLElement> | null;
 
     /**
-     * Note where the script started executing, i.e., the (event) entrypoint of the current script execution.
+     * Note where the script execution started — the entry point of the current script bundle
+     * (in C terms, the file containing `main()`). When a script is spread across multiple code
+     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * bundle shares the same `startNote`, while {@link currentNote} differs per note.
+     * Messages from `api.log()` are grouped under this note.
      */
     startNote: FNote;
 
     /**
-     * Note where the script is currently executing, i.e. the note where the currently executing source code is written.
+     * Note containing the source code that is currently executing (in C terms, `__FILE__`).
+     * Equal to {@link startNote} unless execution has moved into a descendant module note
+     * loaded via `api.require()`. Don't confuse this with the note open in the UI — use
+     * `api.getActiveContextNote()` for that.
      */
     currentNote: FNote;
 
     /**
-     * Entity whose event triggered this execution.
+     * Entity whose event triggered this execution, or `null`.
      *
-     * <p>
-     * For front-end scripts, generally there's no origin entity specified since the scripts are run by the user or automatically by the UI (widgets).
-     * If there is an origin entity specified, then it's going to be a note entity.
+     * Most frontend scripts are started by the user or by the UI (startup scripts, widgets),
+     * so this is usually `null`. It is set to a note when:
+     * - the script runs through a `~renderNote` relation — then it's the note being rendered
+     *   (the one carrying the relation), not the script note;
+     * - a backend script calls `api.runOnFrontend()` — then it's the backend execution's
+     *   `originEntity`, provided that entity was a note.
      */
     originEntity: unknown | null;
 

--- a/apps/server/src/assets/llm/skills/backend_scripting.md
+++ b/apps/server/src/assets/llm/skills/backend_scripting.md
@@ -30,6 +30,18 @@ Note that most `api.*` methods (e.g. `api.getNote`, `api.searchForNotes`, `api.c
 - `api.currentNote` - note containing the source code currently executing (in C terms, `__FILE__`). Equal to `startNote` except inside child module notes loaded via `require()`. NOT the note open in the UI.
 - `api.originEntity` - entity whose event triggered this execution; `undefined` when the run was not event-driven (manual Execute button, `note.executeScript()`). For `~runOn*` relations see the table under "Events and triggers"; for scheduled scripts (`#run=hourly`/`#run=daily`) it is the script note itself; for `~searchScript` scripts it is the search note.
 
+Concrete examples:
+
+| Scenario | `startNote` | `currentNote` | `originEntity` |
+|---|---|---|---|
+| Execute button / `note.executeScript()` on "Job" | "Job" | "Job" (a child module note while its code runs) | `undefined` |
+| Scheduled "Job" (`#run=backendStartup`/`hourly`/`daily`) | "Job" | "Job" (or module note) | "Job" (the script note itself) |
+| Note "Diary" has `~runOnNoteContentChange` → script "OnChange" | "OnChange" | "OnChange" (or module note) | "Diary" (the changed note; a BAttribute/BBranch for attribute/branch events) |
+| Custom request handler "Endpoint" (`#customRequestHandler`) | "Endpoint" | "Endpoint" (or module note) | `undefined` — the request is in `api.req` |
+| `api.runOnBackend()` called from frontend widget "Clock" | "Clock" (the frontend's `startNote`, preserved) | the frontend note whose function was serialized (the frontend's `currentNote`) | the frontend's `originEntity` (a note) or `null` |
+
+Note: `#customResourceProvider` notes never execute a script — the note's content is served directly as the HTTP response, so there is no `api` context at all. Only `#customRequestHandler` runs code.
+
 ### Note retrieval
 - `api.getNote(noteId)` - get note by ID
 - `api.searchForNotes(query, searchParams)` - search notes (returns array)

--- a/apps/server/src/assets/llm/skills/backend_scripting.md
+++ b/apps/server/src/assets/llm/skills/backend_scripting.md
@@ -25,6 +25,11 @@ Note that most `api.*` methods (e.g. `api.getNote`, `api.searchForNotes`, `api.c
 
 ## Script API (`api` global)
 
+### Script context
+- `api.startNote` - note where the script execution started (the entry point of the script bundle; in C terms, the file with `main()`). All module notes loaded via `require()` share the same `startNote`. May be null when the execution came from the frontend via `runOnBackend()` (the frontend's `startNote` is preserved). `api.log()` messages are grouped under this note.
+- `api.currentNote` - note containing the source code currently executing (in C terms, `__FILE__`). Equal to `startNote` except inside child module notes loaded via `require()`. NOT the note open in the UI.
+- `api.originEntity` - entity whose event triggered this execution; `undefined` when the run was not event-driven (manual Execute button, `note.executeScript()`). For `~runOn*` relations see the table under "Events and triggers"; for scheduled scripts (`#run=hourly`/`#run=daily`) it is the script note itself; for `~searchScript` scripts it is the search note.
+
 ### Note retrieval
 - `api.getNote(noteId)` - get note by ID
 - `api.searchForNotes(query, searchParams)` - search notes (returns array)

--- a/apps/server/src/assets/llm/skills/dashboards.md
+++ b/apps/server/src/assets/llm/skills/dashboards.md
@@ -37,6 +37,7 @@ JSX rules (load the `frontend_scripting` skill for the full API):
 - Use top-level ES `import` only; hooks come from `"trilium:preact"`, API methods from `"trilium:api"`.
 - NEVER use `React`, `require()`, or `await import()` — Trilium uses Preact and JSX notes are ES modules.
 - Export the component as `export default`.
+- To reference the widget's own note (e.g. to read its attributes or store data under it), use `originEntity` from `"trilium:api"` — it is the render note hosting the component. Do NOT use `getActiveContextNote()`: on a dashboard the active note is the dashboard itself, not the widget.
 
 Example — a widget showing the number of notes created in the last 7 days:
 
@@ -78,5 +79,6 @@ export default function RecentNotesWidget() {
 - ❌ Calling `set_attribute` with `~renderNote` — it will be rejected as dangerous. Ask the user to add the relation instead.
 - ❌ Directing the user to set `~renderNote` on the dashboard note itself — it belongs on the `render`-type child.
 - ❌ Trying to write the `dashboard.json` attachment (or any view configuration) to lay out widgets — attachments cannot be modified by tools, and the dashboard picks up new widgets automatically; rely on auto-placement.
+- ❌ Using `getActiveContextNote()` inside a widget's JSX to get "this widget's note" — when the dashboard is open, the active note is the dashboard, not the widget. Use `originEntity` (the render note) instead.
 - ❌ Setting `#viewType=dashboard` on a `text` note — the view type only applies to `book` (and search) notes.
 - ❌ Prepending an emoji to a widget title to decorate it — find an icon with `search_icons` and set the `iconClass` label instead.

--- a/apps/server/src/assets/llm/skills/frontend_scripting.md
+++ b/apps/server/src/assets/llm/skills/frontend_scripting.md
@@ -132,6 +132,13 @@ For rendering custom content inside a note:
 
 IMPORTANT: Always create the JSX code note as a child of the render note, not as a sibling or at the root. This keeps them organized together.
 
+IMPORTANT: To reference "this widget's note" from inside a render note component, use `originEntity` — for render notes it is the note being rendered (the one carrying the `~renderNote` relation). Do NOT use `getActiveContextNote()` for this: it returns the note the user currently has open in the UI, which is the render note's *host* (e.g. a dashboard or a book view), not the render note itself.
+
+```jsx
+import { originEntity } from "trilium:api";
+// originEntity = the render note hosting this component
+```
+
 Stateless example:
 
 ```jsx
@@ -186,6 +193,11 @@ import { showMessage } from "trilium:api";
 ## Script API
 
 In JSX, use `import { method } from "trilium:api"`. In JavaScript (Trilium frontend), use the `api` global.
+
+### Script context
+- `startNote` - note where the script execution started (the entry point of the script bundle). All module notes loaded by the same execution share one `startNote`; `log()` messages are grouped under it.
+- `currentNote` - note containing the source code currently executing. Equal to `startNote` except inside child module notes. NOT the note open in the UI — that is `getActiveContextNote()`.
+- `originEntity` - note whose event triggered this execution, or `null`. Usually `null` (scripts started by the user or the UI). It is set for render notes — the note being rendered, i.e. the one carrying the `~renderNote` relation — and for `api.runOnFrontend()` calls from the backend (the backend's `originEntity`, if it was a note).
 
 ### Navigation & tabs
 - `activateNote(notePath)` - navigate to a note

--- a/apps/server/src/assets/llm/skills/frontend_scripting.md
+++ b/apps/server/src/assets/llm/skills/frontend_scripting.md
@@ -199,6 +199,15 @@ In JSX, use `import { method } from "trilium:api"`. In JavaScript (Trilium front
 - `currentNote` - note containing the source code currently executing. Equal to `startNote` except inside child module notes. NOT the note open in the UI — that is `getActiveContextNote()`.
 - `originEntity` - note whose event triggered this execution, or `null`. Usually `null` (scripts started by the user or the UI). It is set for render notes — the note being rendered, i.e. the one carrying the `~renderNote` relation — and for `api.runOnFrontend()` calls from the backend (the backend's `originEntity`, if it was a note).
 
+Concrete examples:
+
+| Scenario | `startNote` | `currentNote` | `originEntity` |
+|---|---|---|---|
+| Widget script "Clock" (`#widget`) | "Clock" | "Clock" (a child module note while its code runs) | `null` |
+| Startup script (`#run=frontendStartup`) or manual Execute on "Setup" | "Setup" | "Setup" (or module note) | `null` |
+| Render note "Stats" with `~renderNote` → JSX note "StatsComponent" | "StatsComponent" | "StatsComponent" (or module note) | "Stats" (the render note) |
+| `api.runOnFrontend()` called from a backend script | the backend execution's `currentNote` | same | the backend's `originEntity` if it was a note, else `null` |
+
 ### Navigation & tabs
 - `activateNote(notePath)` - navigate to a note
 - `activateNewNote(notePath)` - navigate and wait for sync

--- a/packages/commons/src/lib/script_api.ts
+++ b/packages/commons/src/lib/script_api.ts
@@ -139,7 +139,7 @@ export interface FrontendApi {
     /**
      * Note where the script execution started — the entry point of the current script bundle
      * (in C terms, the file containing `main()`). When a script is spread across multiple code
-     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * notes (descendant code notes loaded as modules via `require()`), every note in the
      * bundle shares the same `startNote`, while {@link currentNote} differs per note.
      * Messages from `api.log()` are grouped under this note.
      */
@@ -147,7 +147,7 @@ export interface FrontendApi {
     /**
      * Note containing the source code that is currently executing (in C terms, `__FILE__`).
      * Equal to {@link startNote} unless execution has moved into a descendant module note
-     * loaded via `api.require()`. Don't confuse this with the note open in the UI — use
+     * loaded via `require()`. Don't confuse this with the note open in the UI — use
      * `api.getActiveContextNote()` for that.
      */
     currentNote: ScriptFNote;
@@ -607,7 +607,7 @@ export interface BackendApi {
     /**
      * Note where the script execution started — the entry point of the current script bundle
      * (in C terms, the file containing `main()`). When a script is spread across multiple code
-     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * notes (descendant code notes loaded as modules via `require()`), every note in the
      * bundle shares the same `startNote`, while {@link currentNote} differs per note.
      * Messages from `api.log()` are grouped under this note.
      *
@@ -618,7 +618,7 @@ export interface BackendApi {
     /**
      * Note containing the source code that is currently executing (in C terms, `__FILE__`).
      * Equal to {@link startNote} unless execution has moved into a descendant module note
-     * loaded via `api.require()`. Don't confuse this with the concept of the active note in
+     * loaded via `require()`. Don't confuse this with the concept of the active note in
      * the UI.
      */
     currentNote: ScriptBNote;
@@ -632,7 +632,8 @@ export interface BackendApi {
      * - `~runOnChildNoteCreation` — the newly created child note;
      * - `~runOnAttributeCreation`, `~runOnAttributeChange` — the attribute;
      * - `~runOnBranchCreation`, `~runOnBranchChange`, `~runOnBranchDeletion` — the branch;
-     * - scheduled scripts (`#run=hourly` / `#run=daily`) — the script note itself;
+     * - scheduled scripts (`#run=backendStartup` / `#run=hourly` / `#run=daily`) — the
+     *   script note itself;
      * - search scripts (`~searchScript`) — the search note.
      */
     originEntity?: unknown | null;

--- a/packages/commons/src/lib/script_api.ts
+++ b/packages/commons/src/lib/script_api.ts
@@ -137,19 +137,29 @@ export interface FrontendApi {
      * */
     $container: unknown;
     /**
-     * Note where the script started executing, i.e., the (event) entrypoint of the current script execution.
+     * Note where the script execution started — the entry point of the current script bundle
+     * (in C terms, the file containing `main()`). When a script is spread across multiple code
+     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * bundle shares the same `startNote`, while {@link currentNote} differs per note.
+     * Messages from `api.log()` are grouped under this note.
      */
     startNote: ScriptFNote;
     /**
-     * Note where the script is currently executing, i.e. the note where the currently executing source code is written.
+     * Note containing the source code that is currently executing (in C terms, `__FILE__`).
+     * Equal to {@link startNote} unless execution has moved into a descendant module note
+     * loaded via `api.require()`. Don't confuse this with the note open in the UI — use
+     * `api.getActiveContextNote()` for that.
      */
     currentNote: ScriptFNote;
     /**
-     * Entity whose event triggered this execution.
+     * Entity whose event triggered this execution, or `null`.
      *
-     * <p>
-     * For front-end scripts, generally there's no origin entity specified since the scripts are run by the user or automatically by the UI (widgets).
-     * If there is an origin entity specified, then it's going to be a note entity.
+     * Most frontend scripts are started by the user or by the UI (startup scripts, widgets),
+     * so this is usually `null`. It is set to a note when:
+     * - the script runs through a `~renderNote` relation — then it's the note being rendered
+     *   (the one carrying the relation), not the script note;
+     * - a backend script calls `api.runOnFrontend()` — then it's the backend execution's
+     *   `originEntity`, provided that entity was a note.
      */
     originEntity: unknown | null;
     /**
@@ -595,19 +605,35 @@ export interface ScriptResponse {
  */
 export interface BackendApi {
     /**
-     * Note where the script started executing (entrypoint).
-     * As an analogy, in C this would be the file which contains the main() function of the current process.
+     * Note where the script execution started — the entry point of the current script bundle
+     * (in C terms, the file containing `main()`). When a script is spread across multiple code
+     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * bundle shares the same `startNote`, while {@link currentNote} differs per note.
+     * Messages from `api.log()` are grouped under this note.
+     *
+     * When a frontend script calls `api.runOnBackend()`, the frontend's `startNote` is
+     * preserved here; since that note may not be resolvable on the backend, this can be null.
      */
     startNote?: ScriptBNote | null;
     /**
-     * Note where the script is currently executing. This comes into play when your script is spread in multiple code
-     * notes, the script starts in "startNote", but then through function calls may jump into another note (currentNote).
-     * A similar concept in C would be __FILE__
-     * Don't mix this up with the concept of active note.
+     * Note containing the source code that is currently executing (in C terms, `__FILE__`).
+     * Equal to {@link startNote} unless execution has moved into a descendant module note
+     * loaded via `api.require()`. Don't confuse this with the concept of the active note in
+     * the UI.
      */
     currentNote: ScriptBNote;
     /**
-     * Entity whose event triggered this execution
+     * Entity whose event triggered this execution; `undefined` when the run was not
+     * event-driven (e.g. started manually via "Execute script" or `note.executeScript()`).
+     *
+     * What it holds depends on the trigger:
+     * - `~runOnNoteCreation`, `~runOnNoteChange`, `~runOnNoteTitleChange`,
+     *   `~runOnNoteContentChange` — the affected note;
+     * - `~runOnChildNoteCreation` — the newly created child note;
+     * - `~runOnAttributeCreation`, `~runOnAttributeChange` — the attribute;
+     * - `~runOnBranchCreation`, `~runOnBranchChange`, `~runOnBranchDeletion` — the branch;
+     * - scheduled scripts (`#run=hourly` / `#run=daily`) — the script note itself;
+     * - search scripts (`~searchScript`) — the search note.
      */
     originEntity?: unknown | null;
 

--- a/packages/trilium-core/src/services/backend_script_api.ts
+++ b/packages/trilium-core/src/services/backend_script_api.ts
@@ -63,7 +63,7 @@ export interface Api {
     /**
      * Note where the script execution started — the entry point of the current script bundle
      * (in C terms, the file containing `main()`). When a script is spread across multiple code
-     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * notes (descendant code notes loaded as modules via `require()`), every note in the
      * bundle shares the same `startNote`, while {@link currentNote} differs per note.
      * Messages from `api.log()` are grouped under this note.
      *
@@ -75,7 +75,7 @@ export interface Api {
     /**
      * Note containing the source code that is currently executing (in C terms, `__FILE__`).
      * Equal to {@link startNote} unless execution has moved into a descendant module note
-     * loaded via `api.require()`. Don't confuse this with the concept of the active note in
+     * loaded via `require()`. Don't confuse this with the concept of the active note in
      * the UI.
      */
     currentNote: BNote;
@@ -90,7 +90,8 @@ export interface Api {
      * - `~runOnChildNoteCreation` — the newly created child note;
      * - `~runOnAttributeCreation`, `~runOnAttributeChange` — the attribute;
      * - `~runOnBranchCreation`, `~runOnBranchChange`, `~runOnBranchDeletion` — the branch;
-     * - scheduled scripts (`#run=hourly` / `#run=daily`) — the script note itself;
+     * - scheduled scripts (`#run=backendStartup` / `#run=hourly` / `#run=daily`) — the
+     *   script note itself;
      * - search scripts (`~searchScript`) — the search note.
      */
     originEntity?: AbstractBeccaEntity<any> | null;

--- a/packages/trilium-core/src/services/backend_script_api.ts
+++ b/packages/trilium-core/src/services/backend_script_api.ts
@@ -61,21 +61,37 @@ interface NoteAndBranch {
 
 export interface Api {
     /**
-     * Note where the script started executing (entrypoint).
-     * As an analogy, in C this would be the file which contains the main() function of the current process.
+     * Note where the script execution started — the entry point of the current script bundle
+     * (in C terms, the file containing `main()`). When a script is spread across multiple code
+     * notes (descendant code notes loaded as modules via `api.require()`), every note in the
+     * bundle shares the same `startNote`, while {@link currentNote} differs per note.
+     * Messages from `api.log()` are grouped under this note.
+     *
+     * When a frontend script calls `api.runOnBackend()`, the frontend's `startNote` is
+     * preserved here; since that note may not be resolvable on the backend, this can be null.
      */
     startNote?: BNote | null;
 
     /**
-     * Note where the script is currently executing. This comes into play when your script is spread in multiple code
-     * notes, the script starts in "startNote", but then through function calls may jump into another note (currentNote).
-     * A similar concept in C would be __FILE__
-     * Don't mix this up with the concept of active note.
+     * Note containing the source code that is currently executing (in C terms, `__FILE__`).
+     * Equal to {@link startNote} unless execution has moved into a descendant module note
+     * loaded via `api.require()`. Don't confuse this with the concept of the active note in
+     * the UI.
      */
     currentNote: BNote;
 
     /**
-     * Entity whose event triggered this execution
+     * Entity whose event triggered this execution; `undefined` when the run was not
+     * event-driven (e.g. started manually via "Execute script" or `note.executeScript()`).
+     *
+     * What it holds depends on the trigger:
+     * - `~runOnNoteCreation`, `~runOnNoteChange`, `~runOnNoteTitleChange`,
+     *   `~runOnNoteContentChange` — the affected note ({@link BNote});
+     * - `~runOnChildNoteCreation` — the newly created child note;
+     * - `~runOnAttributeCreation`, `~runOnAttributeChange` — the attribute;
+     * - `~runOnBranchCreation`, `~runOnBranchChange`, `~runOnBranchDeletion` — the branch;
+     * - scheduled scripts (`#run=hourly` / `#run=daily`) — the script note itself;
+     * - search scripts (`~searchScript`) — the search note.
      */
     originEntity?: AbstractBeccaEntity<any> | null;
 


### PR DESCRIPTION
## Summary

The JSDoc for `api.startNote`, `api.currentNote` and `api.originEntity` was vague about how the three differ and silent about several behaviors. This PR documents their actual semantics (verified against the implementations) and teaches the LLM skills about them.

### Script API docs (commons + client + core, kept word-for-word in sync)

- **`startNote`** — the entry point of the script *bundle*; shared by every module note loaded via `api.require()`; groups `api.log()` messages; preserved across `api.runOnBackend()` (which is also why it is nullable on the backend).
- **`currentNote`** — the note whose source code is currently executing; diverges from `startNote` only inside module notes. Explicitly disambiguated from the active note in the UI.
- **`originEntity`** — enumerates every trigger that sets it: the `~runOn*` relations (note / attribute / branch), scheduled `#run=hourly|daily` scripts (the script note itself), `~searchScript` (the search note), render notes (the rendered note), and `api.runOnFrontend()` forwarding — plus when it is empty.

The script-deployer typings and the in-editor completion (`trilium:api`) destructure the shared commons interfaces, so they pick the new docs up automatically.

### LLM skills

- `backend_scripting.md` / `frontend_scripting.md`: new "Script context" section covering the three properties.
- `frontend_scripting.md` (render notes) and `dashboards.md`: warn against `getActiveContextNote()` to reference "this widget''s note" — on a dashboard the active note is the dashboard itself; use `originEntity` (the render note) instead.

### Pre-existing inaccuracy fixed

The old frontend `originEntity` doc claimed there is "generally no origin entity" without mentioning the render-note case, and neither `currentNote` doc explained *when* it diverges from `startNote`.

Comment/markdown-only change — no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)