### PR TITLE
fix(server): reject nested multipart fields to complete CVE-2026-5079 mitigation

### DIFF
--- a/apps/server/src/routes/route_api.ts
+++ b/apps/server/src/routes/route_api.ts
@@ -175,6 +175,10 @@ export const uploadMiddlewareWithErrorHandling = function (req: express.Request,
     uploadMiddleware(req, res, (err) => {
         if (err?.code === "LIMIT_FILE_SIZE") {
             res.setHeader("Content-Type", "text/plain").status(400).send(`Cannot upload file because it excceeded max allowed file size of ${MAX_ALLOWED_FILE_SIZE_MB} MiB`);
+        } else if (err?.code === "LIMIT_FIELD_NESTING") {
+            // Triggered by the fieldNestingDepth: 0 limit (CVE-2026-5079 guard). Without this branch the
+            // error would be swallowed and the request forwarded to the handler with no file.
+            res.setHeader("Content-Type", "text/plain").status(400).send("Upload rejected: nested multipart field names are not allowed.");
         } else {
             next();
         }

--- a/apps/server/src/routes/route_api.ts
+++ b/apps/server/src/routes/route_api.ts
@@ -143,7 +143,21 @@ function handleException(e: unknown | Error, method: HttpMethod, path: string, r
 }
 
 export function createUploadMiddleware(): RequestHandler {
+    // None of our upload routes consume nested multipart text fields, so reject any bracketed field
+    // name outright. This activates multer 2.2.0's guard against CVE-2026-5079 (DoS via deeply-nested
+    // field names) and must be set unconditionally — it is a safety limit, not a user-facing size
+    // limit gated by TRILIUM_NO_UPLOAD_LIMIT. `fieldNestingDepth` is not yet in @types/multer 2.1.0,
+    // hence the local intersection type.
+    const limits: NonNullable<multer.Options["limits"]> & { fieldNestingDepth?: number } = {
+        fieldNestingDepth: 0
+    };
+
+    if (!process.env.TRILIUM_NO_UPLOAD_LIMIT) {
+        limits.fileSize = MAX_ALLOWED_FILE_SIZE_MB * 1024 * 1024;
+    }
+
     const multerOptions: multer.Options = {
+        limits,
         fileFilter: (req: express.Request, file, cb) => {
             // UTF-8 file names are not well decoded by multer/busboy, so we handle the conversion on our side.
             // See https://github.com/expressjs/multer/pull/1102.
@@ -151,12 +165,6 @@ export function createUploadMiddleware(): RequestHandler {
             cb(null, true);
         }
     };
-
-    if (!process.env.TRILIUM_NO_UPLOAD_LIMIT) {
-        multerOptions.limits = {
-            fileSize: MAX_ALLOWED_FILE_SIZE_MB * 1024 * 1024
-        };
-    }
 
     return multer(multerOptions).single("upload");
 }

--- a/apps/server/src/routes/transport.spec.ts
+++ b/apps/server/src/routes/transport.spec.ts
@@ -77,6 +77,29 @@ describe("Route transport & middleware", () => {
                 .expect(200);
             expect(res.body.uploaded).toBe(true);
         });
+
+        it("accepts a flat (non-bracketed) multipart field alongside the file", async () => {
+            // fieldNestingDepth: 0 rejects only bracketed names; a flat field has zero brackets.
+            const { noteId } = await createTextNote(ctx, { title: "Flat field target" });
+            const res = await ctx.agent.put(`/api/notes/${noteId}/file`)
+                .set("x-csrf-token", ctx.csrfToken)
+                .field("description", "a plain field")
+                .attach("upload", Buffer.from("uploaded bytes"), { filename: "doc.txt", contentType: "text/plain" })
+                .expect(200);
+            expect(res.body.uploaded).toBe(true);
+        });
+
+        it("rejects a nested (bracketed) multipart field name with 400 (CVE-2026-5079 guard)", async () => {
+            // The fieldNestingDepth: 0 limit aborts with LIMIT_FIELD_NESTING, which the upload error
+            // handler maps to a 400 instead of letting the request reach the route handler file-less.
+            const { noteId } = await createTextNote(ctx, { title: "Nested field target" });
+            const res = await ctx.agent.put(`/api/notes/${noteId}/file`)
+                .set("x-csrf-token", ctx.csrfToken)
+                .field("a[b][c]", "deep")
+                .attach("upload", Buffer.from("uploaded bytes"), { filename: "doc.txt", contentType: "text/plain" })
+                .expect(400);
+            expect(res.text).toContain("nested multipart field names are not allowed");
+        });
     });
 
     it("redirects /setup to the app when the DB is already initialized", async () => {


### PR DESCRIPTION
## What

Sets multer's `limits.fieldNestingDepth: 0` on the upload middleware in `apps/server/src/routes/route_api.ts`, rejecting any bracketed multipart field name outright.

## Why

[PR #10194](https://github.com/TriliumNext/Trilium/pull/10194) bumps multer to 2.2.0 to patch two DoS CVEs. As Greptile noted on that PR, **CVE-2026-5079** (deeply-nested field names, CVSS 7.5) is only *partially* fixed by the version bump — the advisory requires also configuring `limits.fieldNestingDepth`. Multer 2.2.0 ships the guard but leaves it **inert unless explicitly set**, so without this change the upgrade does not close the nesting-depth DoS vector.

I traced all three routes that use the upload middleware:

| Route | Handler | Fields read |
|---|---|---|
| `PUT /api/notes/:noteId/file` | `updateFile` | only `req.file` |
| `PUT /api/attachments/:attachmentId/file` | `updateAttachment` | only `req.file` |
| `POST /api/sender/image` | `uploadImage` | only `req.file` + the `x-labels` HTTP header |

None of them consume nested (or even flat) multipart text fields, so `fieldNestingDepth: 0` — which rejects any field name containing a `[` — fully disables nesting with zero functional impact. This is stricter and safer than the advisory's suggested non-zero depth.

## Notes

- The limit is set **unconditionally**, not inside the `TRILIUM_NO_UPLOAD_LIMIT` guard, because it's a DoS safety limit rather than a user-facing size cap — running with `TRILIUM_NO_UPLOAD_LIMIT` must not reopen the vector.
- A local intersection type is used because `@types/multer` (latest: 2.1.0) does not yet declare `fieldNestingDepth`. It compiles today and stays valid once the types catch up.
- The option is **ignored by multer 2.1.1** and only takes effect once #10194 lands, so this should merge alongside or after that PR. Harmless before then.

## Follow-up

The three upload routes have thin test coverage (one happy-path test for `updateFile`, none through the middleware for the other two), and nothing asserts the nesting guard. A natural follow-up — once 2.2.0 is in the tree so the assertion can actually run — is to add route coverage plus a `LIMIT_FIELD_NESTING` rejection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)