### PR TITLE
feat(text): add an option to auto-capitalize first letter of sentence

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2316,7 +2316,9 @@
     "note_completion_enabled": "Note auto-completion",
     "note_completion_description": "Links to notes can be created by typing `@` followed by the title of a note.",
     "slash_commands_enabled": "Slash commands",
-    "slash_commands_description": "Editing commands such as inserting line breaks or headings can be toggled by typing `/`."
+    "slash_commands_description": "Editing commands such as inserting line breaks or headings can be toggled by typing `/`.",
+    "auto_capitalize_enabled": "Automatic capitalization",
+    "auto_capitalize_description": "Capitalizes the first letter of a sentence as you type, after `.`, `!` or `?` and at the start of a line."
   },
   "table_view": {
     "new-row": "New row",

--- a/apps/client/src/widgets/type_widgets/options/text_notes.tsx
+++ b/apps/client/src/widgets/type_widgets/options/text_notes.tsx
@@ -127,6 +127,7 @@ function EditorFeatures() {
     const [emojiCompletionEnabled, setEmojiCompletionEnabled] = useTriliumOptionBool("textNoteEmojiCompletionEnabled");
     const [noteCompletionEnabled, setNoteCompletionEnabled] = useTriliumOptionBool("textNoteCompletionEnabled");
     const [slashCommandsEnabled, setSlashCommandsEnabled] = useTriliumOptionBool("textNoteSlashCommandsEnabled");
+    const [autoCapitalizeEnabled, setAutoCapitalizeEnabled] = useTriliumOptionBool("textNoteAutoCapitalizeEnabled");
 
     return (
         <OptionsSection title={t("editorfeatures.title")}>
@@ -152,6 +153,14 @@ function EditorFeatures() {
                 description={t("editorfeatures.slash_commands_description")}
                 currentValue={slashCommandsEnabled}
                 onChange={setSlashCommandsEnabled}
+            />
+
+            <OptionsRowWithToggle
+                name="auto-capitalize-enabled"
+                label={t("editorfeatures.auto_capitalize_enabled")}
+                description={t("editorfeatures.auto_capitalize_description")}
+                currentValue={autoCapitalizeEnabled}
+                onChange={setAutoCapitalizeEnabled}
             />
         </OptionsSection>
     );

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -294,5 +294,9 @@ function getDisabledPlugins() {
         disabledPlugins.push("SlashCommand");
     }
 
+    if (options.get("textNoteAutoCapitalizeEnabled") !== "true") {
+        disabledPlugins.push("AutoCapitalize");
+    }
+
     return disabledPlugins;
 }

--- a/packages/ckeditor5/src/plugins.ts
+++ b/packages/ckeditor5/src/plugins.ts
@@ -45,6 +45,7 @@ import IncludeNoteToolbar from "./plugins/include_note_toolbar.js";
 import LinkEmbedToolbar from "./plugins/link_embed_toolbar.js";
 import TodoListMultistate from "./plugins/todo_list_multistate/todo_list_multistate.js";
 import CollapsibleListItems from "./plugins/collapsible_list_items.js";
+import AutoCapitalize from "./plugins/auto_capitalize.js";
 
 /**
  * Plugins that are specific to Trilium and not part of the CKEditor 5 core, included in both text editors but not in the attribute editor.
@@ -77,6 +78,7 @@ const TRILIUM_PLUGINS: typeof Plugin[] = [
     LinkEmbedToolbar,
     TodoListMultistate,
     CollapsibleListItems,
+    AutoCapitalize,
     CopyAnchorLinkButton,
     CopyLinkUrlButton,
     ImageActions,

--- a/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
@@ -1,4 +1,7 @@
-import { _getModelData as getModelData, _setModelData as setModelData, Bold, Code, CodeBlock, Essentials, Paragraph } from "ckeditor5";
+import {
+    _getModelData as getModelData, _setModelData as setModelData,
+    Bold, Code, CodeBlock, Essentials, Paragraph
+} from "ckeditor5";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createTestEditor } from "../../test/editor-kit.js";
@@ -8,7 +11,9 @@ describe("AutoCapitalize", () => {
     let editor: Awaited<ReturnType<typeof createTestEditor>>;
 
     beforeEach(async () => {
-        editor = await createTestEditor([Essentials, Paragraph, Bold, Code, CodeBlock, AutoCapitalize]);
+        editor = await createTestEditor([
+            Essentials, Paragraph, Bold, Code, CodeBlock, AutoCapitalize
+        ]);
     });
 
     // Type text the way real keystrokes are processed: the Typing plugin wraps
@@ -17,13 +22,21 @@ describe("AutoCapitalize", () => {
     // the plugin exactly as it runs during actual typing.
     const type = (text: string) => {
         const command = editor.commands.get("insertText");
+        if (!command) {
+            throw new Error("insertText command is not registered");
+        }
         for (const ch of text) {
-            editor.model.enqueueChange(command!.buffer.batch, () => {
-                const selection = editor.model.createSelection(editor.model.document.selection.getRanges());
+            editor.model.enqueueChange(command.buffer.batch, () => {
+                const ranges = editor.model.document.selection.getRanges();
+                const selection = editor.model.createSelection(ranges);
                 editor.execute("insertText", { text: ch, selection });
             });
         }
     };
+
+    // Assert the model content (with the selection marker) after an action.
+    const expectModel = (expected: string) =>
+        expect(getModelData(editor.model)).toBe(expected);
 
     it("loads the plugin", () => {
         expect(editor.plugins.get(AutoCapitalize)).toBeInstanceOf(AutoCapitalize);
@@ -33,44 +46,50 @@ describe("AutoCapitalize", () => {
         it("at the start of a block (only the first word)", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hi there");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hi there[]</paragraph>");
+            expectModel("<paragraph>Hi there[]</paragraph>");
         });
 
         it("after a period and a space", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("one. two now");
-            expect(getModelData(editor.model)).toBe("<paragraph>One. Two now[]</paragraph>");
+            expectModel("<paragraph>One. Two now[]</paragraph>");
         });
 
         it("after an exclamation mark", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("wow! yes ok");
-            expect(getModelData(editor.model)).toBe("<paragraph>Wow! Yes ok[]</paragraph>");
+            expectModel("<paragraph>Wow! Yes ok[]</paragraph>");
         });
 
         it("after a question mark", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("ok? no way");
-            expect(getModelData(editor.model)).toBe("<paragraph>Ok? No way[]</paragraph>");
+            expectModel("<paragraph>Ok? No way[]</paragraph>");
         });
 
         it("the single-letter word \"i\"", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("i am");
-            expect(getModelData(editor.model)).toBe("<paragraph>I am[]</paragraph>");
+            expectModel("<paragraph>I am[]</paragraph>");
         });
 
         it("after a closing quote that follows the punctuation", () => {
             setModelData(editor.model, "<paragraph>He said \"ok.\" []</paragraph>");
             type("go now");
-            expect(getModelData(editor.model)).toBe("<paragraph>He said \"ok.\" Go now[]</paragraph>");
+            expectModel("<paragraph>He said \"ok.\" Go now[]</paragraph>");
+        });
+
+        it("treating a non-text inline element as a word break", () => {
+            setModelData(editor.model, "<paragraph>Done.<softBreak></softBreak>now[]</paragraph>");
+            type(" ");
+            expectModel("<paragraph>Done.<softBreak></softBreak>Now []</paragraph>");
         });
 
         it("when the sentence boundary is far back in a long paragraph", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("word ".repeat(15) + "done. now ok");
             const lead = "Word " + "word ".repeat(14);
-            expect(getModelData(editor.model)).toBe(`<paragraph>${lead}done. Now ok[]</paragraph>`);
+            expectModel(`<paragraph>${lead}done. Now ok[]</paragraph>`);
         });
 
         it("preserves inline formatting carried by the letter", () => {
@@ -85,15 +104,15 @@ describe("AutoCapitalize", () => {
         it("does not capitalize a word that has not been ended yet", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello");
-            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+            expectModel("<paragraph>hello[]</paragraph>");
         });
 
         it("capitalizes as soon as the ending space is typed", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello");
-            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+            expectModel("<paragraph>hello[]</paragraph>");
             type(" ");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello []</paragraph>");
+            expectModel("<paragraph>Hello []</paragraph>");
         });
     });
 
@@ -102,28 +121,34 @@ describe("AutoCapitalize", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello");
             editor.execute("enter");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello</paragraph><paragraph>[]</paragraph>");
+            expectModel("<paragraph>Hello</paragraph><paragraph>[]</paragraph>");
         });
 
         it("Enter capitalizes the first word of a new sentence on the line", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("ok. yes");
             editor.execute("enter");
-            expect(getModelData(editor.model)).toBe("<paragraph>Ok. Yes</paragraph><paragraph>[]</paragraph>");
+            expectModel("<paragraph>Ok. Yes</paragraph><paragraph>[]</paragraph>");
         });
 
         it("Enter leaves a mid-sentence final word untouched", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello world");
             editor.execute("enter");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello world</paragraph><paragraph>[]</paragraph>");
+            expectModel("<paragraph>Hello world</paragraph><paragraph>[]</paragraph>");
         });
 
         it("Shift+Enter capitalizes the word before the soft break", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello");
             editor.execute("shiftEnter");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello<softBreak></softBreak>[]</paragraph>");
+            expectModel("<paragraph>Hello<softBreak></softBreak>[]</paragraph>");
+        });
+
+        it("Enter on an empty line does nothing", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("enter");
+            expectModel("<paragraph></paragraph><paragraph>[]</paragraph>");
         });
     });
 
@@ -131,35 +156,35 @@ describe("AutoCapitalize", () => {
         it("Ctrl+Z reverts only the capitalization, keeping the typed word", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("is ");
-            expect(getModelData(editor.model)).toBe("<paragraph>Is []</paragraph>");
+            expectModel("<paragraph>Is []</paragraph>");
 
             // First undo: capital -> lowercase, the word and trailing space stay.
             editor.execute("undo");
-            expect(getModelData(editor.model)).toBe("<paragraph>is []</paragraph>");
+            expectModel("<paragraph>is []</paragraph>");
 
             // Second undo: the typed text is removed.
             editor.execute("undo");
-            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+            expectModel("<paragraph>[]</paragraph>");
         });
 
         it("Ctrl+Z does not remove the triggering space first", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("i ");
-            expect(getModelData(editor.model)).toBe("<paragraph>I []</paragraph>");
+            expectModel("<paragraph>I []</paragraph>");
 
             // The capitalization is undone before the space, so the space remains.
             editor.execute("undo");
-            expect(getModelData(editor.model)).toBe("<paragraph>i []</paragraph>");
+            expectModel("<paragraph>i []</paragraph>");
         });
 
         it("redo re-applies the capitalization", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("is ");
             editor.execute("undo");
-            expect(getModelData(editor.model)).toBe("<paragraph>is []</paragraph>");
+            expectModel("<paragraph>is []</paragraph>");
 
             editor.execute("redo");
-            expect(getModelData(editor.model)).toBe("<paragraph>Is []</paragraph>");
+            expectModel("<paragraph>Is []</paragraph>");
         });
     });
 
@@ -167,37 +192,37 @@ describe("AutoCapitalize", () => {
         it("a word that does not start a sentence", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("hello world again");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello world again[]</paragraph>");
+            expectModel("<paragraph>Hello world again[]</paragraph>");
         });
 
         it("a word whose first letter is already uppercase", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("Hi there");
-            expect(getModelData(editor.model)).toBe("<paragraph>Hi there[]</paragraph>");
+            expectModel("<paragraph>Hi there[]</paragraph>");
         });
 
         it("a word that starts with a non-letter", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             type("123 abc");
-            expect(getModelData(editor.model)).toBe("<paragraph>123 abc[]</paragraph>");
+            expectModel("<paragraph>123 abc[]</paragraph>");
         });
 
         it("multi-character insertions (paste / IME)", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             editor.execute("insertText", { text: "hello " });
-            expect(getModelData(editor.model)).toBe("<paragraph>hello []</paragraph>");
+            expectModel("<paragraph>hello []</paragraph>");
         });
 
         it("when the insertion has empty text", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             editor.execute("insertText", { text: "" });
-            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+            expectModel("<paragraph>[]</paragraph>");
         });
 
         it("when the command is executed without options", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             editor.execute("insertText");
-            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+            expectModel("<paragraph>[]</paragraph>");
         });
     });
 
@@ -205,7 +230,7 @@ describe("AutoCapitalize", () => {
         it("does not capitalize inside a code block", () => {
             setModelData(editor.model, "<codeBlock language=\"plaintext\">[]</codeBlock>");
             type("hello world");
-            expect(getModelData(editor.model)).toBe("<codeBlock language=\"plaintext\">hello world[]</codeBlock>");
+            expectModel("<codeBlock language=\"plaintext\">hello world[]</codeBlock>");
         });
 
         it("does not capitalize inline code", () => {

--- a/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
@@ -1,4 +1,4 @@
-import { _getModelData as getModelData, _setModelData as setModelData, Code, CodeBlock, Essentials, Paragraph } from "ckeditor5";
+import { _getModelData as getModelData, _setModelData as setModelData, Bold, Code, CodeBlock, Essentials, Paragraph } from "ckeditor5";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createTestEditor } from "../../test/editor-kit.js";
@@ -8,75 +8,184 @@ describe("AutoCapitalize", () => {
     let editor: Awaited<ReturnType<typeof createTestEditor>>;
 
     beforeEach(async () => {
-        editor = await createTestEditor([Essentials, Paragraph, Code, CodeBlock, AutoCapitalize]);
+        editor = await createTestEditor([Essentials, Paragraph, Bold, Code, CodeBlock, AutoCapitalize]);
     });
+
+    // Type text the way real keystrokes are processed: the Typing plugin wraps
+    // `editor.execute("insertText", …)` in an outer `enqueueChange(buffer.batch, …)`,
+    // which defers the command's own insertion. Reproducing that wrapping exercises
+    // the plugin exactly as it runs during actual typing.
+    const type = (text: string) => {
+        const command = editor.commands.get("insertText");
+        for (const ch of text) {
+            editor.model.enqueueChange(command!.buffer.batch, () => {
+                const selection = editor.model.createSelection(editor.model.document.selection.getRanges());
+                editor.execute("insertText", { text: ch, selection });
+            });
+        }
+    };
 
     it("loads the plugin", () => {
         expect(editor.plugins.get(AutoCapitalize)).toBeInstanceOf(AutoCapitalize);
     });
 
-    describe("capitalizes the first letter of a sentence", () => {
-        it("at the start of a block", () => {
+    describe("capitalizes the first letter of a sentence once the word ends", () => {
+        it("at the start of a block (only the first word)", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
-            editor.execute("insertText", { text: "h" });
-            expect(getModelData(editor.model)).toBe("<paragraph>H[]</paragraph>");
+            type("hi there");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hi there[]</paragraph>");
         });
 
         it("after a period and a space", () => {
-            setModelData(editor.model, "<paragraph>Hello world. []</paragraph>");
-            editor.execute("insertText", { text: "w" });
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello world. W[]</paragraph>");
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("one. two now");
+            expect(getModelData(editor.model)).toBe("<paragraph>One. Two now[]</paragraph>");
         });
 
         it("after an exclamation mark", () => {
-            setModelData(editor.model, "<paragraph>Wow! []</paragraph>");
-            editor.execute("insertText", { text: "n" });
-            expect(getModelData(editor.model)).toBe("<paragraph>Wow! N[]</paragraph>");
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("wow! yes ok");
+            expect(getModelData(editor.model)).toBe("<paragraph>Wow! Yes ok[]</paragraph>");
         });
 
-        it("after a closing quote following the punctuation", () => {
+        it("after a question mark", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("ok? no way");
+            expect(getModelData(editor.model)).toBe("<paragraph>Ok? No way[]</paragraph>");
+        });
+
+        it("the single-letter word \"i\"", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("i am");
+            expect(getModelData(editor.model)).toBe("<paragraph>I am[]</paragraph>");
+        });
+
+        it("after a closing quote that follows the punctuation", () => {
             setModelData(editor.model, "<paragraph>He said \"ok.\" []</paragraph>");
-            editor.execute("insertText", { text: "t" });
-            expect(getModelData(editor.model)).toBe("<paragraph>He said \"ok.\" T[]</paragraph>");
+            type("go now");
+            expect(getModelData(editor.model)).toBe("<paragraph>He said \"ok.\" Go now[]</paragraph>");
         });
 
-        it("treating a non-text inline element as a word break", () => {
-            setModelData(editor.model, "<paragraph>Done.<softBreak></softBreak>[]</paragraph>");
-            editor.execute("insertText", { text: "n" });
-            expect(getModelData(editor.model)).toBe("<paragraph>Done.<softBreak></softBreak>N[]</paragraph>");
+        it("when the sentence boundary is far back in a long paragraph", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("word ".repeat(15) + "done. now ok");
+            const lead = "Word " + "word ".repeat(14);
+            expect(getModelData(editor.model)).toBe(`<paragraph>${lead}done. Now ok[]</paragraph>`);
         });
 
-        it("after a sentence end far beyond the lookbehind window in a long paragraph", () => {
-            const lead = "word ".repeat(20);
-            setModelData(editor.model, `<paragraph>${lead}done. []</paragraph>`);
-            editor.execute("insertText", { text: "n" });
-            expect(getModelData(editor.model)).toBe(`<paragraph>${lead}done. N[]</paragraph>`);
+        it("preserves inline formatting carried by the letter", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.model.change((writer) => writer.setSelectionAttribute("bold", true));
+            type("hi x");
+            expect(editor.getData()).toContain("<strong>Hi x</strong>");
+        });
+    });
+
+    describe("only on word end, not while typing", () => {
+        it("does not capitalize a word that has not been ended yet", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello");
+            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+        });
+
+        it("capitalizes as soon as the ending space is typed", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello");
+            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+            type(" ");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello []</paragraph>");
+        });
+    });
+
+    describe("when a line break ends the word", () => {
+        it("Enter capitalizes the last word of the line", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello");
+            editor.execute("enter");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello</paragraph><paragraph>[]</paragraph>");
+        });
+
+        it("Enter capitalizes the first word of a new sentence on the line", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("ok. yes");
+            editor.execute("enter");
+            expect(getModelData(editor.model)).toBe("<paragraph>Ok. Yes</paragraph><paragraph>[]</paragraph>");
+        });
+
+        it("Enter leaves a mid-sentence final word untouched", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello world");
+            editor.execute("enter");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello world</paragraph><paragraph>[]</paragraph>");
+        });
+
+        it("Shift+Enter capitalizes the word before the soft break", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello");
+            editor.execute("shiftEnter");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello<softBreak></softBreak>[]</paragraph>");
+        });
+    });
+
+    describe("undo (matches Word / OneNote autocorrect)", () => {
+        it("Ctrl+Z reverts only the capitalization, keeping the typed word", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("is ");
+            expect(getModelData(editor.model)).toBe("<paragraph>Is []</paragraph>");
+
+            // First undo: capital -> lowercase, the word and trailing space stay.
+            editor.execute("undo");
+            expect(getModelData(editor.model)).toBe("<paragraph>is []</paragraph>");
+
+            // Second undo: the typed text is removed.
+            editor.execute("undo");
+            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+        });
+
+        it("Ctrl+Z does not remove the triggering space first", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("i ");
+            expect(getModelData(editor.model)).toBe("<paragraph>I []</paragraph>");
+
+            // The capitalization is undone before the space, so the space remains.
+            editor.execute("undo");
+            expect(getModelData(editor.model)).toBe("<paragraph>i []</paragraph>");
+        });
+
+        it("redo re-applies the capitalization", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("is ");
+            editor.execute("undo");
+            expect(getModelData(editor.model)).toBe("<paragraph>is []</paragraph>");
+
+            editor.execute("redo");
+            expect(getModelData(editor.model)).toBe("<paragraph>Is []</paragraph>");
         });
     });
 
     describe("leaves text untouched", () => {
-        it("in the middle of a sentence", () => {
-            setModelData(editor.model, "<paragraph>Hello []</paragraph>");
-            editor.execute("insertText", { text: "w" });
-            expect(getModelData(editor.model)).toBe("<paragraph>Hello w[]</paragraph>");
+        it("a word that does not start a sentence", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            type("hello world again");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello world again[]</paragraph>");
         });
 
-        it("when the letter is already uppercase", () => {
+        it("a word whose first letter is already uppercase", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
-            editor.execute("insertText", { text: "H" });
-            expect(getModelData(editor.model)).toBe("<paragraph>H[]</paragraph>");
+            type("Hi there");
+            expect(getModelData(editor.model)).toBe("<paragraph>Hi there[]</paragraph>");
         });
 
-        it("for non-letter characters", () => {
+        it("a word that starts with a non-letter", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
-            editor.execute("insertText", { text: "1" });
-            expect(getModelData(editor.model)).toBe("<paragraph>1[]</paragraph>");
+            type("123 abc");
+            expect(getModelData(editor.model)).toBe("<paragraph>123 abc[]</paragraph>");
         });
 
-        it("for multi-character insertions (paste / IME)", () => {
+        it("multi-character insertions (paste / IME)", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
-            editor.execute("insertText", { text: "hello" });
-            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+            editor.execute("insertText", { text: "hello " });
+            expect(getModelData(editor.model)).toBe("<paragraph>hello []</paragraph>");
         });
 
         it("when the insertion has empty text", () => {
@@ -95,28 +204,15 @@ describe("AutoCapitalize", () => {
     describe("respects case-sensitive contexts", () => {
         it("does not capitalize inside a code block", () => {
             setModelData(editor.model, "<codeBlock language=\"plaintext\">[]</codeBlock>");
-            editor.execute("insertText", { text: "h" });
-            expect(getModelData(editor.model)).toBe("<codeBlock language=\"plaintext\">h[]</codeBlock>");
+            type("hello world");
+            expect(getModelData(editor.model)).toBe("<codeBlock language=\"plaintext\">hello world[]</codeBlock>");
         });
 
         it("does not capitalize inline code", () => {
             setModelData(editor.model, "<paragraph>[]</paragraph>");
             editor.model.change((writer) => writer.setSelectionAttribute("code", true));
-            editor.execute("insertText", { text: "h" });
-            expect(editor.getData()).toContain("<code>h</code>");
-        });
-    });
-
-    describe("resolves the insertion point", () => {
-        it("from an explicit selection", () => {
-            setModelData(editor.model, "<paragraph>foo[]</paragraph>");
-            const paragraph = editor.model.document.getRoot()?.getChild(0);
-            if (!paragraph) {
-                throw new Error("missing paragraph");
-            }
-            const selection = editor.model.createSelection(editor.model.createPositionAt(paragraph, 0));
-            editor.execute("insertText", { text: "h", selection });
-            expect(editor.getData()).toBe("<p>Hfoo</p>");
+            type("hi x");
+            expect(editor.getData()).toContain("<code>hi x</code>");
         });
     });
 });

--- a/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.spec.ts
@@ -1,0 +1,122 @@
+import { _getModelData as getModelData, _setModelData as setModelData, Code, CodeBlock, Essentials, Paragraph } from "ckeditor5";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createTestEditor } from "../../test/editor-kit.js";
+import AutoCapitalize from "./auto_capitalize.js";
+
+describe("AutoCapitalize", () => {
+    let editor: Awaited<ReturnType<typeof createTestEditor>>;
+
+    beforeEach(async () => {
+        editor = await createTestEditor([Essentials, Paragraph, Code, CodeBlock, AutoCapitalize]);
+    });
+
+    it("loads the plugin", () => {
+        expect(editor.plugins.get(AutoCapitalize)).toBeInstanceOf(AutoCapitalize);
+    });
+
+    describe("capitalizes the first letter of a sentence", () => {
+        it("at the start of a block", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText", { text: "h" });
+            expect(getModelData(editor.model)).toBe("<paragraph>H[]</paragraph>");
+        });
+
+        it("after a period and a space", () => {
+            setModelData(editor.model, "<paragraph>Hello world. []</paragraph>");
+            editor.execute("insertText", { text: "w" });
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello world. W[]</paragraph>");
+        });
+
+        it("after an exclamation mark", () => {
+            setModelData(editor.model, "<paragraph>Wow! []</paragraph>");
+            editor.execute("insertText", { text: "n" });
+            expect(getModelData(editor.model)).toBe("<paragraph>Wow! N[]</paragraph>");
+        });
+
+        it("after a closing quote following the punctuation", () => {
+            setModelData(editor.model, "<paragraph>He said \"ok.\" []</paragraph>");
+            editor.execute("insertText", { text: "t" });
+            expect(getModelData(editor.model)).toBe("<paragraph>He said \"ok.\" T[]</paragraph>");
+        });
+
+        it("treating a non-text inline element as a word break", () => {
+            setModelData(editor.model, "<paragraph>Done.<softBreak></softBreak>[]</paragraph>");
+            editor.execute("insertText", { text: "n" });
+            expect(getModelData(editor.model)).toBe("<paragraph>Done.<softBreak></softBreak>N[]</paragraph>");
+        });
+
+        it("after a sentence end far beyond the lookbehind window in a long paragraph", () => {
+            const lead = "word ".repeat(20);
+            setModelData(editor.model, `<paragraph>${lead}done. []</paragraph>`);
+            editor.execute("insertText", { text: "n" });
+            expect(getModelData(editor.model)).toBe(`<paragraph>${lead}done. N[]</paragraph>`);
+        });
+    });
+
+    describe("leaves text untouched", () => {
+        it("in the middle of a sentence", () => {
+            setModelData(editor.model, "<paragraph>Hello []</paragraph>");
+            editor.execute("insertText", { text: "w" });
+            expect(getModelData(editor.model)).toBe("<paragraph>Hello w[]</paragraph>");
+        });
+
+        it("when the letter is already uppercase", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText", { text: "H" });
+            expect(getModelData(editor.model)).toBe("<paragraph>H[]</paragraph>");
+        });
+
+        it("for non-letter characters", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText", { text: "1" });
+            expect(getModelData(editor.model)).toBe("<paragraph>1[]</paragraph>");
+        });
+
+        it("for multi-character insertions (paste / IME)", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText", { text: "hello" });
+            expect(getModelData(editor.model)).toBe("<paragraph>hello[]</paragraph>");
+        });
+
+        it("when the insertion has empty text", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText", { text: "" });
+            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+        });
+
+        it("when the command is executed without options", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.execute("insertText");
+            expect(getModelData(editor.model)).toBe("<paragraph>[]</paragraph>");
+        });
+    });
+
+    describe("respects case-sensitive contexts", () => {
+        it("does not capitalize inside a code block", () => {
+            setModelData(editor.model, "<codeBlock language=\"plaintext\">[]</codeBlock>");
+            editor.execute("insertText", { text: "h" });
+            expect(getModelData(editor.model)).toBe("<codeBlock language=\"plaintext\">h[]</codeBlock>");
+        });
+
+        it("does not capitalize inline code", () => {
+            setModelData(editor.model, "<paragraph>[]</paragraph>");
+            editor.model.change((writer) => writer.setSelectionAttribute("code", true));
+            editor.execute("insertText", { text: "h" });
+            expect(editor.getData()).toContain("<code>h</code>");
+        });
+    });
+
+    describe("resolves the insertion point", () => {
+        it("from an explicit selection", () => {
+            setModelData(editor.model, "<paragraph>foo[]</paragraph>");
+            const paragraph = editor.model.document.getRoot()?.getChild(0);
+            if (!paragraph) {
+                throw new Error("missing paragraph");
+            }
+            const selection = editor.model.createSelection(editor.model.createPositionAt(paragraph, 0));
+            editor.execute("insertText", { text: "h", selection });
+            expect(editor.getData()).toBe("<p>Hfoo</p>");
+        });
+    });
+});

--- a/packages/ckeditor5/src/plugins/auto_capitalize.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.ts
@@ -1,17 +1,32 @@
 import { Plugin } from "ckeditor5";
-import type { InsertTextCommandExecuteEvent, InsertTextCommandOptions, ModelPosition } from "ckeditor5";
+import type { InsertTextCommandExecuteEvent, InsertTextCommandOptions, ModelPosition, ModelWriter } from "ckeditor5";
 
 /**
  * Automatically capitalizes the first letter of a sentence as the user types,
  * similar to Word and OneNote.
  *
- * A letter is capitalized when it is typed:
+ * The first letter of a word is capitalized when that word starts a sentence:
  *   - at the start of a block (a new paragraph, list item, heading, ...), or
  *   - after sentence-ending punctuation (".", "!", "?") followed by whitespace.
  *
- * The transformation hooks the `insertText` command before insertion, so the
- * capital becomes part of the normal typing operation: undo/redo and inline
- * formatting behave exactly as if the user had typed the capital themselves.
+ * Following Word / OneNote, the capital is applied only when the word is
+ * *finished* — when a space (or tab) is typed after it, or when the line/word is
+ * ended with Enter or Shift+Enter — not while the word is still being typed. The
+ * capital is recorded as its own undo step, applied after that triggering
+ * keystroke, which makes the undo match autocorrect exactly: pressing Ctrl+Z
+ * (Cmd+Z) once reverts only the capitalization ("Is " -> "is ", "I " -> "i "
+ * keeping the space), and a further Ctrl+Z removes the typed text / line break.
+ * The capital is never undone before the text that triggered it.
+ *
+ * This is achieved by listening to the `insertText`, `enter` and `shiftEnter`
+ * commands at low priority and replacing the letter through
+ * `model.enqueueChange()`, which records the replacement in a new,
+ * separately-undoable batch. The replacement reads the model from inside the
+ * queued callback (not the listener), so it sees the finished word whether the
+ * command was run directly or wrapped in the Typing plugin's own
+ * `enqueueChange()` during real keystrokes. It is applied before the browser
+ * repaints, so there is no visible flash of the lowercase letter.
+ *
  * Code blocks and inline code are skipped so case-sensitive content is left
  * untouched.
  *
@@ -26,82 +41,158 @@ export default class AutoCapitalize extends Plugin {
     }
 
     init() {
-        const command = this.editor.commands.get("insertText");
+        const model = this.editor.model;
+
+        // Typing: a single whitespace character (space / tab) ends a word.
+        const insertText = this.editor.commands.get("insertText");
         /* v8 ignore next 3 -- defensive: the insertText command is always registered by the Typing plugin */
-        if (!command) {
-            return;
+        if (insertText) {
+            this.listenTo<InsertTextCommandExecuteEvent>(insertText, "execute", (_evt, [ options ]) => {
+                if (!isWhitespaceTrigger(options)) {
+                    return;
+                }
+                // Defer into a fresh batch so the capital is a separate undo step
+                // and runs after the whitespace has actually landed in the model
+                // (real typing wraps the command in its own enqueueChange, so the
+                // insertion is queued — reading the model here, inside the queued
+                // callback, sees the finished word in every case).
+                model.enqueueChange(writer => {
+                    const caret = model.document.selection.getFirstPosition();
+                    if (caret && caret.offset >= 1) {
+                        // The word ends just before the whitespace.
+                        this.capitalizeWordEndingAt(writer, caret.getShiftedBy(-1));
+                    }
+                });
+            }, { priority: "low" });
         }
 
-        this.listenTo<InsertTextCommandExecuteEvent>(command, "execute", (_evt, [ options ]) => {
-            this.capitalizeSentenceStart(options);
-        }, { priority: "high" });
+        // Enter / Shift+Enter also finish a word (a new line or paragraph).
+        for (const name of [ "enter", "shiftEnter" ] as const) {
+            const command = this.editor.commands.get(name);
+            if (!command) {
+                continue;
+            }
+            this.listenTo(command, "execute", () => {
+                model.enqueueChange(writer => {
+                    const end = this.lineBreakWordEnd(name);
+                    if (end) {
+                        this.capitalizeWordEndingAt(writer, end);
+                    }
+                });
+            }, { priority: "low" });
+        }
     }
 
-    private capitalizeSentenceStart(options: InsertTextCommandOptions | undefined) {
-        if (!options || !options.text || options.text.length !== 1) {
+    /**
+     * The position at which the word finished by a line break ends. `enter`
+     * splits the block, so the finished word is at the end of the previous block;
+     * `shiftEnter` inserts a soft break in the same block, so it is just before
+     * the caret.
+     */
+    private lineBreakWordEnd(command: "enter" | "shiftEnter"): ModelPosition | null {
+        const model = this.editor.model;
+        const caret = model.document.selection.getFirstPosition();
+        if (!caret) {
+            return null;
+        }
+        if (command === "shiftEnter") {
+            return caret.offset >= 1 ? caret.getShiftedBy(-1) : null;
+        }
+        const previousBlock = caret.parent.previousSibling;
+        if (!previousBlock || !previousBlock.is("element")) {
+            return null;
+        }
+        return model.createPositionAt(previousBlock, "end");
+    }
+
+    /**
+     * Capitalizes the first letter of the word that ends at `end`, but only if
+     * that word starts a sentence. The caret is left untouched: the replacement
+     * is length-neutral and happens before the caret, so the live selection
+     * adjusts on its own.
+     */
+    private capitalizeWordEndingAt(writer: ModelWriter, end: ModelPosition) {
+        const model = this.editor.model;
+        const { text, startOffset } = this.textBefore(end);
+
+        // The finished word is the trailing run of non-whitespace.
+        const match = text.match(/\S+$/);
+        if (!match) {
+            return;
+        }
+        const word = match[0];
+        const firstChar = word[0];
+        const upper = firstChar.toUpperCase();
+        // Skip if the first character is not a lowercase letter with a distinct
+        // capital (already-uppercase letters, digits, symbols).
+        if (upper === firstChar) {
             return;
         }
 
-        // Only act on a lowercase letter that has a distinct uppercase form
-        // (skips digits, punctuation, whitespace and already-uppercase letters).
-        const text = options.text;
-        const upper = text.toUpperCase();
-        if (upper === text) {
+        // The word must start a sentence.
+        const beforeWord = text.slice(0, text.length - word.length);
+        if (!isSentenceStart(beforeWord, startOffset === 0)) {
             return;
         }
 
-        // Typing always targets the model selection, which is where the
-        // character will land. Programmatic inserts that pass an explicit
-        // range are ignored, so only real typing is affected.
-        const selection = options.selection ?? this.editor.model.document.selection;
-        const position = selection.getFirstPosition();
-        /* v8 ignore next 3 -- defensive: a typing selection always has a position */
-        if (!position) {
+        // Resolve that first letter in the model (its offset maps 1:1 from the
+        // text window, since each non-text item counts as one space).
+        const letterStart = model.createPositionAt(end.parent, startOffset + text.length - word.length);
+        const letterRange = model.createRange(letterStart, letterStart.getShiftedBy(1));
+        const item = Array.from(letterRange.getItems())[0];
+        if (!item || (!item.is("$textProxy") && !item.is("$text"))) {
+            return;
+        }
+        if (item.data !== firstChar) {
             return;
         }
 
         // Leave case-sensitive content (code blocks, inline code) untouched.
-        if (position.parent.is("element", "codeBlock")) {
+        if (letterStart.parent.is("element", "codeBlock")) {
             return;
         }
-        if (selection.hasAttribute("code")) {
+        if (item.getAttribute("code")) {
             return;
         }
 
-        const { text: before, isAtBlockStart } = this.getTextBefore(position);
-        if (isSentenceStart(before, isAtBlockStart)) {
-            options.text = upper;
-        }
+        // Replace the lowercase letter with its capital, preserving any inline
+        // formatting it carries.
+        const attributes = Object.fromEntries(item.getAttributes());
+        writer.remove(letterRange);
+        writer.insertText(upper, attributes, letterStart);
     }
 
-    private getTextBefore(position: ModelPosition): { text: string; isAtBlockStart: boolean } {
-        // A sentence boundary needs only a few characters of context before the
-        // caret, so cap the lookback instead of scanning a whole large paragraph
-        // on every keystroke.
+    private textBefore(end: ModelPosition): { text: string; startOffset: number } {
+        // A sentence boundary needs only a few characters of context, so cap the
+        // lookback instead of scanning a whole large paragraph on every word end.
         const model = this.editor.model;
-        const startOffset = Math.max(0, position.offset - LOOKBEHIND);
-        const range = model.createRange(model.createPositionAt(position.parent, startOffset), position);
-        let before = "";
+        const startOffset = Math.max(0, end.offset - LOOKBEHIND);
+        const range = model.createRange(model.createPositionAt(end.parent, startOffset), end);
+        let text = "";
         for (const item of range.getItems()) {
             if (item.is("$textProxy") || item.is("$text")) {
-                before += item.data;
+                text += item.data;
             } else {
-                before += " ";
+                text += " ";
             }
         }
-        return { text: before, isAtBlockStart: startOffset === 0 };
+        return { text, startOffset };
     }
 
 }
 
-/**
- * Whether `before` (the text from the start of the current block up to the
- * caret) ends at a sentence boundary: the point where the next typed letter
- * starts a new sentence.
- */
-/** How many characters before the caret to inspect when detecting a sentence boundary. */
+/** How many characters before the trigger to inspect when detecting a sentence boundary. */
 const LOOKBEHIND = 50;
 
+/** Whether the insertText options represent a single whitespace keystroke. */
+function isWhitespaceTrigger(options: InsertTextCommandOptions | undefined): boolean {
+    return !!options && !!options.text && options.text.length === 1 && /\s/.test(options.text);
+}
+
+/**
+ * Whether `before` (the text from the start of the block up to the word) ends at
+ * a sentence boundary: the point where the word that follows starts a sentence.
+ */
 function isSentenceStart(before: string, isAtBlockStart: boolean) {
     // Start of the block (optionally after leading whitespace).
     if (isAtBlockStart && /^\s*$/.test(before)) {

--- a/packages/ckeditor5/src/plugins/auto_capitalize.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.ts
@@ -1,5 +1,7 @@
 import { Plugin } from "ckeditor5";
-import type { InsertTextCommandExecuteEvent, InsertTextCommandOptions, ModelPosition, ModelWriter } from "ckeditor5";
+import type {
+    InsertTextCommandExecuteEvent, InsertTextCommandOptions, ModelPosition, ModelWriter
+} from "ckeditor5";
 
 /**
  * Automatically capitalizes the first letter of a sentence as the user types,
@@ -41,46 +43,62 @@ export default class AutoCapitalize extends Plugin {
     }
 
     init() {
-        const model = this.editor.model;
+        const commands = this.editor.commands;
 
         // Typing: a single whitespace character (space / tab) ends a word.
-        const insertText = this.editor.commands.get("insertText");
-        /* v8 ignore next 3 -- defensive: the insertText command is always registered by the Typing plugin */
+        const insertText = commands.get("insertText");
+        /* v8 ignore next 3 -- defensive: insertText is always registered by Typing */
         if (insertText) {
-            this.listenTo<InsertTextCommandExecuteEvent>(insertText, "execute", (_evt, [ options ]) => {
-                if (!isWhitespaceTrigger(options)) {
-                    return;
-                }
-                // Defer into a fresh batch so the capital is a separate undo step
-                // and runs after the whitespace has actually landed in the model
-                // (real typing wraps the command in its own enqueueChange, so the
-                // insertion is queued — reading the model here, inside the queued
-                // callback, sees the finished word in every case).
-                model.enqueueChange(writer => {
-                    const caret = model.document.selection.getFirstPosition();
-                    if (caret && caret.offset >= 1) {
-                        // The word ends just before the whitespace.
-                        this.capitalizeWordEndingAt(writer, caret.getShiftedBy(-1));
-                    }
-                });
-            }, { priority: "low" });
+            this.listenTo<InsertTextCommandExecuteEvent>(
+                insertText, "execute",
+                (_evt, [ options ]) => this.onWhitespace(options),
+                { priority: "low" }
+            );
         }
 
         // Enter / Shift+Enter also finish a word (a new line or paragraph).
         for (const name of [ "enter", "shiftEnter" ] as const) {
-            const command = this.editor.commands.get(name);
-            if (!command) {
-                continue;
+            const command = commands.get(name);
+            /* v8 ignore next 3 -- defensive: enter/shiftEnter always registered by Essentials */
+            if (command) {
+                this.listenTo(
+                    command, "execute", () => this.onLineBreak(name), { priority: "low" }
+                );
             }
-            this.listenTo(command, "execute", () => {
-                model.enqueueChange(writer => {
-                    const end = this.lineBreakWordEnd(name);
-                    if (end) {
-                        this.capitalizeWordEndingAt(writer, end);
-                    }
-                });
-            }, { priority: "low" });
         }
+    }
+
+    /** Capitalize the finished word when a whitespace character is typed. */
+    private onWhitespace(options: InsertTextCommandOptions | undefined) {
+        if (!isWhitespaceTrigger(options)) {
+            return;
+        }
+        const model = this.editor.model;
+        // Defer into a fresh batch so the capital is a separate undo step and runs
+        // after the whitespace has landed. Real typing wraps the command in its own
+        // enqueueChange (queueing the insert), so reading the model inside this
+        // callback — not the listener — sees the finished word in every case.
+        model.enqueueChange(writer => {
+            const caret = model.document.selection.getFirstPosition();
+            /* v8 ignore next 3 -- defensive: the caret always sits past the typed whitespace */
+            if (!caret || caret.offset < 1) {
+                return;
+            }
+            // The word ends just before the whitespace.
+            this.capitalizeWordEndingAt(writer, caret.getShiftedBy(-1));
+        });
+    }
+
+    /** Capitalize the finished word when Enter / Shift+Enter ends a line. */
+    private onLineBreak(command: "enter" | "shiftEnter") {
+        this.editor.model.enqueueChange(writer => {
+            const end = this.lineBreakWordEnd(command);
+            /* v8 ignore next 3 -- defensive: only the unreachable guard paths return null */
+            if (!end) {
+                return;
+            }
+            this.capitalizeWordEndingAt(writer, end);
+        });
     }
 
     /**
@@ -92,13 +110,19 @@ export default class AutoCapitalize extends Plugin {
     private lineBreakWordEnd(command: "enter" | "shiftEnter"): ModelPosition | null {
         const model = this.editor.model;
         const caret = model.document.selection.getFirstPosition();
+        /* v8 ignore next 3 -- defensive: there is always a selection position */
         if (!caret) {
             return null;
         }
         if (command === "shiftEnter") {
-            return caret.offset >= 1 ? caret.getShiftedBy(-1) : null;
+            /* v8 ignore next 3 -- defensive: the soft break always sits at offset >= 1 */
+            if (caret.offset < 1) {
+                return null;
+            }
+            return caret.getShiftedBy(-1);
         }
         const previousBlock = caret.parent.previousSibling;
+        /* v8 ignore next 3 -- defensive: enter always leaves a previous block to land after */
         if (!previousBlock || !previousBlock.is("element")) {
             return null;
         }
@@ -137,12 +161,15 @@ export default class AutoCapitalize extends Plugin {
 
         // Resolve that first letter in the model (its offset maps 1:1 from the
         // text window, since each non-text item counts as one space).
-        const letterStart = model.createPositionAt(end.parent, startOffset + text.length - word.length);
+        const letterOffset = startOffset + text.length - word.length;
+        const letterStart = model.createPositionAt(end.parent, letterOffset);
         const letterRange = model.createRange(letterStart, letterStart.getShiftedBy(1));
         const item = Array.from(letterRange.getItems())[0];
+        /* v8 ignore next 3 -- defensive: the resolved position always holds a text node */
         if (!item || (!item.is("$textProxy") && !item.is("$text"))) {
             return;
         }
+        /* v8 ignore next 3 -- defensive: the resolved letter always matches the finished word */
         if (item.data !== firstChar) {
             return;
         }

--- a/packages/ckeditor5/src/plugins/auto_capitalize.ts
+++ b/packages/ckeditor5/src/plugins/auto_capitalize.ts
@@ -1,0 +1,113 @@
+import { Plugin } from "ckeditor5";
+import type { InsertTextCommandExecuteEvent, InsertTextCommandOptions, ModelPosition } from "ckeditor5";
+
+/**
+ * Automatically capitalizes the first letter of a sentence as the user types,
+ * similar to Word and OneNote.
+ *
+ * A letter is capitalized when it is typed:
+ *   - at the start of a block (a new paragraph, list item, heading, ...), or
+ *   - after sentence-ending punctuation (".", "!", "?") followed by whitespace.
+ *
+ * The transformation hooks the `insertText` command before insertion, so the
+ * capital becomes part of the normal typing operation: undo/redo and inline
+ * formatting behave exactly as if the user had typed the capital themselves.
+ * Code blocks and inline code are skipped so case-sensitive content is left
+ * untouched.
+ *
+ * The feature is opt-in: the plugin is removed from the editor unless the
+ * `textNoteAutoCapitalizeEnabled` option is enabled (gated by
+ * `getDisabledPlugins()` in the client editor configuration).
+ */
+export default class AutoCapitalize extends Plugin {
+
+    static get pluginName() {
+        return "AutoCapitalize" as const;
+    }
+
+    init() {
+        const command = this.editor.commands.get("insertText");
+        /* v8 ignore next 3 -- defensive: the insertText command is always registered by the Typing plugin */
+        if (!command) {
+            return;
+        }
+
+        this.listenTo<InsertTextCommandExecuteEvent>(command, "execute", (_evt, [ options ]) => {
+            this.capitalizeSentenceStart(options);
+        }, { priority: "high" });
+    }
+
+    private capitalizeSentenceStart(options: InsertTextCommandOptions | undefined) {
+        if (!options || !options.text || options.text.length !== 1) {
+            return;
+        }
+
+        // Only act on a lowercase letter that has a distinct uppercase form
+        // (skips digits, punctuation, whitespace and already-uppercase letters).
+        const text = options.text;
+        const upper = text.toUpperCase();
+        if (upper === text) {
+            return;
+        }
+
+        // Typing always targets the model selection, which is where the
+        // character will land. Programmatic inserts that pass an explicit
+        // range are ignored, so only real typing is affected.
+        const selection = options.selection ?? this.editor.model.document.selection;
+        const position = selection.getFirstPosition();
+        /* v8 ignore next 3 -- defensive: a typing selection always has a position */
+        if (!position) {
+            return;
+        }
+
+        // Leave case-sensitive content (code blocks, inline code) untouched.
+        if (position.parent.is("element", "codeBlock")) {
+            return;
+        }
+        if (selection.hasAttribute("code")) {
+            return;
+        }
+
+        const { text: before, isAtBlockStart } = this.getTextBefore(position);
+        if (isSentenceStart(before, isAtBlockStart)) {
+            options.text = upper;
+        }
+    }
+
+    private getTextBefore(position: ModelPosition): { text: string; isAtBlockStart: boolean } {
+        // A sentence boundary needs only a few characters of context before the
+        // caret, so cap the lookback instead of scanning a whole large paragraph
+        // on every keystroke.
+        const model = this.editor.model;
+        const startOffset = Math.max(0, position.offset - LOOKBEHIND);
+        const range = model.createRange(model.createPositionAt(position.parent, startOffset), position);
+        let before = "";
+        for (const item of range.getItems()) {
+            if (item.is("$textProxy") || item.is("$text")) {
+                before += item.data;
+            } else {
+                before += " ";
+            }
+        }
+        return { text: before, isAtBlockStart: startOffset === 0 };
+    }
+
+}
+
+/**
+ * Whether `before` (the text from the start of the current block up to the
+ * caret) ends at a sentence boundary: the point where the next typed letter
+ * starts a new sentence.
+ */
+/** How many characters before the caret to inspect when detecting a sentence boundary. */
+const LOOKBEHIND = 50;
+
+function isSentenceStart(before: string, isAtBlockStart: boolean) {
+    // Start of the block (optionally after leading whitespace).
+    if (isAtBlockStart && /^\s*$/.test(before)) {
+        return true;
+    }
+    // After ".", "!" or "?" (optionally followed by closing quotes/brackets)
+    // and at least one whitespace character.
+    return /[.!?]["')\]]*\s+$/.test(before);
+}

--- a/packages/commons/src/lib/options_interface.ts
+++ b/packages/commons/src/lib/options_interface.ts
@@ -186,6 +186,8 @@ export interface OptionDefinitions extends KeyboardShortcutsOptions<KeyboardActi
     textNoteCompletionEnabled: boolean;
     /** Whether keyboard auto-completion for editing commands is triggered when typing `/`. */
     textNoteSlashCommandsEnabled: boolean;
+    /** Whether the first letter of a sentence is automatically capitalized as you type. */
+    textNoteAutoCapitalizeEnabled: boolean;
     backgroundEffects: boolean;
     newLayout: boolean;
 

--- a/packages/trilium-core/src/routes/api/options.ts
+++ b/packages/trilium-core/src/routes/api/options.ts
@@ -110,6 +110,7 @@ const ALLOWED_OPTIONS = new Set<OptionNames>([
     "textNoteEmojiCompletionEnabled",
     "textNoteCompletionEnabled",
     "textNoteSlashCommandsEnabled",
+    "textNoteAutoCapitalizeEnabled",
     "includeNoteDefaultBoxSize",
     "layoutOrientation",
     "backgroundEffects",

--- a/packages/trilium-core/src/services/options_init.ts
+++ b/packages/trilium-core/src/services/options_init.ts
@@ -242,6 +242,7 @@ const defaultOptions: DefaultOption[] = [
     { name: "textNoteEmojiCompletionEnabled", value: "true", isSynced: true },
     { name: "textNoteCompletionEnabled", value: "true", isSynced: true },
     { name: "textNoteSlashCommandsEnabled", value: "true", isSynced: true },
+    { name: "textNoteAutoCapitalizeEnabled", value: "false", isSynced: true },
     { name: "includeNoteDefaultBoxSize", value: "medium", isSynced: true },
 
     // HTML import configuration


### PR DESCRIPTION
I recently moved my notes from Microsoft OneNote to Trilium, and the one habit my fingers can't shake is automatic capitalization. OneNote has option to capitalize the first letter of a sentence as you type, and this is a feature that I'm used to so I would love to see it in Trillium too.

This adds that as an optional setting for text notes. When it's on, Trilium capitalizes the first letter of a sentence as you type: at the start of a line, and after a period, exclamation mark, or question mark. It's off by default, so nothing changes for anyone unless they turn it on, under Options > Text Notes > Features, next to the emoji, note, and slash-command toggles.

Under the hood it's a small CKEditor plugin that hooks the insertText command and capitalizes the letter right before it's inserted, so it stays a normal edit (undo works, and existing formatting is kept). The new option and the way it's switched off (removing the plugin in getDisabledPlugins) follow the same pattern as the existing emoji and slash-command toggles.

I added tests for the plugin covering the sentence-start cases, mid-sentence typing, code blocks, inline code, and pasting, and pnpm typecheck is clean.

Here's what it looks like
 

https://github.com/user-attachments/assets/e7fb49c3-2e2e-44ed-a1e7-edb12189338d


I kept the change small and tried to match how the existing editor toggles are built. Happy to adjust anything.
