### PR TITLE
fix(ci): remove duplicate pnpm cache setup in server E2E job

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,23 +68,19 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps
-
+      # The build-server composite already sets up pnpm, Node (with the pnpm
+      # cache) and installs dependencies. Running setup-node a second time at the
+      # job level registered a duplicate pnpm cache post-step that failed the job
+      # during cleanup ("Path Validation Error ... do not exist"), so we rely on
+      # the composite alone for environment setup.
       - name: Build the server
         uses: ./.github/actions/build-server
         with:
           os: linux
           arch: ${{ matrix.arch }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
 
       - name: Copy test fixture database
         run: cp packages/trilium-core/src/test/fixtures/document.db apps/server/spec/db/document.db


### PR DESCRIPTION
## Problem

The `E2E tests on linux-x64` / `linux-arm64` jobs in the `playwright` workflow have been failing on `main` even though the tests pass. Example: [run 27808642138](https://github.com/TriliumNext/Trilium/actions/runs/27808642138/job/82293798026).

The test step (`Server end-to-end tests`) **succeeds** — flaky tests pass on retry (`2 flaky, 48 passed`). The job is failed by the post-job cleanup step `Post Build the server`:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

## Root cause

The `e2e-server` job sets up Node **twice** with the pnpm cache:

1. At the job level (`actions/setup-node@v6` with `cache: 'pnpm'`).
2. Inside the `build-server` composite action it then calls, which sets up Node with the pnpm cache again.

Two `setup-node` steps in one job register two pnpm cache post-steps. The second post-save fails path validation, and under `actions/setup-node@v6` this is emitted as an `##[error]` (not a warning), failing the post step and the whole job.

Confirming evidence from the run: **both** server E2E jobs (which use the composite) failed identically — test step `success`, `Post Build the server` `failure` — while **both** standalone E2E jobs (single `setup-node`, no composite) passed.

This is a long-standing CI config issue (the duplication has existed since the workflow was added in `3776c40b8d`, and became job-failing after the `setup-node@v6` bump). It is unrelated to any application code.

## Fix

The `build-server` composite already sets up pnpm, Node (with cache) and installs dependencies — the `nightly-server` and `release` server jobs rely on it for exactly that. The job-level setup in the E2E job was fully redundant, so this removes it and relies on the composite, leaving a single pnpm cache post-step. Playwright browser install now runs after the build, using the composite's Node.

Only `playwright.yml` is touched; `nightly.yml` / `release.yml` (which depend on the composite for setup) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)