### PR TITLE
Revive the Mermaid diagram linter and improve render-error display

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1159,6 +1159,11 @@
   "editable_code": {
     "placeholder": "Type the content of your code note here..."
   },
+  "split_editor": {
+    "render_error": "Unable to render the preview",
+    "show_details": "Show details",
+    "last_valid_render": "Showing last valid render"
+  },
   "editable_text": {
     "placeholder": "Type the content of your note here...",
     "editor_crashed_title": "The text editor crashed",

--- a/apps/client/src/widgets/react/Admonition.css
+++ b/apps/client/src/widgets/react/Admonition.css
@@ -1,0 +1,41 @@
+/* Extended admonition: an icon + title header, a body and an optional details
+   collapsible. Builds on the base `.admonition`, but swaps its accent border for a
+   neutral hairline and shows the type accent as a clipped leading bar instead. */
+.admonition.extended-admonition {
+    /* The header carries its own icon, so the space reserved for the base
+       `::before` icon is not needed. A neutral hairline border surrounds the card,
+       with the type accent shown only as the leading bar below. */
+    padding-inline-start: 1em;
+    border-color: var(--main-border-color);
+}
+
+/* Thick accent bar on the leading edge. It has no radius of its own; the card's
+   rounded corners (with the base `overflow: hidden`) clip it to shape. */
+.admonition.extended-admonition::before {
+    content: "";
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    width: 4px;
+    background-color: var(--accent-color);
+}
+
+.extended-admonition .admonition-header {
+    display: flex;
+    align-items: center;
+    gap: 0.4em;
+    margin-block-end: 0.35em;
+}
+
+.extended-admonition .admonition-header .tn-icon {
+    color: var(--accent-color);
+    font-size: 1.2em;
+}
+
+.extended-admonition .admonition-title {
+    font-weight: 600;
+}
+
+.extended-admonition .admonition-details {
+    margin-block-start: 0.5em;
+}

--- a/apps/client/src/widgets/react/Admonition.tsx
+++ b/apps/client/src/widgets/react/Admonition.tsx
@@ -1,5 +1,10 @@
-import { HTML } from "mermaid/dist/diagram-api/types.js";
+import "./Admonition.css";
+
+import clsx from "clsx";
 import { ComponentChildren, HTMLAttributes } from "preact";
+
+import Collapsible from "./Collapsible";
+import Icon from "./Icon";
 
 interface AdmonitionProps extends Pick<HTMLAttributes<HTMLDivElement>, "style"> {
     type: "warning" | "note" | "caution";
@@ -9,8 +14,43 @@ interface AdmonitionProps extends Pick<HTMLAttributes<HTMLDivElement>, "style"> 
 
 export default function Admonition({ type, children, className, ...props }: AdmonitionProps) {
     return (
-        <div className={`admonition ${type} ${className}`} role="alert" {...props}>
+        <div className={clsx("admonition", type, className)} role="alert" {...props}>
             {children}
+        </div>
+    );
+}
+
+interface ExtendedAdmonitionProps extends AdmonitionProps {
+    /** Boxicons class for the header icon, e.g. `bx bx-error-circle`. */
+    icon: string;
+    /** Bold heading shown next to the icon. */
+    title: string;
+    /** Optional content revealed by a collapsible below the body. */
+    details?: ComponentChildren;
+    /** Label for the details collapsible toggle; provide it whenever `details` is set. */
+    detailsLabel?: string;
+}
+
+/**
+ * An {@link Admonition} with a richer layout: an icon + title header, a body
+ * (`children`) and an optional collapsible "details" section. Reuse for inline
+ * error/notice cards that need more than a single block of text.
+ */
+export function ExtendedAdmonition({ type, icon, title, details, detailsLabel, className, children, ...props }: ExtendedAdmonitionProps) {
+    return (
+        <div className={clsx("admonition", "extended-admonition", type, className)} role="alert" {...props}>
+            <div className="admonition-header">
+                <Icon icon={icon} />
+                <span className="admonition-title">{title}</span>
+            </div>
+            <div className="admonition-body">
+                {children}
+            </div>
+            {details && (
+                <Collapsible className="admonition-details" title={detailsLabel ?? ""}>
+                    {details}
+                </Collapsible>
+            )}
         </div>
     );
 }

--- a/apps/client/src/widgets/type_widgets/helpers/SplitEditor.css
+++ b/apps/client/src/widgets/type_widgets/helpers/SplitEditor.css
@@ -61,7 +61,7 @@ body.desktop .note-detail-split .note-detail-code-editor {
     user-select: text;
 }
 
-.note-detail-error-card pre {
+.note-detail-split .note-detail-error-card pre {
     margin: 0.5em 0 0;
     padding: 0.5em 0.75em;
     border-radius: 4px;

--- a/apps/client/src/widgets/type_widgets/helpers/SplitEditor.css
+++ b/apps/client/src/widgets/type_widgets/helpers/SplitEditor.css
@@ -36,13 +36,54 @@ body.desktop .note-detail-split .note-detail-code-editor {
     margin-top: 1px;
 }
 
-.note-detail-split .note-detail-error-container {
-    font-family: var(--monospace-font-family);
-    margin: 5px;
-    white-space: pre-wrap;
-    font-size: 0.85em;
+/* Error card, anchored to the top so the dimmed last render stays visible behind it.
+   The card's header/details layout comes from `.extended-admonition`; here we only
+   position it as an overlay and give it a solid background so the dimmed preview
+   underneath doesn't bleed through the text. */
+.note-detail-split .note-detail-split-preview-col .note-detail-error-card {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline: 0;
+    margin: 10px;
+    max-height: calc(100% - 20px);
     overflow: auto;
+    z-index: 10;
+
+    background-color: var(--main-background-color);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.note-detail-split .note-detail-error-message {
+    font-family: var(--monospace-font-family);
+    font-size: 0.85em;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
     user-select: text;
+}
+
+.note-detail-error-card pre {
+    margin: 0.5em 0 0;
+    padding: 0.5em 0.75em;
+    border-radius: 4px;
+    background-color: var(--accented-background-color);
+    font-family: var(--monospace-font-family);
+    font-size: 0.8em;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    user-select: text;
+}
+
+/* "Showing last valid render" badge, anchored bottom-left over the dimmed preview. */
+.note-detail-split .note-detail-error-stale-badge.ext-badge {
+    position: absolute;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    margin: 10px;
+    z-index: 10;
+
+    --badge-radius: 12px;
+    --color: var(--accented-background-color);
+    color: var(--muted-text-color);
 }
 
 .note-detail-split .note-detail-split-preview {

--- a/apps/client/src/widgets/type_widgets/helpers/SplitEditor.tsx
+++ b/apps/client/src/widgets/type_widgets/helpers/SplitEditor.tsx
@@ -4,16 +4,20 @@ import Split from "@triliumnext/split.js";
 import { ComponentChildren } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
+import { t } from "../../../services/i18n";
 import { DEFAULT_GUTTER_SIZE } from "../../../services/resizer";
 import utils, { isMobile } from "../../../services/utils";
 import ActionButton, { ActionButtonProps } from "../../react/ActionButton";
-import Admonition from "../../react/Admonition";
+import { ExtendedAdmonition } from "../../react/Admonition";
+import { Badge } from "../../react/Badge";
 import { useEffectiveReadOnly, useNoteBlob, useNoteLabel, useTriliumOption } from "../../react/hooks";
 import { EditableCode, EditableCodeProps, ReadOnlyCode } from "../code/Code";
 
 export interface SplitEditorProps extends EditableCodeProps {
     className?: string;
     error?: string | null;
+    /** When the preview still shows a previous successful render despite the current {@link error}. */
+    previewStale?: boolean;
     splitOptions?: Split.Options;
     previewContent: ComponentChildren;
     previewButtons?: ComponentChildren;
@@ -37,7 +41,7 @@ export interface SplitEditorProps extends EditableCodeProps {
  * - Can display errors to the user via {@link setError}.
  * - Horizontal or vertical orientation for the editor/preview split, adjustable via the switch split orientation button floating button.
  */
-export default function SplitEditor({ note, noteContext, error, splitOptions, previewContent, previewButtons, className, editorBefore, forceOrientation, extraContent, ...editorProps }: SplitEditorProps) {
+export default function SplitEditor({ note, noteContext, error, previewStale, splitOptions, previewContent, previewButtons, className, editorBefore, forceOrientation, extraContent, ...editorProps }: SplitEditorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const splitEditorOrientation = useSplitOrientation(forceOrientation);
     const [ displayMode ] = useNoteLabel(note, "displayMode");
@@ -80,17 +84,13 @@ export default function SplitEditor({ note, noteContext, error, splitOptions, pr
                         {...editorProps}
                     />}
             </div>
-            {error && (
-                <Admonition type="caution" className="note-detail-error-container">
-                    {error}
-                </Admonition>
-            )}
             {extraContent}
         </div>
     );
 
     const preview = previewMounted.current && <PreviewContainer
         error={error}
+        previewStale={previewStale}
         previewContent={previewContent}
         previewButtons={previewButtons}
     />;
@@ -123,21 +123,60 @@ export default function SplitEditor({ note, noteContext, error, splitOptions, pr
     );
 }
 
-function PreviewContainer({ error, previewContent, previewButtons }: {
+function PreviewContainer({ error, previewStale, previewContent, previewButtons }: {
     error?: string | null;
+    previewStale?: boolean;
     previewContent: ComponentChildren;
     previewButtons?: ComponentChildren;
 }) {
+    const { summary, details } = error ? splitPreviewError(error) : {};
     return (
         <div className="note-detail-split-preview-col">
             <div className={`note-detail-split-preview ${error ? "on-error" : ""}`}>
                 {previewContent}
             </div>
+            {error && (
+                <ExtendedAdmonition
+                    className="note-detail-error-card"
+                    type="caution"
+                    icon="bx bx-error-circle"
+                    title={t("split_editor.render_error")}
+                    detailsLabel={t("split_editor.show_details")}
+                    details={details && <pre>{details}</pre>}
+                >
+                    <div className="note-detail-error-message">{summary}</div>
+                </ExtendedAdmonition>
+            )}
+            {error && previewStale && (
+                <Badge
+                    className="note-detail-error-stale-badge"
+                    icon="bx bx-history"
+                    text={t("split_editor.last_valid_render")}
+                />
+            )}
             <div className="btn-group btn-group-sm map-type-switcher content-floating-buttons preview-buttons bottom-right" role="group">
                 {previewButtons}
             </div>
         </div>
     );
+}
+
+/**
+ * Splits a raw preview/render error into its first line, shown under the title as a
+ * headline, and the remaining lines, revealed by the "show details" collapsible. The
+ * first line is never repeated in the details; `details` is omitted when the error is
+ * a single line.
+ */
+function splitPreviewError(error: string): { summary: string; details?: string } {
+    const trimmed = error.trim();
+    const newlineIndex = trimmed.indexOf("\n");
+    if (newlineIndex < 0) {
+        return { summary: trimmed };
+    }
+    return {
+        summary: trimmed.slice(0, newlineIndex).trim(),
+        details: trimmed.slice(newlineIndex + 1).trim() || undefined
+    };
 }
 
 export function PreviewButton(props: Omit<ActionButtonProps, "titlePosition">) {

--- a/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
+++ b/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
@@ -115,6 +115,7 @@ export default function SvgSplitEditor({ ntxId, note, attachmentName, renderSvg,
             className="svg-editor"
             note={note} ntxId={ntxId}
             error={error}
+            previewStale={!!svg}
             onContentChanged={onContentChanged}
             dataSaved={onSave}
             placeholder={t("mermaid.placeholder")}

--- a/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
+++ b/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
@@ -41,6 +41,13 @@ export default function SvgSplitEditor({ ntxId, note, attachmentName, renderSvg,
     const [ error, setError ] = useState<string | null | undefined>();
     const containerRef = useRef<HTMLDivElement>(null);
 
+    // Reset the render state when switching notes so a previous note's render (and the
+    // "showing last valid render" badge) can't briefly carry over to a different note.
+    useEffect(() => {
+        setSvg(undefined);
+        setError(undefined);
+    }, [ note.noteId ]);
+
     // Render the SVG.
     async function onContentChanged(content: string) {
         try {

--- a/apps/client/src/widgets/type_widgets/linters/mermaid.spec.ts
+++ b/apps/client/src/widgets/type_widgets/linters/mermaid.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { trimIndentation } from "@triliumnext/commons";
+import { getMermaidDiagnostics } from "./mermaid.js";
+
+describe("Mermaid linter", () => {
+
+    it("reports correctly bad diagram type", async () => {
+        const input = trimIndentation`\
+            stateDiagram-v23
+            [*] -> Still
+        `;
+
+        const result = await getMermaidDiagnostics(input);
+        expect(result).toMatchObject([{
+            message: "Expecting 'SPACE', 'NL', 'SD', got 'ID'",
+            fromLine: 1,
+            fromColumn: 0,
+            toLine: 1,
+            toColumn: 1
+        }]);
+    });
+
+    it("reports lexical errors by highlighting the whole line", async () => {
+        const input = trimIndentation`\
+            flowchart TDs
+                A[Christmas] -->|Get money| B(Go shopping)
+        `;
+
+        const result = await getMermaidDiagnostics(input);
+        expect(result).toMatchObject([{
+            message: "Lexical error on line 1. Unrecognized text.",
+            fromLine: 1,
+            fromColumn: 0,
+            toLine: 1,
+            toColumn: "flowchart TDs".length
+        }]);
+    });
+
+    it("reports correctly basic arrow missing in diagram", async () => {
+        const input = trimIndentation`\
+            xychart-beta horizontal
+            title "Percentage usge"
+            x-axis [data, sys, usr, var]
+            y-axis 0--->100
+            bar [20, 70, 0, 0]
+        `;
+
+        const result = await getMermaidDiagnostics(input);
+        expect(result).toMatchObject([{
+            message: "Expecting 'ARROW_DELIMITER', got 'MINUS'",
+            fromLine: 4,
+            fromColumn: 8,
+            toLine: 4,
+            toColumn: 9
+        }]);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/linters/mermaid.ts
+++ b/apps/client/src/widgets/type_widgets/linters/mermaid.ts
@@ -46,12 +46,26 @@ export async function validateMermaid(view: EditorView): Promise<Diagnostic[]> {
     const { doc } = view.state;
     const diagnostics = await getMermaidDiagnostics(doc.toString());
 
-    return diagnostics.map(({ message, fromLine, fromColumn, toLine, toColumn }) => ({
-        severity: "error",
-        message,
-        from: doc.line(fromLine).from + fromColumn,
-        to: doc.line(toLine).from + toColumn
-    }));
+    return diagnostics.map(({ message, fromLine, fromColumn, toLine, toColumn }) => {
+        // Clamp to the document/line bounds: an out-of-range position reported by a future
+        // Mermaid version would otherwise throw from doc.line() and (since this is an async
+        // lint source) silently drop every diagnostic.
+        const fromLineObj = doc.line(clampLine(fromLine, doc.lines));
+        const toLineObj = doc.line(clampLine(toLine, doc.lines));
+        const from = Math.min(fromLineObj.from + fromColumn, fromLineObj.to);
+        const to = Math.min(toLineObj.from + toColumn, toLineObj.to);
+
+        return {
+            severity: "error",
+            message,
+            from: Math.min(from, to),
+            to: Math.max(from, to)
+        };
+    });
+}
+
+function clampLine(line: number, lineCount: number) {
+    return Math.max(1, Math.min(line, lineCount));
 }
 
 /**
@@ -73,6 +87,11 @@ export async function getMermaidDiagnostics(text: string): Promise<MermaidLineDi
     try {
         await mermaid.parse(text);
     } catch (e: unknown) {
+        if (typeof e !== "object" || e === null) {
+            // mermaid.parse is expected to throw a structured error object; bail out
+            // gracefully if it ever rejects with a primitive or null.
+            return [];
+        }
         const hash = (e as MermaidParseError).hash;
         if (!hash) {
             // Some diagram types (e.g. the newer Langium-based parsers) throw errors

--- a/apps/client/src/widgets/type_widgets/linters/mermaid.ts
+++ b/apps/client/src/widgets/type_widgets/linters/mermaid.ts
@@ -1,0 +1,142 @@
+import { type Diagnostic, linter, lintGutter } from "@codemirror/lint";
+import type { EditorView } from "@codemirror/view";
+
+interface MermaidParseError extends Error {
+    hash: {
+        text: string;
+        token: string | null;
+        /** 0-based line number reported for lexical errors. */
+        line: number;
+        /** Present for parser (grammar) errors; absent for lexical errors. */
+        loc?: {
+            first_line: number;
+            first_column: number;
+            last_line: number;
+            last_column: number;
+        };
+        expected?: string[];
+    };
+}
+
+/** A Mermaid parse error expressed in editor line/column coordinates. */
+export interface MermaidLineDiagnostic {
+    message: string;
+    /** 1-based line number, matching CodeMirror's `doc.line()`. */
+    fromLine: number;
+    fromColumn: number;
+    toLine: number;
+    toColumn: number;
+}
+
+/**
+ * Builds a CodeMirror 6 lint extension that surfaces Mermaid parse errors inline
+ * as the user edits the diagram source. The extension re-runs (debounced) on
+ * every document change, so no manual re-triggering is required. `lintGutter()`
+ * adds the error markers in the gutter alongside the inline underline.
+ */
+export default function mermaidLinter() {
+    return [ linter(validateMermaid), lintGutter() ];
+}
+
+/**
+ * Lint source for {@link mermaidLinter}: parses the editor content and maps any
+ * Mermaid error onto CodeMirror's absolute-offset {@link Diagnostic} positions.
+ */
+export async function validateMermaid(view: EditorView): Promise<Diagnostic[]> {
+    const { doc } = view.state;
+    const diagnostics = await getMermaidDiagnostics(doc.toString());
+
+    return diagnostics.map(({ message, fromLine, fromColumn, toLine, toColumn }) => ({
+        severity: "error",
+        message,
+        from: doc.line(fromLine).from + fromColumn,
+        to: doc.line(toLine).from + toColumn
+    }));
+}
+
+/**
+ * Parses Mermaid diagram source and returns any parse error as a line/column
+ * diagnostic. Extracted from {@link validateMermaid} so the message and position
+ * handling can be unit-tested without a live editor.
+ *
+ * Mermaid throws two differently-shaped errors: grammar (parser) errors carry a
+ * `hash.loc` with precise positions, while lexical errors only report a 0-based
+ * `hash.line` — for those we highlight the whole offending line.
+ */
+export async function getMermaidDiagnostics(text: string): Promise<MermaidLineDiagnostic[]> {
+    if (!text.trim()) {
+        return [];
+    }
+
+    const mermaid = (await import("mermaid")).default;
+
+    try {
+        await mermaid.parse(text);
+    } catch (e: unknown) {
+        const hash = (e as MermaidParseError).hash;
+        if (!hash) {
+            // Some diagram types (e.g. the newer Langium-based parsers) throw errors
+            // without jison-style position info; we can't place a marker for those.
+            return [];
+        }
+
+        const message = (e as MermaidParseError).message;
+
+        if (hash.loc) {
+            return [ buildParseDiagnostic(message, hash.loc) ];
+        }
+
+        if (typeof hash.line === "number") {
+            return [ buildLexicalDiagnostic(message, hash.line, text) ];
+        }
+
+        return [];
+    }
+
+    return [];
+}
+
+/** Builds a precise diagnostic from a grammar (parser) error's `loc`. */
+function buildParseDiagnostic(message: string, loc: NonNullable<MermaidParseError["hash"]["loc"]>): MermaidLineDiagnostic {
+    let fromColumn = loc.first_column + 1;
+    const toColumn = loc.last_column + 1;
+
+    // A zero-width error at the very start of a line points before the first
+    // character; anchor it to the line start so the marker stays visible.
+    if (fromColumn === 1 && toColumn === 1) {
+        fromColumn = 0;
+    }
+
+    // Mermaid prepends a few lines of boilerplate ("Parse error on line N:" plus
+    // a caret diagram) before the useful "Expecting …" message.
+    let messageLines = message.split("\n");
+    if (messageLines.length >= 4) {
+        messageLines = messageLines.slice(3);
+    }
+
+    return {
+        message: messageLines.join("\n"),
+        fromLine: loc.first_line,
+        fromColumn,
+        toLine: loc.last_line,
+        toColumn
+    };
+}
+
+/**
+ * Builds a diagnostic for a lexical error, which carries no column info — only a
+ * 0-based line. The whole offending line is highlighted, and only the first
+ * message line is kept (the rest is a caret diagram that can't be re-aligned).
+ */
+function buildLexicalDiagnostic(message: string, zeroBasedLine: number, text: string): MermaidLineDiagnostic {
+    const line = zeroBasedLine + 1;
+    const lineContent = text.split("\n")[line - 1] ?? "";
+
+    return {
+        message: message.split("\n")[0],
+        fromLine: line,
+        fromColumn: 0,
+        toLine: line,
+        toColumn: lineContent.length
+    };
+}

--- a/apps/client/src/widgets/type_widgets/mermaid/Mermaid.tsx
+++ b/apps/client/src/widgets/type_widgets/mermaid/Mermaid.tsx
@@ -1,3 +1,4 @@
+import type CodeMirror from "@triliumnext/codemirror";
 import { useCallback } from "preact/hooks";
 
 import { t } from "../../../services/i18n";
@@ -5,19 +6,15 @@ import { getMermaidConfig, loadElkIfNeeded, postprocessMermaidSvg } from "../../
 import NoteContentSwitcher from "../../layout/NoteContentSwitcher";
 import SvgSplitEditor from "../helpers/SvgSplitEditor";
 import { TypeWidgetProps } from "../type_widget";
+import mermaidLinter from "../linters/mermaid";
 import SAMPLE_DIAGRAMS from "./sample_diagrams";
 
 let idCounter = 1;
-let registeredErrorReporter = false;
 
 export default function Mermaid(props: TypeWidgetProps) {
     const renderSvg = useCallback(async (content: string) => {
         const mermaid = (await import("mermaid")).default;
         await loadElkIfNeeded(mermaid, content);
-        if (!registeredErrorReporter) {
-            // (await import("./linters/mermaid.js")).default();
-            registeredErrorReporter = true;
-        }
 
         if (!content.trim()) {
             return "";
@@ -33,10 +30,16 @@ export default function Mermaid(props: TypeWidgetProps) {
         return postprocessMermaidSvg(svg);
     }, []);
 
+    // Attach the Mermaid lint extension once the underlying CodeMirror editor is ready.
+    const setupEditor = useCallback((editor: CodeMirror | null) => {
+        editor?.setNamedExtension("mermaid-lint", mermaidLinter());
+    }, []);
+
     return (
         <SvgSplitEditor
             attachmentName="mermaid-export"
             renderSvg={renderSvg}
+            editorRef={setupEditor}
             noteType="mermaid"
             extraContent={(
                 <NoteContentSwitcher

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -26,6 +26,21 @@ const preventCtrlEnterKeymap: readonly KeyBinding[] = [
     }
 ];
 
+// Lint diagnostics (e.g. the TypeScript script linter or the Mermaid linter) can produce very
+// long messages; without a width cap and wrapping the tooltip overflows the editor and gets
+// clipped at the edges. `.cm-tooltip-lint` is the diagnostics list shared by both the gutter
+// tooltip (where it also carries `.cm-tooltip`) and the inline hover tooltip (where it's nested
+// inside a `.cm-tooltip-hover` wrapper), so targeting it directly covers both.
+const lintTooltipTheme = EditorView.baseTheme({
+    ".cm-tooltip-lint": {
+        maxWidth: "min(40em, 90vw)"
+    },
+    ".cm-diagnostic": {
+        whiteSpace: "normal",
+        overflowWrap: "anywhere"
+    }
+});
+
 type ContentChangedListener = () => void;
 
 export interface EditorConfig {
@@ -91,6 +106,7 @@ export default class CodeMirror extends EditorView {
             languageCompartment.of([]),
             lineWrappingCompartment.of(config.lineWrapping ? EditorView.lineWrapping : []),
             searchMatchHighlightTheme,
+            lintTooltipTheme,
             searchHighlightCompartment.of([]),
             typeCompletionCompartment.of([]),
             completionSourceCompartment.of([]),


### PR DESCRIPTION
## Summary

Revives the previously-removed Mermaid diagram linter (ported to CodeMirror 6) and overhauls how render errors are surfaced in the split editor.

### Mermaid linter (CodeMirror 6)
- Restores the linter that was removed in `c597ad7694`, ported from the legacy CM5 `registerHelper` API to `@codemirror/lint`'s `linter()` (auto-runs, debounced, on every doc change).
- Handles both **grammar errors** (precise `loc` positions) and **lexical errors** (no `loc` — highlights the whole offending line).
- Adds `lintGutter()` for gutter markers alongside the inline underline.
- Wired into the Mermaid widget via the editor `editorRef`.
- Unit tests for grammar, lexical, and missing-arrow cases.

### Lint tooltip wrapping (codemirror package)
- Long lint diagnostics (Mermaid's `Expecting … got …`, or the TypeScript script linter) no longer overflow and clip. A package-level `baseTheme` caps `.cm-tooltip-lint` width and wraps the text, covering both the gutter and inline-hover tooltips for **every** linter.

### Render-error display (split editor)
- Moves the render-error out from under the code editor into the **preview pane**, so it shows in preview-only mode and doesn't compete with the inline linter.
- Renders as a new reusable **`ExtendedAdmonition`** component (icon + title header, body, optional collapsible "Show details"), with a neutral hairline border and a clipped accent bar on the leading edge.
- Anchored over the dimmed last-good render, with a "Showing last valid render" badge.
- Body shows the error's first line; the collapsible holds the remainder (no duplication).

## Test plan
- `pnpm --filter @triliumnext/client test src/widgets/type_widgets/linters/mermaid.spec.ts` — passes (3 tests).
- Client + codemirror typecheck clean; ESLint clean (no new warnings).
- Manual: break a Mermaid diagram and verify inline + gutter lint markers, wrapped tooltips, and the error card across source / split / preview modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)