### PR TITLE
fix(client): harden SpacedUpdate retry edge cases

### DIFF
--- a/apps/client/src/services/spaced_update.spec.ts
+++ b/apps/client/src/services/spaced_update.spec.ts
@@ -353,7 +353,7 @@ describe("SpacedUpdate", () => {
             expect(commits).toEqual([{ key: "A", data: "typed into A" }]);
         });
 
-        it("re-arms the debounce timer when an asynchronous snapshot rejects, so the change is not stranded", async () => {
+        it("schedules a retry when an asynchronous snapshot rejects, so the change is not stranded", async () => {
             let rejectPrepare: (e: Error) => void = () => {};
             const commits: { key: string; data: string }[] = [];
             const spacedUpdate = new SpacedUpdate<string>({

--- a/apps/client/src/services/spaced_update.spec.ts
+++ b/apps/client/src/services/spaced_update.spec.ts
@@ -353,6 +353,67 @@ describe("SpacedUpdate", () => {
             expect(commits).toEqual([{ key: "A", data: "typed into A" }]);
         });
 
+        it("re-arms the debounce timer when an asynchronous snapshot rejects, so the change is not stranded", async () => {
+            let rejectPrepare: (e: Error) => void = () => {};
+            const commits: { key: string; data: string }[] = [];
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => new Promise<string>((_, reject) => {
+                    rejectPrepare = reject;
+                }),
+                commit: async (data) => {
+                    commits.push({ key: "A", data });
+                }
+            }, 50);
+
+            spacedUpdate.scheduleUpdate();
+            spacedUpdate.rebind("B", () => "B content", async (data) => {
+                commits.push({ key: "B", data });
+            });
+
+            // The debounce timer fires while the snapshot is still being captured and goes idle.
+            await vi.advanceTimersByTimeAsync(60);
+            expect(commits).toEqual([]);
+
+            // The capture fails: the restored change must be retried (under the current
+            // binding), not stranded until the next keystroke.
+            rejectPrepare(new Error("editor crashed"));
+            await vi.advanceTimersByTimeAsync(100);
+
+            expect(commits).toEqual([{ key: "B", data: "B content" }]);
+        });
+
+        it("keeps growing the retry backoff while a commit keeps failing, even if a sibling key succeeds", async () => {
+            const failingAttempts: number[] = [];
+            const spacedUpdate = new SpacedUpdate<string>({
+                key: "A",
+                prepare: () => "A content",
+                commit: async () => {
+                    failingAttempts.push(Date.now());
+                    throw new Error("offline");
+                }
+            }, 50);
+
+            // First attempt fails at ~50ms and schedules a retry.
+            spacedUpdate.scheduleUpdate();
+            await vi.advanceTimersByTimeAsync(60);
+            expect(failingAttempts).toHaveLength(1);
+
+            // A change for another note succeeds within the same retry pass.
+            spacedUpdate.rebind("B", () => "B content", async () => {});
+            spacedUpdate.scheduleUpdate();
+
+            await vi.advanceTimersByTimeAsync(1000);
+
+            // The sibling success must not reset the failing key's backoff: the gaps
+            // between consecutive failing attempts keep doubling.
+            expect(failingAttempts.length).toBeGreaterThanOrEqual(3);
+            const gaps = failingAttempts.slice(1).map((t, i) => t - failingAttempts[i]);
+            for (let i = 1; i < gaps.length; i++) {
+                expect(gaps[i]).toBeGreaterThan(gaps[i - 1]);
+            }
+        });
+
         it("supports an asynchronous prepare", async () => {
             const commits: string[] = [];
             const spacedUpdate = new SpacedUpdate<string>({

--- a/apps/client/src/services/spaced_update.ts
+++ b/apps/client/src/services/spaced_update.ts
@@ -208,9 +208,10 @@ export default class SpacedUpdate<T = void> {
             this.changed = true;
             this.onStateChanged("error");
             // The debounce timer may have already fired and gone idle while the snapshot was
-            // being captured; re-arm it so the restored change is retried instead of being
-            // stranded until the next scheduleUpdate() call.
-            this.armDebounceTimer();
+            // being captured; schedule a retry so the restored change is not stranded until
+            // the next scheduleUpdate() call. Going through the retry timer (rather than the
+            // debounce timer) gives persistent prepare() failures exponential backoff.
+            this.scheduleRetry();
             throw e;
         };
 

--- a/apps/client/src/services/spaced_update.ts
+++ b/apps/client/src/services/spaced_update.ts
@@ -207,6 +207,10 @@ export default class SpacedUpdate<T = void> {
         const restoreOnError = (e: unknown): never => {
             this.changed = true;
             this.onStateChanged("error");
+            // The debounce timer may have already fired and gone idle while the snapshot was
+            // being captured; re-arm it so the restored change is retried instead of being
+            // stranded until the next scheduleUpdate() call.
+            this.armDebounceTimer();
             throw e;
         };
 
@@ -285,7 +289,6 @@ export default class SpacedUpdate<T = void> {
 
                 try {
                     await entry.commit(entry.data);
-                    this.retryCount = 0;
 
                     // Delete only if the entry was not superseded by a newer snapshot during the await.
                     if (this.pendingCommits.get(key) === entry) {
@@ -307,6 +310,9 @@ export default class SpacedUpdate<T = void> {
             }
         }
 
+        // Reset the retry backoff only once everything has landed; resetting it on individual
+        // successes would shorten the backoff of a still-failing sibling key.
+        this.retryCount = 0;
         this.onStateChanged(this.changed ? "unsaved" : "saved");
     }
 


### PR DESCRIPTION
Follow-up to #10131, addressing the two findings Greptile posted after the merge.

## 1. Async `prepare()` rejection could strand a pending change

When an asynchronous `prepare()` rejects, `restoreOnError` re-arms the `changed` flag — but if the debounce timer had already fired and gone idle while the snapshot was being captured (it sees `!changed` mid-capture), nothing retried the restored change until the next keystroke. Text/code editors have synchronous `getData`, but the blob-editor consumers (canvas, mind map) can be async, so the path is live there. `restoreOnError` now re-arms the debounce timer, so the change is folded and saved under the current binding on the next tick.

## 2. Sibling success reset the shared retry backoff

`retryCount = 0` fired on every successful commit inside the drain loop, so a still-failing key (e.g. a note deleted server-side) retried at 1–2× the update interval indefinitely as long as any other key kept succeeding in the same passes. The counter is now reset only after a fully clean drain, so the backoff of a persistently failing commit keeps doubling up to the 60s cap regardless of sibling traffic.

## Testing

Both behaviors are pinned by new unit tests in `spaced_update.spec.ts`, verified red against the pre-fix code and green after. Full client suite (104 files) and repo typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)