### PR TITLE
feat: open new tabs next to the current tab; view SVG image source

### DIFF
--- a/apps/client/src/components/tab_manager.spec.ts
+++ b/apps/client/src/components/tab_manager.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import TabManager from "./tab_manager.js";
+
+describe("TabManager tab placement", () => {
+    it("opens a blank tab at the end of the row, regardless of which tab is active", async () => {
+        const tm = new TabManager();
+        const [a, b, c] = await openEmptyTabs(tm, 3);
+        tm.activeNtxId = b.ntxId; // active tab sits in the middle
+
+        const blank = await tm.openEmptyTab();
+
+        expect(ntxOrder(tm)).toEqual([a.ntxId, b.ntxId, c.ntxId, blank.ntxId]);
+    });
+
+    it("opens a tab spawned from a link right after the active tab", async () => {
+        const tm = new TabManager();
+        const [a, b, c] = await openEmptyTabs(tm, 3);
+        tm.activeNtxId = b.ntxId; // active tab sits in the middle
+
+        // A link / middle-click open goes through openContextWithNote. A null notePath keeps the
+        // test focused on placement — the position is decided before any note loads.
+        const fromLink = await tm.openContextWithNote(null, { placement: "afterCurrent" });
+
+        expect(ntxOrder(tm)).toEqual([a.ntxId, b.ntxId, fromLink.ntxId, c.ntxId]);
+    });
+
+    it("inserts the new tab after the active tab and all of its splits", async () => {
+        const tm = new TabManager();
+        const [a] = await openEmptyTabs(tm, 1);
+        // tab "a" gets two extra splits, then a plain tab "b" follows it
+        const aSplit1 = await tm.openEmptyTab(null, "root", a.ntxId);
+        const aSplit2 = await tm.openEmptyTab(null, "root", a.ntxId);
+        const b = await tm.openEmptyTab();
+        tm.activeNtxId = a.ntxId; // the split tab is active
+
+        const fromLink = await tm.openContextWithNote(null, { placement: "afterCurrent" });
+
+        // the new tab lands after the whole "a" group (main + both splits), before "b"
+        expect(tm.children.map((nc) => nc.ntxId)).toEqual([
+            a.ntxId, aSplit1.ntxId, aSplit2.ntxId, fromLink.ntxId, b.ntxId
+        ]);
+    });
+
+    it("never inserts an unpinned tab inside the pinned group", async () => {
+        const tm = new TabManager();
+        const p1 = await tm.openEmptyTab(null, "root", null, true); // pinned
+        const p2 = await tm.openEmptyTab(null, "root", null, true); // pinned
+        const a = await tm.openEmptyTab();
+        tm.activeNtxId = p1.ntxId; // the first pinned tab is active
+
+        const fromLink = await tm.openContextWithNote(null, { placement: "afterCurrent" });
+
+        // inserting right after p1 would split the pinned group, so it clamps past the group
+        expect(ntxOrder(tm)).toEqual([p1.ntxId, p2.ntxId, fromLink.ntxId, a.ntxId]);
+    });
+});
+
+function openEmptyTabs(tm: TabManager, count: number) {
+    return Promise.all(Array.from({ length: count }, () => tm.openEmptyTab()));
+}
+
+function ntxOrder(tm: TabManager) {
+    return tm.mainNoteContexts.map((nc) => nc.ntxId);
+}

--- a/apps/client/src/components/tab_manager.ts
+++ b/apps/client/src/components/tab_manager.ts
@@ -12,6 +12,9 @@ import { partitionPinnedFirst } from "../services/tab_pinning.js";
 import type { EventData } from "./app_context.js";
 import type FNote from "../entities/fnote.js";
 
