### PR TITLE
feat: launch bar config tree popup & mobile revisions

### DIFF
--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -139,6 +139,7 @@ export type CommandMappings = {
     openNewNoteSplit: NoteCommandData;
     openInWindow: NoteCommandData;
     openInPopup: CommandData & { noteIdOrPath: string; };
+    openInTreePopup: CommandData & { noteIdOrPath: string; hoistedNoteId: string; };
     openNoteInNewTab: CommandData;
     openNoteInNewSplit: CommandData;
     openNoteInNewWindow: CommandData;

--- a/apps/client/src/components/root_command_executor.ts
+++ b/apps/client/src/components/root_command_executor.ts
@@ -101,8 +101,7 @@ export default class RootCommandExecutor extends Component {
 
     async showLaunchBarSubtreeCommand() {
         const rootNote = utils.isMobile() ? "_lbMobileRoot" : "_lbRoot";
-        await this.showAndHoistSubtree(rootNote);
-        this.showLeftPaneCommand();
+        appContext.triggerCommand("openInTreePopup", { noteIdOrPath: rootNote, hoistedNoteId: rootNote });
     }
 
     async showShareSubtreeCommand() {

--- a/apps/client/src/layouts/layout_commons.tsx
+++ b/apps/client/src/layouts/layout_commons.tsx
@@ -38,6 +38,7 @@ export function applyModals(rootContainer: RootContainer) {
         .child(<LazyDialog triggerEvents={["showOptions"]} loader={() => import("../widgets/dialogs/OptionsDialog.jsx")} />)
         .child(<LazyDialog triggerEvents={["showOcrTextDialog"]} loader={() => import("../widgets/dialogs/ocr_text.js")} />)
         .child(<LazyDialog triggerEvents={["showUploadAttachmentsDialog"]} loader={() => import("../widgets/dialogs/upload_attachments.js")} />)
+        .child(<LazyDialog triggerEvents={["openInTreePopup"]} loader={() => import("../widgets/dialogs/TreePopupEditor.jsx")} />)
         // The following three are deliberately eager (not wrapped in LazyDialog):
         //  - PopupEditor keeps itself in the DOM (`keepInDom`) for fast hover-preview latency, so deferring its module would defeat the purpose.
         //  - CallToAction has no summon event; it decides whether to show itself on startup, so there is nothing to lazily mount against.

--- a/apps/client/src/services/task_states.spec.ts
+++ b/apps/client/src/services/task_states.spec.ts
@@ -135,18 +135,15 @@ describe("getTaskStateDefinitions", () => {
 });
 
 describe("openCustomTaskStateConfig", () => {
-    it("opens the task-states container hoisted in a new tab", () => {
-        const openInNewTab = vi.fn();
-        (appContext as unknown as { tabManager: { openInNewTab: typeof openInNewTab } }).tabManager = {
-            openInNewTab
-        };
+    it("opens the task-states container hoisted in the tree popup", () => {
+        const triggerCommand = vi.fn();
+        (appContext as unknown as { triggerCommand: typeof triggerCommand }).triggerCommand = triggerCommand;
 
         openCustomTaskStateConfig();
 
-        expect(openInNewTab).toHaveBeenCalledWith(
-            TASK_STATES_CONTAINER_ID,
-            TASK_STATES_CONTAINER_ID,
-            true
-        );
+        expect(triggerCommand).toHaveBeenCalledWith("openInTreePopup", {
+            noteIdOrPath: TASK_STATES_CONTAINER_ID,
+            hoistedNoteId: TASK_STATES_CONTAINER_ID
+        });
     });
 });

--- a/apps/client/src/services/task_states.ts
+++ b/apps/client/src/services/task_states.ts
@@ -70,7 +70,10 @@ export async function getTaskStateDefinitions(): Promise<TaskStateDef[]> {
     return valid.length ? valid : DEFAULT_TASK_STATES;
 }
 
-/** Opens the "Task States" configuration note in a new tab, hoisted to it. */
+/** Opens the "Task States" configuration subtree in a tree-sidebar popup, hoisted to it. */
 export function openCustomTaskStateConfig(): void {
-    void appContext.tabManager.openInNewTab(TASK_STATES_CONTAINER_ID, TASK_STATES_CONTAINER_ID, true);
+    void appContext.triggerCommand("openInTreePopup", {
+        noteIdOrPath: TASK_STATES_CONTAINER_ID,
+        hoistedNoteId: TASK_STATES_CONTAINER_ID
+    });
 }

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -341,6 +341,7 @@
   },
   "revisions": {
     "note_revisions": "Note Revisions",
+    "back": "Back",
     "delete_all_revisions": "Delete all revisions of this note",
     "delete_all_button": "Delete all revisions",
     "help_title": "Help on Note Revisions",
@@ -2455,9 +2456,6 @@
   },
   "popup-editor": {
     "maximize": "Switch to full editor"
-  },
-  "tree-popup": {
-    "title": "Configure"
   },
   "server": {
     "unknown_http_error_title": "Communication error with the server",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2456,6 +2456,9 @@
   "popup-editor": {
     "maximize": "Switch to full editor"
   },
+  "tree-popup": {
+    "title": "Configure"
+  },
   "server": {
     "unknown_http_error_title": "Communication error with the server",
     "unknown_http_error_content": "Status code: {{statusCode}}\nURL: {{method}} {{url}}\nMessage: {{message}}",

--- a/apps/client/src/widgets/NoteDetail.css
+++ b/apps/client/src/widgets/NoteDetail.css
@@ -4,30 +4,6 @@
     font-size: var(--detail-font-size);
     contain: none;
     position: relative; /* anchor for the content-loading overlay */
-
-    &.fixed-tree {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-
-        .fixed-note-tree-container {
-            height: 60%;
-            border-bottom: 1px solid var(--main-border-color);
-            overflow: auto;
-
-            .tree-wrapper {
-                padding: 0;
-            }
-
-            .tree {
-                padding: 0;
-            }
-
-            ul {
-                margin: 0;
-            }
-        }
-    }
 }
 
 body.prefers-centered-content .note-detail {

--- a/apps/client/src/widgets/NoteDetail.tsx
+++ b/apps/client/src/widgets/NoteDetail.tsx
@@ -13,11 +13,10 @@ import dialog from "../services/dialog";
 import { t } from "../services/i18n";
 import protected_session_holder from "../services/protected_session_holder";
 import toast from "../services/toast.js";
-import { isElectron, isMobile } from "../services/utils";
-import NoteTreeWidget from "./note_tree";
+import { isElectron } from "../services/utils";
 import { ExtendedNoteType, TYPE_MAPPINGS, TypeWidget } from "./note_types";
 import Button from "./react/Button";
-import { useDelayedVisibility, useGetContextDataFrom, useLegacyWidget, useNoteContext, useTriliumEvent } from "./react/hooks";
+import { useDelayedVisibility, useGetContextDataFrom, useNoteContext, useTriliumEvent } from "./react/hooks";
 import Icon from "./react/Icon";
 import NoItems from "./react/NoItems";
 import { NoteListWithLinks } from "./react/NoteList";
@@ -42,7 +41,6 @@ export default function NoteDetail() {
     const [ noteTypesToRender, setNoteTypesToRender ] = useState<{ [ key in ExtendedNoteType ]?: (props: TypeWidgetProps) => VNode }>({});
     const [ activeNoteType, setActiveNoteType ] = useState<ExtendedNoteType>();
     const widgetRequestId = useRef(0);
-    const hasFixedTree = note && noteContext?.hoistedNoteId === "_lbMobileRoot" && isMobile() && note.noteId.startsWith("_lbMobile");
 
     // Defer loading for tabs that haven't been active yet (e.g. on app refresh).
     // A tab can hold multiple splits; activating the tab makes all of them visible at once, so deferral
@@ -221,12 +219,9 @@ export default function NoteDetail() {
         <div
             ref={containerRef}
             class={clsx("component note-detail", {
-                "full-height": isFullHeight,
-                "fixed-tree": hasFixedTree
+                "full-height": isFullHeight
             })}
         >
-            {hasFixedTree && <FixedTree noteContext={noteContext} />}
-
             {Object.entries(noteTypesToRender).map(([ itemType, Element ]) => {
                 return <NoteDetailWrapper
                     Element={Element}
@@ -255,11 +250,6 @@ export function isContextInActiveTab(noteContext: NoteContext | undefined, activ
     }
 
     return activeMainNtxId === noteContext.getMainContext().ntxId;
-}
-
-function FixedTree({ noteContext }: { noteContext: NoteContext }) {
-    const [ treeEl ] = useLegacyWidget(() => new NoteTreeWidget(), { noteContext });
-    return <div class="fixed-note-tree-container">{treeEl}</div>;
 }
 
 /**

--- a/apps/client/src/widgets/dialogs/OptionsDialog.tsx
+++ b/apps/client/src/widgets/dialogs/OptionsDialog.tsx
@@ -1,6 +1,6 @@
 import "./OptionsDialog.css";
 
-import { useCallback, useContext, useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
 import appContext from "../../components/app_context";
 import NoteContext from "../../components/note_context";
@@ -9,17 +9,13 @@ import utils from "../../services/utils";
 import NoteDetail from "../NoteDetail";
 import ActionButton from "../react/ActionButton";
 import FormList, { FormListItem } from "../react/FormList";
-import { useChildNotes, useContainedLinkNavigation, useNoteContext, useTriliumEvent, useWindowSize } from "../react/hooks";
+import { useChildNotes, useContainedLinkNavigation, useMobileMasterDetail, useNoteContext, useTriliumEvent } from "../react/hooks";
 import Modal from "../react/Modal";
 import { NoteContextContext, ParentComponent } from "../react/react_utils";
 import SettingsNavigation from "../type_widgets/options/components/SettingsNavigation";
 
 /** The settings page shown when no specific section was requested and none was viewed yet this session. */
 const DEFAULT_SECTION = "_optionsAppearance";
-
-/** Mobile viewports at least this wide (tablets) keep the desktop-style side-by-side sidebar
- *  layout; narrower ones get the master-detail flow. */
-const TABLET_MIN_WIDTH = 768;
 
 /**
  * The settings dialog, opened via the `showOptions` command. Settings open in a dialog rather than
@@ -36,29 +32,9 @@ export default function OptionsDialog() {
     // Remembers the page last viewed this session so reopening the dialog lands there instead of
     // always on Appearance. Kept in component state (resets on reload), not persisted.
     const [ lastSection, setLastSection ] = useState<string | null>(null);
-    // Which half of the mobile master-detail flow is visible; has no effect on desktop.
-    const [ mobileView, setMobileView ] = useState<"list" | "page">("list");
-    // Direction of the in-flight slide between the two mobile views, or null when at rest. While
-    // set, both panes stay rendered so the outgoing one can slide away as the incoming one slides
-    // in; cleared when the slide animation finishes.
-    const [ mobileTransition, setMobileTransition ] = useState<"to-list" | "to-page" | null>(null);
     const modalRef = useRef<HTMLDivElement>(null);
     const isMobile = utils.isMobile();
-    const { windowWidth } = useWindowSize();
-    // Only narrow mobile viewports get the master-detail flow; tablets keep the sidebar layout.
-    const isMasterDetail = isMobile && windowWidth < TABLET_MIN_WIDTH;
-
-    // Switches between the mobile master/detail views with a slide. The initial view on open is
-    // set directly (without animating) by the showOptions handler instead.
-    const switchMobileView = useCallback((view: "list" | "page") => {
-        if (view === mobileView) return;
-        setMobileView(view);
-        // With animations globally disabled there is no animationend to clear the transition,
-        // so switch directly. Outside the master-detail flow there is nothing to animate.
-        if (isMasterDetail && !document.body.classList.contains("motion-disabled")) {
-            setMobileTransition(view === "page" ? "to-page" : "to-list");
-        }
-    }, [ mobileView, isMasterDetail ]);
+    const { isMasterDetail, mobileView, switchMobileView, resetMobileView } = useMobileMasterDetail(modalRef, "options-slide");
 
     useTriliumEvent("showOptions", async ({ section }) => {
         const noteContext = new NoteContext("_options-dialog");
@@ -68,34 +44,9 @@ export default function OptionsDialog() {
         noteContext.triggerEvent = (name, data) => parentComponent?.handleEventInChildren(name, data);
         setNoteContext(noteContext);
         // Requesting a specific section (e.g. "set up a password") skips the mobile master list.
-        setMobileView(section ? "page" : "list");
-        setMobileTransition(null);
+        resetMobileView(section ? "page" : "list");
         setShown(true);
     });
-
-    // Bootstrap adds its own classes (e.g. `show`) to the modal element at runtime, so the
-    // className prop must stay static — rewriting it from a render would wipe them and visually
-    // dismiss the dialog. Toggle the mobile view classes directly on the element instead.
-    useEffect(() => {
-        modalRef.current?.classList.toggle("mobile-master-detail", isMasterDetail);
-        modalRef.current?.classList.toggle("mobile-view-list", mobileView === "list");
-        modalRef.current?.classList.toggle("mobile-view-page", mobileView === "page");
-        modalRef.current?.classList.toggle("mobile-transition-to-list", mobileTransition === "to-list");
-        modalRef.current?.classList.toggle("mobile-transition-to-page", mobileTransition === "to-page");
-    }, [ isMasterDetail, mobileView, mobileTransition ]);
-
-    // End the view transition once the slide finishes (animationend bubbles up from the panes).
-    useEffect(() => {
-        const modalElement = modalRef.current;
-        if (!modalElement) return;
-        function onAnimationEnd(e: AnimationEvent) {
-            if (e.animationName.startsWith("options-slide")) {
-                setMobileTransition(null);
-            }
-        }
-        modalElement.addEventListener("animationend", onAnimationEnd);
-        return () => modalElement.removeEventListener("animationend", onAnimationEnd);
-    }, []);
 
     // Keep navigation between settings pages (sidebar entries, "Related settings" links) inside the
     // dialog; links to regular notes open in the quick-edit popup instead.

--- a/apps/client/src/widgets/dialogs/PopupEditor.css
+++ b/apps/client/src/widgets/dialogs/PopupEditor.css
@@ -35,7 +35,10 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
     font-size: 1.1em;
 }
 
-.modal.popup-editor-dialog .modal-header .title-row {
+/* The note-title header (icon + editable title) is shared with the tree popup, which reuses the same
+   TitleRow; keep both selectors together so the two dialogs stay pixel-identical. */
+.modal.popup-editor-dialog .modal-header .title-row,
+.modal.tree-popup-editor-dialog .modal-header .title-row {
     flex-grow: 1;
     display: flex;
     align-items: center;
@@ -48,7 +51,8 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
     }
 }
 
-.modal.popup-editor-dialog .modal-header .note-title-widget {
+.modal.popup-editor-dialog .modal-header .note-title-widget,
+.modal.tree-popup-editor-dialog .modal-header .note-title-widget {
     display: flex;
     align-items: center;
 }
@@ -63,17 +67,22 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
 
 .modal.popup-editor-dialog .title-row,
 .modal.popup-editor-dialog .modal-title,
-.modal.popup-editor-dialog .note-icon-widget {
+.modal.popup-editor-dialog .note-icon-widget,
+.modal.tree-popup-editor-dialog .title-row,
+.modal.tree-popup-editor-dialog .note-icon-widget {
     height: 32px;
     min-height: unset;
 }
 
-:root div.modal.popup-editor-dialog div.note-title-widget {
+:root div.modal.popup-editor-dialog div.note-title-widget,
+:root div.modal.tree-popup-editor-dialog div.note-title-widget {
     --note-title-padding-inline: 8px;
 }
 
 .modal.popup-editor-dialog .note-icon-widget button.note-icon,
-.modal.popup-editor-dialog .note-title-widget input.note-title {
+.modal.popup-editor-dialog .note-title-widget input.note-title,
+.modal.tree-popup-editor-dialog .note-icon-widget button.note-icon,
+.modal.tree-popup-editor-dialog .note-title-widget input.note-title {
     font-size: 1em;
 }
 

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.css
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.css
@@ -9,8 +9,15 @@
 }
 
 /* Sidebar holding the hoisted note tree. */
-.modal.tree-popup-editor-dialog .modal-sidebar {
+body.desktop .modal.tree-popup-editor-dialog .modal-sidebar {
     width: 300px;
+}
+
+/* Match the normal left-pane sidebar so the tree blends in instead of sitting on the plain modal
+   background (mirrors how the Options modal tints its own sidebar). */
+.modal.tree-popup-editor-dialog .modal-sidebar {
+    color: var(--left-pane-text-color);
+    background-color: var(--left-pane-background-color);
 }
 
 .modal.tree-popup-editor-dialog .tree-popup-sidebar {

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.css
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.css
@@ -6,6 +6,10 @@
 
 .modal.tree-popup-editor-dialog .modal-content {
     height: 80vh;
+
+    .note-detail-doc-content {
+        padding: unset;
+    }
 }
 
 /* Sidebar holding the hoisted note tree. */
@@ -30,9 +34,5 @@ body.desktop .modal.tree-popup-editor-dialog .modal-sidebar {
     height: 100%;
 }
 
-.modal.tree-popup-editor-dialog .tree-popup-editor-title {
-    display: flex;
-    align-items: center;
-    gap: 0.35em;
-    margin-bottom: 0.5em;
-}
+/* The header note title (icon + editable title) reuses the quick-edit TitleRow styling — see the
+   shared `.popup-editor-dialog, .tree-popup-editor-dialog` rules in PopupEditor.css. */

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.css
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.css
@@ -1,0 +1,31 @@
+.modal.tree-popup-editor-dialog .modal-dialog {
+    width: 90vw;
+    max-width: 1100px;
+    height: 80vh;
+}
+
+.modal.tree-popup-editor-dialog .modal-content {
+    height: 80vh;
+}
+
+/* Sidebar holding the hoisted note tree. */
+.modal.tree-popup-editor-dialog .modal-sidebar {
+    width: 300px;
+}
+
+.modal.tree-popup-editor-dialog .tree-popup-sidebar {
+    flex-grow: 1;
+    min-height: 0;
+    overflow: auto;
+}
+
+.modal.tree-popup-editor-dialog .tree-popup-sidebar .fancytree-container {
+    height: 100%;
+}
+
+.modal.tree-popup-editor-dialog .tree-popup-editor-title {
+    display: flex;
+    align-items: center;
+    gap: 0.35em;
+    margin-bottom: 0.5em;
+}

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.css
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.css
@@ -17,6 +17,10 @@ body.desktop .modal.tree-popup-editor-dialog .modal-sidebar {
     width: 300px;
 }
 
+body.mobile .modal.tree-popup-editor-dialog .modal-sidebar {
+    border-top: 1px solid var(--main-border-color);
+}
+
 /* Match the normal left-pane sidebar so the tree blends in instead of sitting on the plain modal
    background (mirrors how the Options modal tints its own sidebar). */
 .modal.tree-popup-editor-dialog .modal-sidebar {

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
@@ -1,0 +1,79 @@
+import "./TreePopupEditor.css";
+
+import { useCallback, useContext, useRef, useState } from "preact/hooks";
+
+import appContext from "../../components/app_context";
+import NoteContext from "../../components/note_context";
+import { t } from "../../services/i18n";
+import NoteTreeWidget from "../note_tree";
+import NoteDetail from "../NoteDetail";
+import PromotedAttributes from "../PromotedAttributes";
+import { useContainedLinkNavigation, useLegacyWidget, useTriliumEvent } from "../react/hooks";
+import Modal from "../react/Modal";
+import { NoteContextContext, ParentComponent } from "../react/react_utils";
+import { TitleRow } from "./PopupEditor";
+
+/**
+ * PoC: a quick-edit-style popup whose sidebar is a hoisted note tree.
+ *
+ * Summoned via the `openInTreePopup` command with a `noteIdOrPath` to open and a `hoistedNoteId`
+ * to scope the sidebar tree to. Used to open the launch-bar configuration subtree in a modal
+ * (with the same hoisting it would get in a dedicated tab) instead of a separate tab.
+ */
+export default function TreePopupEditor() {
+    const [ shown, setShown ] = useState(false);
+    const parentComponent = useContext(ParentComponent);
+    const [ noteContext, setNoteContext ] = useState(() => new NoteContext("_tree-popup"));
+    const modalRef = useRef<HTMLDivElement>(null);
+
+    useTriliumEvent("openInTreePopup", async ({ noteIdOrPath, hoistedNoteId }) => {
+        // Fresh context per open so the sidebar tree is hoisted to the requested subtree.
+        const newContext = new NoteContext("_tree-popup", hoistedNoteId);
+        await newContext.setNote(noteIdOrPath, { keepActiveDialog: true });
+
+        // Events triggered at note-context level (e.g. the save indicator) would not work since this
+        // context has no parent component. Propagate them so they can be handled properly.
+        newContext.triggerEvent = (name, data) => parentComponent?.handleEventInChildren(name, data);
+
+        setNoteContext(newContext);
+        setShown(true);
+    });
+
+    // Keep navigation that follows internal links inside the popup, rather than letting the global
+    // link handler open the target in the background tab. Links that stay within the hoisted subtree
+    // navigate the modal's own context; links pointing outside it can't be shown in the hoisted
+    // context, so they fall back to the quick-edit popup.
+    useContainedLinkNavigation(modalRef, useCallback((notePath, viewScope) => {
+        if (notePath.split("/").includes(noteContext.hoistedNoteId)) {
+            void noteContext.setNote(notePath, { viewScope, keepActiveDialog: true });
+        } else {
+            void appContext.triggerCommand("openInPopup", { noteIdOrPath: notePath });
+        }
+    }, [ noteContext ]));
+
+    return (
+        <NoteContextContext.Provider value={noteContext}>
+            <Modal
+                modalRef={modalRef}
+                title={t("tree-popup.title")}
+                className="tree-popup-editor-dialog"
+                size="xl"
+                sidebar={<TreeSidebar noteContext={noteContext} />}
+                show={shown}
+                onShown={() => parentComponent?.handleEvent("focusOnDetail", { ntxId: noteContext.ntxId })}
+                onHidden={() => setShown(false)}
+                scrollable
+                stackable
+            >
+                <div className="tree-popup-editor-title"><TitleRow /></div>
+                <PromotedAttributes />
+                <NoteDetail />
+            </Modal>
+        </NoteContextContext.Provider>
+    );
+}
+
+function TreeSidebar({ noteContext }: { noteContext: NoteContext }) {
+    const [ treeEl ] = useLegacyWidget(() => new NoteTreeWidget(), { noteContext });
+    return <div className="tree-popup-sidebar">{treeEl}</div>;
+}

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
@@ -13,7 +13,7 @@ import { NoteContextContext, ParentComponent } from "../react/react_utils";
 import { TitleRow } from "./PopupEditor";
 
 /**
- * PoC: a quick-edit-style popup whose sidebar is a hoisted note tree.
+ * A quick-edit-style popup whose sidebar is a hoisted note tree.
  *
  * Summoned via the `openInTreePopup` command with a `noteIdOrPath` to open and a `hoistedNoteId`
  * to scope the sidebar tree to. Used to open the launch-bar configuration subtree in a modal

--- a/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
+++ b/apps/client/src/widgets/dialogs/TreePopupEditor.tsx
@@ -4,7 +4,6 @@ import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
 import appContext from "../../components/app_context";
 import NoteContext from "../../components/note_context";
-import { t } from "../../services/i18n";
 import NoteTreeWidget from "../note_tree";
 import NoteDetail from "../NoteDetail";
 import PromotedAttributes from "../PromotedAttributes";
@@ -55,7 +54,10 @@ export default function TreePopupEditor() {
         <NoteContextContext.Provider value={noteContext}>
             <Modal
                 modalRef={modalRef}
-                title={t("tree-popup.title")}
+                // Reuse the quick-edit note header (icon + editable title); it lives in the main
+                // header, so skip the sidebar header that would otherwise duplicate it.
+                title={<TitleRow />}
+                hideSidebarHeader
                 className="tree-popup-editor-dialog"
                 size="xl"
                 sidebar={<TreeSidebar noteContext={noteContext} />}
@@ -65,7 +67,6 @@ export default function TreePopupEditor() {
                 scrollable
                 stackable
             >
-                <div className="tree-popup-editor-title"><TitleRow /></div>
                 <PromotedAttributes />
                 <NoteDetail />
             </Modal>

--- a/apps/client/src/widgets/dialogs/revisions.css
+++ b/apps/client/src/widgets/dialogs/revisions.css
@@ -42,6 +42,16 @@ body.desktop .revisions-dialog {
         flex-direction: column;
     }
 
+    /* Wraps the toolbar + preview so it can fill the body (desktop) and act as the detail pane of
+       the mobile master-detail flow. */
+    .revision-detail {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+        min-height: 0;
+    }
+
     .modal-sidebar {
         background-color: var(--card-background-color);
     }
@@ -245,4 +255,148 @@ body.desktop .revisions-dialog {
         }
     }
 
+}
+
+/* On narrow mobile viewports the dialog becomes a master-detail flow instead of the bottom-strip
+   sidebar layout (the `mobile-master-detail` class, toggled by useMobileMasterDetail, tracks this):
+   the revision list is rendered as a pane inside the modal body (the Modal sidebar is unused) so the
+   list and the selected revision can slide over each other when switching between them. */
+body.mobile .revisions-dialog.mobile-master-detail {
+    .modal-body {
+        position: relative;
+        padding: 0;
+        /* The panes scroll themselves; this also keeps the sliding panes contained. */
+        overflow: hidden;
+    }
+
+    .revision-mobile-nav {
+        height: 100%;
+        overflow: auto;
+    }
+
+    .revision-detail {
+        height: 100%;
+        overflow: hidden;
+    }
+
+    /* The back button + revision date in the custom header replace the static "Note revisions" title. */
+    .modal-header > .modal-title {
+        display: none;
+    }
+
+    /* At rest only the active pane is displayed; during a transition both stay visible so the
+       outgoing pane can slide away as the incoming one slides in. */
+    &.mobile-view-list:not(.mobile-transition-to-list) .revision-detail {
+        display: none;
+    }
+
+    &.mobile-view-page:not(.mobile-transition-to-page) .revision-mobile-nav {
+        display: none;
+    }
+
+    /* Directional slide: opening a revision, the list slides out towards the start side while the
+       detail slides in from the end side; going back reverses the directions. The detail pane stacks
+       above the list, and `forwards` holds the outgoing pane off-screen until the transition classes
+       are removed after animationend. The global `motion-disabled` rule suppresses the animations;
+       the dialog then switches views directly without entering a transition. */
+    &.mobile-transition-to-page,
+    &.mobile-transition-to-list {
+        .revision-mobile-nav,
+        .revision-detail {
+            position: absolute;
+            inset: 0;
+            background-color: var(--modal-background-color);
+        }
+
+        .revision-detail {
+            z-index: 1;
+        }
+    }
+
+    &.mobile-transition-to-page {
+        .revision-detail {
+            animation: revision-slide-in-end 0.35s ease-in-out forwards;
+        }
+
+        .revision-mobile-nav {
+            animation: revision-slide-out-start 0.35s ease-in-out forwards;
+        }
+    }
+
+    &.mobile-transition-to-list {
+        .revision-detail {
+            animation: revision-slide-out-end 0.35s ease-in-out forwards;
+        }
+
+        .revision-mobile-nav {
+            animation: revision-slide-in-start 0.35s ease-in-out forwards;
+        }
+    }
+}
+
+body[dir=rtl].mobile .revisions-dialog.mobile-master-detail.mobile-transition-to-page {
+    .revision-detail {
+        animation-name: revision-slide-in-start;
+    }
+
+    .revision-mobile-nav {
+        animation-name: revision-slide-out-end;
+    }
+}
+
+body[dir=rtl].mobile .revisions-dialog.mobile-master-detail.mobile-transition-to-list {
+    .revision-detail {
+        animation-name: revision-slide-out-start;
+    }
+
+    .revision-mobile-nav {
+        animation-name: revision-slide-in-end;
+    }
+}
+
+.revision-mobile-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-grow: 1;
+    min-width: 0;
+
+    /* Decorative history icon shown in the list view. It borrows `icon-action` so it keeps exactly
+       the back button's footprint (the title doesn't shift between views), with the interactive
+       affordances neutralized. */
+    .revision-header-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        cursor: default;
+    }
+
+    .revision-mobile-title {
+        margin: 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        flex-grow: 1;
+    }
+}
+
+@keyframes revision-slide-in-end {
+    from { transform: translateX(100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes revision-slide-in-start {
+    from { transform: translateX(-100%); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes revision-slide-out-end {
+    from { transform: translateX(0); opacity: 1; }
+    to { transform: translateX(100%); opacity: 0; }
+}
+
+@keyframes revision-slide-out-start {
+    from { transform: translateX(0); opacity: 1; }
+    to { transform: translateX(-100%); opacity: 0; }
 }

--- a/apps/client/src/widgets/dialogs/revisions.css
+++ b/apps/client/src/widgets/dialogs/revisions.css
@@ -34,11 +34,16 @@ body.mobile .revisions-dialog {
         background-color: var(--modal-background-color);
 
         > .btn {
-            flex: 1;
             display: flex;
             align-items: center;
             justify-content: center;
             gap: 4px;
+        }
+
+        /* Restore (the labelled primary action) grows to fill; the icon-only delete/download size
+           to their content. */
+        > .btn:last-child {
+            flex: 1;
         }
     }
 }

--- a/apps/client/src/widgets/dialogs/revisions.css
+++ b/apps/client/src/widgets/dialogs/revisions.css
@@ -3,6 +3,11 @@ body.mobile .revisions-dialog {
         height: 95vh;
     }
 
+    .modal-content {
+        flex: 1;
+        min-height: 0;
+    }
+
     .modal-footer {
         font-size: 0.9em;
     }

--- a/apps/client/src/widgets/dialogs/revisions.css
+++ b/apps/client/src/widgets/dialogs/revisions.css
@@ -118,6 +118,18 @@ body.desktop .revisions-dialog {
                 min-width: 0;
             }
         }
+
+        /* On touch devices the items carry the source/size inline (no hover tooltip), so let the
+           description wrap to its full text and give the rows a little more breathing room. */
+        &.detailed {
+            .dropdown-item {
+                padding-block: 6px;
+            }
+
+            .revision-item-description {
+                white-space: normal;
+            }
+        }
     }
 
     .revision-item-description {

--- a/apps/client/src/widgets/dialogs/revisions.css
+++ b/apps/client/src/widgets/dialogs/revisions.css
@@ -23,6 +23,24 @@ body.mobile .revisions-dialog {
     .revision-content {
         padding: 0.5em;
     }
+
+    /* The action buttons (delete/download/restore) move out of the toolbar into a bottom footer. */
+    .revision-detail-footer {
+        flex-shrink: 0;
+        display: flex;
+        gap: 8px;
+        padding: 12px 16px calc(max(env(safe-area-inset-bottom), 12px));
+        border-top: 1px solid var(--main-border-color);
+        background-color: var(--modal-background-color);
+
+        > .btn {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px;
+        }
+    }
 }
 
 body.desktop .revisions-dialog {

--- a/apps/client/src/widgets/dialogs/revisions.tsx
+++ b/apps/client/src/widgets/dialogs/revisions.tsx
@@ -43,6 +43,7 @@ export default function RevisionsDialog() {
     const [ refreshCounter, setRefreshCounter ] = useState(0);
     const modalRef = useRef<HTMLDivElement>(null);
     const { isMasterDetail, mobileView, switchMobileView, resetMobileView } = useMobileMasterDetail(modalRef, "revision-slide");
+    const isMobile = utils.isMobile();
 
     useTriliumEvent("showRevisions", async ({ noteId }) => {
         const note = await getNote(noteId);
@@ -125,6 +126,13 @@ export default function RevisionsDialog() {
         />
     );
 
+    const handleRevisionDeleted = () => {
+        setRefreshCounter(c => c + 1);
+        setCurrentRevision(undefined);
+        // The detail is now empty; on mobile slide back to the list.
+        switchMobileView("list");
+    };
+
     const menu = note && (
         <RevisionsMenu
             note={note}
@@ -172,12 +180,9 @@ export default function RevisionsDialog() {
                     showDiff={showDiff}
                     setShowDiff={setShowDiff}
                     setShown={setShown}
-                    onRevisionDeleted={() => {
-                        setRefreshCounter(c => c + 1);
-                        setCurrentRevision(undefined);
-                        // The detail is now empty; on mobile slide back to the list.
-                        switchMobileView("list");
-                    }}
+                    // On mobile the action buttons move to a bottom footer instead of the toolbar.
+                    showActions={!isMobile}
+                    onRevisionDeleted={handleRevisionDeleted}
                     onDescriptionUpdated={(revisionId, description) => {
                         setRevisions(prev => prev?.map(r =>
                             r.revisionId === revisionId ? { ...r, description } : r
@@ -194,6 +199,16 @@ export default function RevisionsDialog() {
                         showDiff={showDiff}
                     />
                 </div>
+                {isMobile && currentRevision && canInteractWithRevision(currentRevision) && (
+                    <div className="revision-detail-footer">
+                        <RevisionActions
+                            revisionItem={currentRevision}
+                            setShown={setShown}
+                            onRevisionDeleted={handleRevisionDeleted}
+                            variant="footer"
+                        />
+                    </div>
+                )}
             </div>
         </Modal>
     );
@@ -423,16 +438,18 @@ function RevisionsList({ revisions, onSelect, currentRevision, detailed }: { rev
         </FormList>);
 }
 
-function RevisionToolbar({ revisionItem, showDiff, setShowDiff, setShown, onRevisionDeleted, onDescriptionUpdated }: {
+function RevisionToolbar({ revisionItem, showDiff, setShowDiff, setShown, showActions, onRevisionDeleted, onDescriptionUpdated }: {
     revisionItem?: RevisionItem,
     showDiff: boolean,
     setShowDiff: Dispatch<StateUpdater<boolean>>,
     setShown: Dispatch<StateUpdater<boolean>>,
+    /** Whether the delete/download/restore buttons are shown inline; on mobile they move to a footer. */
+    showActions: boolean,
     onRevisionDeleted?: () => void,
     onDescriptionUpdated?: (revisionId: string, description: string) => void,
 }) {
     const canShowDiff = DIFFABLE_TYPES.includes(revisionItem?.type ?? "");
-    const canInteract = revisionItem && (!revisionItem.isProtected || protected_session_holder.isProtectedSessionAvailable());
+    const canInteract = revisionItem && canInteractWithRevision(revisionItem);
     const [ editingDescription, setEditingDescription ] = useState(false);
     const [ descriptionDraft, setDescriptionDraft ] = useState("");
 
@@ -442,7 +459,7 @@ function RevisionToolbar({ revisionItem, showDiff, setShowDiff, setShown, onRevi
 
     return (
         <div className="revision-toolbar">
-            {revisionItem && (
+            {revisionItem && (canShowDiff || (showActions && canInteract)) && (
                 <div className="revision-toolbar-actions">
                     {canShowDiff && (
                         <FormToggle
@@ -453,38 +470,13 @@ function RevisionToolbar({ revisionItem, showDiff, setShowDiff, setShown, onRevi
                         />
                     )}
                     <div style="flex-grow: 1" />
-                    {canInteract && (
-                        <>
-                            <ActionButton
-                                icon="bx bx-trash"
-                                text={t("revisions.delete_button")}
-                                onClick={async () => {
-                                    if (await dialog.confirm(t("revisions.confirm_delete"))) {
-                                        await server.remove(`revisions/${revisionItem.revisionId}`);
-                                        toast.showMessage(t("revisions.revision_deleted"));
-                                        onRevisionDeleted?.();
-                                    }
-                                }} frame />
-                            <ActionButton
-                                icon="bx bx-download"
-                                text={t("revisions.download_button")}
-                                onClick={() => {
-                                    if (revisionItem.revisionId) {
-                                        open.downloadRevision(revisionItem.noteId, revisionItem.revisionId);
-                                    }
-                                }}
-                                frame />
-                            <Button
-                                icon="bx bx-history"
-                                text={t("revisions.restore_button")}
-                                onClick={async () => {
-                                    if (await dialog.confirm(t("revisions.confirm_restore"))) {
-                                        await server.post(`revisions/${revisionItem.revisionId}/restore`);
-                                        setShown(false);
-                                        toast.showMessage(t("revisions.revision_restored"));
-                                    }
-                                }}/>
-                        </>
+                    {showActions && canInteract && (
+                        <RevisionActions
+                            revisionItem={revisionItem}
+                            setShown={setShown}
+                            onRevisionDeleted={onRevisionDeleted}
+                            variant="toolbar"
+                        />
                     )}
                 </div>
             )}
@@ -508,6 +500,61 @@ function RevisionToolbar({ revisionItem, showDiff, setShowDiff, setShown, onRevi
                 />
             )}
         </div>
+    );
+}
+
+/** Whether the user may delete/download/restore the revision (protected revisions need an unlocked session). */
+function canInteractWithRevision(revisionItem: RevisionItem) {
+    return !revisionItem.isProtected || protected_session_holder.isProtectedSessionAvailable();
+}
+
+/**
+ * The delete/download/restore actions for the current revision. Rendered inline in the toolbar on
+ * desktop (`variant="toolbar"`, icon-only) and as labelled buttons in the detail footer on mobile
+ * (`variant="footer"`).
+ */
+function RevisionActions({ revisionItem, setShown, onRevisionDeleted, variant }: {
+    revisionItem: RevisionItem,
+    setShown: Dispatch<StateUpdater<boolean>>,
+    onRevisionDeleted?: () => void,
+    variant: "toolbar" | "footer"
+}) {
+    const onDelete = async () => {
+        if (await dialog.confirm(t("revisions.confirm_delete"))) {
+            await server.remove(`revisions/${revisionItem.revisionId}`);
+            toast.showMessage(t("revisions.revision_deleted"));
+            onRevisionDeleted?.();
+        }
+    };
+    const onDownload = () => {
+        if (revisionItem.revisionId) {
+            open.downloadRevision(revisionItem.noteId, revisionItem.revisionId);
+        }
+    };
+    const onRestore = async () => {
+        if (await dialog.confirm(t("revisions.confirm_restore"))) {
+            await server.post(`revisions/${revisionItem.revisionId}/restore`);
+            setShown(false);
+            toast.showMessage(t("revisions.revision_restored"));
+        }
+    };
+
+    if (variant === "footer") {
+        return (
+            <>
+                <Button kind="secondary" icon="bx bx-trash" text={t("revisions.delete_button")} onClick={onDelete} />
+                <Button kind="secondary" icon="bx bx-download" text={t("revisions.download_button")} onClick={onDownload} />
+                <Button kind="primary" icon="bx bx-history" text={t("revisions.restore_button")} onClick={onRestore} />
+            </>
+        );
+    }
+
+    return (
+        <>
+            <ActionButton icon="bx bx-trash" text={t("revisions.delete_button")} onClick={onDelete} frame />
+            <ActionButton icon="bx bx-download" text={t("revisions.download_button")} onClick={onDownload} frame />
+            <Button icon="bx bx-history" text={t("revisions.restore_button")} onClick={onRestore} />
+        </>
     );
 }
 

--- a/apps/client/src/widgets/dialogs/revisions.tsx
+++ b/apps/client/src/widgets/dialogs/revisions.tsx
@@ -121,6 +121,7 @@ export default function RevisionsDialog() {
             revisions={revisions ?? []}
             onSelect={selectRevision}
             currentRevision={currentRevision}
+            detailed={utils.isMobile()}
         />
     );
 
@@ -371,15 +372,22 @@ function buildRevisionTooltip(item: RevisionItem): string {
     ].filter(Boolean).join("\n");
 }
 
-function RevisionsList({ revisions, onSelect, currentRevision }: { revisions: RevisionItem[], onSelect: (val: string) => void, currentRevision?: RevisionItem }) {
+function RevisionsList({ revisions, onSelect, currentRevision, detailed }: { revisions: RevisionItem[], onSelect: (val: string) => void, currentRevision?: RevisionItem, detailed?: boolean }) {
     let lastGroup: DateGroup | "" = "";
 
     return (
-        <FormList onSelect={onSelect} fullHeight wrapperClassName="revision-list">
+        <FormList onSelect={onSelect} fullHeight wrapperClassName={clsx("revision-list", detailed && "detailed")}>
             {revisions.map((item) => {
                 const group = item.dateCreated ? getDateGroup(item.dateCreated) : "" as DateGroup;
                 const showHeader = group !== lastGroup;
                 lastGroup = group;
+
+                // On touch devices the hover tooltip is unreachable, so the source/size it carries are
+                // surfaced inline as a meta line instead.
+                const meta = detailed && [
+                    getRevisionSourceTitle(item.source),
+                    item.contentLength && utils.formatSize(item.contentLength)
+                ].filter(Boolean).join(" · ");
 
                 return (
                     <Fragment key={item.revisionId}>
@@ -390,7 +398,7 @@ function RevisionsList({ revisions, onSelect, currentRevision }: { revisions: Re
                             key={item.revisionId}
                             value={item.revisionId}
                             icon={REVISION_SOURCE_ICONS[item.source ?? ""] ?? DEFAULT_REVISION_ICON}
-                            title={buildRevisionTooltip(item)}
+                            title={detailed ? undefined : buildRevisionTooltip(item)}
                             active={currentRevision && item.revisionId === currentRevision.revisionId}
                         >
                             <div>
@@ -400,6 +408,11 @@ function RevisionsList({ revisions, onSelect, currentRevision }: { revisions: Re
                                 {item.description && (
                                     <div className="revision-item-description">
                                         {item.description}
+                                    </div>
+                                )}
+                                {meta && (
+                                    <div className="revision-item-meta">
+                                        {meta}
                                     </div>
                                 )}
                             </div>

--- a/apps/client/src/widgets/dialogs/revisions.tsx
+++ b/apps/client/src/widgets/dialogs/revisions.tsx
@@ -542,8 +542,8 @@ function RevisionActions({ revisionItem, setShown, onRevisionDeleted, variant }:
     if (variant === "footer") {
         return (
             <>
-                <Button kind="secondary" icon="bx bx-trash" text={t("revisions.delete_button")} onClick={onDelete} />
-                <Button kind="secondary" icon="bx bx-download" text={t("revisions.download_button")} onClick={onDownload} />
+                <ActionButton icon="bx bx-trash" text={t("revisions.delete_button")} onClick={onDelete} frame />
+                <ActionButton icon="bx bx-download" text={t("revisions.download_button")} onClick={onDownload} frame />
                 <Button kind="primary" icon="bx bx-history" text={t("revisions.restore_button")} onClick={onRestore} />
             </>
         );

--- a/apps/client/src/widgets/dialogs/revisions.tsx
+++ b/apps/client/src/widgets/dialogs/revisions.tsx
@@ -4,7 +4,7 @@ import { dayjs, type RevisionItem, type RevisionPojo } from "@triliumnext/common
 import clsx from "clsx";
 import { diffWords } from "diff";
 import HtmlDiff from "htmldiff-js";
-import { Fragment } from "preact";
+import { ComponentChildren, Fragment } from "preact";
 import type { CSSProperties } from "preact/compat";
 import { Dispatch, StateUpdater, useEffect, useRef, useState } from "preact/hooks";
 
@@ -25,7 +25,7 @@ import Button from "../react/Button";
 import Dropdown from "../react/Dropdown";
 import FormList, { FormDropdownDivider, FormListItem } from "../react/FormList";
 import FormToggle from "../react/FormToggle";
-import { useTriliumEvent } from "../react/hooks";
+import { useMobileMasterDetail, useTriliumEvent } from "../react/hooks";
 import Modal from "../react/Modal";
 import NoItems from "../react/NoItems";
 import { RawHtmlBlock, SanitizedHtml } from "../react/RawHtml";
@@ -41,11 +41,15 @@ export default function RevisionsDialog() {
     const [ shown, setShown ] = useState(false);
     const [ showDiff, setShowDiff ] = useState(true);
     const [ refreshCounter, setRefreshCounter ] = useState(0);
+    const modalRef = useRef<HTMLDivElement>(null);
+    const { isMasterDetail, mobileView, switchMobileView, resetMobileView } = useMobileMasterDetail(modalRef, "revision-slide");
 
     useTriliumEvent("showRevisions", async ({ noteId }) => {
         const note = await getNote(noteId);
         if (note) {
             setNote(note);
+            // Mobile opens on the revision list; selecting one slides to its detail.
+            resetMobileView("list");
             setShown(true);
         }
     });
@@ -104,67 +108,121 @@ export default function RevisionsDialog() {
         );
     }
 
+    const selectRevision = (revisionId: string) => {
+        const correspondingRevision = (revisions ?? []).find((r) => r.revisionId === revisionId);
+        if (correspondingRevision) {
+            setCurrentRevision(correspondingRevision);
+        }
+        switchMobileView("page");
+    };
+
+    const revisionsList = (
+        <RevisionsList
+            revisions={revisions ?? []}
+            onSelect={selectRevision}
+            currentRevision={currentRevision}
+        />
+    );
+
+    const menu = note && (
+        <RevisionsMenu
+            note={note}
+            onRevisionSaved={() => {
+                setRefreshCounter(c => c + 1);
+                setCurrentRevision(undefined);
+            }}
+            onAllDeleted={() => {
+                setRevisions([]);
+                setCurrentRevision(undefined);
+            }}
+            hasRevisions={true}
+        />
+    );
+
     return (
         <Modal
+            modalRef={modalRef}
             className="revisions-dialog"
             size="xl"
             title={t("revisions.note_revisions")}
             helpPageId="vZWERwf8U3nx"
-            header={note && (
-                <RevisionsMenu
-                    note={note}
-                    onRevisionSaved={() => {
-                        setRefreshCounter(c => c + 1);
-                        setCurrentRevision(undefined);
-                    }}
-                    onAllDeleted={() => {
-                        setRevisions([]);
-                        setCurrentRevision(undefined);
-                    }}
-                    hasRevisions={true}
-                />
-            )}
-            sidebar={
-                <RevisionsList
-                    revisions={revisions ?? []}
-                    onSelect={(revisionId) => {
-                        const correspondingRevision = (revisions ?? []).find((r) => r.revisionId === revisionId);
-                        if (correspondingRevision) {
-                            setCurrentRevision(correspondingRevision);
-                        }
-                    }}
-                    currentRevision={currentRevision}
-                />
-            }
+            header={isMasterDetail
+                ? (
+                    <RevisionsMobileHeader
+                        inPage={mobileView === "page"}
+                        onBack={() => switchMobileView("list")}
+                        revisionItem={currentRevision}
+                        menu={menu}
+                    />
+                )
+                : menu}
+            sidebar={isMasterDetail ? undefined : revisionsList}
             onHidden={onHidden}
             show={shown}
         >
-            <RevisionToolbar
-                revisionItem={currentRevision}
-                showDiff={showDiff}
-                setShowDiff={setShowDiff}
-                setShown={setShown}
-                onRevisionDeleted={() => {
-                    setRefreshCounter(c => c + 1);
-                    setCurrentRevision(undefined);
-                }}
-                onDescriptionUpdated={(revisionId, description) => {
-                    setRevisions(prev => prev?.map(r =>
-                        r.revisionId === revisionId ? { ...r, description } : r
-                    ));
-                    if (currentRevision?.revisionId === revisionId) {
-                        setCurrentRevision({ ...currentRevision, description });
-                    }
-                }}
-            />
-            <div className="revision-content-wrapper">
-                <RevisionPreview
-                    noteContent={noteContent}
+            {isMasterDetail && (
+                <div className="revision-mobile-nav">
+                    {revisionsList}
+                </div>
+            )}
+            <div className="revision-detail">
+                <RevisionToolbar
                     revisionItem={currentRevision}
                     showDiff={showDiff}
+                    setShowDiff={setShowDiff}
+                    setShown={setShown}
+                    onRevisionDeleted={() => {
+                        setRefreshCounter(c => c + 1);
+                        setCurrentRevision(undefined);
+                        // The detail is now empty; on mobile slide back to the list.
+                        switchMobileView("list");
+                    }}
+                    onDescriptionUpdated={(revisionId, description) => {
+                        setRevisions(prev => prev?.map(r =>
+                            r.revisionId === revisionId ? { ...r, description } : r
+                        ));
+                        if (currentRevision?.revisionId === revisionId) {
+                            setCurrentRevision({ ...currentRevision, description });
+                        }
+                    }}
                 />
+                <div className="revision-content-wrapper">
+                    <RevisionPreview
+                        noteContent={noteContent}
+                        revisionItem={currentRevision}
+                        showDiff={showDiff}
+                    />
+                </div>
             </div>
         </Modal>
+    );
+}
+
+/**
+ * Replaces the static "Note revisions" title on narrow mobile (the master-detail flow). In the list
+ * view a decorative history icon precedes the dialog title and the actions menu stays available; in
+ * the page view a back button returns to the list, followed by the revision's date.
+ */
+function RevisionsMobileHeader({ inPage, onBack, revisionItem, menu }: {
+    inPage: boolean,
+    onBack: () => void,
+    revisionItem?: RevisionItem,
+    menu?: ComponentChildren
+}) {
+    const pageTitle = revisionItem?.dateCreated
+        ? dayjs(revisionItem.dateCreated).format("MMM D, YYYY · HH:mm")
+        : t("revisions.note_revisions");
+
+    return (
+        <div className="revision-mobile-header">
+            {inPage ? (
+                <ActionButton icon="bx bx-chevron-left" text={t("revisions.back")} onClick={onBack} />
+            ) : (
+                <span className="revision-header-icon icon-action bx bx-history" aria-hidden="true" />
+            )}
+            <h5 className="revision-mobile-title">{inPage ? pageTitle : t("revisions.note_revisions")}</h5>
+            {!inPage && menu}
+        </div>
     );
 }
 

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -457,10 +457,18 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
 
                 const notePath = treeService.getNotePath(data.node);
 
-                const activeNoteContext = appContext.tabManager.getActiveContext();
+                // Prefer the context this tree is bound to (e.g. a popup editor with its own
+                // hoisted context) over the globally active tab. For the main sidebar tree the
+                // bound context already is the active context, so behaviour is unchanged there.
+                const activeNoteContext = this.noteContext ?? appContext.tabManager.getActiveContext();
                 const opts: SetNoteOpts = {};
                 if (activeNoteContext?.viewScope?.viewMode === "contextual-help") {
                     opts.viewScope = activeNoteContext.viewScope;
+                }
+                // When this tree drives a context other than the active tab (e.g. one embedded in a
+                // popup editor), keep any open dialog so navigating the tree doesn't dismiss the popup.
+                if (activeNoteContext && activeNoteContext !== appContext.tabManager.getActiveContext()) {
+                    opts.keepActiveDialog = true;
                 }
                 await activeNoteContext?.setNote(notePath, opts);
             },

--- a/apps/client/src/widgets/react/Modal.tsx
+++ b/apps/client/src/widgets/react/Modal.tsx
@@ -86,12 +86,18 @@ export interface ModalProps {
      */
     sidebar?: ComponentChildren;
     /**
+     * By default a sidebar modal repeats {@link title} as a header above the sidebar. Set this to
+     * skip that header — useful when {@link title} is the active note's own title (which belongs in
+     * the main header, not duplicated over the sidebar).
+     */
+    hideSidebarHeader?: boolean;
+    /**
      * Indicates if the dialog will be displayed as a full page on mobile devices.
      */
     isFullPageOnMobile?: boolean;
 }
 
-export default function Modal({ children, className, size, title, customTitleBarButtons: titleBarButtons, header, footer, footerStyle, footerAlignment, onShown, onSubmit, helpPageId, minWidth, maxWidth, zIndex, scrollable, onHidden, modalRef: externalModalRef, formRef, bodyStyle, show, stackable, keepInDom, noFocus, sidebar, isFullPageOnMobile }: ModalProps) {
+export default function Modal({ children, className, size, title, customTitleBarButtons: titleBarButtons, header, footer, footerStyle, footerAlignment, onShown, onSubmit, helpPageId, minWidth, maxWidth, zIndex, scrollable, onHidden, modalRef: externalModalRef, formRef, bodyStyle, show, stackable, keepInDom, noFocus, sidebar, hideSidebarHeader, isFullPageOnMobile }: ModalProps) {
     const modalRef = useSyncedRef<HTMLDivElement>(externalModalRef);
     const modalInstanceRef = useRef<BootstrapModal>();
     const elementToFocus = useRef<Element | null>();
@@ -158,7 +164,7 @@ export default function Modal({ children, className, size, title, customTitleBar
             {(show || keepInDom) && <div className={clsx("modal-dialog", `modal-${size}`, {"modal-dialog-scrollable": scrollable, "modal-dialog-full-page-on-mobile": isFullPageOnMobile, "modal-content-with-sidebar": sidebar})} style={documentStyle} role="document">
                 <div className={clsx("modal-content", sidebar && "modal-content-with-sidebar")}>
                     {sidebar && <div className="modal-sidebar">
-                        {title && <div className="modal-sidebar-header">
+                        {title && !hideSidebarHeader && <div className="modal-sidebar-header">
                             <h5>{title}</h5>
                         </div>}
                         {sidebar}

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -944,6 +944,79 @@ export function useWindowSize() {
     return size;
 }
 
+/** Mobile viewports at least this wide (tablets) keep a side-by-side layout; narrower ones get the
+ *  master-detail flow. */
+export const MASTER_DETAIL_TABLET_MIN_WIDTH = 768;
+
+export interface MobileMasterDetail {
+    /** True on narrow mobile viewports where the list and detail collapse into a master-detail flow. */
+    isMasterDetail: boolean;
+    /** Which half of the master-detail flow is currently visible. */
+    mobileView: "list" | "page";
+    /** Switch between the two views with a slide animation. */
+    switchMobileView: (view: "list" | "page") => void;
+    /** Set the view directly without animating (e.g. when (re)opening the dialog). */
+    resetMobileView: (view: "list" | "page") => void;
+}
+
+/**
+ * Drives the mobile master-detail flow shared by dialogs that pair a list with a detail pane (e.g.
+ * the settings and revisions dialogs): it tracks which pane is visible, animates the slide between
+ * them, and toggles the corresponding classes on the modal element (`mobile-master-detail`,
+ * `mobile-view-{list,page}`, `mobile-transition-to-{list,page}`). The dialog supplies the layout and
+ * slide keyframes in CSS; the keyframe names must start with `slideAnimationPrefix` so the in-flight
+ * transition can be cleared once the slide finishes.
+ */
+export function useMobileMasterDetail(modalRef: RefObject<HTMLElement>, slideAnimationPrefix: string): MobileMasterDetail {
+    const [ mobileView, setMobileView ] = useState<"list" | "page">("list");
+    // Direction of the in-flight slide between the two views, or null when at rest. While set, both
+    // panes stay rendered so the outgoing one can slide away as the incoming one slides in.
+    const [ mobileTransition, setMobileTransition ] = useState<"to-list" | "to-page" | null>(null);
+    const isMobile = utils.isMobile();
+    const { windowWidth } = useWindowSize();
+    const isMasterDetail = isMobile && windowWidth < MASTER_DETAIL_TABLET_MIN_WIDTH;
+
+    const switchMobileView = useCallback((view: "list" | "page") => {
+        if (view === mobileView) return;
+        setMobileView(view);
+        // With animations globally disabled there is no animationend to clear the transition, so
+        // switch directly. Outside the master-detail flow there is nothing to animate.
+        if (isMasterDetail && !document.body.classList.contains("motion-disabled")) {
+            setMobileTransition(view === "page" ? "to-page" : "to-list");
+        }
+    }, [ mobileView, isMasterDetail ]);
+
+    const resetMobileView = useCallback((view: "list" | "page") => {
+        setMobileView(view);
+        setMobileTransition(null);
+    }, []);
+
+    // Bootstrap adds its own classes (e.g. `show`) to the modal element at runtime, so the className
+    // prop must stay static; toggle the mobile view classes directly on the element instead.
+    useEffect(() => {
+        modalRef.current?.classList.toggle("mobile-master-detail", isMasterDetail);
+        modalRef.current?.classList.toggle("mobile-view-list", mobileView === "list");
+        modalRef.current?.classList.toggle("mobile-view-page", mobileView === "page");
+        modalRef.current?.classList.toggle("mobile-transition-to-list", mobileTransition === "to-list");
+        modalRef.current?.classList.toggle("mobile-transition-to-page", mobileTransition === "to-page");
+    }, [ isMasterDetail, mobileView, mobileTransition ]);
+
+    // End the view transition once the slide finishes (animationend bubbles up from the panes).
+    useEffect(() => {
+        const modalElement = modalRef.current;
+        if (!modalElement) return;
+        function onAnimationEnd(e: AnimationEvent) {
+            if (e.animationName.startsWith(slideAnimationPrefix)) {
+                setMobileTransition(null);
+            }
+        }
+        modalElement.addEventListener("animationend", onAnimationEnd);
+        return () => modalElement.removeEventListener("animationend", onAnimationEnd);
+    }, [ slideAnimationPrefix ]);
+
+    return { isMasterDetail, mobileView, switchMobileView, resetMobileView };
+}
+
 // Workaround for https://github.com/twbs/bootstrap/issues/37474
 // Bootstrap's dispose() sets ALL properties to null. But pending animation callbacks
 // (scheduled via setTimeout) can still fire and crash when accessing null properties.

--- a/apps/client/src/widgets/type_widgets/options/components/RelatedSettings.tsx
+++ b/apps/client/src/widgets/type_widgets/options/components/RelatedSettings.tsx
@@ -40,12 +40,12 @@ export default function RelatedSettings({ items }: RelatedSettingsProps) {
                         noContainedNavigation={!!targetNoteId}
                         onClick={targetNoteId
                             ? (e) => {
-                                // Hidden-subtree config notes open hoisted, in their own tab.
+                                // Hidden-subtree config notes open hoisted, in a tree-sidebar popup.
                                 // stopPropagation keeps the global `a` click handler
                                 // (link.ts `goToLink`) from navigating by href instead.
                                 e.preventDefault();
                                 e.stopPropagation();
-                                void appContext.tabManager.openInNewTab(targetNoteId, targetNoteId, true);
+                                void appContext.triggerCommand("openInTreePopup", { noteIdOrPath: targetNoteId, hoistedNoteId: targetNoteId });
                             }
                             : undefined}
                     />


### PR DESCRIPTION
## Summary

Two related UX improvements, centered on opening hoisted configuration subtrees in a popup and on the mobile revisions experience.

### Launch bar / config tree popup
- Add an `openInTreePopup` command and a `TreePopupEditor` dialog: a quick-edit-style popup whose sidebar is a note tree hoisted to a requested subtree.
- "Configure launch bar" (`showLaunchBarSubtreeCommand`) now opens the launch bar root in this popup, with the same hoisting it would get in a dedicated tab.
- Task-state config and the `RelatedSettings` hidden-subtree links open in the same popup instead of a new hoisted tab.
- `NoteTreeWidget` prefers its bound `noteContext` over the active tab, and keeps the active dialog open while navigating so the popup isn't dismissed.
- Drop the in-detail "fixed tree" (mobile launch-bar config) — now superseded by the popup's own sidebar tree (no more double tree on mobile).
- Tree popup styling: full-width sidebar on mobile, sidebar tinted like the normal left pane, and the note title (icon + editable title) shown in the modal header via the shared quick-edit `TitleRow` (new backward-compatible `Modal` `hideSidebarHeader` prop).

### Mobile revisions
- Master-detail flow for the revisions dialog on mobile: revision details inline, actions moved to a footer, restore action labelled, bottom sheet fills height.

## Test plan
- `pnpm typecheck`
- Manual: configure launch bar (desktop + mobile), task-state config, revisions dialog on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)