### PR TITLE
feat: dashboard and include note improvements

### DIFF
--- a/apps/client/src/services/content_renderer.css
+++ b/apps/client/src/services/content_renderer.css
@@ -13,3 +13,8 @@
         margin-bottom: 0;
     }
 }
+
+/* An interactive embedded web view (RenderOptions.interactive) fills the height its host provides. */
+.rendered-content:has(> .note-detail-web-view) {
+    height: 100%;
+}

--- a/apps/client/src/services/content_renderer.css
+++ b/apps/client/src/services/content_renderer.css
@@ -18,3 +18,10 @@
 .rendered-content:has(> .note-detail-web-view) {
     height: 100%;
 }
+
+/* A full-height embedded collection view (geo map, calendar, board, table) fills the height its host
+   provides; list/grid collections keep their natural, content-driven height. */
+.rendered-content:has(> .rendered-collection > .note-list-widget.full-height),
+.rendered-collection:has(> .note-list-widget.full-height) {
+    height: 100%;
+}

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -86,10 +86,11 @@ vi.mock("@triliumnext/commons/src/lib/markdown_renderer", async (orig) => ({
 }));
 
 // --- Imports AFTER the mocks. ---
+import appContext from "../components/app_context.js";
 import FAttachment from "../entities/fattachment.js";
 import { buildNote } from "../test/easy-froca.js";
-import froca from "./froca.js";
 import { disposeInteractiveContent, getRenderedContent as rawGetRenderedContent } from "./content_renderer.js";
+import froca from "./froca.js";
 import server from "./server.js";
 
 // getRenderedContent declares an explicit `this` parameter; bind it so callers don't need to.
@@ -455,6 +456,37 @@ describe("generic FNote fallback / webView", () => {
         // The live embed replaces the static fallback.
         expect($renderedContent.find(".webview-footer").length).toBe(0);
         expect($renderedContent.hasClass("no-preview")).toBe(false);
+    });
+
+    it("points a freshly mounted .component element at appContext so embedded command buttons resolve", async () => {
+        // The real renderReactWidgetAtElement runs here; make the mounted widget emit a bare
+        // ".component" element (as a real widget root would) with no component prop yet.
+        webViewComponent.mockImplementationOnce(() => h("div", { class: "component" }));
+        const note = buildNote({ title: "WICmp", type: "webView", "#webViewSrc": "https://example.com" });
+
+        const { $renderedContent } = await getRenderedContent(note, { interactive: true });
+
+        const $component = $renderedContent.find(".note-detail-web-view .component");
+        expect($component.length).toBe(1);
+        expect($component.prop("component")).toBe(appContext);
+    });
+
+    it("leaves a .component element that already carries a component prop untouched", async () => {
+        const preexisting = { marker: "already-wired" };
+        webViewComponent.mockImplementationOnce(() => h("div", {
+            class: "component",
+            ref: (el: HTMLElement | null) => {
+                if (el) {
+                    $(el).prop("component", preexisting);
+                }
+            }
+        }));
+        const note = buildNote({ title: "WICmp2", type: "webView", "#webViewSrc": "https://example.com" });
+
+        const { $renderedContent } = await getRenderedContent(note, { interactive: true });
+
+        const $component = $renderedContent.find(".note-detail-web-view .component");
+        expect($component.prop("component")).toBe(preexisting);
     });
 
     it("executes the search and mounts the live collection list for an interactive search note", async () => {

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -68,6 +68,9 @@ vi.mock("mermaid", () => ({
 const pdfViewerComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerComponent }));
 
+const webViewComponent = vi.fn(() => null);
+vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
+
 // `addHook` is a no-op here: sanitize_content.ts registers a DOMPurify hook at
 // module load (pulled in transitively), which would otherwise throw against this mock.
 vi.mock("dompurify", () => ({ default: { sanitize: (s: string) => s, addHook: () => {} } }));
@@ -436,6 +439,37 @@ describe("generic FNote fallback / webView", () => {
         const { $renderedContent } = await getRenderedContent(note);
         expect($renderedContent.find(".webview-footer").length).toBe(0);
         expect($renderedContent.hasClass("no-preview")).toBe(true);
+    });
+
+    it("mounts the live WebView widget when interactive (outside a tooltip)", async () => {
+        const note = buildNote({ title: "WI", type: "webView", "#webViewSrc": "https://example.com" });
+        const { type, $renderedContent } = await getRenderedContent(note, { interactive: true });
+        expect(type).toBe("webView");
+        expect(webViewComponent).toHaveBeenCalledOnce();
+        expect(webViewComponent.mock.calls[0]?.[0]).toMatchObject({ note });
+        expect($renderedContent.find(".note-detail-web-view").length).toBe(1);
+        // The live embed replaces the static fallback.
+        expect($renderedContent.find(".webview-footer").length).toBe(0);
+        expect($renderedContent.hasClass("no-preview")).toBe(false);
+    });
+
+    it("keeps the static fallback in a tooltip or without a src, even when interactive", async () => {
+        // Tooltips never embed the live widget, even with interactive set.
+        const tip = await getRenderedContent(
+            buildNote({ title: "WT", type: "webView", "#webViewSrc": "https://example.com" }),
+            { interactive: true, tooltip: true }
+        );
+        // Interactive set, but the note has no configured src.
+        const noSrc = await getRenderedContent(
+            buildNote({ title: "WN", type: "webView" }),
+            { interactive: true }
+        );
+
+        expect(webViewComponent).not.toHaveBeenCalled();
+        expect(tip.$renderedContent.find(".note-detail-web-view").length).toBe(0);
+        expect(tip.$renderedContent.find(".webview-footer").length).toBe(1);
+        expect(noSrc.$renderedContent.find(".note-detail-web-view").length).toBe(0);
+        expect(noSrc.$renderedContent.hasClass("no-preview")).toBe(true);
     });
 });
 

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -69,10 +69,10 @@ vi.mock("mermaid", () => ({
 const pdfViewerComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerComponent }));
 
-const webViewComponent = vi.fn(() => h("span", { class: "mock-webview-marker" }));
+const webViewComponent = vi.fn((_props: any) => h("span", { class: "mock-webview-marker" }));
 vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
 
-const embeddedNoteListComponent = vi.fn(() => null);
+const embeddedNoteListComponent = vi.fn((_props: any) => null);
 vi.mock("../widgets/collections/NoteList", () => ({ EmbeddedNoteList: embeddedNoteListComponent }));
 
 // `addHook` is a no-op here: sanitize_content.ts registers a DOMPurify hook at

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -71,8 +71,8 @@ vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerCom
 const webViewComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
 
-const searchNoteListComponent = vi.fn(() => null);
-vi.mock("../widgets/collections/NoteList", () => ({ SearchNoteList: searchNoteListComponent }));
+const embeddedNoteListComponent = vi.fn(() => null);
+vi.mock("../widgets/collections/NoteList", () => ({ EmbeddedNoteList: embeddedNoteListComponent }));
 
 // `addHook` is a no-op here: sanitize_content.ts registers a DOMPurify hook at
 // module load (pulled in transitively), which would otherwise throw against this mock.
@@ -456,7 +456,7 @@ describe("generic FNote fallback / webView", () => {
         expect($renderedContent.hasClass("no-preview")).toBe(false);
     });
 