+/** Where a newly created tab is inserted in the row: appended to the end, or right after the active tab. */
+type TabPlacement = "end" | "afterCurrent";
+
 interface TabState {
     contexts: NoteContext[];
     position: number;
@@ -272,7 +275,8 @@ export default class TabManager extends Component {
         ntxId: string | null = null,
         hoistedNoteId: string = "root",
         mainNtxId: string | null = null,
-        pinned: boolean = false
+        pinned: boolean = false,
+        placement: TabPlacement = "end"
     ): Promise<NoteContext> {
         const noteContext = new NoteContext(ntxId, hoistedNoteId, mainNtxId);
         // set before setEmpty/newNoteContextCreated so the tab renders in its pinned state from the start
@@ -286,11 +290,53 @@ export default class TabManager extends Component {
             return existingNoteContext;
         }
 
-        this.child(noteContext);
+        noteContext.setParent(this);
+        this.children.splice(this.getNewTabInsertionIndex(placement), 0, noteContext);
 
         await this.triggerEvent("newNoteContextCreated", { noteContext });
 
         return noteContext;
+    }
+
+    /**
+     * Index in the flat `children` array at which a newly created (unpinned) tab should be inserted.
+     * `"end"` appends; `"afterCurrent"` inserts right after the active tab and all of its splits,
+     * clamped so an unpinned tab never lands inside the pinned group (which `reorderPinnedFirst`
+     * keeps grouped at the front of the row).
+     */
+    private getNewTabInsertionIndex(placement: TabPlacement): number {
+        if (placement === "end") {
+            return this.children.length;
+        }
+
+        const activeMainNtxId = this.getActiveMainContext()?.ntxId;
+        const activeIndex = activeMainNtxId
+            ? this.children.findIndex((nc) => nc.ntxId === activeMainNtxId)
+            : -1;
+
+        if (activeIndex === -1) {
+            return this.children.length;
+        }
+
+        // Skip past the active tab's main context and all of its splits.
+        let index = activeIndex + 1;
+        while (index < this.children.length && this.children[index].mainNtxId === activeMainNtxId) {
+            index++;
+        }
+
+        // Pinned tabs stay grouped at the front, so never insert the new (unpinned) tab inside them.
+        const firstUnpinnedIndex = this.children.findIndex((nc) => !this.isPartOfPinnedTab(nc));
+        const minIndex = firstUnpinnedIndex === -1 ? this.children.length : firstUnpinnedIndex;
+
+        return Math.max(index, minIndex);
+    }
+
+    private isPartOfPinnedTab(noteContext: NoteContext): boolean {
+        const mainContext = noteContext.mainNtxId
+            ? this.children.find((nc) => nc.ntxId === noteContext.mainNtxId)
+            : noteContext;
+
+        return !!mainContext?.pinned;
     }
 
     async openInNewTab(targetNoteId: string, hoistedNoteId: string | null = null, activate: boolean = false) {
@@ -323,6 +369,7 @@ export default class TabManager extends Component {
             mainNtxId?: string | null;
             hoistedNoteId?: string | null;
             viewScope?: Record<string, any> | null;
+            placement?: TabPlacement | null;
         } = {}
     ): Promise<NoteContext> {
         const noteContext = this.getActiveContext();
@@ -350,6 +397,8 @@ export default class TabManager extends Component {
             hoistedNoteId?: string | null;
             viewScope?: Record<string, any> | null;
             pinned?: boolean | null;
+            /** Where the new tab is placed in the row. Defaults to `"end"`; link/middle-click opens pass `"afterCurrent"`. */
+            placement?: TabPlacement | null;
         } = {}
     ): Promise<NoteContext> {
         const activate = !!opts.activate;
@@ -358,7 +407,13 @@ export default class TabManager extends Component {
         const hoistedNoteId = opts.hoistedNoteId || "root";
         const viewScope = opts.viewScope || { viewMode: "default" };
 
-        const noteContext = await this.openEmptyTab(ntxId, hoistedNoteId, mainNtxId, !!opts.pinned);
+        const noteContext = await this.openEmptyTab(
+            ntxId,
+            hoistedNoteId,
+            mainNtxId,
+            !!opts.pinned,
+            opts.placement ?? "end"
+        );
         if (notePath) {
             await noteContext.setNote(notePath, {
                 // if activate is false, then send normal noteSwitched event

--- a/apps/client/src/components/tab_manager.ts
+++ b/apps/client/src/components/tab_manager.ts
@@ -299,7 +299,7 @@ export default class TabManager extends Component {
     }
 
     /**
-     * Index in the flat `children` array at which a newly created (unpinned) tab should be inserted.
+     * Index in `children` where a newly created (unpinned) tab is inserted.
      * `"end"` appends; `"afterCurrent"` inserts right after the active tab and all of its splits,
      * clamped so an unpinned tab never lands inside the pinned group (which `reorderPinnedFirst`
      * keeps grouped at the front of the row).
@@ -309,7 +309,12 @@ export default class TabManager extends Component {
             return this.children.length;
         }
 
-        const activeMainNtxId = this.getActiveMainContext()?.ntxId;
+        // Resolve the active main context without getActiveMainContext(): it throws on a stale
+        // activeNtxId, which would bypass the activeIndex === -1 fallback below.
+        const activeContext = this.activeNtxId
+            ? this.noteContexts.find((nc) => nc.ntxId === this.activeNtxId)
+            : undefined;
+        const activeMainNtxId = activeContext?.getMainContext().ntxId;
         const activeIndex = activeMainNtxId
             ? this.children.findIndex((nc) => nc.ntxId === activeMainNtxId)
             : -1;
@@ -324,7 +329,7 @@ export default class TabManager extends Component {
             index++;
         }
 
-        // Pinned tabs stay grouped at the front, so never insert the new (unpinned) tab inside them.
+        // Pinned tabs stay grouped first, so never insert the new (unpinned) tab inside them.
         const firstUnpinnedIndex = this.children.findIndex((nc) => !this.isPartOfPinnedTab(nc));
         const minIndex = firstUnpinnedIndex === -1 ? this.children.length : firstUnpinnedIndex;
 
@@ -332,11 +337,7 @@ export default class TabManager extends Component {
     }
 
     private isPartOfPinnedTab(noteContext: NoteContext): boolean {
-        const mainContext = noteContext.mainNtxId
-            ? this.children.find((nc) => nc.ntxId === noteContext.mainNtxId)
-            : noteContext;
-
-        return !!mainContext?.pinned;
+        return !!noteContext.getMainContext().pinned;
     }
 
     async openInNewTab(targetNoteId: string, hoistedNoteId: string | null = null, activate: boolean = false) {

--- a/apps/client/src/entities/fnote.ts
+++ b/apps/client/src/entities/fnote.ts
@@ -1078,6 +1078,10 @@ export default class FNote {
         return this.mime.startsWith("application/javascript");
     }
 
+    isSvg() {
+        return this.mime === "image/svg+xml";
+    }
+
     /**
      * Provides note's date metadata.
      */

--- a/apps/client/src/menus/tree_context_menu.ts
+++ b/apps/client/src/menus/tree_context_menu.ts
@@ -342,7 +342,7 @@ export async function handleTreeContextMenuSelect(
     resolved.onBeforeCommand?.();
 
     if (command === "openInTab") {
-        appContext.tabManager.openTabWithNoteWithHoisting(notePath);
+        appContext.tabManager.openTabWithNoteWithHoisting(notePath, { placement: "afterCurrent" });
     } else if (command === "insertNoteAfter") {
         const parentNotePath = parentNotePathOf(notePath);
         const parentNote = await froca.getNote(branch.parentNoteId);

--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -329,7 +329,8 @@ export function goToLinkExt(evt: MouseEvent | JQuery.ClickEvent | JQuery.MouseDo
         } else if (openInNewTab) {
             appContext.tabManager.openTabWithNoteWithHoisting(notePath, {
                 activate: activate ? true : targetIsBlank,
-                viewScope
+                viewScope,
+                placement: "afterCurrent"
             });
         } else if (isLeftClick) {
             openInCurrentNoteContext(evt, notePath, viewScope);

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -244,7 +244,8 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     e.preventDefault();
 
                     appContext.tabManager.openTabWithNoteWithHoisting(notePath, {
-                        activate: !!e.shiftKey
+                        activate: !!e.shiftKey,
+                        placement: "afterCurrent"
                     });
                 }
             }
@@ -410,7 +411,8 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
                     } else if (ctrlKey) {
                         const notePath = treeService.getNotePath(node);
                         appContext.tabManager.openTabWithNoteWithHoisting(notePath, {
-                            activate: !!event.shiftKey
+                            activate: !!event.shiftKey,
+                            placement: "afterCurrent"
                         });
                     } else if (event.altKey) {
                         node.setSelected(!node.isSelected());

--- a/apps/client/src/widgets/ribbon/NoteActions.tsx
+++ b/apps/client/src/widgets/ribbon/NoteActions.tsx
@@ -93,7 +93,7 @@ export function NoteContextMenu({ note, noteContext, itemsAtStart, itemsNearNote
     );
     const isElectron = getIsElectron();
     const isMac = getIsMac();
-    const hasSource = ["text", "code", "relationMap", "mermaid", "canvas", "mindMap", "spreadsheet", "llmChat"].includes(noteType);
+    const hasSource = ["text", "code", "relationMap", "mermaid", "canvas", "mindMap", "spreadsheet", "llmChat"].includes(noteType) || note.isSvg();
     const isSearchOrBook = ["search", "book"].includes(noteType);
     const isHelpPage = note.noteId.startsWith("_help");
     const [syncServerHost] = useTriliumOption("syncServerHost");

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -614,9 +614,12 @@ export default class TabRowWidget extends BasicWidget {
 
         setTimeout(() => $tab.removeClass("note-tab-was-just-added"), 500);
         this.$containerAnchor.before($tab);
-        // The model may insert this tab before the end (e.g. opened from a link, after the
-        // active tab), so mirror the model order in the DOM rather than leaving it appended.
-        this.syncTabOrder();
+        // When opened from a link the model may place this tab before the end; mirror that order in
+        // the DOM. When appended (the common case) it is already correct, so skip the O(n) walk.
+        const mainContexts = appContext.tabManager.getMainNoteContexts();
+        if (mainContexts[mainContexts.length - 1]?.ntxId !== ntxId) {
+            this.syncTabOrder();
+        }
         this.setVisibility();
         this.setTabCloseEvent($tab);
         this.updateTitle($tab, t("tab_row.new_tab"));

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -614,6 +614,9 @@ export default class TabRowWidget extends BasicWidget {
 
         setTimeout(() => $tab.removeClass("note-tab-was-just-added"), 500);
         this.$containerAnchor.before($tab);
+        // The model may insert this tab before the end (e.g. opened from a link, after the
+        // active tab), so mirror the model order in the DOM rather than leaving it appended.
+        this.syncTabOrder();
         this.setVisibility();
         this.setTabCloseEvent($tab);
         this.updateTitle($tab, t("tab_row.new_tab"));

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -6,7 +6,7 @@ import { highlightSelectionMatches } from "@codemirror/search";
 import { autocompletion, type CompletionSource } from "@codemirror/autocomplete";
 import { vim } from "@replit/codemirror-vim";
 import { indentationMarkers } from "@replit/codemirror-indentation-markers";
-import byMimeType from "./syntax_highlighting.js";
+import byMimeType, { MIME_ALIASES } from "./syntax_highlighting.js";
 import smartIndentWithTab from "./extensions/custom_tab.js";
 import type { ThemeDefinition } from "./color_themes.js";
 import { createSearchHighlighter, SearchHighlighter, searchMatchHighlightTheme } from "./find_replace.js";
@@ -318,7 +318,7 @@ export default class CodeMirror extends EditorView {
         this.currentMime = mime;
         let newExtension: Extension[] = [];
 
-        const correspondingSyntax = byMimeType[mime];
+        const correspondingSyntax = byMimeType[MIME_ALIASES[mime] ?? mime];
         if (correspondingSyntax) {
             const resolvedSyntax = await correspondingSyntax();
 

--- a/packages/codemirror/src/syntax_highlighting.ts
+++ b/packages/codemirror/src/syntax_highlighting.ts
@@ -199,4 +199,13 @@ const byMimeType: Record<SupportedMimeTypes, (() => Promise<StreamParser<unknown
     "text/xml": async () => (await import('@codemirror/lang-xml')).xml()
 }
 
+/**
+ * Maps MIME types that aren't first-class code-note languages onto an equivalent
+ * {@link byMimeType} language for syntax highlighting. For example, SVG image notes
+ * (`image/svg+xml`) are XML under the hood, so their source view highlights as XML.
+ */
+export const MIME_ALIASES: Record<string, SupportedMimeTypes> = {
+    "image/svg+xml": "text/xml"
+};
+
 export default byMimeType;


### PR DESCRIPTION
Closes #2710

## Summary

Two independent client-side improvements on this branch.

### Open new tabs next to the current tab
New tabs opened from a **link, middle-click, ctrl-click, or the "Open in a new tab" context menu** are now inserted **right after the active tab** (and all of its splits) instead of always at the end of the row — matching Firefox/Chrome/VS Code. The explicit "+" / Ctrl+T tab and programmatic openers (SQL console, search, scripts, images) still append at the end.

- Placement is decided in `TabManager.openEmptyTab` via a new `"afterCurrent"` option threaded through `openContextWithNote` / `openTabWithNoteWithHoisting`, defaulting to `"end"` so session restore and the "+" button are unchanged.
- An unpinned tab is clamped so it never lands inside the pinned-tab group.
- The tab row mirrors the model order in the DOM via `syncTabOrder()`.

### View source of SVG images
Adds the ability to view the source of SVG images (CodeMirror XML/SVG highlighting + a ribbon action). Commit `ecdcaa748d`, already present on the branch.

## Test plan

- `apps/client/src/components/tab_manager.spec.ts` (new) drives a real `TabManager`: blank tab → end, link → after active, after active + its splits, and the pinned-group clamp.
- Existing `link.spec` / `frontend_script_api.spec` unaffected (123 client tests pass).
- Client typecheck passes.

> [!NOTE]
> The tab feature is verified at the unit level; the DOM reordering was not manually exercised in a running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