-    it("executes the search and mounts the live results list for an interactive search note", async () => {
+    it("executes the search and mounts the live collection list for an interactive search note", async () => {
         const note = buildNote({ title: "Saved", type: "search" });
         vi.spyOn(note, "getBestNotePathString").mockReturnValue("root/saved");
         const loadSpy = vi.spyOn(froca, "loadSearchNote").mockResolvedValue(undefined);
@@ -465,24 +465,51 @@ describe("generic FNote fallback / webView", () => {
 
         expect(type).toBe("search");
         expect(loadSpy).toHaveBeenCalledWith(note.noteId);
-        expect(searchNoteListComponent).toHaveBeenCalledOnce();
-        expect(searchNoteListComponent.mock.calls[0]?.[0]).toMatchObject({ note, media: "screen" });
-        expect($renderedContent.find(".rendered-search").length).toBe(1);
-        expect($renderedContent.hasClass("no-preview")).toBe(false);
+        expect(embeddedNoteListComponent).toHaveBeenCalledOnce();
+        expect(embeddedNoteListComponent.mock.calls[0]?.[0]).toMatchObject({ note, media: "screen", showTextRepresentation: true });
+        expect($renderedContent.find(".rendered-collection").length).toBe(1);
 
         loadSpy.mockRestore();
     });
 
-    it("keeps the static fallback for a search note when interactive is off", async () => {
-        const note = buildNote({ title: "Saved2", type: "search" });
+    it("mounts the collection view for an interactive book note without executing a search", async () => {
+        const note = buildNote({ title: "Coll", type: "book" });
+        vi.spyOn(note, "getBestNotePathString").mockReturnValue("root/coll");
         const loadSpy = vi.spyOn(froca, "loadSearchNote").mockResolvedValue(undefined);
 
-        const { $renderedContent } = await getRenderedContent(note);
+        const { type, $renderedContent } = await getRenderedContent(note, { interactive: true });
+
+        expect(type).toBe("book");
+        expect(loadSpy).not.toHaveBeenCalled();
+        expect(embeddedNoteListComponent).toHaveBeenCalledOnce();
+        expect(embeddedNoteListComponent.mock.calls[0]?.[0]).toMatchObject({ note, media: "screen", showTextRepresentation: false });
+        expect($renderedContent.find(".rendered-collection").length).toBe(1);
+
+        loadSpy.mockRestore();
+    });
+
+    it("does not embed a dashboard-view collection, to avoid recursion", async () => {
+        const note = buildNote({ title: "Dash", type: "book", "#viewType": "dashboard" });
+        const { $renderedContent } = await getRenderedContent(note, { interactive: true });
+        // Falls back to renderText (the basic children list) instead of the live collection.
+        expect(embeddedNoteListComponent).not.toHaveBeenCalled();
+        expect($renderedContent.find(".rendered-collection").length).toBe(0);
+        expect($renderedContent.find(".from-render-text").length).toBe(1);
+    });
+
+    it("keeps the static fallback for book/search notes when interactive is off", async () => {
+        const loadSpy = vi.spyOn(froca, "loadSearchNote").mockResolvedValue(undefined);
+
+        // Book falls back to renderText (basic children list).
+        const book = await getRenderedContent(buildNote({ title: "Coll2", type: "book" }));
+        // Search has no static renderer, so it lands in the no-preview block.
+        const search = await getRenderedContent(buildNote({ title: "Saved2", type: "search" }));
 
         expect(loadSpy).not.toHaveBeenCalled();
-        expect(searchNoteListComponent).not.toHaveBeenCalled();
-        expect($renderedContent.find(".rendered-search").length).toBe(0);
-        expect($renderedContent.hasClass("no-preview")).toBe(true);
+        expect(embeddedNoteListComponent).not.toHaveBeenCalled();
+        expect(book.$renderedContent.find(".from-render-text").length).toBe(1);
+        expect(search.$renderedContent.hasClass("no-preview")).toBe(true);
+        expect(search.$renderedContent.find(".rendered-collection").length).toBe(0);
 
         loadSpy.mockRestore();
     });

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -1,4 +1,4 @@
-import { h } from "preact";
+import { h, VNode } from "preact";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock heavy / side-effecting collaborators BEFORE importing the SUT. ---
@@ -69,7 +69,7 @@ vi.mock("mermaid", () => ({
 const pdfViewerComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerComponent }));
 
-const webViewComponent = vi.fn((_props: any) => h("span", { class: "mock-webview-marker" }));
+const webViewComponent = vi.fn((_props: any): VNode<any> => h("span", { class: "mock-webview-marker" }));
 vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
 
 const embeddedNoteListComponent = vi.fn((_props: any) => null);

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -1,3 +1,4 @@
+import { h } from "preact";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- Mock heavy / side-effecting collaborators BEFORE importing the SUT. ---
@@ -68,7 +69,7 @@ vi.mock("mermaid", () => ({
 const pdfViewerComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerComponent }));
 
-const webViewComponent = vi.fn(() => null);
+const webViewComponent = vi.fn(() => h("span", { class: "mock-webview-marker" }));
 vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
 
 const embeddedNoteListComponent = vi.fn(() => null);
@@ -88,7 +89,7 @@ vi.mock("@triliumnext/commons/src/lib/markdown_renderer", async (orig) => ({
 import FAttachment from "../entities/fattachment.js";
 import { buildNote } from "../test/easy-froca.js";
 import froca from "./froca.js";
-import { getRenderedContent as rawGetRenderedContent } from "./content_renderer.js";
+import { disposeInteractiveContent, getRenderedContent as rawGetRenderedContent } from "./content_renderer.js";
 import server from "./server.js";
 
 // getRenderedContent declares an explicit `this` parameter; bind it so callers don't need to.
@@ -531,6 +532,28 @@ describe("generic FNote fallback / webView", () => {
         expect(tip.$renderedContent.find(".webview-footer").length).toBe(1);
         expect(noSrc.$renderedContent.find(".note-detail-web-view").length).toBe(0);
         expect(noSrc.$renderedContent.hasClass("no-preview")).toBe(true);
+    });
+});
+
+describe("interactive content disposal", () => {
+    it("tags an interactive mount and disposes it, unmounting the widget", async () => {
+        const note = buildNote({ title: "WI", type: "webView", "#webViewSrc": "https://example.com" });
+        const { $renderedContent } = await getRenderedContent(note, { interactive: true });
+
+        const mount = $renderedContent.find("[data-interactive-mount]");
+        expect(mount.length).toBe(1);
+        expect(mount.find(".mock-webview-marker").length).toBe(1);
+
+        disposeInteractiveContent($renderedContent);
+        // render(null, ...) unmounted the widget, clearing the mount's rendered tree.
+        expect(mount.find(".mock-webview-marker").length).toBe(0);
+    });
+
+    it("is a no-op for content with no interactive mounts", async () => {
+        const note = buildNote({ title: "T", type: "text" });
+        const { $renderedContent } = await getRenderedContent(note);
+        expect($renderedContent.find("[data-interactive-mount]").length).toBe(0);
+        expect(() => disposeInteractiveContent($renderedContent)).not.toThrow();
     });
 });
 

--- a/apps/client/src/services/content_renderer.spec.ts
+++ b/apps/client/src/services/content_renderer.spec.ts
@@ -71,6 +71,9 @@ vi.mock("../widgets/type_widgets/file/PdfViewer", () => ({ default: pdfViewerCom
 const webViewComponent = vi.fn(() => null);
 vi.mock("../widgets/type_widgets/WebView", () => ({ default: webViewComponent }));
 
+const searchNoteListComponent = vi.fn(() => null);
+vi.mock("../widgets/collections/NoteList", () => ({ SearchNoteList: searchNoteListComponent }));
+
 // `addHook` is a no-op here: sanitize_content.ts registers a DOMPurify hook at
 // module load (pulled in transitively), which would otherwise throw against this mock.
 vi.mock("dompurify", () => ({ default: { sanitize: (s: string) => s, addHook: () => {} } }));
@@ -451,6 +454,37 @@ describe("generic FNote fallback / webView", () => {
         // The live embed replaces the static fallback.
         expect($renderedContent.find(".webview-footer").length).toBe(0);
         expect($renderedContent.hasClass("no-preview")).toBe(false);
+    });
+
+    it("executes the search and mounts the live results list for an interactive search note", async () => {
+        const note = buildNote({ title: "Saved", type: "search" });
+        vi.spyOn(note, "getBestNotePathString").mockReturnValue("root/saved");
+        const loadSpy = vi.spyOn(froca, "loadSearchNote").mockResolvedValue(undefined);
+
+        const { type, $renderedContent } = await getRenderedContent(note, { interactive: true });
+
+        expect(type).toBe("search");
+        expect(loadSpy).toHaveBeenCalledWith(note.noteId);
+        expect(searchNoteListComponent).toHaveBeenCalledOnce();
+        expect(searchNoteListComponent.mock.calls[0]?.[0]).toMatchObject({ note, media: "screen" });
+        expect($renderedContent.find(".rendered-search").length).toBe(1);
+        expect($renderedContent.hasClass("no-preview")).toBe(false);
+
+        loadSpy.mockRestore();
+    });
+
+    it("keeps the static fallback for a search note when interactive is off", async () => {
+        const note = buildNote({ title: "Saved2", type: "search" });
+        const loadSpy = vi.spyOn(froca, "loadSearchNote").mockResolvedValue(undefined);
+
+        const { $renderedContent } = await getRenderedContent(note);
+
+        expect(loadSpy).not.toHaveBeenCalled();
+        expect(searchNoteListComponent).not.toHaveBeenCalled();
+        expect($renderedContent.find(".rendered-search").length).toBe(0);
+        expect($renderedContent.hasClass("no-preview")).toBe(true);
+
+        loadSpy.mockRestore();
     });
 
     it("keeps the static fallback in a tooltip or without a src, even when interactive", async () => {

--- a/apps/client/src/services/content_renderer.ts
+++ b/apps/client/src/services/content_renderer.ts
@@ -364,6 +364,9 @@ async function renderWebView(note: FNote, $renderedContent: JQuery<HTMLElement>)
     $renderedContent.append($container);
 }
 
+/** Marks a standalone Preact root mounted by {@link mountInteractiveWidget} so it can be unmounted. */
+const INTERACTIVE_MOUNT_ATTR = "data-interactive-mount";
+
 /**
  * Mounts an interactive embedded widget (web view, collection) through the Trilium event bridge.
  * Wrapping it in a {@link ParentComponent} provider connected to {@link appContext} is what lets its
@@ -376,6 +379,8 @@ async function mountInteractiveWidget(vnode: JSX.Element, container: HTMLElement
         import("../components/app_context")
     ]);
     renderReactWidgetAtElement(appContext, vnode, container);
+    // Mark the standalone Preact root so disposeInteractiveContent() can later unmount it.
+    container.setAttribute(INTERACTIVE_MOUNT_ATTR, "");
 
     // The global [data-trigger-command] click delegate resolves its handler via
     // closest(".component").prop("component"). A standalone mount has no legacy widget setting that
@@ -387,6 +392,19 @@ async function mountInteractiveWidget(vnode: JSX.Element, container: HTMLElement
         if (!$(el).prop("component")) {
             $(el).prop("component", appContext);
         }
+    }
+}
+
+/**
+ * Unmounts any interactive widgets (web views, collections) that {@link getRenderedContent} mounted
+ * into the given content, running their cleanup — `useTriliumEvent` unsubscribe, Bootstrap dropdown
+ * disposal, map teardown. A caller embedding interactive content must call this when it replaces or
+ * discards that content, otherwise the standalone Preact roots leak. Safe (no-op) for content with no
+ * interactive widgets.
+ */
+export function disposeInteractiveContent($renderedContent: JQuery<HTMLElement>) {
+    for (const el of $renderedContent.find(`[${INTERACTIVE_MOUNT_ATTR}]`).toArray()) {
+        render(null, el);
     }
 }
 
@@ -460,5 +478,6 @@ function getRenderingType(entity: FNote | FAttachment) {
 }
 
 export default {
-    getRenderedContent
+    getRenderedContent,
+    disposeInteractiveContent
 };

--- a/apps/client/src/services/content_renderer.ts
+++ b/apps/client/src/services/content_renderer.ts
@@ -87,6 +87,8 @@ export async function getRenderedContent(this: {} | { ctx: string }, entity: FNo
         $renderedContent.append($("<div>").append("<div>This note is protected and to access it you need to enter password.</div>").append("<br/>").append($button));
     } else if (type === "webView" && options.interactive && !options.tooltip && entity instanceof FNote && entity.hasLabel("webViewSrc")) {
         await renderWebView(entity, $renderedContent);
+    } else if (type === "search" && options.interactive && !options.tooltip && entity instanceof FNote) {
+        await renderSearch(entity, $renderedContent);
     } else if (entity instanceof FNote) {
         $renderedContent.addClass("no-preview");
         $renderedContent.append(
@@ -353,6 +355,36 @@ async function renderWebView(note: FNote, $renderedContent: JQuery<HTMLElement>)
             viewScope: undefined,
             parentComponent: undefined,
             noteContext: undefined
+        }), container);
+    }
+    $renderedContent.append($container);
+}
+
+/**
+ * Executes a saved search and mounts the live {@link SearchNoteList} — the same results widget used
+ * in the note detail — into the rendered content. Used by interactive contexts (e.g. the dashboard
+ * and included notes) that opt in via {@link RenderOptions.interactive}; every other context keeps
+ * the static no-preview fallback. Loaded lazily so the collection views (and their dependencies) are
+ * only pulled in when a saved search is actually embedded.
+ */
+async function renderSearch(note: FNote, $renderedContent: JQuery<HTMLElement>) {
+    const [ { SearchNoteList }, { default: froca } ] = await Promise.all([
+        import("../widgets/collections/NoteList"),
+        import("./froca.js")
+    ]);
+
+    // A saved search must run server-side before its (virtual) result children exist.
+    await froca.loadSearchNote(note.noteId);
+
+    const $container = $('<div class="rendered-search">');
+    const container = $container.get(0);
+    if (container) {
+        render(h(SearchNoteList, {
+            note,
+            notePath: note.getBestNotePathString(),
+            ntxId: undefined,
+            media: "screen",
+            highlightedTokens: note.highlightedTokens
         }), container);
     }
     $renderedContent.append($container);

--- a/apps/client/src/services/content_renderer.ts
+++ b/apps/client/src/services/content_renderer.ts
@@ -33,6 +33,12 @@ export interface RenderOptions {
     /** Set of note IDs that have already been seen during rendering to prevent infinite recursion. */
     seenNoteIds?: Set<string>;
     showTextRepresentation?: boolean;
+    /**
+     * If enabled, note types that have a richer live representation (currently only web views) are
+     * mounted as their interactive type widget instead of a static preview/placeholder. Off by
+     * default and intentionally left off for lightweight previews such as tooltips and the note list.
+     */
+    interactive?: boolean;
 }
 
 const CODE_MIME_TYPES = new Set(["application/json"]);
@@ -79,6 +85,8 @@ export async function getRenderedContent(this: {} | { ctx: string }, entity: FNo
         const $button = $(`<button class="btn btn-sm"><span class="tn-icon bx bx-log-in"></span> Enter protected session</button>`).on("click", protectedSessionService.enterProtectedSession);
 
         $renderedContent.append($("<div>").append("<div>This note is protected and to access it you need to enter password.</div>").append("<br/>").append($button));
+    } else if (type === "webView" && options.interactive && !options.tooltip && entity instanceof FNote && entity.hasLabel("webViewSrc")) {
+        await renderWebView(entity, $renderedContent);
     } else if (entity instanceof FNote) {
         $renderedContent.addClass("no-preview");
         $renderedContent.append(
@@ -326,6 +334,28 @@ async function renderMermaid(note: FNote | FAttachment, $renderedContent: JQuery
 
         $renderedContent.append($error);
     }
+}
+
+/**
+ * Mounts the live {@link WebView} type widget — an Electron `<webview>` or a sandboxed `<iframe>` —
+ * into the rendered content. Used by interactive contexts (e.g. the dashboard) that opt in via
+ * {@link RenderOptions.interactive}; every other context keeps the static "open externally" fallback.
+ * Loaded lazily so the widget (and its dependencies) are only pulled in when a web view is embedded.
+ */
+async function renderWebView(note: FNote, $renderedContent: JQuery<HTMLElement>) {
+    const WebView = (await import("../widgets/type_widgets/WebView")).default;
+    const $container = $('<div class="note-detail-web-view">');
+    const container = $container.get(0);
+    if (container) {
+        render(h(WebView, {
+            note,
+            ntxId: undefined,
+            viewScope: undefined,
+            parentComponent: undefined,
+            noteContext: undefined
+        }), container);
+    }
+    $renderedContent.append($container);
 }
 
 function getRenderingType(entity: FNote | FAttachment) {

--- a/apps/client/src/services/content_renderer.ts
+++ b/apps/client/src/services/content_renderer.ts
@@ -2,7 +2,7 @@ import "./content_renderer.css";
 
 import { normalizeMimeTypeForCKEditor, type TextRepresentationResponse } from "@triliumnext/commons";
 import DOMPurify from "dompurify";
-import { h, render } from "preact";
+import { h, type JSX, render } from "preact";
 
 import FAttachment from "../entities/fattachment.js";
 import FNote from "../entities/fnote.js";
@@ -57,7 +57,13 @@ export async function getRenderedContent(this: {} | { ctx: string }, entity: FNo
 
     const $renderedContent = $('<div class="rendered-content">');
 
-    if (type === "text" || type === "book") {
+    if ((type === "book" || type === "search") && options.interactive && !options.tooltip
+        && entity instanceof FNote && entity.getLabelValue("viewType") !== "dashboard") {
+        // Render the live collection view (grid/table/board/calendar/map/presentation). The dashboard
+        // view type is excluded: it's the only view that re-propagates `interactive` to its tiles, so
+        // skipping it here is what keeps an embedded collection from recursing into itself.
+        await renderCollection(entity, $renderedContent);
+    } else if (type === "text" || type === "book") {
         await renderText(entity, $renderedContent, options);
     } else if (type === "markdown") {
         await renderMarkdown(entity, $renderedContent, options);
@@ -87,8 +93,6 @@ export async function getRenderedContent(this: {} | { ctx: string }, entity: FNo
         $renderedContent.append($("<div>").append("<div>This note is protected and to access it you need to enter password.</div>").append("<br/>").append($button));
     } else if (type === "webView" && options.interactive && !options.tooltip && entity instanceof FNote && entity.hasLabel("webViewSrc")) {
         await renderWebView(entity, $renderedContent);
-    } else if (type === "search" && options.interactive && !options.tooltip && entity instanceof FNote) {
-        await renderSearch(entity, $renderedContent);
     } else if (entity instanceof FNote) {
         $renderedContent.addClass("no-preview");
         $renderedContent.append(
@@ -349,7 +353,7 @@ async function renderWebView(note: FNote, $renderedContent: JQuery<HTMLElement>)
     const $container = $('<div class="note-detail-web-view">');
     const container = $container.get(0);
     if (container) {
-        render(h(WebView, {
+        await mountInteractiveWidget(h(WebView, {
             note,
             ntxId: undefined,
             viewScope: undefined,
@@ -361,30 +365,49 @@ async function renderWebView(note: FNote, $renderedContent: JQuery<HTMLElement>)
 }
 
 /**
- * Executes a saved search and mounts the live {@link SearchNoteList} — the same results widget used
- * in the note detail — into the rendered content. Used by interactive contexts (e.g. the dashboard
- * and included notes) that opt in via {@link RenderOptions.interactive}; every other context keeps
- * the static no-preview fallback. Loaded lazily so the collection views (and their dependencies) are
- * only pulled in when a saved search is actually embedded.
+ * Mounts an interactive embedded widget (web view, collection) through the Trilium event bridge.
+ * Wrapping it in a {@link ParentComponent} provider connected to {@link appContext} is what lets its
+ * `useTriliumEvent` subscriptions actually receive events — a bare standalone Preact root has no
+ * parent component in context, so otherwise e.g. an embedded collection never reacts to new notes.
  */
-async function renderSearch(note: FNote, $renderedContent: JQuery<HTMLElement>) {
-    const [ { SearchNoteList }, { default: froca } ] = await Promise.all([
+async function mountInteractiveWidget(vnode: JSX.Element, container: HTMLElement) {
+    const [ { renderReactWidgetAtElement }, { default: appContext } ] = await Promise.all([
+        import("../widgets/react/react_utils"),
+        import("../components/app_context")
+    ]);
+    renderReactWidgetAtElement(appContext, vnode, container);
+}
+
+/**
+ * Mounts a collection — a book or a saved search — as the live {@link EmbeddedNoteList}, the same
+ * results widget used in the note detail (grid/list/table/board/calendar/map/presentation). Used by
+ * interactive contexts (e.g. the dashboard and included notes) that opt in via
+ * {@link RenderOptions.interactive}; every other context keeps the static fallback. Loaded lazily so
+ * the collection views (and their dependencies) are only pulled in when a collection is embedded.
+ */
+async function renderCollection(note: FNote, $renderedContent: JQuery<HTMLElement>) {
+    const [ { EmbeddedNoteList }, { default: froca } ] = await Promise.all([
         import("../widgets/collections/NoteList"),
         import("./froca.js")
     ]);
 
-    // A saved search must run server-side before its (virtual) result children exist.
-    await froca.loadSearchNote(note.noteId);
+    // A saved search must run server-side before its (virtual) result children exist; a book already
+    // has real children, so it skips execution.
+    if (note.type === "search") {
+        await froca.loadSearchNote(note.noteId);
+    }
 
-    const $container = $('<div class="rendered-search">');
+    const $container = $('<div class="rendered-collection">');
     const container = $container.get(0);
     if (container) {
-        render(h(SearchNoteList, {
+        await mountInteractiveWidget(h(EmbeddedNoteList, {
             note,
             notePath: note.getBestNotePathString(),
             ntxId: undefined,
             media: "screen",
-            highlightedTokens: note.highlightedTokens
+            highlightedTokens: note.highlightedTokens,
+            // Search results get text-representation (highlighted snippets); books don't.
+            showTextRepresentation: note.type === "search"
         }), container);
     }
     $renderedContent.append($container);

--- a/apps/client/src/services/content_renderer.ts
+++ b/apps/client/src/services/content_renderer.ts
@@ -376,6 +376,18 @@ async function mountInteractiveWidget(vnode: JSX.Element, container: HTMLElement
         import("../components/app_context")
     ]);
     renderReactWidgetAtElement(appContext, vnode, container);
+
+    // The global [data-trigger-command] click delegate resolves its handler via
+    // closest(".component").prop("component"). A standalone mount has no legacy widget setting that
+    // prop (ReactWrappedWidget does it in the note detail), so point the rendered ".component"
+    // element(s) at appContext — an unhandled command there is converted into an event, reaching the
+    // widget's own useTriliumEvent subscription. Without it an embedded command button (e.g. the geo
+    // map "Add marker") throws "component is undefined".
+    for (const el of container.querySelectorAll<HTMLElement>(".component")) {
+        if (!$(el).prop("component")) {
+            $(el).prop("component", appContext);
+        }
+    }
 }
 
 /**

--- a/apps/client/src/services/note_tooltip.ts
+++ b/apps/client/src/services/note_tooltip.ts
@@ -78,7 +78,10 @@ export async function mouseEnterHandler<T>(this: HTMLElement, e: JQuery.Triggere
 
     let renderPromise;
     let note: FNote | null = null;
-    if (url && url.startsWith("#") && !url.startsWith("#root/")) {
+    // In-page anchors and footnotes are always bare `#fragment` references; a `?` means this is a
+    // note link carrying view params (e.g. the calendar's `#<noteId>?popup`), which must render a
+    // note tooltip rather than being fed into a jQuery selector (the `?` is an invalid selector).
+    if (url && url.startsWith("#") && !url.startsWith("#root/") && !url.includes("?")) {
         renderPromise = renderFootnoteOrAnchor($link, url);
     } else {
         note = await froca.getNote(noteId);

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1305,10 +1305,11 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
 
 .include-note {
     margin-bottom: 10px;
-    padding: 10px;
-    border-radius: 10px;
-    background-color: var(--accented-background-color);
+    border-radius: 8px;
+    border: 1px solid var(--card-border-color, var(--main-border-color));
+    background-color: var(--card-background-color, var(--accented-background-color));
     display: flex; /* see https://github.com/zadam/trilium/issues/1590 */
+    transition: background-color 200ms ease-out;
 }
 
 /* CKEditor counts only non-UIElements as content (see `hasContent` in the
@@ -1345,18 +1346,54 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
 
 .include-note-wrapper {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+/* Header: the standalone title (non-expandable) and the title row (expandable)
+   both act as the card header, mirroring the grid/list note-book-card header. */
+.include-note-wrapper > .include-note-title,
+.include-note-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    padding: .5rem 1rem;
+    font-size: 1em;
+    font-weight: 500;
+    border-bottom: 1px solid var(--card-border-color, var(--main-border-color));
+}
+
+.include-note-title .bx {
+    flex-shrink: 0;
+    font-size: 1.2em;
+    color: var(--note-list-view-icon-color, var(--muted-text-color));
+}
+
+/* Neutralize the default link color and pill hover so the title reads as a
+   plain card header (matching .note-book-title in the grid/list view). */
+.include-note-title a {
+    --link-hover-background: transparent;
+    --link-hover-color: currentColor;
+    color: inherit;
+    font-weight: 500;
+    text-decoration: none;
 }
 
 /* Expandable include note styles */
 .include-note-title-row {
-    display: flex;
-    align-items: center;
-    gap: 5px;
     cursor: pointer;
 }
 
+/* The title inside the expandable row defers its header styling to the row. */
 .include-note-title-row .include-note-title {
-    margin: 0;
+    padding: 0;
+    border-bottom: none;
+    font-weight: inherit;
+    font-size: inherit;
+    min-width: 0;
+    flex-grow: 1;
 }
 
 .include-note-toggle {
@@ -1365,11 +1402,12 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     padding: 2px;
     cursor: pointer;
     font-size: 1.2em;
-    color: var(--main-text-color);
+    color: var(--muted-text-color);
     transition: transform 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 }
 
 .include-note-toggle:hover {
@@ -1380,8 +1418,24 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     transform: rotate(90deg);
 }
 
+.include-note-content {
+    padding: .75rem 1rem;
+}
+
+.include-note-content > .rendered-content > *:last-child {
+    margin-bottom: 0;
+}
+
+/* Media that renders edge-to-edge (iframes, images, video) shouldn't be inset. */
+.include-note-content.type-pdf,
+.include-note-content.type-image,
+.include-note-content.type-video,
+.include-note-content.type-canvas {
+    padding: 0;
+}
+
 .include-note[data-box-size="expandable"] .include-note-content {
-    margin-top: 10px;
+    padding-top: 0;
 }
 
 .alert {

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1353,6 +1353,30 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     height: 20em;
 }
 
+/* Full-height collection views (table, board, calendar, geo map, presentation) render their own
+   scroll region with no intrinsic height, so — like PDFs and web views — they need an explicit
+   height per box size. The inner widget fills it via its existing height:100% chain. List/grid
+   collections are content-driven and keep the generic max-height above. */
+.include-note[data-box-size="small"] .include-note-content.type-book:has(.note-list-widget.full-height),
+.include-note[data-box-size="small"] .include-note-content.type-search:has(.note-list-widget.full-height) {
+    height: 10em;
+}
+
+.include-note[data-box-size="medium"] .include-note-content.type-book:has(.note-list-widget.full-height),
+.include-note[data-box-size="medium"] .include-note-content.type-search:has(.note-list-widget.full-height) {
+    height: 20em;
+}
+
+.include-note[data-box-size="full"] .include-note-content.type-book:has(.note-list-widget.full-height),
+.include-note[data-box-size="full"] .include-note-content.type-search:has(.note-list-widget.full-height) {
+    height: 50em; /* a full-height view can't take a percentage full height, so fall back to a large fixed one */
+}
+
+.include-note[data-box-size="expandable"] .include-note-content.type-book:has(.note-list-widget.full-height),
+.include-note[data-box-size="expandable"] .include-note-content.type-search:has(.note-list-widget.full-height) {
+    height: 20em;
+}
+
 .include-note-wrapper {
     width: 100%;
     display: flex;
@@ -1446,12 +1470,15 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     margin-bottom: 0;
 }
 
-/* Media that renders edge-to-edge (iframes, images, video) shouldn't be inset. */
+/* Media that renders edge-to-edge (iframes, images, video, full-height collection views) shouldn't
+   be inset. List/grid collections keep their padding (they are content-driven, not full-height). */
 .include-note-content.type-pdf,
 .include-note-content.type-image,
 .include-note-content.type-video,
 .include-note-content.type-canvas,
-.include-note-content.type-webView {
+.include-note-content.type-webView,
+.include-note-content.type-book:has(.note-list-widget.full-height),
+.include-note-content.type-search:has(.note-list-widget.full-height) {
     padding: 0;
 }
 

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1365,6 +1365,16 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     border-bottom: 1px solid var(--card-border-color, var(--main-border-color));
 }
 
+/* createLink wraps the icon and anchor in a single <span>; lay it out as a flex
+   row so the (larger) note icon lines up vertically with the title text instead
+   of sitting on the text baseline. */
+.include-note-title > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+
 .include-note-title .bx {
     flex-shrink: 0;
     font-size: 1.2em;
@@ -1388,6 +1398,7 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
 
 /* The title inside the expandable row defers its header styling to the row. */
 .include-note-title-row .include-note-title {
+    margin: 0;
     padding: 0;
     border-bottom: none;
     font-weight: inherit;

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1327,8 +1327,11 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     overflow: auto;
 }
 
-.include-note[data-box-size="small"] .include-note-content.type-pdf {
-    height: 10em; /* PDF is rendered in iframe and must be sized absolutely */
+/* PDFs and web views render in an (absolutely positioned) iframe, so they need an explicit
+   height per box size instead of an intrinsic, content-driven one. */
+.include-note[data-box-size="small"] .include-note-content.type-pdf,
+.include-note[data-box-size="small"] .include-note-content.type-webView {
+    height: 10em;
 }
 
 .include-note[data-box-size="medium"] .include-note-content {
@@ -1336,12 +1339,18 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
     overflow: auto;
 }
 
-.include-note[data-box-size="medium"] .include-note-content.type-pdf .rendered-content {
-    height: 20em; /* PDF is rendered in iframe and must be sized absolutely */
+.include-note[data-box-size="medium"] .include-note-content.type-pdf .rendered-content,
+.include-note[data-box-size="medium"] .include-note-content.type-webView .rendered-content {
+    height: 20em;
 }
 
-.include-note[data-box-size="full"] .include-note-content.type-pdf .rendered-content {
-    height: 50em; /* PDF is rendered in iframe and it's not possible to put full height so at least a large height */
+.include-note[data-box-size="full"] .include-note-content.type-pdf .rendered-content,
+.include-note[data-box-size="full"] .include-note-content.type-webView .rendered-content {
+    height: 50em; /* an iframe can't take a percentage full height, so fall back to a large fixed one */
+}
+
+.include-note[data-box-size="expandable"] .include-note-content.type-webView .rendered-content {
+    height: 20em;
 }
 
 .include-note-wrapper {
@@ -1441,7 +1450,8 @@ body.mobile .modal-content-with-sidebar > .modal-main > .modal-header > .modal-t
 .include-note-content.type-pdf,
 .include-note-content.type-image,
 .include-note-content.type-video,
-.include-note-content.type-canvas {
+.include-note-content.type-canvas,
+.include-note-content.type-webView {
     padding: 0;
 }
 

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1152,7 +1152,9 @@
   "book": {
     "no_children_help": "This collection doesn't have any child notes so there's nothing to display.",
     "drag_locked_title": "Locked for editing",
-    "drag_locked_message": "Dragging not allowed since the collection is locked for editing."
+    "drag_locked_message": "Dragging not allowed since the collection is locked for editing.",
+    "archived_notes_hidden_one": "An archived note was copied here but stays hidden until you enable \"Show archived notes\".",
+    "archived_notes_hidden_other": "{{count}} archived notes were copied here but stay hidden until you enable \"Show archived notes\"."
   },
   "editable_code": {
     "placeholder": "Type the content of your code note here..."

--- a/apps/client/src/widgets/collections/NoteList.spec.tsx
+++ b/apps/client/src/widgets/collections/NoteList.spec.tsx
@@ -80,11 +80,11 @@ describe("useNoteIds refresh race", () => {
         container = document.createElement("div");
         document.body.appendChild(container);
 
-        return { note, pending, parent };
+        return { note, pending, parent, container };
     }
 
     it("commits the newest refresh even when an older one resolves last", async () => {
-        const { note, pending, parent } = setup();
+        const { note, pending, parent, container } = setup();
 
         // Mount issues the first refresh (reflecting the pre-clone child set).
         await act(async () => {
@@ -120,7 +120,7 @@ describe("useNoteIds refresh race", () => {
     });
 
     it("applies a single refresh's result normally", async () => {
-        const { note, pending, parent } = setup();
+        const { note, pending, parent, container } = setup();
 
         await act(async () => {
             render(
@@ -150,15 +150,16 @@ describe("useNoteIds refresh race", () => {
         note.getChildNoteIdsWithArchiveFiltering = vi.fn(async () => liveChildren);
 
         const parent = new Component();
-        container = document.createElement("div");
-        document.body.appendChild(container);
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
 
         await act(async () => {
             render(
                 <ParentComponent.Provider value={parent}>
                     <Harness note={note} />
                 </ParentComponent.Provider>,
-                container
+                mountPoint
             );
         });
         // Drain the mount refresh's async chain (effect → getNoteIds → setNoteIds).

--- a/apps/client/src/widgets/collections/NoteList.spec.tsx
+++ b/apps/client/src/widgets/collections/NoteList.spec.tsx
@@ -1,0 +1,142 @@
+/**
+ * Regression test for the dashboard (and other collection views) intermittently not refreshing
+ * after a note is dragged in from the tree.
+ *
+ * `useNoteIds` refreshes its id list by calling `note.getChildNoteIdsWithArchiveFiltering()`, which
+ * does a server round-trip (archive filtering search). Several refreshes can be in flight at once
+ * (initial mount, an `entitiesReloaded` from the clone, an `includeArchived` change). Without
+ * sequencing, whichever server response lands *last* wins — so a stale, pre-clone result can clobber
+ * the fresh post-clone one, leaving the new widget invisible until a manual reload. The hook guards
+ * against this by only committing the most recently issued refresh.
+ */
+import { deferred } from "@triliumnext/commons";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Component from "../../components/component";
+import type FNote from "../../entities/fnote";
+import type { EntityChange } from "../../server_types";
+import LoadResults from "../../services/load_results";
+import { buildNote } from "../../test/easy-froca";
+import { ParentComponent } from "../react/react_utils";
+import { useNoteIds } from "./NoteList";
+
+let currentNoteIds: string[] = [];
+
+/** Drains the chained awaits in `refreshNoteIds` (getNoteIds → search promise → setNoteIds). */
+async function flushMicrotasks() {
+    await new Promise((resolve) => setTimeout(resolve));
+}
+
+/** Renders `useNoteIds` and exposes its current value through the module-level `currentNoteIds`. */
+function Harness({ note }: { note: FNote }) {
+    currentNoteIds = useNoteIds(note, "dashboard", "ntx-1");
+    return null;
+}
+
+function branchEntitiesReloaded(parentNoteId: string, childNoteId: string) {
+    const branchId = `br-${childNoteId}`;
+    const loadResults = new LoadResults([
+        {
+            entityName: "branches",
+            entityId: branchId,
+            entity: { branchId, parentNoteId, noteId: childNoteId },
+            componentId: "comp-1"
+        } as unknown as EntityChange
+    ]);
+    loadResults.addBranch(branchId, "comp-1");
+    return loadResults;
+}
+
+describe("useNoteIds refresh race", () => {
+    let container: HTMLElement | undefined;
+
+    beforeEach(() => {
+        currentNoteIds = [];
+    });
+
+    afterEach(() => {
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    function setup() {
+        const note = buildNote({ title: "Dashboard", type: "book" });
+
+        // Each refresh's child-id lookup hangs until the test resolves it, so resolution order is
+        // fully controllable (it stands in for a slow/variable-latency server search).
+        const pending: ReturnType<typeof deferred<string[]>>[] = [];
+        note.getChildNoteIdsWithArchiveFiltering = vi.fn(() => {
+            const d = deferred<string[]>();
+            pending.push(d);
+            return d;
+        });
+
+        const parent = new Component();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+
+        return { note, pending, parent };
+    }
+
+    it("commits the newest refresh even when an older one resolves last", async () => {
+        const { note, pending, parent } = setup();
+
+        // Mount issues the first refresh (reflecting the pre-clone child set).
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={parent}>
+                    <Harness note={note} />
+                </ParentComponent.Provider>,
+                container
+            );
+        });
+
+        // The clone arrives as an entitiesReloaded with a branch under this note, issuing a second refresh.
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "child-new")
+            });
+        });
+
+        expect(pending).toHaveLength(2);
+
+        // The newer refresh resolves first with the post-clone set...
+        await act(async () => {
+            pending[1].resolve(["child-new"]);
+            await flushMicrotasks();
+        });
+        // ...then the stale one resolves with the pre-clone set and must NOT clobber it.
+        await act(async () => {
+            pending[0].resolve([]);
+            await flushMicrotasks();
+        });
+
+        expect(currentNoteIds).toEqual(["child-new"]);
+    });
+
+    it("applies a single refresh's result normally", async () => {
+        const { note, pending, parent } = setup();
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={parent}>
+                    <Harness note={note} />
+                </ParentComponent.Provider>,
+                container
+            );
+        });
+
+        expect(pending).toHaveLength(1);
+        await act(async () => {
+            pending[0].resolve(["child-a", "child-b"]);
+            await flushMicrotasks();
+        });
+
+        expect(currentNoteIds).toEqual(["child-a", "child-b"]);
+    });
+});

--- a/apps/client/src/widgets/collections/NoteList.spec.tsx
+++ b/apps/client/src/widgets/collections/NoteList.spec.tsx
@@ -139,4 +139,48 @@ describe("useNoteIds refresh race", () => {
 
         expect(currentNoteIds).toEqual(["child-a", "child-b"]);
     });
+
+    it("hands React a fresh array when froca's live children array is mutated in place", async () => {
+        // The `includeArchived`/hidden/search paths of getChildNoteIdsWithArchiveFiltering return
+        // froca's *live* `note.children` array, which `addChild` mutates in place on a clone. If the
+        // hook re-published that same reference, React's Object.is bail-out would skip the update and
+        // downstream effects (note resolution, grid reconcile) would never see the new child.
+        const note = buildNote({ title: "Dashboard", type: "book" });
+        const liveChildren = [ "child-a", "child-b" ];
+        note.getChildNoteIdsWithArchiveFiltering = vi.fn(async () => liveChildren);
+
+        const parent = new Component();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={parent}>
+                    <Harness note={note} />
+                </ParentComponent.Provider>,
+                container
+            );
+        });
+        // Drain the mount refresh's async chain (effect → getNoteIds → setNoteIds).
+        await act(async () => {
+            await flushMicrotasks();
+        });
+        expect(currentNoteIds).toEqual([ "child-a", "child-b" ]);
+        // Must be a copy, not froca's internal array.
+        expect(currentNoteIds).not.toBe(liveChildren);
+        const afterMount = currentNoteIds;
+
+        // Simulate the clone: addChild pushes into the same array, then an entitiesReloaded arrives.
+        liveChildren.push("child-new");
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "child-new")
+            });
+            await flushMicrotasks();
+        });
+
+        expect(currentNoteIds).toEqual([ "child-a", "child-b", "child-new" ]);
+        // A new reference is what makes React/`useEffect([noteIds])` downstream actually re-run.
+        expect(currentNoteIds).not.toBe(afterMount);
+    });
 });

--- a/apps/client/src/widgets/collections/NoteList.tsx
+++ b/apps/client/src/widgets/collections/NoteList.tsx
@@ -170,7 +170,10 @@ export function useNoteIds(note: FNote | null | undefined, viewType: ViewTypeOpt
             // A newer refresh was issued while we were awaiting; let it win.
             return;
         }
-        setNoteIds(result);
+        // getNoteIds may hand back froca's live children array, which is mutated in place when notes
+        // are cloned/removed. Setting that same reference would be a no-op for React (Object.is), so
+        // downstream effects never re-run. Copy it, and skip the update only when nothing changed.
+        setNoteIds(prev => sameNoteIds(prev, result) ? prev : [ ...result ]);
     }
 
     async function getNoteIds(note: FNote) {
@@ -227,6 +230,11 @@ export function useNoteIds(note: FNote | null | undefined, viewType: ViewTypeOpt
     }, [ note, noteIds, setNoteIds ]);
 
     return noteIds;
+}
+
+/** Order-sensitive equality for note-id lists, used to skip no-op `noteIds` updates. */
+function sameNoteIds(a: string[], b: string[]) {
+    return a.length === b.length && a.every((id, index) => id === b[index]);
 }
 
 export function useViewModeConfig<T extends object>(note: FNote | null | undefined, viewType: ViewModeStorageType | undefined) {

--- a/apps/client/src/widgets/collections/NoteList.tsx
+++ b/apps/client/src/widgets/collections/NoteList.tsx
@@ -70,8 +70,17 @@ export default function NoteList(props: Pick<NoteListProps, "displayOnlyCollecti
 }
 
 export function SearchNoteList(props: Omit<NoteListProps, "isEnabled" | "viewType">) {
+    return <EmbeddedNoteList {...props} showTextRepresentation />;
+}
+
+/**
+ * Mounts a collection — a book or an (already-executed) saved search — as a live, prop-driven note
+ * list, picking the view type from the note's `viewType` label. Unlike {@link NoteList} it reads no
+ * note context, so it can be embedded outside the note detail (e.g. dashboard tiles, included notes).
+ */
+export function EmbeddedNoteList(props: Omit<NoteListProps, "isEnabled" | "viewType">) {
     const viewType = useNoteViewType(props.note);
-    return <CustomNoteList {...props} isEnabled={true} viewType={viewType} showTextRepresentation />;
+    return <CustomNoteList {...props} isEnabled={true} viewType={viewType} />;
 }
 
 export function CustomNoteList({ note, viewType, isEnabled: shouldEnable, notePath, highlightedTokens, displayOnlyCollections, ntxId, onReady, onProgressChanged, ...restProps }: NoteListProps) {

--- a/apps/client/src/widgets/collections/NoteList.tsx
+++ b/apps/client/src/widgets/collections/NoteList.tsx
@@ -159,13 +159,18 @@ export function useNoteIds(note: FNote | null | undefined, viewType: ViewTypeOpt
     const [ noteIds, setNoteIds ] = useState<string[]>([]);
     const [ includeArchived ] = useNoteLabelBoolean(note, "includeArchived");
     const directChildrenOnly = (viewType === "list" || viewType === "grid" || viewType === "table" || viewType === "dashboard" || note?.type === "search");
+    // getNoteIds can do a server round-trip (archive filtering), so concurrent refreshes may resolve
+    // out of order. Track the latest issued refresh so a stale one can't clobber a newer result.
+    const refreshSeqRef = useRef(0);
 
     async function refreshNoteIds() {
-        if (!note) {
-            setNoteIds([]);
-        } else {
-            setNoteIds(await getNoteIds(note));
+        const seq = ++refreshSeqRef.current;
+        const result = note ? await getNoteIds(note) : [];
+        if (seq !== refreshSeqRef.current) {
+            // A newer refresh was issued while we were awaiting; let it win.
+            return;
         }
+        setNoteIds(result);
     }
 
     async function getNoteIds(note: FNote) {

--- a/apps/client/src/widgets/collections/dashboard/context_menu.ts
+++ b/apps/client/src/widgets/collections/dashboard/context_menu.ts
@@ -5,7 +5,7 @@ import branches from "../../../services/branches";
 import { t } from "../../../services/i18n";
 
 export default function openWidgetContextMenu(notePath: string, branchId: string, e: ContextMenuEvent, { onRefresh }: {
-    /** When provided (i.e. the widget is a render note), adds a "Refresh" item that re-renders it. */
+    /** When provided (i.e. the widget is a render note or web view), adds a "Refresh" item that re-renders it. */
     onRefresh?: () => void;
 }) {
     const items: MenuItem<CommandNames>[] = [

--- a/apps/client/src/widgets/collections/dashboard/index.css
+++ b/apps/client/src/widgets/collections/dashboard/index.css
@@ -103,7 +103,8 @@
             &.type-canvas,
             &.type-video,
             &.type-code,
-            &.type-mindMap {
+            &.type-mindMap,
+            &.type-webView {
                 padding: 0;
 
                 .rendered-content {

--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -311,9 +311,10 @@ interface DashboardWidgetProps {
 
 function DashboardWidget({ note, parentNote, highlightedTokens, includeArchived, showTextRepresentation }: DashboardWidgetProps) {
     const notePath = getNotePath(parentNote, note);
-    // Bumping the key remounts NoteContent, which re-runs the render — only meaningful for render notes.
+    // Bumping the key remounts NoteContent, which re-runs the render — meaningful for render notes
+    // (re-runs the script) and web views (reloads the embedded page).
     const [ refreshKey, setRefreshKey ] = useState(0);
-    const isRenderNote = note.type === "render";
+    const canRefresh = note.type === "render" || note.type === "webView";
 
     /* The outer .grid-stack-item class list must stay constant across renders so that Preact never
        clobbers the classes gridstack adds there; dynamic classes go on the inner content element. */
@@ -337,7 +338,7 @@ function DashboardWidget({ note, parentNote, highlightedTokens, includeArchived,
                             const branchId = note.parentToBranch[parentNote.noteId];
                             if (!branchId) return;
                             openWidgetContextMenu(notePath, branchId, e, {
-                                onRefresh: isRenderNote ? () => setRefreshKey((key) => key + 1) : undefined
+                                onRefresh: canRefresh ? () => setRefreshKey((key) => key + 1) : undefined
                             });
                         }} />
                 </div>

--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -346,6 +346,7 @@ function DashboardWidget({ note, parentNote, highlightedTokens, includeArchived,
                     <NoteContent key={refreshKey}
                         note={note}
                         trim
+                        interactive
                         highlightedTokens={highlightedTokens}
                         includeArchivedNotes={includeArchived}
                         showTextRepresentation={showTextRepresentation} />

--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -18,7 +18,7 @@ import NoteLink from "../../react/NoteLink";
 import { ViewModeProps } from "../interface";
 import { getNotePath, NoteContent } from "../legacy/ListOrGridView";
 import openWidgetContextMenu from "./context_menu";
-import { computeDropCell, DEFAULT_WIDGET_SIZE, GRID_COLUMNS, sameLayout, WidgetLayouts } from "./layout";
+import { computeDropCell, DEFAULT_WIDGET_SIZE, GRID_COLUMNS, reconcilePersistedLayout, sameLayout, WidgetLayouts } from "./layout";
 
 export interface DashboardViewConfig {
     widgets?: WidgetLayouts;
@@ -116,12 +116,13 @@ function useDashboardLayoutPersistence({ viewConfig, saveConfig, gridRef, contai
             return;
         }
 
-        const widgets: WidgetLayouts = {};
+        const present: WidgetLayouts = {};
         for (const node of grid.engine.nodes) {
             if (typeof node.id === "string") {
-                widgets[node.id] = { x: node.x ?? 0, y: node.y ?? 0, w: node.w ?? 1, h: node.h ?? 1 };
+                present[node.id] = { x: node.x ?? 0, y: node.y ?? 0, w: node.w ?? 1, h: node.h ?? 1 };
             }
         }
+        const widgets = reconcilePersistedLayout(savedWidgetsRef.current, present);
         if (sameLayout(widgets, savedWidgetsRef.current)) {
             return;
         }

--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -92,7 +92,8 @@ function useIsCollapsed(containerRef: RefObject<HTMLElement>) {
  *  layout and external changes arriving through the viewConfig prop. Returns the bits the grid
  *  lifecycle needs: a `persistLayout(grid)` to call after the grid mutates, and `savedWidgetsRef`,
  *  the last-known persisted layout used to position widgets as they're created. */
-function useDashboardLayoutPersistence({ viewConfig, saveConfig, gridRef, containerRef }: {
+function useDashboardLayoutPersistence({ note, viewConfig, saveConfig, gridRef, containerRef }: {
+    note: FNote;
     viewConfig: DashboardViewConfig | undefined;
     saveConfig: (config: DashboardViewConfig) => void;
     gridRef: MutableRef<GridStack | null>;
@@ -122,7 +123,10 @@ function useDashboardLayoutPersistence({ viewConfig, saveConfig, gridRef, contai
                 present[node.id] = { x: node.x ?? 0, y: node.y ?? 0, w: node.w ?? 1, h: node.h ?? 1 };
             }
         }
-        const widgets = reconcilePersistedLayout(savedWidgetsRef.current, present);
+        // The grid only carries the widgets currently shown; pass the dashboard's full child set so
+        // hidden (e.g. archived) widgets keep their saved geometry while widgets whose note is no
+        // longer a child are pruned instead of lingering in the persisted layout forever.
+        const widgets = reconcilePersistedLayout(savedWidgetsRef.current, present, new Set(note.children));
         if (sameLayout(widgets, savedWidgetsRef.current)) {
             return;
         }
@@ -184,7 +188,7 @@ function useDashboardGrid({ note, notes, viewConfig, saveConfig, containerRef, g
     dropPositionsRef: MutableRef<WidgetLayouts>;
     isCollapsed: boolean;
 }) {
-    const { persistLayout, savedWidgetsRef } = useDashboardLayoutPersistence({ viewConfig, saveConfig, gridRef, containerRef });
+    const { persistLayout, savedWidgetsRef } = useDashboardLayoutPersistence({ note, viewConfig, saveConfig, gridRef, containerRef });
 
     // Initialize the grid once per parent note.
     useLayoutEffect(() => {

--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -12,7 +12,7 @@ import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import ActionButton from "../../react/ActionButton";
-import { useElementSize, useNoteLabelBoolean, useNoteTreeDrag, useSpacedUpdate } from "../../react/hooks";
+import { useCollectionTreeDrag, useElementSize, useNoteLabelBoolean, useSpacedUpdate } from "../../react/hooks";
 import Icon from "../../react/Icon";
 import NoteLink from "../../react/NoteLink";
 import { ViewModeProps } from "../interface";
@@ -39,7 +39,7 @@ export default function DashboardView({ note, noteIds, viewConfig, saveConfig, h
 
     const notes = useDashboardNotes(noteIds);
     const isCollapsed = useIsCollapsed(containerRef);
-    const dropPositionsRef = useNoteTreeDropToDashboard(note, scrollContainerRef, containerRef, gridRef);
+    const dropPositionsRef = useNoteTreeDropToDashboard(note, includeArchived, scrollContainerRef, containerRef, gridRef);
     useDashboardGrid({ note, notes, viewConfig, saveConfig, containerRef, gridRef, dropPositionsRef, isCollapsed });
 
     return (
@@ -264,22 +264,19 @@ function useDashboardGrid({ note, notes, viewConfig, saveConfig, containerRef, g
  *  the dashboard and the first one is positioned under the cursor. Returns a ref holding the drop
  *  positions of the freshly cloned notes, which the reconcile effect consumes (once) when it
  *  promotes them to grid widgets — kept out of savedWidgetsRef so persistLayout still saves them. */
-function useNoteTreeDropToDashboard(note: FNote, dropAreaRef: RefObject<HTMLDivElement>, gridContainerRef: RefObject<HTMLDivElement>, gridRef: RefObject<GridStack | null>) {
+function useNoteTreeDropToDashboard(note: FNote, includeArchived: boolean, dropAreaRef: RefObject<HTMLDivElement>, gridContainerRef: RefObject<HTMLDivElement>, gridRef: RefObject<GridStack | null>) {
     const dropPositionsRef = useRef<WidgetLayouts>({});
 
-    useNoteTreeDrag(dropAreaRef, {
+    useCollectionTreeDrag(dropAreaRef, {
         dragEnabled: true,
-        dragNotEnabledMessage: {
-            icon: "bx bx-lock-alt",
-            title: t("book.drag_locked_title"),
-            message: t("book.drag_locked_message")
-        },
+        includeArchived,
         async callback(treeData, e) {
             const grid = gridRef.current;
             const gridContainer = gridContainerRef.current;
-            if (!grid || !gridContainer) return;
+            if (!grid || !gridContainer) return [];
 
             const dropCell = computeDropCell(grid, gridContainer, e);
+            const addedNoteIds: string[] = [];
             let isFirstNewNote = true;
             for (const { noteId } of treeData) {
                 const childNote = await froca.getNote(noteId, true);
@@ -295,7 +292,9 @@ function useNoteTreeDropToDashboard(note: FNote, dropAreaRef: RefObject<HTMLDivE
                 }
                 isFirstNewNote = false;
                 await branches.cloneNoteToParentNote(noteId, note.noteId);
+                addedNoteIds.push(noteId);
             }
+            return addedNoteIds;
         }
     });
 

--- a/apps/client/src/widgets/collections/dashboard/layout.spec.ts
+++ b/apps/client/src/widgets/collections/dashboard/layout.spec.ts
@@ -57,16 +57,31 @@ describe("reconcilePersistedLayout", () => {
 
         // Archived notes hidden: only the normal widget remains in the grid. Persisting the layout
         // now must not drop the archived widget's geometry just because it is no longer rendered —
-        // otherwise re-showing it would auto-position it instead of restoring its placement.
-        const afterHide = reconcilePersistedLayout(shown, { normal });
+        // it is still a child of the dashboard, so re-showing it should restore its placement
+        // instead of auto-positioning it.
+        const afterHide = reconcilePersistedLayout(shown, { normal }, new Set([ "archived", "normal" ]));
         expect(afterHide).toEqual({ archived, normal });
     });
 
     it("applies position changes and additions coming from the grid", () => {
         const previous: WidgetLayouts = { a: normal };
-        const next = reconcilePersistedLayout(previous, { a: { ...normal, x: 6 }, b: archived });
+        const next = reconcilePersistedLayout(previous, { a: { ...normal, x: 6 }, b: archived }, new Set([ "a", "b" ]));
         // Moved widgets win over their previous geometry, and brand-new widgets are included.
         expect(next).toEqual({ a: { ...normal, x: 6 }, b: archived });
+    });
+
+    it("prunes the saved position of a widget whose note is no longer a child of the dashboard", () => {
+        // `removed` is absent from the grid AND no longer a live child (its branch was deleted) —
+        // its stale geometry must be dropped so the persisted layout doesn't grow unbounded.
+        const previous: WidgetLayouts = { normal, removed: archived };
+        const next = reconcilePersistedLayout(previous, { normal }, new Set([ "normal" ]));
+        expect(next).toEqual({ normal });
+    });
+
+    it("keeps a hidden child but prunes a removed note in the same pass", () => {
+        const previous: WidgetLayouts = { normal, hidden: archived, removed: { x: 8, y: 8, w: 1, h: 1 } };
+        const next = reconcilePersistedLayout(previous, { normal }, new Set([ "normal", "hidden" ]));
+        expect(next).toEqual({ normal, hidden: archived });
     });
 });
 

--- a/apps/client/src/widgets/collections/dashboard/layout.spec.ts
+++ b/apps/client/src/widgets/collections/dashboard/layout.spec.ts
@@ -1,7 +1,7 @@
 import type { GridStack } from "gridstack";
 import { describe, expect, it } from "vitest";
 
-import { computeDropCell, DEFAULT_WIDGET_SIZE, GRID_COLUMNS, sameLayout, WidgetLayouts } from "./layout";
+import { computeDropCell, DEFAULT_WIDGET_SIZE, GRID_COLUMNS, reconcilePersistedLayout, sameLayout, WidgetLayouts } from "./layout";
 
 /** Minimal GridStack stand-in exposing only what computeDropCell reads. */
 function fakeGrid({ columns = GRID_COLUMNS, cellHeight = 80 }: { columns?: number; cellHeight?: number } = {}) {
@@ -44,6 +44,29 @@ describe("computeDropCell", () => {
     it("returns null when the grid has no measurable geometry yet", () => {
         expect(computeDropCell(fakeGrid({ cellHeight: 0 }), fakeContainer(), { clientX: 100, clientY: 100 })).toBeNull();
         expect(computeDropCell(fakeGrid(), fakeContainer({ width: 0 }), { clientX: 100, clientY: 100 })).toBeNull();
+    });
+});
+
+describe("reconcilePersistedLayout", () => {
+    const archived = { x: 5, y: 3, w: 4, h: 3 };
+    const normal = { x: 0, y: 0, w: 4, h: 3 };
+
+    it("retains a widget's saved position while it is filtered out of the grid (archived hidden → shown)", () => {
+        // Archived notes shown: both widgets live in the grid and are persisted together.
+        const shown: WidgetLayouts = { archived, normal };
+
+        // Archived notes hidden: only the normal widget remains in the grid. Persisting the layout
+        // now must not drop the archived widget's geometry just because it is no longer rendered —
+        // otherwise re-showing it would auto-position it instead of restoring its placement.
+        const afterHide = reconcilePersistedLayout(shown, { normal });
+        expect(afterHide).toEqual({ archived, normal });
+    });
+
+    it("applies position changes and additions coming from the grid", () => {
+        const previous: WidgetLayouts = { a: normal };
+        const next = reconcilePersistedLayout(previous, { a: { ...normal, x: 6 }, b: archived });
+        // Moved widgets win over their previous geometry, and brand-new widgets are included.
+        expect(next).toEqual({ a: { ...normal, x: 6 }, b: archived });
     });
 });
 

--- a/apps/client/src/widgets/collections/dashboard/layout.ts
+++ b/apps/client/src/widgets/collections/dashboard/layout.ts
@@ -34,11 +34,20 @@ export function computeDropCell(grid: GridStack, container: HTMLElement, e: { cl
  * previously-persisted layout (`previous`), producing the layout to persist next.
  *
  * A widget can be absent from `present` not only because it was removed from the dashboard, but
- * also because it was filtered out of view (e.g. archived notes hidden). Its saved position must be
- * retained so that toggling it back restores its placement instead of auto-positioning it.
+ * also because it was filtered out of view (e.g. archived notes hidden). To tell the two apart we
+ * take `liveNoteIds` — the note IDs that are still children of the dashboard. A saved position is
+ * retained only while its note is still a live child (so toggling a hidden widget back restores its
+ * placement); the geometry of notes that are no longer children is pruned so the persisted layout
+ * doesn't accumulate stale entries over repeated remove-and-add cycles.
  */
-export function reconcilePersistedLayout(previous: WidgetLayouts, present: WidgetLayouts): WidgetLayouts {
-    return { ...previous, ...present };
+export function reconcilePersistedLayout(previous: WidgetLayouts, present: WidgetLayouts, liveNoteIds: Set<string>): WidgetLayouts {
+    const result: WidgetLayouts = { ...present };
+    for (const [ noteId, layout ] of Object.entries(previous)) {
+        if (!(noteId in result) && liveNoteIds.has(noteId)) {
+            result[noteId] = layout;
+        }
+    }
+    return result;
 }
 
 /** Whether two layouts describe the same widgets in the same positions. */

--- a/apps/client/src/widgets/collections/dashboard/layout.ts
+++ b/apps/client/src/widgets/collections/dashboard/layout.ts
@@ -29,6 +29,18 @@ export function computeDropCell(grid: GridStack, container: HTMLElement, e: { cl
     return { x, y };
 }
 
+/**
+ * Merge the geometry of the widgets currently present in the grid (`present`) over the
+ * previously-persisted layout (`previous`), producing the layout to persist next.
+ *
+ * A widget can be absent from `present` not only because it was removed from the dashboard, but
+ * also because it was filtered out of view (e.g. archived notes hidden). Its saved position must be
+ * retained so that toggling it back restores its placement instead of auto-positioning it.
+ */
+export function reconcilePersistedLayout(previous: WidgetLayouts, present: WidgetLayouts): WidgetLayouts {
+    return { ...previous, ...present };
+}
+
 /** Whether two layouts describe the same widgets in the same positions. */
 export function sameLayout(a: WidgetLayouts, b: WidgetLayouts) {
     const aKeys = Object.keys(a);

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -64,8 +64,11 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
         setZoom(viewConfig?.view?.zoom ?? DEFAULT_ZOOM);
     }, [ note, viewConfig ]);
 
-    // Note creation.
-    useTriliumEvent("geoMapCreateChildNote", () => {
+    // Note creation. Scoped to this map instance via a local callback rather than the global
+    // geoMapCreateChildNote command: embedded maps share no note context (no distinct ntxId), so a
+    // broadcast command would arm placement mode on every map at once. The button is this command's
+    // only trigger, so a direct handler keeps it isolated to the clicked map.
+    const startNotePlacement = useCallback(() => {
         toast.showPersistent({
             icon: "plus",
             id: "geo-new-note",
@@ -75,7 +78,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
 
         setState(State.NewNote);
 
-        const globalKeyListener: (this: Window, ev: KeyboardEvent) => any = (e) => {
+        const globalKeyListener: (this: Window, ev: KeyboardEvent) => void = (e) => {
             if (e.key === "Escape") {
                 setState(State.Normal);
 
@@ -84,7 +87,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
             }
         };
         window.addEventListener("keydown", globalKeyListener);
-    });
+    }, []);
 
     useTriliumEvent("deleteFromMap", ({ noteId }) => {
         moveMarker(noteId, null);
@@ -142,7 +145,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                         icon="bx bx-plus"
                         text={t("geo-map.create-child-note-text")}
                         title={t("geo-map.create-child-note-title")}
-                        triggerCommand="geoMapCreateChildNote"
+                        onClick={startNotePlacement}
                         disabled={isReadOnly}
                     />
                 </>}

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -127,7 +127,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
             if (parents?.includes(note.noteId)) {
                 await moveMarker(noteId, latlng);
             } else {
-                await branches.cloneNoteToParentNote(noteId, noteId);
+                await branches.cloneNoteToParentNote(noteId, note.noteId);
                 await moveMarker(noteId, latlng);
             }
         }

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -16,7 +16,7 @@ import { escapeHtml } from "../../../services/utils";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import ActionButton from "../../react/ActionButton";
 import { ButtonOrActionButton } from "../../react/Button";
-import { useNoteBlob, useNoteLabel, useNoteLabelBoolean, useNoteProperty, useNoteTreeDrag, useSpacedUpdate, useTriliumEvent } from "../../react/hooks";
+import { useCollectionTreeDrag, useNoteBlob, useNoteLabel, useNoteLabelBoolean, useNoteProperty, useSpacedUpdate, useTriliumEvent } from "../../react/hooks";
 import { ViewModeProps } from "../interface";
 import { createNewNote, moveMarker } from "./api";
 import openContextMenu, { openMapContextMenu } from "./context_menu";
@@ -47,6 +47,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     const [ hasScale ] = useNoteLabelBoolean(note, "map:scale");
     const [ hideLabels ] = useNoteLabelBoolean(note, "map:hideLabels");
     const [ isReadOnly ] = useNoteLabelBoolean(note, "readOnly");
+    const [ includeArchived ] = useNoteLabelBoolean(note, "includeArchived");
     const [ notes, setNotes ] = useState<FNote[]>([]);
     const layerData = useLayerData(note);
     const spacedUpdate = useSpacedUpdate(() => {
@@ -104,16 +105,12 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // Dragging
     const containerRef = useRef<HTMLDivElement>(null);
     const apiRef = useRef<L.Map>(null);
-    useNoteTreeDrag(containerRef, {
+    useCollectionTreeDrag(containerRef, {
         dragEnabled: !isReadOnly,
-        dragNotEnabledMessage: {
-            icon: "bx bx-lock-alt",
-            title: t("book.drag_locked_title"),
-            message: t("book.drag_locked_message")
-        },
+        includeArchived,
         async callback(treeData, e) {
             const api = apiRef.current;
-            if (!note || !api || isReadOnly) return;
+            if (!note || !api || isReadOnly) return [];
 
             const { noteId } = treeData[0];
 
@@ -126,10 +123,12 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
             const parents = targetNote?.getParentNoteIds();
             if (parents?.includes(note.noteId)) {
                 await moveMarker(noteId, latlng);
-            } else {
-                await branches.cloneNoteToParentNote(noteId, note.noteId);
-                await moveMarker(noteId, latlng);
+                return [];
             }
+
+            await branches.cloneNoteToParentNote(noteId, note.noteId);
+            await moveMarker(noteId, latlng);
+            return [ noteId ];
         }
     });
 

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -68,7 +68,15 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // geoMapCreateChildNote command: embedded maps share no note context (no distinct ntxId), so a
     // broadcast command would arm placement mode on every map at once. The button is this command's
     // only trigger, so a direct handler keeps it isolated to the clicked map.
-    const startNotePlacement = useCallback(() => {
+    const startNotePlacement = useCallback(() => setState(State.NewNote), []);
+
+    // Placement mode (NewNote) is armed by the button. Tying the instruction toast and the global
+    // Escape-to-cancel listener to the state (rather than the click handler) guarantees both are
+    // torn down on cancel, on completion (map click) and on unmount — otherwise the listener leaks
+    // and a fresh one accumulates on every placement cycle.
+    useEffect(() => {
+        if (state !== State.NewNote) return;
+
         toast.showPersistent({
             icon: "plus",
             id: "geo-new-note",
@@ -76,18 +84,18 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
             message: t("geo-map.create-child-note-instruction")
         });
 
-        setState(State.NewNote);
-
-        const globalKeyListener: (this: Window, ev: KeyboardEvent) => void = (e) => {
+        const globalKeyListener = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
                 setState(State.Normal);
-
-                window.removeEventListener("keydown", globalKeyListener);
-                toast.closePersistent("geo-new-note");
             }
         };
         window.addEventListener("keydown", globalKeyListener);
-    }, []);
+
+        return () => {
+            window.removeEventListener("keydown", globalKeyListener);
+            toast.closePersistent("geo-new-note");
+        };
+    }, [ state ]);
 
     useTriliumEvent("deleteFromMap", ({ noteId }) => {
         moveMarker(noteId, null);
@@ -95,7 +103,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
 
     const onClick = useCallback(async (e: LeafletMouseEvent) => {
         if (state === State.NewNote) {
-            toast.closePersistent("geo-new-note");
+            // Leaving NewNote closes the instruction toast via the placement-mode effect cleanup.
             await createNewNote(note, e);
             setState(State.Normal);
         }
@@ -113,7 +121,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
         includeArchived,
         async callback(treeData, e) {
             const api = apiRef.current;
-            if (!note || !api || isReadOnly) return [];
+            // treeData is non-empty in practice (useNoteTreeDrag drops empty payloads), but guard
+            // explicitly so the treeData[0] access can't throw.
+            if (!note || !api || isReadOnly || !treeData.length) return [];
 
             const { noteId } = treeData[0];
 

--- a/apps/client/src/widgets/collections/legacy/ListOrGridView.tsx
+++ b/apps/client/src/widgets/collections/legacy/ListOrGridView.tsx
@@ -207,13 +207,15 @@ function NoteAttributes({ note }: { note: FNote }) {
     return <span className="note-list-attributes" ref={ref} />;
 }
 
-export function NoteContent({ note, trim, noChildrenList, highlightedTokens, includeArchivedNotes, showTextRepresentation, onReady }: {
+export function NoteContent({ note, trim, noChildrenList, highlightedTokens, includeArchivedNotes, showTextRepresentation, interactive, onReady }: {
     note: FNote;
     trim?: boolean;
     noChildrenList?: boolean;
     highlightedTokens: string[] | null | undefined;
     includeArchivedNotes: boolean;
     showTextRepresentation?: boolean;
+    /** Render live interactive type widgets (e.g. web views) instead of static previews. */
+    interactive?: boolean;
     onReady?: () => void;
 }) {
     const contentRef = useRef<HTMLDivElement>(null);
@@ -242,7 +244,8 @@ export function NoteContent({ note, trim, noChildrenList, highlightedTokens, inc
             noChildrenList,
             noIncludedNotes: true,
             includeArchivedNotes,
-            showTextRepresentation
+            showTextRepresentation,
+            interactive
         })
             .then(({ $renderedContent, type }) => {
                 if (!contentRef.current) return;

--- a/apps/client/src/widgets/collections/legacy/ListOrGridView.tsx
+++ b/apps/client/src/widgets/collections/legacy/ListOrGridView.tsx
@@ -238,6 +238,11 @@ export function NoteContent({ note, trim, noChildrenList, highlightedTokens, inc
     }, []);
 
     useEffect(() => {
+        let cancelled = false;
+        // Tracks the rendered content so the cleanup can unmount any interactive widget it carries
+        // (collections, web views) — otherwise their standalone Preact roots leak when the note
+        // changes or the card unmounts.
+        let rendered: JQuery<HTMLElement> | undefined;
         setReady(false);
         content_renderer.getRenderedContent(note, {
             trim,
@@ -248,7 +253,13 @@ export function NoteContent({ note, trim, noChildrenList, highlightedTokens, inc
             interactive
         })
             .then(({ $renderedContent, type }) => {
-                if (!contentRef.current) return;
+                if (cancelled || !contentRef.current) {
+                    // Superseded by a newer render or unmounted while rendering — tear down what was
+                    // just mounted instead of letting it leak (and don't clobber newer content).
+                    content_renderer.disposeInteractiveContent($renderedContent);
+                    return;
+                }
+                rendered = $renderedContent;
                 if ($renderedContent[0].innerHTML) {
                     contentRef.current.replaceChildren(...$renderedContent);
                 } else {
@@ -260,12 +271,19 @@ export function NoteContent({ note, trim, noChildrenList, highlightedTokens, inc
                 onReadyRef.current?.();
             })
             .catch(e => {
+                if (cancelled) return;
                 console.warn(`Caught error while rendering note '${note.noteId}' of type '${note.type}'`);
                 console.error(e);
                 contentRef.current?.replaceChildren(t("collections.rendering_error"));
                 setReady(true);
                 onReadyRef.current?.();
             });
+        return () => {
+            cancelled = true;
+            if (rendered) {
+                content_renderer.disposeInteractiveContent(rendered);
+            }
+        };
     }, [ note, highlightedTokens ]);
 
     return <div ref={contentRef} className={clsx("note-book-content", `type-${noteType}`, {"note-book-content-ready": ready})} />;

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -13,6 +13,7 @@ import FBlob from "../../entities/fblob";
 import FNote from "../../entities/fnote";
 import attributes from "../../services/attributes";
 import froca from "../../services/froca";
+import { t } from "../../services/i18n";
 import keyboard_actions from "../../services/keyboard_actions";
 import { parseNavigationStateFromUrl, ViewScope } from "../../services/link";
 import options, { type OptionValue } from "../../services/options";
@@ -1161,6 +1162,48 @@ export function useNoteTreeDrag(containerRef: MutableRef<HTMLElement | null | un
             container.removeEventListener("dragleave", onDragLeave);
         };
     }, [ containerRef, callback ]);
+}
+
+/**
+ * Collection-specific wrapper around {@link useNoteTreeDrag}. It standardizes the drag-locked
+ * message shared by every collection view and, when the collection hides archived notes, warns the
+ * user after a drop that any archived notes were cloned in but stay hidden until "Show archived
+ * notes" is enabled (otherwise the note silently has no effect on the view).
+ *
+ * The `callback` should return the IDs of the notes it actually added (cloned) to the collection so
+ * the warning only mentions newly-copied notes, not ones that were already present.
+ */
+export function useCollectionTreeDrag(containerRef: MutableRef<HTMLElement | null | undefined>, { dragEnabled, includeArchived, callback }: {
+    dragEnabled: boolean,
+    includeArchived: boolean,
+    callback: (data: DragData[], e: DragEvent) => string[] | Promise<string[]>
+}) {
+    const wrappedCallback = useCallback(async (data: DragData[], e: DragEvent) => {
+        const addedNoteIds = await callback(data, e);
+        if (!includeArchived && addedNoteIds?.length) {
+            await warnIfArchivedNotesHidden(addedNoteIds);
+        }
+    }, [ includeArchived, callback ]);
+
+    useNoteTreeDrag(containerRef, {
+        dragEnabled,
+        dragNotEnabledMessage: {
+            icon: "bx bx-lock-alt",
+            title: t("book.drag_locked_title"),
+            message: t("book.drag_locked_message")
+        },
+        callback: wrappedCallback
+    });
+}
+
+/** Toast a heads-up when freshly cloned notes are archived and the collection hides them. */
+async function warnIfArchivedNotesHidden(addedNoteIds: string[]) {
+    const notes = await froca.getNotes(addedNoteIds);
+    const archivedCount = notes.filter((note) => note.isArchived).length;
+    if (!archivedCount) {
+        return;
+    }
+    toast.showMessage(t("book.archived_notes_hidden", { count: archivedCount }), 5000, "bx bx-archive");
 }
 
 /**

--- a/apps/client/src/widgets/sidebar/RightPanelContainer.tsx
+++ b/apps/client/src/widgets/sidebar/RightPanelContainer.tsx
@@ -7,12 +7,12 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import appContext from "../../components/app_context";
 import { WidgetsByParent } from "../../services/bundle";
-import { isExperimentalFeatureEnabled } from "../../services/experimental_features";
 import { t } from "../../services/i18n";
 import options from "../../services/options";
 import { DEFAULT_GUTTER_SIZE } from "../../services/resizer";
+import { isStandalone } from "../../services/utils";
 import Button from "../react/Button";
-import { useActiveNoteContext, useLegacyWidget, useNoteProperty, useTriliumEvent, useTriliumOptionJson } from "../react/hooks";
+import { useActiveNoteContext, useLegacyWidget, useNoteProperty, useTriliumEvent, useTriliumOptionBool, useTriliumOptionJson } from "../react/hooks";
 import LazyComponent from "../react/LazyComponent";
 import NoItems from "../react/NoItems";
 import LegacyRightPanelWidget from "../right_panel_widget";
@@ -70,6 +70,8 @@ function useItems(rightPaneVisible: boolean, widgetsByParent: WidgetsByParent) {
     const noteType = useNoteProperty(note, "type");
     const noteMime = useNoteProperty(note, "mime");
     const [ highlightsList ] = useTriliumOptionJson<string[]>("highlightsList");
+    // Subscribe to the AI toggle so the LLM sidebar is added/removed reactively without a page reload.
+    const [ aiEnabled ] = useTriliumOptionBool("aiEnabled");
     const isPdf = noteType === "file" && noteMime === "application/pdf";
 
     if (!rightPaneVisible) return [];
@@ -102,7 +104,7 @@ function useItems(rightPaneVisible: boolean, widgetsByParent: WidgetsByParent) {
             // Loaded lazily because the chat pulls in the whole LLM + CKEditor graph,
             // which users without the LLM experimental feature should never download.
             el: <LazyComponent loader={() => import("./SidebarChat.jsx")} />,
-            enabled: noteType !== "llmChat" && isExperimentalFeatureEnabled("llm"),
+            enabled: noteType !== "llmChat" && !isStandalone && aiEnabled,
             position: 1000
         },
         ...widgetsByParent.getLegacyWidgets("right-pane").map((widget) => ({

--- a/apps/client/src/widgets/type_widgets/canvas/Canvas.tsx
+++ b/apps/client/src/widgets/type_widgets/canvas/Canvas.tsx
@@ -6,11 +6,13 @@ import { useCallback, useMemo, useRef } from "preact/hooks";
 import { type ExcalidrawImperativeAPI, type AppState } from "@excalidraw/excalidraw/types";
 import options from "../../../services/options";
 import "./Canvas.css";
-import { NonDeletedExcalidrawElement } from "@excalidraw/excalidraw/element/types";
+import { NonDeleted, NonDeletedExcalidrawElement, ExcalidrawEmbeddableElement } from "@excalidraw/excalidraw/element/types";
 import { goToLinkExt } from "../../../services/link";
 import useCanvasPersistence from "./persistence";
 import { LANGUAGE_MAPPINGS } from "./i18n";
 import { DISPLAYABLE_LOCALE_IDS } from "@triliumnext/commons";
+import tree from "../../../services/tree";
+import NoteEmbeddable from "./NoteEmbeddable";
 
 // currently required by excalidraw, in order to allows self-hosting fonts locally.
 // this avoids making excalidraw load the fonts from an external CDN.
@@ -46,6 +48,18 @@ export default function Canvas({ note, noteContext }: TypeWidgetProps) {
         return goToLinkExt(nativeEvent, link, null);
     }, []);
 
+    // Allow embeddables that point at a Trilium note (e.g. `root/<noteId>`), which Excalidraw would
+    // otherwise reject as an unrecognized provider. Returning `undefined` defers to the default
+    // whitelist so normal web embeds keep working.
+    const validateEmbeddable = useCallback((link: string) => getNoteIdFromEmbeddableLink(link) ? true : undefined, []);
+
+    // Render the note's content via the shared content renderer instead of the default iframe.
+    // Returning `null` falls back to Excalidraw's built-in embeddable rendering.
+    const renderEmbeddable = useCallback((element: NonDeleted<ExcalidrawEmbeddableElement>) => {
+        const noteId = getNoteIdFromEmbeddableLink(element.link);
+        return noteId ? <NoteEmbeddable noteId={noteId} /> : null;
+    }, []);
+
     return (
         <div className="canvas-render" onWheel={onWheel}>
             <div className="excalidraw-wrapper">
@@ -66,9 +80,29 @@ export default function Canvas({ note, noteContext }: TypeWidgetProps) {
                         }
                     }}
                     onLinkOpen={onLinkOpen}
+                    validateEmbeddable={validateEmbeddable}
+                    renderEmbeddable={renderEmbeddable}
                     {...persistence}
                 />
             </div>
         </div>
     )
+}
+
+/**
+ * Extracts a Trilium note ID from an embeddable's link, accepting the canonical note-path form
+ * (`root/<noteId>` or `#root/<noteId>`). Returns `null` for anything else so non-note embeds are
+ * left to Excalidraw's default handling.
+ */
+function getNoteIdFromEmbeddableLink(link: string | null) {
+    if (!link) {
+        return null;
+    }
+
+    const cleaned = link.replace(/^#/, "");
+    if (!cleaned.startsWith("root/")) {
+        return null;
+    }
+
+    return tree.getNoteIdFromUrl(cleaned);
 }

--- a/apps/client/src/widgets/type_widgets/canvas/Canvas.tsx
+++ b/apps/client/src/widgets/type_widgets/canvas/Canvas.tsx
@@ -9,6 +9,7 @@ import "./Canvas.css";
 import { NonDeleted, NonDeletedExcalidrawElement, ExcalidrawEmbeddableElement } from "@excalidraw/excalidraw/element/types";
 import { goToLinkExt } from "../../../services/link";
 import useCanvasPersistence from "./persistence";
+import useCanvasNoteDrop from "./useCanvasNoteDrop";
 import { LANGUAGE_MAPPINGS } from "./i18n";
 import { DISPLAYABLE_LOCALE_IDS } from "@triliumnext/commons";
 import tree from "../../../services/tree";
@@ -24,6 +25,7 @@ export default function Canvas({ note, noteContext }: TypeWidgetProps) {
     const colorScheme = useColorScheme();
     const [ locale ] = useTriliumOption("locale");
     const persistence = useCanvasPersistence(note, noteContext, apiRef, colorScheme, isReadOnly);
+    const noteDrop = useCanvasNoteDrop(apiRef, isReadOnly);
 
     /** Use excalidraw's native zoom instead of the global zoom. */
     const onWheel = useCallback((e: MouseEvent) => {
@@ -62,7 +64,7 @@ export default function Canvas({ note, noteContext }: TypeWidgetProps) {
 
     return (
         <div className="canvas-render" onWheel={onWheel}>
-            <div className="excalidraw-wrapper">
+            <div className="excalidraw-wrapper" {...noteDrop}>
                 <Excalidraw
                     excalidrawAPI={api => apiRef.current = api}
                     theme={colorScheme}

--- a/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.css
+++ b/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.css
@@ -1,0 +1,8 @@
+.canvas-note-embeddable {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    padding: 10px;
+    background-color: var(--main-background-color);
+    color: var(--main-text-color);
+}

--- a/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.css
+++ b/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.css
@@ -6,3 +6,13 @@
     background-color: var(--main-background-color);
     color: var(--main-text-color);
 }
+
+/* Excalidraw uses the same `.dropdown-menu` class for its own (conditionally rendered) menus, so its
+   styles assume the element is absent when closed and never apply a hidden state. An embedded note's
+   Bootstrap dropdowns (e.g. a geo map's view switcher) are always in the DOM and hide via Bootstrap's
+   `.dropdown-menu { display: none }` when they lack `.show` — but inside `.excalidraw` that collision
+   leaves a closed menu displayed, and its backdrop-filter shows as a blurry band over the embed.
+   Restore the hidden state, scoped to embedded note content so Excalidraw's own dropdowns are untouched. */
+.canvas-note-embeddable .dropdown-menu:not(.show) {
+    display: none;
+}

--- a/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.tsx
+++ b/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "preact/hooks";
+import content_renderer from "../../../services/content_renderer";
+import froca from "../../../services/froca";
+import "./NoteEmbeddable.css";
+
+/**
+ * Renders an arbitrary Trilium note inside an Excalidraw embeddable element, reusing the shared
+ * {@link content_renderer}. Excalidraw hands us a sized box (via its `renderEmbeddable` prop); we
+ * mount the rendered note content into it, opting into `interactive` so live note types
+ * (collections, web views) behave the same as they do in an included note.
+ */
+export default function NoteEmbeddable({ noteId }: { noteId: string }) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        const container = ref.current;
+        if (!container) {
+            return;
+        }
+
+        (async () => {
+            const note = await froca.getNote(noteId);
+            if (!note || cancelled) {
+                return;
+            }
+
+            const { $renderedContent } = await content_renderer.getRenderedContent(note, { interactive: true });
+            if (cancelled) {
+                return;
+            }
+
+            container.replaceChildren(...$renderedContent.toArray());
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [noteId]);
+
+    return <div ref={ref} className="canvas-note-embeddable ck-content" />;
+}

--- a/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.tsx
+++ b/apps/client/src/widgets/type_widgets/canvas/NoteEmbeddable.tsx
@@ -19,6 +19,11 @@ export default function NoteEmbeddable({ noteId }: { noteId: string }) {
             return;
         }
 
+        // Holds the rendered content while it is mounted so the cleanup can unmount any interactive
+        // widgets it carries (collections, web views) — their standalone Preact roots would otherwise
+        // leak, keeping event subscriptions, maps and Bootstrap dropdowns alive after the embed is gone.
+        let rendered: JQuery<HTMLElement> | undefined;
+
         (async () => {
             const note = await froca.getNote(noteId);
             if (!note || cancelled) {
@@ -27,14 +32,20 @@ export default function NoteEmbeddable({ noteId }: { noteId: string }) {
 
             const { $renderedContent } = await content_renderer.getRenderedContent(note, { interactive: true });
             if (cancelled) {
+                // We were unmounted while rendering; tear down what was just mounted.
+                content_renderer.disposeInteractiveContent($renderedContent);
                 return;
             }
 
+            rendered = $renderedContent;
             container.replaceChildren(...$renderedContent.toArray());
         })();
 
         return () => {
             cancelled = true;
+            if (rendered) {
+                content_renderer.disposeInteractiveContent(rendered);
+            }
         };
     }, [noteId]);
 

--- a/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.spec.tsx
@@ -1,0 +1,161 @@
+import { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import { type RefObject, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import useCanvasNoteDrop from "./useCanvasNoteDrop";
+
+const restoreElements = vi.fn((elements: unknown[]) => elements.map((el, i) => ({ ...(el as object), id: `el${i}` })));
+const viewportCoordsToSceneCoords = vi.fn(() => ({ x: 100, y: 200 }));
+
+vi.mock("@excalidraw/excalidraw", () => ({
+    restoreElements: (...args: unknown[]) => restoreElements(...(args as [unknown[]])),
+    viewportCoordsToSceneCoords: () => viewportCoordsToSceneCoords()
+}));
+
+type Handlers = ReturnType<typeof useCanvasNoteDrop>;
+
+let handlers: Handlers | undefined;
+
+function Probe({ apiRef, isReadOnly }: { apiRef: RefObject<ExcalidrawImperativeAPI>; isReadOnly: boolean }) {
+    handlers = useCanvasNoteDrop(apiRef, isReadOnly);
+    return null;
+}
+
+describe("useCanvasNoteDrop", () => {
+    let container: HTMLElement;
+    let sceneElements: unknown[];
+    let api: ExcalidrawImperativeAPI;
+    let updateScene: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        restoreElements.mockClear();
+        viewportCoordsToSceneCoords.mockClear();
+        sceneElements = [{ id: "existing" }];
+        updateScene = vi.fn();
+        api = {
+            getAppState: vi.fn(() => ({})),
+            getSceneElements: vi.fn(() => sceneElements),
+            updateScene
+        } as unknown as ExcalidrawImperativeAPI;
+        handlers = undefined;
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+    });
+
+    async function mountHook(isReadOnly: boolean, apiRef?: RefObject<ExcalidrawImperativeAPI>) {
+        const ref = apiRef ?? ({ current: api } as RefObject<ExcalidrawImperativeAPI>);
+        await act(async () => {
+            render(<Probe apiRef={ref} isReadOnly={isReadOnly} />, container);
+        });
+    }
+
+    function dragEvent(overrides: Partial<{ types: string[]; payload: string | undefined }> = {}) {
+        const { types = ["text/plain"], payload } = overrides;
+        return {
+            clientX: 10,
+            clientY: 20,
+            dataTransfer: {
+                types,
+                getData: vi.fn(() => payload)
+            },
+            preventDefault: vi.fn(),
+            stopPropagation: vi.fn()
+        };
+    }
+
+    describe("onDragOverCapture", () => {
+        it("accepts the drop (preventDefault + stopPropagation) when a text/plain drag is editable", async () => {
+            await mountHook(false);
+            const e = dragEvent();
+            handlers?.onDragOverCapture(e as never);
+            expect(e.preventDefault).toHaveBeenCalled();
+            expect(e.stopPropagation).toHaveBeenCalled();
+        });
+
+        it("ignores the drag when read-only", async () => {
+            await mountHook(true);
+            const e = dragEvent();
+            handlers?.onDragOverCapture(e as never);
+            expect(e.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it("ignores a drag that does not carry text/plain", async () => {
+            await mountHook(false);
+            const e = dragEvent({ types: ["Files"] });
+            handlers?.onDragOverCapture(e as never);
+            expect(e.preventDefault).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onDropCapture", () => {
+        it("inserts an embeddable per dropped note, stacked, appended to the existing scene", async () => {
+            await mountHook(false);
+            const e = dragEvent({ payload: JSON.stringify([{ noteId: "aaa" }, { noteId: "bbb" }]) });
+            handlers?.onDropCapture(e as never);
+
+            expect(e.preventDefault).toHaveBeenCalled();
+            expect(e.stopPropagation).toHaveBeenCalled();
+            expect(viewportCoordsToSceneCoords).toHaveBeenCalled();
+
+            const partials = restoreElements.mock.calls[0][0] as Array<Record<string, unknown>>;
+            expect(partials).toHaveLength(2);
+            expect(partials[0]).toMatchObject({ type: "embeddable", x: 100, y: 200, link: "root/aaa" });
+            // The second note is offset by STACK_OFFSET (24) from the first on both axes.
+            expect(partials[1]).toMatchObject({ x: 124, y: 224, link: "root/bbb" });
+
+            const { elements } = updateScene.mock.calls[0][0];
+            expect(elements).toHaveLength(3); // 1 existing + 2 new
+            expect(elements[0]).toEqual({ id: "existing" });
+        });
+
+        it("does nothing when read-only", async () => {
+            await mountHook(true);
+            const e = dragEvent({ payload: JSON.stringify([{ noteId: "aaa" }]) });
+            handlers?.onDropCapture(e as never);
+            expect(e.preventDefault).not.toHaveBeenCalled();
+            expect(updateScene).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when the Excalidraw API is not ready", async () => {
+            await mountHook(false, { current: null } as RefObject<ExcalidrawImperativeAPI>);
+            const e = dragEvent({ payload: JSON.stringify([{ noteId: "aaa" }]) });
+            handlers?.onDropCapture(e as never);
+            expect(e.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it("ignores a drop whose payload contains no usable note IDs", async () => {
+            await mountHook(false);
+            const e = dragEvent({ payload: JSON.stringify([{ notANoteId: true }]) });
+            handlers?.onDropCapture(e as never);
+            expect(e.preventDefault).not.toHaveBeenCalled();
+            expect(updateScene).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("dropped-payload parsing", () => {
+        // Drives parseDroppedNoteIds through onDropCapture: a payload is "usable" only if it parses
+        // to an array whose entries carry a string noteId. updateScene firing is the proxy for that.
+        const cases: Array<{ name: string; payload: string | undefined; usable: boolean }> = [
+            { name: "missing payload", payload: undefined, usable: false },
+            { name: "non-array JSON", payload: JSON.stringify({ noteId: "aaa" }), usable: false },
+            { name: "entries without a string noteId", payload: JSON.stringify([{ noteId: 5 }, null]), usable: false },
+            { name: "invalid JSON", payload: "{not json", usable: false },
+            { name: "valid note entries", payload: JSON.stringify([{ noteId: "aaa" }]), usable: true }
+        ];
+
+        for (const { name, payload, usable } of cases) {
+            it(`${usable ? "accepts" : "rejects"} ${name}`, async () => {
+                await mountHook(false);
+                const e = dragEvent({ payload });
+                handlers?.onDropCapture(e as never);
+                expect(updateScene.mock.calls.length).toBe(usable ? 1 : 0);
+            });
+        }
+    });
+});

--- a/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
@@ -1,4 +1,5 @@
 import { restoreElements, viewportCoordsToSceneCoords } from "@excalidraw/excalidraw";
+import { ExcalidrawEmbeddableElement } from "@excalidraw/excalidraw/element/types";
 import { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
 import { RefObject } from "preact";
 import { JSX } from "preact";
@@ -48,7 +49,8 @@ export default function useCanvasNoteDrop(apiRef: RefObject<ExcalidrawImperative
         // `restoreElements` (rather than `convertToExcalidrawElements`) normalizes these partial
         // elements: Excalidraw's element factory is skipped for embeddables, so a bare skeleton
         // would omit `backgroundColor`/`strokeColor`/`seed`/etc. and crash hit-testing. restore
-        // fills every default (and generates fresh ids).
+        // fills every default (and generates fresh ids). We assert to the concrete embeddable type
+        // (a superset of these literals); an embeddable array is a valid restoreElements input.
         const partialElements = noteIds.map((noteId, i) => ({
             type: "embeddable",
             x: x + i * STACK_OFFSET,
@@ -56,7 +58,7 @@ export default function useCanvasNoteDrop(apiRef: RefObject<ExcalidrawImperative
             width: EMBEDDABLE_WIDTH,
             height: EMBEDDABLE_HEIGHT,
             link: `root/${noteId}`
-        })) as Parameters<typeof restoreElements>[0];
+        })) as ExcalidrawEmbeddableElement[];
 
         const newElements = restoreElements(partialElements, null);
         api.updateScene({ elements: [...api.getSceneElements(), ...newElements] });

--- a/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
@@ -17,8 +17,11 @@ const STACK_OFFSET = 24;
  * `text/plain` payload; we read it, translate the drop point into scene coordinates, and insert an
  * `embeddable` element linking to each note (`root/<noteId>`).
  *
- * The handlers run in the capture phase and stop propagation once a note payload is recognized, so
- * Excalidraw's own drop handling never sees the event; non-note drags fall through untouched.
+ * The handlers run in the capture phase. During `dragover` the browser only exposes the available
+ * data *types*, not the data, so we can't yet tell a note drag from any other `text/plain` drag — we
+ * accept (and stop propagation for) every `text/plain` drag to claim the drop. On `drop` the actual
+ * payload is readable: a recognized note payload is handled here and kept from Excalidraw, while any
+ * other `text/plain` drop falls through to Excalidraw's own handling.
  */
 export default function useCanvasNoteDrop(apiRef: RefObject<ExcalidrawImperativeAPI>, isReadOnly: boolean) {
     const onDragOverCapture = useCallback((e: JSX.TargetedDragEvent<HTMLElement>) => {

--- a/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/useCanvasNoteDrop.ts
@@ -1,0 +1,85 @@
+import { restoreElements, viewportCoordsToSceneCoords } from "@excalidraw/excalidraw";
+import { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import { RefObject } from "preact";
+import { JSX } from "preact";
+import { useCallback } from "preact/hooks";
+
+/** Default size of an embeddable created by dropping a note onto the canvas. */
+const EMBEDDABLE_WIDTH = 480;
+const EMBEDDABLE_HEIGHT = 320;
+/** Offset between successive embeddables when several notes are dropped at once. */
+const STACK_OFFSET = 24;
+
+/**
+ * Lets the user drag notes from the note tree onto the canvas to create note embeddables (rendered
+ * by {@link NoteEmbeddable}). The note tree puts `[{ noteId, ... }]` JSON into the drag's
+ * `text/plain` payload; we read it, translate the drop point into scene coordinates, and insert an
+ * `embeddable` element linking to each note (`root/<noteId>`).
+ *
+ * The handlers run in the capture phase and stop propagation once a note payload is recognized, so
+ * Excalidraw's own drop handling never sees the event; non-note drags fall through untouched.
+ */
+export default function useCanvasNoteDrop(apiRef: RefObject<ExcalidrawImperativeAPI>, isReadOnly: boolean) {
+    const onDragOverCapture = useCallback((e: JSX.TargetedDragEvent<HTMLElement>) => {
+        if (isReadOnly || !e.dataTransfer?.types.includes("text/plain")) {
+            return;
+        }
+        // Signal that we accept the drop so the browser fires a `drop` event here.
+        e.preventDefault();
+        e.stopPropagation();
+    }, [isReadOnly]);
+
+    const onDropCapture = useCallback((e: JSX.TargetedDragEvent<HTMLElement>) => {
+        const api = apiRef.current;
+        if (isReadOnly || !api) {
+            return;
+        }
+
+        const noteIds = parseDroppedNoteIds(e.dataTransfer?.getData("text/plain"));
+        if (!noteIds.length) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const { x, y } = viewportCoordsToSceneCoords({ clientX: e.clientX, clientY: e.clientY }, api.getAppState());
+
+        // `restoreElements` (rather than `convertToExcalidrawElements`) normalizes these partial
+        // elements: Excalidraw's element factory is skipped for embeddables, so a bare skeleton
+        // would omit `backgroundColor`/`strokeColor`/`seed`/etc. and crash hit-testing. restore
+        // fills every default (and generates fresh ids).
+        const partialElements = noteIds.map((noteId, i) => ({
+            type: "embeddable",
+            x: x + i * STACK_OFFSET,
+            y: y + i * STACK_OFFSET,
+            width: EMBEDDABLE_WIDTH,
+            height: EMBEDDABLE_HEIGHT,
+            link: `root/${noteId}`
+        })) as Parameters<typeof restoreElements>[0];
+
+        const newElements = restoreElements(partialElements, null);
+        api.updateScene({ elements: [...api.getSceneElements(), ...newElements] });
+    }, [apiRef, isReadOnly]);
+
+    return { onDragOverCapture, onDropCapture };
+}
+
+/** Extracts note IDs from the note tree's drag payload, returning `[]` for anything unrecognized. */
+function parseDroppedNoteIds(payload: string | undefined): string[] {
+    if (!payload) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(payload);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed
+            .map((entry) => (entry && typeof entry.noteId === "string" ? entry.noteId : null))
+            .filter((noteId): noteId is string => noteId !== null);
+    } catch {
+        return [];
+    }
+}

--- a/apps/client/src/widgets/type_widgets/llm_chat/useLlmChat.ts
+++ b/apps/client/src/widgets/type_widgets/llm_chat/useLlmChat.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks"
 
 import { getAvailableModels, streamChatCompletion } from "../../../services/llm_chat.js";
 import { randomString } from "../../../services/utils.js";
+import { useTriliumEvent } from "../../react/hooks.js";
 import type { ContentBlock, FileBlock, ImageBlock, LlmChatContent, StoredMessage, TextFileBlock } from "./llm_chat_types.js";
 import { useSmoothStreaming } from "./useSmoothStreaming.js";
 
@@ -205,6 +206,16 @@ export function useLlmChat(
     useEffect(() => {
         refreshModels();
     }, []);
+
+    // Re-fetch models when providers are (re)configured elsewhere — e.g. via the
+    // settings page — so the chat picks up newly added providers and clears the
+    // "no provider configured" prompt without requiring a page reload.
+    useTriliumEvent("entitiesReloaded", useCallback(({ loadResults }) => {
+        const optionNames = loadResults.getOptionNames();
+        if (optionNames.includes("llmProviders") || optionNames.includes("aiEnabled")) {
+            refreshModels();
+        }
+    }, [refreshModels]));
 
     // Track whether the user is near the bottom of the scroll container
     useEffect(() => {

--- a/apps/client/src/widgets/type_widgets/text/utils.spec.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type FNote from "../../../entities/fnote";
+
+vi.mock("../../../services/froca", () => ({
+    default: { getNote: vi.fn() }
+}));
+vi.mock("../../../services/link", () => ({
+    default: { createLink: vi.fn() }
+}));
+vi.mock("../../../services/content_renderer", () => ({
+    default: { getRenderedContent: vi.fn(), disposeInteractiveContent: vi.fn() }
+}));
+
+import content_renderer from "../../../services/content_renderer";
+import froca from "../../../services/froca";
+import link from "../../../services/link";
+import { loadIncludedNote } from "./utils";
+
+const note = { noteId: "noteY" } as unknown as FNote;
+
+describe("loadIncludedNote", () => {
+    beforeEach(() => {
+        vi.mocked(froca.getNote).mockResolvedValue(note);
+        vi.mocked(link.createLink).mockResolvedValue($('<span class="link"><a href="#">noteY</a></span>'));
+        vi.mocked(content_renderer.getRenderedContent).mockResolvedValue({ $renderedContent: $("<p>body</p>"), type: "text" } as never);
+        vi.mocked(content_renderer.disposeInteractiveContent).mockReset();
+    });
+
+    it("reuses the wrapper element without nesting a second one (editing-view path)", async () => {
+        // The editing-view downcast hands us the `.include-note-wrapper` element itself.
+        const $el = $('<div class="include-note-wrapper">');
+
+        await loadIncludedNote("noteY", $el, "small");
+
+        const wrappers = $el.find(".include-note-wrapper");
+        expect(wrappers.length).toBe(0);
+        expect($el.children(".include-note-title").length).toBe(1);
+        expect($el.children(".include-note-content").length).toBe(1);
+    });
+
+    it("builds a single wrapper inside the section (read-only / refresh path)", async () => {
+        // The read-only and refresh paths hand us the outer `section.include-note`.
+        const $el = $('<section class="include-note" data-note-id="noteY">');
+
+        await loadIncludedNote("noteY", $el, "small");
+
+        const wrappers = $el.find(".include-note-wrapper");
+        expect(wrappers.length).toBe(1);
+        expect(wrappers.children(".include-note-title").length).toBe(1);
+        expect(wrappers.children(".include-note-content").length).toBe(1);
+    });
+
+    it("disposes interactive content of a previous render before replacing it", async () => {
+        const $el = $('<div class="include-note-wrapper">');
+
+        await loadIncludedNote("noteY", $el, "small");
+
+        expect(content_renderer.disposeInteractiveContent).toHaveBeenCalledWith($el);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -15,7 +15,8 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>,
 
     const $wrapper = $('<div class="include-note-wrapper">');
     const $link = await link.createLink(note.noteId, {
-        showTooltip: false
+        showTooltip: false,
+        showNoteIcon: true
     });
 
     if (isExpandable) {

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -48,6 +48,10 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>,
         $wrapper.append($(`<div class="include-note-content type-${type}">`).append($renderedContent));
     }
 
+    // Unmount any interactive widgets from a previous render of this include (e.g. on a box-size
+    // change or refreshIncludedNote) before $el.empty() discards their DOM — otherwise their
+    // standalone Preact roots (collections, web views) would leak.
+    content_renderer.disposeInteractiveContent($el);
     $el.empty().append($wrapper);
 }
 

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -4,14 +4,14 @@ import froca from "../../../services/froca";
 import link, { ViewScope } from "../../../services/link";
 import utils from "../../../services/utils";
 
-export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>) {
+export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>, boxSize?: string) {
     const note = await froca.getNote(noteId);
     if (!note) return;
 
-    // Get the box size from the parent section element
-    const $section = $el.closest('section.include-note');
-    const boxSize = $section.attr('data-box-size');
-    const isExpandable = boxSize === 'expandable';
+    // The box size is supplied explicitly by the editing-view downcast; for the other
+    // callers (read-only rendering, script API refresh) fall back to reading it from the DOM.
+    const effectiveBoxSize = boxSize ?? $el.closest('section.include-note').attr('data-box-size');
+    const isExpandable = effectiveBoxSize === 'expandable';
 
     const $wrapper = $('<div class="include-note-wrapper">');
     const $link = await link.createLink(note.noteId, {
@@ -48,37 +48,6 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>)
     }
 
     $el.empty().append($wrapper);
-
-    // Watch for box-size attribute changes and re-render
-    setupBoxSizeObserver($section[0], noteId, $el);
-}
-
-// Track observers to avoid duplicates
-const boxSizeObservers = new WeakMap<Element, MutationObserver>();
-
-function setupBoxSizeObserver(section: Element, noteId: string, $el: JQuery<HTMLElement>) {
-    // Clean up existing observer if any
-    const existingObserver = boxSizeObservers.get(section);
-    if (existingObserver) {
-        existingObserver.disconnect();
-    }
-
-    const observer = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            if (mutation.type === 'attributes' && mutation.attributeName === 'data-box-size') {
-                // Re-render the included note with the new box size
-                loadIncludedNote(noteId, $el);
-                break;
-            }
-        }
-    });
-
-    observer.observe(section, {
-        attributes: true,
-        attributeFilter: ['data-box-size']
-    });
-
-    boxSizeObservers.set(section, observer);
 }
 
 export function refreshIncludedNote(container: HTMLDivElement, noteId: string) {

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -13,6 +13,12 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>,
     const effectiveBoxSize = boxSize ?? $el.closest('section.include-note').attr('data-box-size');
     const isExpandable = effectiveBoxSize === 'expandable';
 
+    // The editing-view downcast passes the `.include-note-wrapper` element itself as $el, whereas the
+    // read-only and refresh paths pass the outer `section.include-note`. Build the content in a
+    // detached wrapper either way (so the old content stays visible during the async render — no
+    // flicker), then swap it in; when $el is already the wrapper we move the built children straight
+    // into it instead of nesting a redundant second `.include-note-wrapper`.
+    const isWrapper = $el.hasClass('include-note-wrapper');
     const $wrapper = $('<div class="include-note-wrapper">');
     const $link = await link.createLink(note.noteId, {
         showTooltip: false,
@@ -52,7 +58,7 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>,
     // change or refreshIncludedNote) before $el.empty() discards their DOM — otherwise their
     // standalone Preact roots (collections, web views) would leak.
     content_renderer.disposeInteractiveContent($el);
-    $el.empty().append($wrapper);
+    $el.empty().append(isWrapper ? $wrapper.children() : $wrapper);
 }
 
 export function refreshIncludedNote(container: HTMLDivElement, noteId: string) {

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -27,7 +27,7 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>)
         $titleRow.append($toggle, $title);
         $wrapper.append($titleRow);
 
-        const { $renderedContent, type } = await content_renderer.getRenderedContent(note);
+        const { $renderedContent, type } = await content_renderer.getRenderedContent(note, { interactive: true });
         const $content = $(`<div class="include-note-content type-${type}" style="display: none;">`).append($renderedContent);
         $wrapper.append($content);
 
@@ -43,7 +43,7 @@ export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>)
         // Standard display
         $wrapper.append($('<h4 class="include-note-title">').append($link));
 
-        const { $renderedContent, type } = await content_renderer.getRenderedContent(note);
+        const { $renderedContent, type } = await content_renderer.getRenderedContent(note, { interactive: true });
         $wrapper.append($(`<div class="include-note-content type-${type}">`).append($renderedContent));
     }
 

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
@@ -12,17 +12,19 @@
 <ul>
   <li>The grid layout is not fixed, allowing for tiles of varying widths and
     heights. The grid has 12 columns and an unlimited number of rows.</li>
-  <li>Each widget represents a child note of the collection and can be reordered
+  <li
+ >Each widget represents a child note of the collection and can be reordered
     or resized.</li>
-  <li>The grid will distribute the columns evenly to fill the entire screen.
-    <ul>
-      <li>If the available space is too low (e.g. in a split or in mobile), the
-        columns are collapsed so that all widgets are displayed one under the other.</li>
-      <li>While the columns are collapsed, the widgets cannot be reordered or resized.</li>
+    <li>The grid will distribute the columns evenly to fill the entire screen.
+      <ul>
+        <li>If the available space is too low (e.g. in a split or in mobile), the
+          columns are collapsed so that all widgets are displayed one under the other.</li>
+        <li
+       >While the columns are collapsed, the widgets cannot be reordered or resized.</li>
     </ul>
-  </li>
-  <li>Unlike the&nbsp;<a class="reference-link" href="#root/_help_8QqnMzx393bx">Grid View</a>,
-    the widgets are not clickable which allows them to be interactive.</li>
+    </li>
+    <li>Unlike the&nbsp;<a class="reference-link" href="#root/_help_8QqnMzx393bx">Grid View</a>,
+      the widgets are not clickable which allows them to be interactive.</li>
 </ul>
 <h2>Types of widgets</h2>
 <p>The dashboard uses the same rendering mechanism as the&nbsp;<a class="reference-link"
@@ -36,7 +38,10 @@
   <li>Images via&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>,&nbsp;
     <a
     class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,&nbsp;<a class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>.</li>
-  <li>Interactive widgets via&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>.</li>
+  <li
+ >Interactive widgets via&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>.</li>
+    <li
+   >Web pages can be displayed via&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_1vHRoWCEjj0L">Web View</a>.</li>
 </ul>
 <aside class="admonition tip">
   <p>Interactive widgets through the use of&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
@@ -41,7 +41,10 @@
   <li
  >Interactive widgets via&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>.</li>
     <li
-   >Web pages can be displayed via&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_1vHRoWCEjj0L">Web View</a>.</li>
+   >Web pages can be displayed via&nbsp;<a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>&nbsp;and
+      refreshed via the context menu.</li>
+      <li><a class="reference-link" href="#root/pOsGYCXsbNQG/_help_GTwFsgaA0lCt">Collections</a>&nbsp;render
+        interactively inside the dashboard</li>
 </ul>
 <aside class="admonition tip">
   <p>Interactive widgets through the use of&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Canvas.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Canvas.html
@@ -11,3 +11,19 @@
     <a
     class="reference-link" href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;section.</li>
 </ul>
+<h2>Embedding notes</h2>
+<p>Since v0.104.0, Canvas supports embedding notes in a similar fashion to
+  the&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_nBAXQFj20hS1">Include Note</a>&nbsp;functionality
+  for&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_iPIMuisry3hd">Text</a>&nbsp;notes.</p>
+<p>To embed a note:</p>
+<ul>
+  <li>From the&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/Vc8PjrjAGuOp/_help_oPVyFC7WL2Lp">Note Tree</a>,
+    drag the item onto the canvas.</li>
+  <li>Manually, by choosing <em>More tools</em> → <em>Web Embed</em> and pasting
+    the link to the note (e.g. <code spellcheck="false">root/MujWAc9fQ1nj</code>).</li>
+</ul>
+<p>Embedding notes in the canvas follows the same rules as&nbsp;<a class="reference-link"
+  href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_nBAXQFj20hS1">Include Note</a>:
+  some notes are rendered as images (e.g.&nbsp;<a class="reference-link"
+  href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_gBbsAeiuUxI5">Mind Map</a>), whereas
+  some render fully interactive such as&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/_help_GTwFsgaA0lCt">Collections</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Include Note.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Include Note.html
@@ -1,6 +1,7 @@
-<p>Text notes can "include" another note as a read-only widget. This can
-  be useful for e.g. including a dynamically generated chart (from scripts
-  &amp; "render HTML" note) or other more advanced use cases.</p>
+<p>Text notes can "include" another note as a read-only widget or an interactive
+  widget, depending on the type of note.</p>
+<p>This can be useful for e.g. including a dynamically generated chart (from
+  scripts &amp; "render HTML" note) or other more advanced use cases.</p>
 <h2>Including a note</h2>
 <p>In the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>,
   look for the
@@ -13,3 +14,21 @@
 <p>For this to work, the included notes must also be shared, otherwise they
   will not be shown. However, the included notes can still be hidden from
   the note tree via <code spellcheck="false">#shareHiddenFromTree</code>.</p>
+<h2>Interactive notes</h2>
+<p>Since v0.104.0, included notes might become interactive depending on their
+  note type:</p>
+<ul>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/_help_GTwFsgaA0lCt">Collections</a>&nbsp;(e.g.&nbsp;
+      <a
+      class="reference-link" href="#root/pOsGYCXsbNQG/GTwFsgaA0lCt/_help_81SGnPGMk7Xc">Geo Map</a>) will render fully interactive, including creating new notes.</p>
+  </li>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_m523cpzocqaD">Saved Search</a>&nbsp;will
+      also display the results.</p>
+  </li>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_1vHRoWCEjj0L">Web View</a>&nbsp;provides
+      an interactive preview of the website.</p>
+  </li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Lists.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Lists.html
@@ -31,79 +31,76 @@
   </li>
   <li>To create a new item in the list, press <kbd>Enter</kbd>.</li>
   <li>To create a blank line within a list item, press <kbd>Shift</kbd>+<kbd>Enter</kbd>.</li>
-  <li
- >To exit out of the list, press <kbd>Enter</kbd> twice.</li>
-    <li>To merge two lists, simply delete the gap between them.</li>
-    <li>To create nested lists, simply use the
-      <img src="7_Lists_image.png"
-      width="17" height="14">button (see <em>Indentation</em> in&nbsp;<a class="reference-link" href="#root/_help_dEHYtoWWi8ct">Other features</a>)
-      or the <kbd>Tab</kbd> key. To decrease the nesting level for the current
-      element, press <kbd>Shift</kbd>+<kbd>Tab</kbd>.</li>
+  <li>To exit out of the list, press <kbd>Enter</kbd> twice.</li>
+  <li>To merge two lists, simply delete the gap between them.</li>
+  <li>To create nested lists, simply use the
+    <img src="7_Lists_image.png"
+    width="17" height="14">button (see <em>Indentation</em> in&nbsp;<a class="reference-link" href="#root/_help_dEHYtoWWi8ct">Other features</a>)
+    or the <kbd>Tab</kbd> key. To decrease the nesting level for the current
+    element, press <kbd>Shift</kbd>+<kbd>Tab</kbd>.</li>
 </ul>
 <h2>Headings, code blocks within lists</h2>
 <p>It possible to add content-level blocks such as headings, code blocks,
   tables within lists, as follows:</p>
-<figure class="table">
-  <table>
-    <thead>
-      <tr>
-        <th>&nbsp;</th>
-        <th>&nbsp;</th>
-        <th>&nbsp;</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>
-          <img src="6_Lists_image.png">
-        </td>
-        <td>First, create a list.</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>
-          <img src="9_Lists_image.png">
-        </td>
-        <td>Press Enter to create a new list item.</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>
-          <img src="5_Lists_image.png">
-        </td>
-        <td>Press Backspace to get rid of the bullet point. Notice the cursor position.</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>
-          <img class="image_resized" style="aspect-ratio:676/112;width:98.29%;"
-          src="10_Lists_image.png" width="676"
-          height="112">
-        </td>
-        <td>At this point, insert any desired block-level item such as a code block.</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>
-          <img class="image_resized" style="aspect-ratio:675/129;width:94.22%;"
-          src="8_Lists_image.png" width="675"
-          height="129">
-        </td>
-        <td>To continue with a new bullet point, press Enter until the cursor moves
-          to a new blank position.</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>
-          <img class="image_resized" style="aspect-ratio:675/129;width:100%;" src="3_Lists_image.png"
-          width="675" height="129">
-        </td>
-        <td>Press Enter once more to create the new bullet.</td>
-      </tr>
-    </tbody>
-  </table>
-</figure>
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>
+        <img src="6_Lists_image.png">
+      </td>
+      <td>First, create a list.</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>
+        <img src="9_Lists_image.png">
+      </td>
+      <td>Press Enter to create a new list item.</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>
+        <img src="5_Lists_image.png">
+      </td>
+      <td>Press Backspace to get rid of the bullet point. Notice the cursor position.</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>
+        <img class="image_resized" style="aspect-ratio:676/112;width:98.29%;"
+        src="10_Lists_image.png" width="676"
+        height="112">
+      </td>
+      <td>At this point, insert any desired block-level item such as a code block.</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td>
+        <img class="image_resized" style="aspect-ratio:675/129;width:94.22%;"
+        src="8_Lists_image.png" width="675"
+        height="129">
+      </td>
+      <td>To continue with a new bullet point, press Enter until the cursor moves
+        to a new blank position.</td>
+    </tr>
+    <tr>
+      <td>6</td>
+      <td>
+        <img class="image_resized" style="aspect-ratio:675/129;width:100%;" src="3_Lists_image.png"
+        width="675" height="129">
+      </td>
+      <td>Press Enter once more to create the new bullet.</td>
+    </tr>
+  </tbody>
+</table>
 <p>The same principle applies to all three list types (bullet, numbered and
   to-do).</p>
 <h2>To-do lists</h2>
@@ -119,41 +116,24 @@
   items. This applies to bullet lists, numbered lists as well as to-do lists.</p>
 <p>To collapse or expand a list item that has nested sub-items:</p>
 <ul>
-  <li>
-    <p>Using the mouse, move the cursor over the list item and an arrow will
-      appear to its left. Clicking it will toggle between collapsed and expanded.</p>
-  </li>
-  <li>
-    <p>For bullet lists and numbered lists, it's also possible to click directly
-      on the marker (e.g. the bullet or the number) instead of on the arrow to
-      collapse or expand it. This won't work for to-do lists since this would
-      toggle the to-do instead.</p>
-  </li>
-  <li>
-    <p>Press <kbd spellcheck="false">Ctrl</kbd>+<kbd spellcheck="false">Alt</kbd>+
-      <kbd
-      spellcheck="false">Enter</kbd>which will toggle the collapse/expand state for the item at
-        the cursor position.</p>
-  </li>
+  <li>Using the mouse, move the cursor over the list item and an arrow will
+    appear to its left. Clicking it will toggle between collapsed and expanded.</li>
+  <li>For bullet lists and numbered lists, it's also possible to click directly
+    on the marker (e.g. the bullet or the number) instead of on the arrow to
+    collapse or expand it. This won't work for to-do lists since this would
+    toggle the to-do instead.</li>
+  <li>Press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Enter</kbd> which will toggle
+    the collapse/expand state for the item at the cursor position.</li>
 </ul>
 <p>Of note:</p>
 <ul>
   <li>Collapsed items always show the arrow to indicate its state.</li>
-  <li>
-    <p>The collapsed state is saved at note level and synced across instances,
-      which means that it will restore after a refresh or reopening of the application.</p>
-  </li>
-  <li>
-    <p>The collapsed state is also persisted in&nbsp;<a class="reference-link"
-      href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/_help_mHbBMPDPkVV5">Import &amp; Export</a>,
-      but only for the HTML format. Markdown exports will not preserve the collapse
-      state.</p>
-  </li>
-  <li>
-    <p>Collapsible bullets only exist in the context of editable text notes.
-      Read-only lists will always be fully expanded.</p>
-  </li>
-  <li>
-    <p>The list items will auto-expand on edit to avoid typing in a hidden area.</p>
-  </li>
+  <li>The collapsed state is saved at note level and synced across instances,
+    which means that it will restore after a refresh or reopening of the application.</li>
+  <li>The collapsed state is also persisted in&nbsp;<a class="reference-link"
+    href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>, but only for the HTML
+    format. Markdown exports will not preserve the collapse state.</li>
+  <li>Collapsible bullets only exist in the context of editable text notes.
+    Read-only lists will always be fully expanded.</li>
+  <li>The list items will auto-expand on edit to avoid typing in a hidden area.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Web View.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Web View.html
@@ -24,3 +24,19 @@
   above, feel free to report them.</p>
 <p>On the desktop side, a different technology is used which bypasses the
   constraints of an <code spellcheck="false">iframe</code> (<code spellcheck="false">webview</code>).</p>
+<h2>Embedding in other note types</h2>
+<p>Starting with v0.104.0, web views can be embedded into other note types:</p>
+<ul>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/GTwFsgaA0lCt/_help_IF7Q6I9x7zuw">Dashboard</a>
+    </p>
+  </li>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_grjYqerjn243">Canvas</a>
+    </p>
+  </li>
+  <li>
+    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_iPIMuisry3hd">Text</a>&nbsp;notes
+      via&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_nBAXQFj20hS1">Include Note</a>.</p>
+  </li>
+</ul>

--- a/docs/Developer Guide/Developer Guide/Documentation.md
+++ b/docs/Developer Guide/Developer Guide/Documentation.md
@@ -1,5 +1,5 @@
 # Documentation
-There are multiple types of documentation for Trilium:<img class="image-style-align-right" src="api/images/zmrKO8pPH6ie/Documentation_image.png" width="205" height="162">
+There are multiple types of documentation for Trilium:<img class="image-style-align-right" src="api/images/yHIs3mh4gQ3F/Documentation_image.png" width="205" height="162">
 
 *   The _User Guide_ represents the user-facing documentation. This documentation can be browsed by users directly from within Trilium, by pressing <kbd>F1</kbd>.
 *   The _Developer's Guide_ represents a set of Markdown documents that present the internals of Trilium, for developers.

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -9102,6 +9102,13 @@
                                             "position": 10
                                         },
                                         {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "mHbBMPDPkVV5",
+                                            "isInheritable": false,
+                                            "position": 20
+                                        },
+                                        {
                                             "type": "label",
                                             "name": "iconClass",
                                             "value": "bx bx-list-ul",
@@ -9114,13 +9121,6 @@
                                             "value": "lists",
                                             "isInheritable": false,
                                             "position": 20
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "mHbBMPDPkVV5",
-                                            "isInheritable": false,
-                                            "position": 30
                                         }
                                     ],
                                     "format": "markdown",
@@ -12676,6 +12676,13 @@
                                     "value": "bx bxs-dashboard",
                                     "isInheritable": false,
                                     "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "1vHRoWCEjj0L",
+                                    "isInheritable": false,
+                                    "position": 120
                                 }
                             ],
                             "format": "markdown",

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -8580,6 +8580,34 @@
                                             "value": "include-note",
                                             "isInheritable": false,
                                             "position": 30
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "GTwFsgaA0lCt",
+                                            "isInheritable": false,
+                                            "position": 40
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "81SGnPGMk7Xc",
+                                            "isInheritable": false,
+                                            "position": 50
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "m523cpzocqaD",
+                                            "isInheritable": false,
+                                            "position": 60
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "1vHRoWCEjj0L",
+                                            "isInheritable": false,
+                                            "position": 70
                                         }
                                     ],
                                     "format": "markdown",
@@ -10749,6 +10777,41 @@
                                     "value": "canvas",
                                     "isInheritable": false,
                                     "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "nBAXQFj20hS1",
+                                    "isInheritable": false,
+                                    "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "iPIMuisry3hd",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "oPVyFC7WL2Lp",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "gBbsAeiuUxI5",
+                                    "isInheritable": false,
+                                    "position": 60
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "GTwFsgaA0lCt",
+                                    "isInheritable": false,
+                                    "position": 70
                                 }
                             ],
                             "format": "markdown",
@@ -10799,6 +10862,34 @@
                                     "value": "webview",
                                     "isInheritable": false,
                                     "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "IF7Q6I9x7zuw",
+                                    "isInheritable": false,
+                                    "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "grjYqerjn243",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "iPIMuisry3hd",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "nBAXQFj20hS1",
+                                    "isInheritable": false,
+                                    "position": 60
                                 }
                             ],
                             "format": "markdown",
@@ -12652,23 +12743,30 @@
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "GBBMSlVSOIGP",
+                                    "value": "1vHRoWCEjj0L",
                                     "isInheritable": false,
                                     "position": 90
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "oPVyFC7WL2Lp",
+                                    "value": "GBBMSlVSOIGP",
                                     "isInheritable": false,
                                     "position": 100
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "IakOLONlIfGI",
+                                    "value": "oPVyFC7WL2Lp",
                                     "isInheritable": false,
                                     "position": 110
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "IakOLONlIfGI",
+                                    "isInheritable": false,
+                                    "position": 120
                                 },
                                 {
                                     "type": "label",
@@ -12680,9 +12778,9 @@
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "1vHRoWCEjj0L",
+                                    "value": "GTwFsgaA0lCt",
                                     "isInheritable": false,
-                                    "position": 120
+                                    "position": 130
                                 }
                             ],
                             "format": "markdown",

--- a/docs/User Guide/User Guide/Collections/Dashboard.md
+++ b/docs/User Guide/User Guide/Collections/Dashboard.md
@@ -20,7 +20,8 @@ The dashboard uses the same rendering mechanism as the <a class="reference-link
 *   Static content, via <a class="reference-link" href="../Note%20Types/Text.md">Text</a> or <a class="reference-link" href="../Note%20Types/Code.md">Code</a>.
 *   Images via <a class="reference-link" href="../Note%20Types/File.md">File</a>, <a class="reference-link" href="../Note%20Types/Mermaid%20Diagrams.md">Mermaid Diagrams</a>, <a class="reference-link" href="../Note%20Types/Mind%20Map.md">Mind Map</a>.
 *   Interactive widgets via <a class="reference-link" href="../Note%20Types/Render%20Note.md">Render Note</a>.
-*   Web pages can be displayed via <a class="reference-link" href="../Note%20Types/Web%20View.md">Web View</a>.
+*   Web pages can be displayed via <a class="reference-link" href="../Note%20Types/Web%20View.md">Web View</a> and refreshed via the context menu.
+*   <a class="reference-link" href="../Collections.md">Collections</a> render interactively inside the dashboard
 
 > [!TIP]
 > Interactive widgets through the use of <a class="reference-link" href="../Note%20Types/Render%20Note.md">Render Note</a> is the highlighted use case of the dashboard. Using the <a class="reference-link" href="../AI.md">AI</a> chat, these widgets can be easily created as the AI is instructed in how to write them.

--- a/docs/User Guide/User Guide/Collections/Dashboard.md
+++ b/docs/User Guide/User Guide/Collections/Dashboard.md
@@ -20,6 +20,7 @@ The dashboard uses the same rendering mechanism as the <a class="reference-link
 *   Static content, via <a class="reference-link" href="../Note%20Types/Text.md">Text</a> or <a class="reference-link" href="../Note%20Types/Code.md">Code</a>.
 *   Images via <a class="reference-link" href="../Note%20Types/File.md">File</a>, <a class="reference-link" href="../Note%20Types/Mermaid%20Diagrams.md">Mermaid Diagrams</a>, <a class="reference-link" href="../Note%20Types/Mind%20Map.md">Mind Map</a>.
 *   Interactive widgets via <a class="reference-link" href="../Note%20Types/Render%20Note.md">Render Note</a>.
+*   Web pages can be displayed via <a class="reference-link" href="../Note%20Types/Web%20View.md">Web View</a>.
 
 > [!TIP]
 > Interactive widgets through the use of <a class="reference-link" href="../Note%20Types/Render%20Note.md">Render Note</a> is the highlighted use case of the dashboard. Using the <a class="reference-link" href="../AI.md">AI</a> chat, these widgets can be easily created as the AI is instructed in how to write them.

--- a/docs/User Guide/User Guide/Note Types/Canvas.md
+++ b/docs/User Guide/User Guide/Note Types/Canvas.md
@@ -8,3 +8,14 @@ Canvas notes use the Excalidraw library to allow handwritten notes with mouse, p
 ## Interaction
 
 *   The note can be togged [read-only](../Basic%20Concepts%20and%20Features/Notes/Read-Only%20Notes.md) from the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Floating%20buttons.md">Floating buttons</a> section.
+
+## Embedding notes
+
+Since v0.104.0, Canvas supports embedding notes in a similar fashion to the <a class="reference-link" href="Text/Include%20Note.md">Include Note</a> functionality for <a class="reference-link" href="Text.md">Text</a> notes.
+
+To embed a note:
+
+*   From the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Note%20Tree.md">Note Tree</a>, drag the item onto the canvas.
+*   Manually, by choosing _More tools_ → _Web Embed_ and pasting the link to the note (e.g. `root/MujWAc9fQ1nj`).
+
+Embedding notes in the canvas follows the same rules as <a class="reference-link" href="Text/Include%20Note.md">Include Note</a>: some notes are rendered as images (e.g. <a class="reference-link" href="Mind%20Map.md">Mind Map</a>), whereas some render fully interactive such as <a class="reference-link" href="../Collections.md">Collections</a>.

--- a/docs/User Guide/User Guide/Note Types/Text/Include Note.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Include Note.md
@@ -1,5 +1,7 @@
 # Include Note
-Text notes can "include" another note as a read-only widget. This can be useful for e.g. including a dynamically generated chart (from scripts & "render HTML" note) or other more advanced use cases.
+Text notes can "include" another note as a read-only widget or an interactive widget, depending on the type of note.
+
+This can be useful for e.g. including a dynamically generated chart (from scripts & "render HTML" note) or other more advanced use cases.
 
 ## Including a note
 
@@ -10,3 +12,11 @@ In the <a class="reference-link" href="Formatting%20toolbar.md">Formatting tool
 If a [shared note](../../Advanced%20Usage/Sharing.md) contains one or more included notes, they will be displayed in the content of the note as if they were part of the note itself.
 
 For this to work, the included notes must also be shared, otherwise they will not be shown. However, the included notes can still be hidden from the note tree via `#shareHiddenFromTree`.
+
+## Interactive notes
+
+Since v0.104.0, included notes might become interactive depending on their note type:
+
+*   <a class="reference-link" href="../../Collections.md">Collections</a> (e.g. <a class="reference-link" href="../../Collections/Geo%20Map.md">Geo Map</a>) will render fully interactive, including creating new notes.
+*   <a class="reference-link" href="../Saved%20Search.md">Saved Search</a> will also display the results.
+*   <a class="reference-link" href="../Web%20View.md">Web View</a> provides an interactive preview of the website.

--- a/docs/User Guide/User Guide/Note Types/Text/Lists.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Lists.md
@@ -47,7 +47,7 @@ To collapse or expand a list item that has nested sub-items:
 
 *   Using the mouse, move the cursor over the list item and an arrow will appear to its left. Clicking it will toggle between collapsed and expanded.
 *   For bullet lists and numbered lists, it's also possible to click directly on the marker (e.g. the bullet or the number) instead of on the arrow to collapse or expand it. This won't work for to-do lists since this would toggle the to-do instead.
-*   Press <kbd spellcheck="false">Ctrl</kbd>+<kbd spellcheck="false">Alt</kbd>+<kbd spellcheck="false">Enter</kbd> which will toggle the collapse/expand state for the item at the cursor position.
+*   Press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>Enter</kbd> which will toggle the collapse/expand state for the item at the cursor position.
 
 Of note:
 

--- a/docs/User Guide/User Guide/Note Types/Web View.md
+++ b/docs/User Guide/User Guide/Note Types/Web View.md
@@ -23,3 +23,11 @@ There are a few websites that do render such as `wikipedia.org`.
 Do note that we are also applying some sandboxing constraints on the server side, so if you have any issues other than the unresolvable `X-Frame-Options` described above, feel free to report them.
 
 On the desktop side, a different technology is used which bypasses the constraints of an `iframe` (`webview`).
+
+## Embedding in other note types
+
+Starting with v0.104.0, web views can be embedded into other note types:
+
+*   <a class="reference-link" href="../Collections/Dashboard.md">Dashboard</a>
+*   <a class="reference-link" href="Canvas.md">Canvas</a>
+*   <a class="reference-link" href="Text.md">Text</a> notes via <a class="reference-link" href="Text/Include%20Note.md">Include Note</a>.

--- a/packages/ckeditor5/src/augmentation.ts
+++ b/packages/ckeditor5/src/augmentation.ts
@@ -18,7 +18,7 @@ declare global {
     interface EditorComponent extends Component {
         loadReferenceLinkTitle($el: JQuery<HTMLElement>, href: string): Promise<void>;
         createNoteForReferenceLink(title: string): Promise<string>;
-        loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>): void;
+        loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>, boxSize?: string): void;
         fetchLinkMetadata(url: string): Promise<LinkEmbedMetadata>;
         detectEmbedType(url: string): string;
         renderLinkEmbed(container: HTMLElement, metadata: LinkEmbedMetadata, editable?: boolean): void;

--- a/packages/ckeditor5/src/plugins/includenote.spec.ts
+++ b/packages/ckeditor5/src/plugins/includenote.spec.ts
@@ -306,16 +306,45 @@ describe("IncludeNote", () => {
         wrapper.dispatchEvent(plainEvt);
         expect(plainPrevent).toHaveBeenCalled();
 
-        // Clicking a link must keep native behaviour, so preventDefault must NOT be called (the
-        // capture-phase handler on the wrapper still sees the event via its child target).
+        // Clicking a link must keep native behaviour: the handler steps aside entirely, so neither
+        // preventDefault nor stopPropagation is called.
         const innerLink = document.createElement("a");
         innerLink.href = "#root/abc";
         wrapper.appendChild(innerLink);
 
         const linkEvt = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
         const linkPrevent = vi.spyOn(linkEvt, "preventDefault");
+        const linkStop = vi.spyOn(linkEvt, "stopPropagation");
         innerLink.dispatchEvent(linkEvt);
         expect(linkPrevent).not.toHaveBeenCalled();
+        expect(linkStop).not.toHaveBeenCalled();
+    });
+
+    it("leaves a mousedown inside an embedded collection untouched so the live widget keeps working", () => {
+        insertIncludeNote(editor, "noteColl", "full");
+
+        const domRoot = editor.editing.view.getDomRoot();
+        const wrapper = domRoot?.querySelector("div.include-note-wrapper");
+        expect(wrapper).not.toBeNull();
+        if (!wrapper) {
+            return;
+        }
+
+        // Simulate the embedded collection markup (e.g. a geo-map marker lives under .rendered-collection).
+        const collection = document.createElement("div");
+        collection.className = "rendered-collection";
+        const marker = document.createElement("div");
+        collection.appendChild(marker);
+        wrapper.appendChild(collection);
+
+        const evt = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+        const prevent = vi.spyOn(evt, "preventDefault");
+        const stop = vi.spyOn(evt, "stopPropagation");
+        marker.dispatchEvent(evt);
+
+        // The handler must step aside completely so Leaflet (and other live widgets) get the event.
+        expect(prevent).not.toHaveBeenCalled();
+        expect(stop).not.toHaveBeenCalled();
     });
 
     it("stops propagation on focus and keydown inside the wrapper", () => {

--- a/packages/ckeditor5/src/plugins/includenote.spec.ts
+++ b/packages/ckeditor5/src/plugins/includenote.spec.ts
@@ -107,6 +107,9 @@ describe("IncludeNote", () => {
 
         expect(loadIncludedNote).toHaveBeenCalledTimes(1);
         expect(loadIncludedNote.mock.calls[0]?.[0]).toBe("noteY");
+        // The box size is passed explicitly so the client render does not have to read it back
+        // from the DOM (which may not be flushed yet at conversion time).
+        expect(loadIncludedNote.mock.calls[0]?.[2]).toBe("small");
     });
 
     it("updates the box-size class on the editing view when the boxSize attribute changes", () => {
@@ -121,6 +124,22 @@ describe("IncludeNote", () => {
         expect(section?.classList.contains("box-size-small")).toBe(false);
         expect(section?.classList.contains("box-size-full")).toBe(true);
         expect(section?.getAttribute("data-box-size")).toBe("full");
+    });
+
+    it("re-renders the included note content with the new size on a genuine box-size change", () => {
+        insertIncludeNote(editor, "noteReload", "small");
+
+        // One call for the initial render.
+        expect(loadIncludedNote).toHaveBeenCalledTimes(1);
+        expect(loadIncludedNote.mock.calls[0]?.[2]).toBe("small");
+
+        editor.execute(BOX_SIZE_COMMAND_NAME, { value: "expandable" });
+
+        // The downcast handler drives a second render with the new size, without any DOM observer.
+        expect(loadIncludedNote).toHaveBeenCalledTimes(2);
+        const reloadCall = loadIncludedNote.mock.calls[1];
+        expect(reloadCall?.[0]).toBe("noteReload");
+        expect(reloadCall?.[2]).toBe("expandable");
     });
 
     it("handles a boxSize change from an empty old value (no class to remove)", () => {

--- a/packages/ckeditor5/src/plugins/includenote.spec.ts
+++ b/packages/ckeditor5/src/plugins/includenote.spec.ts
@@ -289,6 +289,35 @@ describe("IncludeNote", () => {
         expect(selected?.name).toBe("includeNote");
     });
 
+    it("suppresses the native caret on a non-interactive mousedown but not on interactive targets", () => {
+        insertIncludeNote(editor, "noteCaret", "small");
+
+        const domRoot = editor.editing.view.getDomRoot();
+        const wrapper = domRoot?.querySelector("div.include-note-wrapper");
+        expect(wrapper).not.toBeNull();
+        if (!wrapper) {
+            return;
+        }
+
+        // Clicking a plain (non-interactive) area should preventDefault so the browser does not
+        // drop a caret next to the contenteditable=false widget.
+        const plainEvt = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+        const plainPrevent = vi.spyOn(plainEvt, "preventDefault");
+        wrapper.dispatchEvent(plainEvt);
+        expect(plainPrevent).toHaveBeenCalled();
+
+        // Clicking a link must keep native behaviour, so preventDefault must NOT be called (the
+        // capture-phase handler on the wrapper still sees the event via its child target).
+        const innerLink = document.createElement("a");
+        innerLink.href = "#root/abc";
+        wrapper.appendChild(innerLink);
+
+        const linkEvt = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+        const linkPrevent = vi.spyOn(linkEvt, "preventDefault");
+        innerLink.dispatchEvent(linkEvt);
+        expect(linkPrevent).not.toHaveBeenCalled();
+    });
+
     it("stops propagation on focus and keydown inside the wrapper", () => {
         insertIncludeNote(editor, "noteKbd", "small");
 

--- a/packages/ckeditor5/src/plugins/includenote.spec.ts
+++ b/packages/ckeditor5/src/plugins/includenote.spec.ts
@@ -347,6 +347,31 @@ describe("IncludeNote", () => {
         expect(stop).not.toHaveBeenCalled();
     });
 
+    it("treats a mousedown whose target is not an Element (e.g. a text node) as non-interactive", () => {
+        insertIncludeNote(editor, "noteText", "small");
+
+        const domRoot = editor.editing.view.getDomRoot();
+        const wrapper = domRoot?.querySelector("div.include-note-wrapper");
+        expect(wrapper).not.toBeNull();
+        if (!wrapper) {
+            return;
+        }
+
+        // A capture-phase mousedown on a bare text node makes evt.target a Text, not an Element. The
+        // interactive-target guard must short-circuit and report "not interactive", so the widget's
+        // normal suppression (preventDefault + stopPropagation) still runs.
+        const textNode = document.createTextNode("plain text");
+        wrapper.appendChild(textNode);
+
+        const evt = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+        const prevent = vi.spyOn(evt, "preventDefault");
+        const stop = vi.spyOn(evt, "stopPropagation");
+        textNode.dispatchEvent(evt);
+
+        expect(prevent).toHaveBeenCalled();
+        expect(stop).toHaveBeenCalled();
+    });
+
     it("stops propagation on focus and keydown inside the wrapper", () => {
         insertIncludeNote(editor, "noteKbd", "small");
 

--- a/packages/ckeditor5/src/plugins/includenote.ts
+++ b/packages/ckeditor5/src/plugins/includenote.ts
@@ -262,11 +262,20 @@ function preventCKEditorHandling( domElement: HTMLElement, editor: Editor ) {
 	// commenting out click events to allow link click handler to still work
 	//domElement.addEventListener( 'click', stopEventPropagationAndHackRendererFocus, { capture: true } );
 
-	domElement.addEventListener( 'mousedown', ( evt: Event ) => {
+	domElement.addEventListener( 'mousedown', ( evt: MouseEvent ) => {
 		evt.stopPropagation();
 		// This prevents rendering changed view selection thus preventing to changing DOM selection while inside a widget.
 		//@ts-expect-error: We are accessing a private field.
 		editor.editing.view._renderer.isFocused = false;
+
+		// Suppress the browser's native caret for clicks on non-interactive areas. The widget's
+		// <section> is contenteditable=false inside an editable root, so the default mousedown action
+		// drops a caret next to it that visibly moves as the user clicks around. Interactive targets
+		// (links, buttons, form controls, embedded editables) keep their native behaviour — `click`
+		// and focus still fire because preventing the default of `mousedown` does not cancel them.
+		if ( !isInteractiveTarget( evt.target, domElement ) ) {
+			evt.preventDefault();
+		}
 
 		// Select the widget so the toolbar can appear
 		selectIncludeNoteWidget( domElement, editor );
@@ -283,6 +292,27 @@ function preventCKEditorHandling( domElement: HTMLElement, editor: Editor ) {
         //@ts-expect-error: We are accessing a private field.
 		editor.editing.view._renderer.isFocused = false;
 	}
+}
+
+/**
+ * Whether a mousedown target needs the browser's native handling (focus, caret placement, media
+ * controls) to keep working. Used to decide when it is safe to `preventDefault()` on a widget click
+ * in order to suppress the stray native caret without breaking interactive embedded content.
+ *
+ * The match is bounded to within `boundary` (the widget wrapper) so the editable editor root — an
+ * ancestor with `contenteditable="true"` — is never mistaken for an interactive target.
+ */
+function isInteractiveTarget( target: EventTarget | null, boundary: HTMLElement ): boolean {
+	if ( !( target instanceof Element ) ) {
+		return false;
+	}
+
+	const match = target.closest(
+		'a, button, input, textarea, select, label, audio, video, ' +
+		'[role="button"], [role="textbox"], [contenteditable]:not([contenteditable="false"])'
+	);
+
+	return !!match && boundary.contains( match );
 }
 
 function selectIncludeNoteWidget( domElement: HTMLElement, editor: Editor ) {

--- a/packages/ckeditor5/src/plugins/includenote.ts
+++ b/packages/ckeditor5/src/plugins/includenote.ts
@@ -263,19 +263,24 @@ function preventCKEditorHandling( domElement: HTMLElement, editor: Editor ) {
 	//domElement.addEventListener( 'click', stopEventPropagationAndHackRendererFocus, { capture: true } );
 
 	domElement.addEventListener( 'mousedown', ( evt: MouseEvent ) => {
+		// Interactive embedded content — links, form controls, and live widgets such as collections
+		// (geo map, calendar, board, table) — needs the browser's native event handling to remain
+		// usable, e.g. dragging a geo-map marker relies on the mousedown reaching Leaflet. Leave those
+		// events completely alone: don't stop propagation, suppress the default, or steal selection.
+		if ( isInteractiveTarget( evt.target, domElement ) ) {
+			return;
+		}
+
 		evt.stopPropagation();
+
+		// Suppress the browser's native caret on non-interactive areas. The widget's <section> is
+		// contenteditable=false inside an editable root, so the default mousedown action drops a caret
+		// next to it that visibly moves as the user clicks around.
+		evt.preventDefault();
+
 		// This prevents rendering changed view selection thus preventing to changing DOM selection while inside a widget.
 		//@ts-expect-error: We are accessing a private field.
 		editor.editing.view._renderer.isFocused = false;
-
-		// Suppress the browser's native caret for clicks on non-interactive areas. The widget's
-		// <section> is contenteditable=false inside an editable root, so the default mousedown action
-		// drops a caret next to it that visibly moves as the user clicks around. Interactive targets
-		// (links, buttons, form controls, embedded editables) keep their native behaviour — `click`
-		// and focus still fire because preventing the default of `mousedown` does not cancel them.
-		if ( !isInteractiveTarget( evt.target, domElement ) ) {
-			evt.preventDefault();
-		}
 
 		// Select the widget so the toolbar can appear
 		selectIncludeNoteWidget( domElement, editor );
@@ -295,9 +300,10 @@ function preventCKEditorHandling( domElement: HTMLElement, editor: Editor ) {
 }
 
 /**
- * Whether a mousedown target needs the browser's native handling (focus, caret placement, media
- * controls) to keep working. Used to decide when it is safe to `preventDefault()` on a widget click
- * in order to suppress the stray native caret without breaking interactive embedded content.
+ * Whether a mousedown target needs the browser's native handling to keep working — so the widget's
+ * event interception should step aside. Covers form controls, links and media (which need focus,
+ * caret or their own controls) and, crucially, live embedded widgets: web views and collection views
+ * (geo map, calendar, board, table) whose own drag/click handlers rely on the native event.
  *
  * The match is bounded to within `boundary` (the widget wrapper) so the editable editor root — an
  * ancestor with `contenteditable="true"` — is never mistaken for an interactive target.
@@ -308,6 +314,7 @@ function isInteractiveTarget( target: EventTarget | null, boundary: HTMLElement 
 	}
 
 	const match = target.closest(
+		'.rendered-collection, .note-detail-web-view, ' +
 		'a, button, input, textarea, select, label, audio, video, ' +
 		'[role="button"], [role="textbox"], [contenteditable]:not([contenteditable="false"])'
 	);

--- a/packages/ckeditor5/src/plugins/includenote.ts
+++ b/packages/ckeditor5/src/plugins/includenote.ts
@@ -1,4 +1,4 @@
-import { ButtonView, Command, type Editor, Plugin, toWidget, Widget, type Observable } from 'ckeditor5';
+import { ButtonView, Command, type Editor, type ModelElement, Plugin, toWidget, type ViewElement, Widget, type Observable } from 'ckeditor5';
 import noteIcon from '../icons/note.svg?raw';
 
 export const COMMAND_NAME = 'insertIncludeNote';
@@ -115,7 +115,7 @@ class IncludeNoteEditing extends Plugin {
 			view: ( modelElement, { writer: viewWriter } ) => {
 
 				const noteId = modelElement.getAttribute( 'noteId' ) as string;
-				const boxSize = modelElement.getAttribute( 'boxSize' );
+				const boxSize = modelElement.getAttribute( 'boxSize' ) as string | undefined;
 
 				const section = viewWriter.createContainerElement( 'section', {
 					class: 'include-note box-size-' + boxSize,
@@ -132,7 +132,7 @@ class IncludeNoteEditing extends Plugin {
 					const editorEl = editor.editing.view.getDomRoot();
 					const component = glob.getComponentByEl<EditorComponent>( editorEl );
 
-					component.loadIncludedNote( noteId, $( domElement ) );
+					component.loadIncludedNote( noteId, $( domElement ), boxSize );
 
 					preventCKEditorHandling( domElement, editor );
 
@@ -165,6 +165,12 @@ class IncludeNoteEditing extends Plugin {
 				if ( newBoxSize ) {
 					viewWriter.addClass( 'box-size-' + newBoxSize, viewElement );
 					viewWriter.setAttribute( 'data-box-size', newBoxSize, viewElement );
+
+					// Re-render the included note content with the new box size. We drive this
+					// directly from the converter (rather than observing the DOM attribute) so the
+					// content is only rebuilt on a genuine box-size change — not whenever CKEditor
+					// re-applies unrelated attributes (e.g. `draggable` while selecting the widget).
+					reloadIncludedNote( editor, viewElement, data.item as ModelElement, newBoxSize );
 				}
 			} );
 		} );
@@ -221,6 +227,28 @@ class IncludeNoteBoxSizeCommand extends Command {
 		// Check if we're inside an include note
 		const firstPosition = selection.getFirstPosition();
 		return firstPosition?.findAncestor( 'includeNote' ) ?? null;
+	}
+}
+
+/**
+ * Re-renders the included note content of an already-rendered widget after its box size changed.
+ *
+ * The wrapper is a `UIElement` whose DOM is opaque to CKEditor, so we reach into it directly to
+ * trigger the client-side render. The box size is passed explicitly because, at conversion time,
+ * the updated `data-box-size` attribute may not yet be flushed to the DOM.
+ *
+ * On the initial insert the attribute converter runs before the widget has been rendered to the
+ * DOM, so `mapViewToDom()` returns nothing and this is a no-op — the `UIElement` render callback
+ * performs that first paint instead. It only does work on a subsequent, genuine box-size change.
+ */
+function reloadIncludedNote( editor: Editor, viewElement: ViewElement, modelElement: ModelElement, boxSize: string ) {
+	const sectionDom = editor.editing.view.domConverter.mapViewToDom( viewElement );
+	const wrapperDom = sectionDom?.querySelector<HTMLElement>( '.include-note-wrapper' );
+	const noteId = modelElement.getAttribute( 'noteId' ) as string | undefined;
+
+	if ( wrapperDom && noteId ) {
+		const component = glob.getComponentByEl<EditorComponent>( editor.editing.view.getDomRoot() );
+		component.loadIncludedNote( noteId, $( wrapperDom ), boxSize );
 	}
 }
 


### PR DESCRIPTION
## Summary

Improvements to dashboards and include notes, centered on rendering collections and web views interactively.

### Dashboard / collections
- Embed live web views in dashboard tiles, with a refresh action and reactive updates.
- Render any collection interactively via the content renderer; embeds react to froca changes.
- Preserve the layout of hidden archived widgets and warn when dropped archived notes stay hidden.
- Fix note-list refresh edge cases (stale refresh clobbering, in-place froca children mutation).

### Include notes (CKEditor)
- Render interactive widgets and support interactive web views inside include notes.
- Style include notes like the grid/list card view; align the title icon and fix spacing.
- Stop include-note flicker on widget click; make embedded collection command buttons work.

### Canvas
- Drag notes from the tree onto the canvas to embed them, rendered through the content renderer.

### Misc
- Tooltip: don't treat note links with view params as anchors.
- LLM: refresh chat models when providers change; toggle the sidebar chat widget reactively on AI enable/disable.
- Geomap: clone dropped notes under the map instead of onto themselves.

Closes #3902.

## Test plan
- `pnpm test:all`
- Manual: dashboards, include notes, and canvas embedding behaviours above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
