### PR TITLE
feat: Adds area annotations and linkable annotations to PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Thumbs.db
 vite.config.*.timestamp*
 vitest.config.*.timestamp*
 test-output
+test-results
 __screenshots__
 .vitest-attachments
 

--- a/apps/client/src/components/note_context.ts
+++ b/apps/client/src/components/note_context.ts
@@ -58,6 +58,14 @@ export interface NoteContextDataMap {
     pdfAnnotations: {
         annotations: PdfAnnotationInfo[];
         scrollToAnnotation(annotationId: string, pageNumber: number): void;
+        setAnnotationColor(annotationId: string, color: string): void;
+        deleteAnnotation(annotationId: string, pageNumber: number): void;
+    };
+    pdfAreaAnnotations: {
+        annotations: PdfAreaAnnotationInfo[];
+        scrollToArea(pageNumber: number, rect: { x: number; y: number; width: number; height: number }): void;
+        deleteArea(attachmentId: string, attributeId: string): void;
+        updateArea(attributeId: string, patch: { comment?: string; color?: string }): void;
     };
     saveState: {
         state: SaveState;

--- a/apps/client/src/services/clipboard_ext.ts
+++ b/apps/client/src/services/clipboard_ext.ts
@@ -35,3 +35,41 @@ export function copyTextWithToast(text: string) {
         toast.showError(t("clipboard.copy_failed"));
     }
 }
+
+/**
+ * Copies both an HTML and a plain-text representation to the clipboard, so pasting into
+ * a rich-text editor (e.g. CKEditor) preserves formatting (links, images) while pasting
+ * into a plain-text field falls back to readable text.
+ *
+ * Uses the `copy` event's `clipboardData.setData()` instead of the classic "select a hidden
+ * DOM node, then execCommand('copy')" trick. The latter relies on each browser's own
+ * selection-to-clipboard HTML serialization, which is inconsistent — in particular Firefox
+ * does not reliably populate the `text/html` clipboard flavor that way, so pasted content
+ * silently degrades to plain text. Writing the flavors directly during the `copy` event is
+ * the documented cross-browser-reliable approach and does not require any selection at all.
+ */
+export function copyRichText(html: string, plainText: string): boolean {
+    function listener(e: ClipboardEvent) {
+        e.clipboardData?.setData("text/plain", plainText);
+        e.clipboardData?.setData("text/html", html);
+        e.preventDefault();
+    }
+
+    try {
+        document.addEventListener("copy", listener);
+        return document.execCommand("copy");
+    } catch (e) {
+        console.warn(e);
+        return false;
+    } finally {
+        document.removeEventListener("copy", listener);
+    }
+}
+
+export function copyRichTextWithToast(html: string, plainText: string) {
+    if (copyRichText(html, plainText)) {
+        toast.showMessage(t("clipboard.copy_success"));
+    } else {
+        toast.showError(t("clipboard.copy_failed"));
+    }
+}

--- a/apps/client/src/services/link.spec.ts
+++ b/apps/client/src/services/link.spec.ts
@@ -173,6 +173,74 @@ describe("calculateHash", () => {
     it("produces only the param string when note path is empty", () => {
         expect(calculateHash({ ntxId: "n1" } as any)).toBe("#?ntxId=n1");
     });
+
+    it("includes annotationId and annotationPage when set", () => {
+        const hash = calculateHash({
+            notePath: "root/abc",
+            viewScope: { annotationId: "12R", annotationPage: 5 }
+        } as any);
+        expect(hash).toBe("#root/abc?annotationId=12R&annotationPage=5");
+    });
+
+    it("includes annotationPreview when set", () => {
+        const hash = calculateHash({
+            notePath: "root/abc",
+            viewScope: { annotationId: "12R", annotationPage: 3, annotationPreview: "hello world" }
+        } as any);
+        expect(hash).toContain("annotationId=12R");
+        expect(hash).toContain("annotationPage=3");
+        expect(hash).toContain("annotationPreview=hello%20world");
+    });
+
+    it("omits annotationPage when falsy", () => {
+        const hash = calculateHash({
+            notePath: "root/abc",
+            viewScope: { annotationId: "12R" }
+        } as any);
+        expect(hash).not.toContain("annotationPage");
+        expect(hash).not.toContain("annotationPreview");
+    });
+});
+
+describe("parseNavigationStateFromUrl — annotation params", () => {
+    it("round-trips annotationId, annotationPage and annotationPreview", () => {
+        const hash = calculateHash({
+            notePath: "root/aaaaaaaaaaaa",
+            viewScope: { annotationId: "12R", annotationPage: 5, annotationPreview: "fox jumps" }
+        } as any);
+
+        const parsed = parseNavigationStateFromUrl(hash);
+        expect((parsed as any).viewScope).toMatchObject({
+            annotationId: "12R",
+            annotationPage: 5,
+            annotationPreview: "fox jumps"
+        });
+    });
+
+    it("parses annotationId without a preview", () => {
+        const parsed = parseNavigationStateFromUrl("#root/aaaaaaaaaaaa?annotationId=15R&annotationPage=2");
+        expect((parsed as any).viewScope).toMatchObject({
+            annotationId: "15R",
+            annotationPage: 2
+        });
+        expect((parsed as any).viewScope.annotationPreview).toBeUndefined();
+    });
+
+    it("parses area: prefixed annotationId used for image annotations", () => {
+        const parsed = parseNavigationStateFromUrl(
+            "#root/aaaaaaaaaaaa?annotationId=area%3AattachmentXyz&annotationPage=7"
+        );
+        expect((parsed as any).viewScope.annotationId).toBe("area:attachmentXyz");
+        expect((parsed as any).viewScope.annotationPage).toBe(7);
+    });
+
+    it("ignores an invalid annotationPage value", () => {
+        const parsed = parseNavigationStateFromUrl(
+            "#root/aaaaaaaaaaaa?annotationId=12R&annotationPage=notanumber"
+        );
+        // parseInt("notanumber") || undefined → undefined
+        expect((parsed as any).viewScope.annotationPage).toBeUndefined();
+    });
 });
 
 describe("getNotePathFromUrl", () => {

--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -62,6 +62,12 @@ export interface ViewScope {
     tocCollapsedHeadings?:  Set<string>;
     /** When set, scrolls to a bookmark anchor within the note after navigation. */
     bookmark?: string;
+    /** When set, scrolls to a specific annotation within a PDF note after navigation. */
+    annotationId?: string;
+    /** Page number of the annotation. Used as fallback when annotationId no longer matches (IDs rotate after PDF save). */
+    annotationPage?: number;
+    /** Short preview of the annotation text (highlighted text or comment), shown in reference link labels and used for ID-mismatch fallback matching. */
+    annotationPreview?: string;
 }
 
 interface CreateLinkOptions {
@@ -196,7 +202,10 @@ export function calculateHash({ notePath, ntxId, hoistedNoteId, viewScope = {} }
         ntxId ? { ntxId } : null,
         hoistedNoteId && hoistedNoteId !== "root" ? { hoistedNoteId } : null,
         viewScope.viewMode && viewScope.viewMode !== "default" ? { viewMode: viewScope.viewMode } : null,
-        viewScope.attachmentId ? { attachmentId: viewScope.attachmentId } : null
+        viewScope.attachmentId ? { attachmentId: viewScope.attachmentId } : null,
+        viewScope.annotationId ? { annotationId: viewScope.annotationId } : null,
+        viewScope.annotationPage ? { annotationPage: String(viewScope.annotationPage) } : null,
+        viewScope.annotationPreview ? { annotationPreview: viewScope.annotationPreview } : null
     ].filter((p) => !!p);
 
     const paramStr = params
@@ -261,8 +270,10 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
                 hoistedNoteId = value;
             } else if (name === "searchString") {
                 searchString = value; // supports triggering search from URL, e.g. #?searchString=blabla
-            } else if (["viewMode", "attachmentId", "bookmark"].includes(name)) {
+            } else if (["viewMode", "attachmentId", "bookmark", "annotationId", "annotationPreview"].includes(name)) {
                 (viewScope as any)[name] = value;
+            } else if (name === "annotationPage") {
+                viewScope.annotationPage = parseInt(value, 10) || undefined;
             } else if (name === "popup") {
                 openInPopup = true;
             } else {
@@ -467,7 +478,9 @@ async function loadReferenceLinkTitle($el: JQuery<HTMLElement>, href: string | n
         ));
     }
 
-    if (note) {
+    if (viewScope?.annotationId) {
+        $el.prepend($("<span>").addClass("bx bx-highlight").css("marginRight", "4px"));
+    } else if (note) {
         const icon = await getLinkIcon(noteId, viewScope.viewMode);
 
         if (icon) {
@@ -493,6 +506,12 @@ async function getReferenceLinkTitle(href: string) {
         return attachment ? attachment.title : "[missing attachment]";
     }
 
+    if (viewScope?.annotationId) {
+        return viewScope.annotationPreview
+            ? `${note.title} › "${viewScope.annotationPreview}"`
+            : `${note.title} (annotation)`;
+    }
+
     return note.title;
 }
 
@@ -515,6 +534,12 @@ function getReferenceLinkTitleSync(href: string) {
         const attachment = note.attachments.find((att) => att.attachmentId === viewScope.attachmentId);
 
         return attachment ? attachment.title : "[missing attachment]";
+    }
+
+    if (viewScope?.annotationId) {
+        return viewScope.annotationPreview
+            ? `${note.title} › "${viewScope.annotationPreview}"`
+            : `${note.title} (annotation)`;
     }
 
     if (viewScope?.bookmark) {

--- a/apps/client/src/services/textPrompt.ts
+++ b/apps/client/src/services/textPrompt.ts
@@ -1,0 +1,52 @@
+/**
+ * Non-blocking alternative to `window.prompt()` that renders a small dialog
+ * using Trilium's Bootstrap classes, matching the application's design.
+ *
+ * Resolves with the entered string on confirm, or `null` on cancel / Escape.
+ */
+export function textPrompt(label: string, defaultValue = ""): Promise<string | null> {
+    return new Promise((resolve) => {
+        const $backdrop = $('<div class="modal-backdrop fade show">').appendTo("body");
+
+        const $modal = $(`
+            <div class="modal show" tabindex="-1" style="display:block">
+                <div class="modal-dialog modal-sm modal-dialog-centered">
+                    <div class="modal-content">
+                        <div class="modal-body" style="padding:16px 16px 8px">
+                            <label style="display:block;margin-bottom:8px;font-weight:500"></label>
+                            <input type="text" class="form-control">
+                        </div>
+                        <div class="modal-footer" style="padding:8px 16px 12px">
+                            <button class="btn btn-primary btn-sm">OK</button>
+                            <button class="btn btn-secondary btn-sm">Cancel</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        `).appendTo("body");
+
+        // Set text safely (no XSS)
+        $modal.find("label").text(label);
+        $modal.find("input").val(defaultValue);
+
+        function done(value: string | null) {
+            $modal.remove();
+            $backdrop.remove();
+            $(document).off("keydown.textPrompt");
+            resolve(value);
+        }
+
+        $modal.find(".btn-primary").on("click", () => done($modal.find("input").val() as string));
+        $modal.find(".btn-secondary").on("click", () => done(null));
+
+        // Close on backdrop click
+        $modal.on("click", (e) => { if ($(e.target).is($modal)) done(null); });
+
+        $(document).on("keydown.textPrompt", (e) => {
+            if (e.key === "Enter")  done($modal.find("input").val() as string);
+            if (e.key === "Escape") done(null);
+        });
+
+        setTimeout(() => ($modal.find("input")[0] as HTMLInputElement | undefined)?.select(), 50);
+    });
+}

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3259,7 +3259,20 @@
     "pages_alt": "Page {{pageNumber}}",
     "pages_loading": "Loading...",
     "annotations_one": "{{count}} annotation",
-    "annotations_other": "{{count}} annotations"
+    "annotations_other": "{{count}} annotations",
+    "copy_annotation_link": "Copy link to annotation",
+    "annotation_link_copied": "Annotation link copied to clipboard",
+    "annotation_delete": "Delete annotation",
+    "area_capture_saved": "Area captured and saved as annotation",
+    "area_capture_failed": "Failed to save area capture",
+    "area_annotations_one": "{{count}} area annotation",
+    "area_annotations_other": "{{count}} area annotations",
+    "area_annotation_label": "Page {{page}}",
+    "area_annotation_delete": "Delete area annotation",
+    "area_add_note": "Add note",
+    "area_edit_note": "Edit note",
+    "area_change_color": "Change color",
+    "area_note_prompt": "Enter a note for this area annotation"
   },
   "platform_indicator": {
     "available_on": "Available on {{platform}}"

--- a/apps/client/src/types-pdfjs.d.ts
+++ b/apps/client/src/types-pdfjs.d.ts
@@ -153,6 +153,35 @@ interface PdfViewerAnnotationsMessage {
     annotations: PdfAnnotationInfo[];
 }
 
+interface PdfAreaAnnotationInfo {
+    attachmentId: string;
+    attributeId: string;
+    pageNumber: number;
+    rect: { x: number; y: number; width: number; height: number };
+    imageUrl: string;
+    comment?: string;
+    color?: string;
+}
+
+interface PdfViewerReadyForOverlaysMessage {
+    type: "pdfjs-viewer-ready-for-overlays";
+}
+
+interface PdfViewerAreaRightClickMessage extends WithContext {
+    type: "pdfjs-viewer-area-right-click";
+    attachmentId: string;
+    attributeId: string;
+    clientX: number;
+    clientY: number;
+}
+
+interface PdfViewerAreaCaptureMessage extends WithContext {
+    type: "pdfjs-viewer-area-capture";
+    imageData: string;
+    pageNumber: number;
+    rect: { x: number; y: number; width: number; height: number };
+}
+
 type PdfMessageEvent = MessageEvent<
     PdfDocumentModifiedMessage
     | PdfSaveViewHistoryMessage
@@ -166,4 +195,7 @@ type PdfMessageEvent = MessageEvent<
     | PdfViewerLayersMessage
     | PdfViewerAnnotationsMessage
     | PdfDocumentBlobResultMessage
+    | PdfViewerAreaCaptureMessage
+    | PdfViewerAreaRightClickMessage
+    | PdfViewerReadyForOverlaysMessage
 >;

--- a/apps/client/src/widgets/sidebar/RightPanelContainer.tsx
+++ b/apps/client/src/widgets/sidebar/RightPanelContainer.tsx
@@ -23,6 +23,7 @@ import AttributeList from "./AttributeList";
 import ChatHighlightsList from "./ChatHighlightsList";
 import HighlightsList from "./HighlightsList";
 import PdfAnnotations from "./pdf/PdfAnnotations";
+import PdfAreaAnnotations from "./pdf/PdfAreaAnnotations";
 import PdfAttachments from "./pdf/PdfAttachments";
 import PdfLayers from "./pdf/PdfLayers";
 import PdfPages from "./pdf/PdfPages";
@@ -208,6 +209,10 @@ function useItems(rightPaneVisible: boolean, widgetsByParent: WidgetsByParent): 
             el: <PdfAnnotations />,
             enabled: isPdf,
             tab: "outline"
+        },
+        {
+            el: <PdfAreaAnnotations />,
+            enabled: isPdf,
         },
         {
             el: <HighlightsList />,

--- a/apps/client/src/widgets/sidebar/pdf/PdfAnnotations.css
+++ b/apps/client/src/widgets/sidebar/pdf/PdfAnnotations.css
@@ -57,3 +57,29 @@
     color: #555;
     margin-top: 2px;
 }
+
+.pdf-annotation-copy-link {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: #555;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s, background 0.15s;
+}
+
+.pdf-annotation-item:hover .pdf-annotation-copy-link {
+    opacity: 1;
+}
+
+.pdf-annotation-copy-link:hover {
+    background: rgba(0, 0, 0, 0.12);
+    color: #222;
+}

--- a/apps/client/src/widgets/sidebar/pdf/PdfAnnotations.tsx
+++ b/apps/client/src/widgets/sidebar/pdf/PdfAnnotations.tsx
@@ -1,20 +1,93 @@
 import "./PdfAnnotations.css";
 
+import { useEffect } from "preact/hooks";
 import { t } from "../../../services/i18n";
+import { calculateHash } from "../../../services/link";
+import { copyRichText, copyTextWithToast } from "../../../services/clipboard_ext";
+import toast from "../../../services/toast";
+import contextMenu from "../../../menus/context_menu";
 import { useActiveNoteContext, useGetContextData, useNoteProperty } from "../../react/hooks";
 import Icon from "../../react/Icon";
 import RightPanelWidget from "../RightPanelWidget";
+import { PDF_ANNOTATION_COLORS } from "./pdfAnnotationColors";
 
 const TYPE_ICONS: Record<string, string> = {
     text: "bx bxs-comment-detail",
     highlight: "bx bx-highlight",
 };
 
+const MAX_PREVIEW_LENGTH = 60;
+const PRESET_COLORS = PDF_ANNOTATION_COLORS;
+
 export default function PdfAnnotations() {
-    const { note } = useActiveNoteContext();
+    const { note, noteContext } = useActiveNoteContext();
     const noteType = useNoteProperty(note, "type");
     const noteMime = useNoteProperty(note, "mime");
     const annotationsData = useGetContextData("pdfAnnotations");
+
+    // Use jQuery document delegation instead of Preact's onContextMenu — the legacy
+    // widget wrapper can swallow Preact synthetic events before they fire.
+    useEffect(() => {
+        if (!annotationsData) return;
+
+        const handler = (e: JQuery.ContextMenuEvent) => {
+            const $item = $(e.target as HTMLElement).closest(".pdf-annotation-item[data-annotation-id]");
+            if (!$item.length) return;
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const annotationId = $item.attr("data-annotation-id");
+            if (!annotationId) return;
+            const annotation = annotationsData.annotations.find((a) => a.id === annotationId);
+            const notePath = noteContext?.notePath ?? "";
+            const noteTitleVal = note?.title ?? "";
+            if (!annotation) return;
+
+            const rawPreview = (annotation.highlightedText || annotation.contents).trim();
+            const annotationPreview = rawPreview.length > MAX_PREVIEW_LENGTH
+                ? `${rawPreview.substring(0, MAX_PREVIEW_LENGTH)}…`
+                : rawPreview || undefined;
+            const hash = calculateHash({
+                notePath,
+                viewScope: { annotationId: annotation.id, annotationPage: annotation.pageNumber, annotationPreview }
+            });
+            const linkTitle = annotationPreview
+                ? `${noteTitleVal} › "${annotationPreview}"`
+                : `${noteTitleVal} (annotation)`;
+
+            contextMenu.show({
+                x: e.pageX,
+                y: e.pageY,
+                items: [
+                    { title: t("pdf.copy_annotation_link"), command: "copyLink", uiIcon: "bx bx-link" },
+                    {
+                        title: t("pdf.area_change_color"), command: "changeColor", uiIcon: "bx bx-palette",
+                        items: PRESET_COLORS.map((c) => ({ title: c.label, command: `color:${c.value}`, uiIcon: `bx bx-circle ${c.cssClass}` }))
+                    },
+                    { kind: "separator" },
+                    { title: t("pdf.annotation_delete"), command: "delete", uiIcon: "bx bx-trash" }
+                ],
+                selectMenuItemHandler: ({ command }) => {
+                    if (command === "copyLink") {
+                        const html = $('<a class="reference-link">').attr("href", hash).text(linkTitle)[0].outerHTML;
+                        if (copyRichText(html, hash)) {
+                            toast.showMessage(t("pdf.annotation_link_copied"));
+                        } else {
+                            copyTextWithToast(hash);
+                        }
+                    } else if (command?.startsWith("color:")) {
+                        annotationsData.setAnnotationColor(annotation.id, command.slice(6));
+                    } else if (command === "delete") {
+                        annotationsData.deleteAnnotation(annotation.id, annotation.pageNumber);
+                    }
+                }
+            });
+        };
+
+        $(document).on("contextmenu.pdf-text-annotations", ".pdf-annotations-list .pdf-annotation-item", handler);
+        return () => { $(document).off("contextmenu.pdf-text-annotations"); };
+    }, [annotationsData, noteContext, note]);
 
     if (noteType !== "file" || noteMime !== "application/pdf") {
         return null;
@@ -31,6 +104,8 @@ export default function PdfAnnotations() {
                     <PdfAnnotationItem
                         key={annotation.id}
                         annotation={annotation}
+                        noteTitle={note?.title ?? ""}
+                        notePath={noteContext?.notePath ?? ""}
                         onNavigate={annotationsData.scrollToAnnotation}
                     />
                 ))}
@@ -41,18 +116,56 @@ export default function PdfAnnotations() {
 
 function PdfAnnotationItem({
     annotation,
-    onNavigate
+    noteTitle,
+    notePath,
+    onNavigate,
 }: {
     annotation: PdfAnnotationInfo;
+    noteTitle: string;
+    notePath: string;
     onNavigate: (annotationId: string, pageNumber: number) => void;
 }) {
     const icon = annotation.contents
         ? "bx bxs-comment-detail"
         : TYPE_ICONS[annotation.type] ?? "bx bx-comment";
 
+    function buildHash() {
+        const rawPreview = (annotation.highlightedText || annotation.contents).trim();
+        const annotationPreview = rawPreview.length > MAX_PREVIEW_LENGTH
+            ? `${rawPreview.substring(0, MAX_PREVIEW_LENGTH)}…`
+            : rawPreview || undefined;
+
+        return {
+            hash: calculateHash({
+                notePath,
+                viewScope: { annotationId: annotation.id, annotationPage: annotation.pageNumber, annotationPreview }
+            }),
+            linkTitle: annotationPreview
+                ? `${noteTitle} › "${annotationPreview}"`
+                : `${noteTitle} (annotation)`,
+        };
+    }
+
+    function copyLink() {
+        const { hash, linkTitle } = buildHash();
+
+        const html = $('<a class="reference-link">').attr("href", hash).text(linkTitle)[0].outerHTML;
+        if (copyRichText(html, hash)) {
+            toast.showMessage(t("pdf.annotation_link_copied"));
+        } else {
+            copyTextWithToast(hash);
+        }
+    }
+
+    function handleCopyLink(e: MouseEvent) {
+        e.stopPropagation();
+        copyLink();
+    }
+
     return (
         <div
             className="pdf-annotation-item"
+            data-annotation-id={annotation.id}
             onClick={() => onNavigate(annotation.id, annotation.pageNumber)}
             style={annotation.color ? { backgroundColor: annotation.color } : undefined}
         >
@@ -68,6 +181,13 @@ function PdfAnnotationItem({
                     <div className="pdf-annotation-author">{annotation.author}</div>
                 )}
             </div>
+            <button
+                className="pdf-annotation-copy-link"
+                title={t("pdf.copy_annotation_link")}
+                onClick={handleCopyLink}
+            >
+                <Icon icon="bx bx-link" />
+            </button>
         </div>
     );
 }

--- a/apps/client/src/widgets/sidebar/pdf/PdfAreaAnnotations.css
+++ b/apps/client/src/widgets/sidebar/pdf/PdfAreaAnnotations.css
@@ -1,0 +1,131 @@
+/* Colour the circle icons in the annotation colour-picker context menu.
+   These rules are global (CSS is not scoped) so they reach the context
+   menu DOM which lives directly in <body>, outside our component tree.
+   Specificity must beat .dropdown-item .tn-icon { color: !important } (0,2,0),
+   so we use .dropdown-item .tn-icon.<class> (0,3,0) to win. */
+.dropdown-item .tn-icon.pdf-color-blue   { color: #4a90d9 !important; }
+.dropdown-item .tn-icon.pdf-color-yellow { color: #f5c519 !important; }
+.dropdown-item .tn-icon.pdf-color-green  { color: #52b788 !important; }
+.dropdown-item .tn-icon.pdf-color-red    { color: #e63946 !important; }
+.dropdown-item .tn-icon.pdf-color-purple { color: #9c6ade !important; }
+
+.pdf-area-annotations-list {
+    width: 100%;
+}
+
+.pdf-area-annotation-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px 8px 14px;
+    margin: 4px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.15s;
+    position: relative;
+}
+
+.pdf-area-annotation-item:hover {
+    background: var(--hover-item-background-color, rgba(0,0,0,0.06));
+}
+
+/* Coloured left stripe matching the overlay colour */
+.pdf-area-annotation-color-bar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    border-radius: 6px 0 0 6px;
+}
+
+.pdf-area-annotation-thumbnail {
+    width: 100%;
+    border-radius: 4px;
+    border: 1px solid var(--main-border-color, #ddd);
+    display: block;
+    object-fit: contain;
+    max-height: 160px;
+    background: #fff;
+}
+
+.pdf-area-annotation-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.pdf-area-annotation-page {
+    font-size: 11px;
+    color: var(--muted-text-color, #777);
+}
+
+.pdf-area-annotation-comment {
+    font-size: 12px;
+    color: var(--main-text-color, #333);
+    font-style: italic;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+/* Hover-zoom: enlarged preview centred in viewport */
+.pdf-area-annotation-zoom {
+    display: none;
+    position: fixed;
+    z-index: 9999;
+    max-width: 500px;
+    max-height: 380px;
+    width: auto;
+    height: auto;
+    border-radius: 6px;
+    border: 2px solid var(--main-border-color, #ccc);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+    pointer-events: none;
+    background: #fff;
+    object-fit: contain;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.pdf-area-annotation-item:hover .pdf-area-annotation-zoom {
+    display: block;
+}
+
+/* Action buttons (copy link) shown on hover */
+.pdf-area-annotation-actions {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: flex;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 0.15s;
+    z-index: 1;
+}
+
+.pdf-area-annotation-item:hover .pdf-area-annotation-actions {
+    opacity: 1;
+}
+
+.pdf-area-annotation-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: var(--button-background-color, rgba(255,255,255,0.92));
+    color: var(--main-text-color, #333);
+    cursor: pointer;
+    font-size: 14px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.pdf-area-annotation-btn:hover {
+    background: var(--button-hover-background-color, #e0e0e0);
+}

--- a/apps/client/src/widgets/sidebar/pdf/PdfAreaAnnotations.tsx
+++ b/apps/client/src/widgets/sidebar/pdf/PdfAreaAnnotations.tsx
@@ -1,0 +1,194 @@
+import "./PdfAreaAnnotations.css";
+
+import { t } from "../../../services/i18n";
+import { calculateHash } from "../../../services/link";
+import { copyRichText, copyTextWithToast } from "../../../services/clipboard_ext";
+import toast from "../../../services/toast";
+import contextMenu from "../../../menus/context_menu";
+import { textPrompt } from "../../../services/textPrompt";
+import { useActiveNoteContext, useGetContextData, useNoteProperty } from "../../react/hooks";
+import { PDF_ANNOTATION_COLORS } from "./pdfAnnotationColors";
+import Icon from "../../react/Icon";
+import RightPanelWidget from "../RightPanelWidget";
+
+const PRESET_COLORS = PDF_ANNOTATION_COLORS;
+
+export default function PdfAreaAnnotations() {
+    const { note, noteContext } = useActiveNoteContext();
+    const noteType = useNoteProperty(note, "type");
+    const noteMime = useNoteProperty(note, "mime");
+    const data = useGetContextData("pdfAreaAnnotations");
+
+    if (noteType !== "file" || noteMime !== "application/pdf") return null;
+    if (!data || data.annotations.length === 0) return null;
+
+    return (
+        <RightPanelWidget
+            id="pdf-area-annotations"
+            title={t("pdf.area_annotations", { count: data.annotations.length })}
+        >
+            <div className="pdf-area-annotations-list">
+                {data.annotations.map((ann) => (
+                    <PdfAreaAnnotationItem
+                        key={ann.attachmentId}
+                        annotation={ann}
+                        notePath={noteContext?.notePath ?? ""}
+                        onNavigate={data.scrollToArea}
+                        onDelete={data.deleteArea}
+                        onUpdate={data.updateArea}
+                    />
+                ))}
+            </div>
+        </RightPanelWidget>
+    );
+}
+
+function PdfAreaAnnotationItem({
+    annotation, notePath, onNavigate, onDelete, onUpdate
+}: {
+    annotation: PdfAreaAnnotationInfo;
+    notePath: string;
+    onNavigate: (page: number, rect: PdfAreaAnnotationInfo["rect"]) => void;
+    onDelete: (attachmentId: string, attributeId: string) => void;
+    onUpdate: (attributeId: string, patch: { comment?: string; color?: string }) => void;
+}) {
+    const color = annotation.color ?? "#4a90d9";
+
+    // Shared copy logic — called from both the hover button and the context menu.
+    function doCopyLink() {
+        const hash = calculateHash({
+            notePath,
+            viewScope: {
+                annotationId: `area:${annotation.attachmentId}`,
+                annotationPage: annotation.pageNumber,
+            }
+        });
+
+        // Paste as <figure class="image"><a href="hash"><img src="..."></a></figure>:
+        // • ImageResize plugin gives resize handles in CKEditor.
+        // • The <a> makes it a linked image — clicking navigates to the PDF area.
+        // • The <img src> loads the existing attachment; no new note is created.
+        const html = $('<figure class="image">')
+            .append(
+                $('<a>').attr("href", hash).append(
+                    $('<img>')
+                        .attr("src", annotation.imageUrl)
+                        .attr("alt", t("pdf.area_annotation_label", { page: annotation.pageNumber }))
+                )
+            )[0].outerHTML;
+
+        // Fall back to the navigable hash link, not the bare image URL — the latter
+        // would silently drop the ability to jump back to this annotation.
+        if (copyRichText(html, hash)) {
+            toast.showMessage(t("pdf.annotation_link_copied"));
+        } else {
+            copyTextWithToast(hash);
+        }
+    }
+
+    function handleCopyLink(e: MouseEvent) {
+        e.stopPropagation();
+        doCopyLink();
+    }
+
+    function handleContextMenu(e: MouseEvent) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        contextMenu.show({
+            x: e.pageX,
+            y: e.pageY,
+            items: [
+                {
+                    title: t("pdf.copy_annotation_link"),
+                    command: "copyLink",
+                    uiIcon: "bx bx-link"
+                },
+                { kind: "separator" },
+                {
+                    title: annotation.comment
+                        ? t("pdf.area_edit_note")
+                        : t("pdf.area_add_note"),
+                    command: "editNote",
+                    uiIcon: "bx bx-comment-add"
+                },
+                {
+                    title: t("pdf.area_change_color"),
+                    command: "changeColor",
+                    uiIcon: "bx bx-palette",
+                    items: PRESET_COLORS.map((c) => ({
+                        title: c.label,
+                        command: `color:${c.value}`,
+                        uiIcon: `bx bx-circle ${c.cssClass}`
+                    }))
+                },
+                { kind: "separator" },
+                {
+                    title: t("pdf.area_annotation_delete"),
+                    command: "delete",
+                    uiIcon: "bx bx-trash"
+                }
+            ],
+            selectMenuItemHandler: async ({ command }) => {
+                if (command === "copyLink") {
+                    doCopyLink();
+                } else if (command === "editNote") {
+                    const current = annotation.comment ?? "";
+                    const entered = await textPrompt(t("pdf.area_note_prompt"), current);
+                    if (entered !== null) {
+                        onUpdate(annotation.attributeId, { comment: entered.trim() });
+                    }
+                } else if (command?.startsWith("color:")) {
+                    onUpdate(annotation.attributeId, { color: command.slice(6) });
+                } else if (command === "delete") {
+                    onDelete(annotation.attachmentId, annotation.attributeId);
+                }
+            }
+        });
+    }
+
+    return (
+        <div
+            className="pdf-area-annotation-item"
+            onClick={() => onNavigate(annotation.pageNumber, annotation.rect)}
+            onContextMenu={handleContextMenu}
+        >
+            {/* Colour stripe along the left edge */}
+            <div className="pdf-area-annotation-color-bar" style={{ background: color }} />
+
+            <img
+                className="pdf-area-annotation-thumbnail"
+                src={annotation.imageUrl}
+                alt={t("pdf.area_annotation_label", { page: annotation.pageNumber })}
+                loading="lazy"
+            />
+
+            {/* Enlarged preview centred in viewport on hover */}
+            <img
+                className="pdf-area-annotation-zoom"
+                src={annotation.imageUrl}
+                alt=""
+                aria-hidden="true"
+            />
+
+            <div className="pdf-area-annotation-meta">
+                <span className="pdf-area-annotation-page">
+                    {t("pdf.area_annotation_label", { page: annotation.pageNumber })}
+                </span>
+                {annotation.comment && (
+                    <span className="pdf-area-annotation-comment">{annotation.comment}</span>
+                )}
+            </div>
+
+            <div className="pdf-area-annotation-actions">
+                <button
+                    className="pdf-area-annotation-btn"
+                    title={t("pdf.copy_annotation_link")}
+                    onClick={handleCopyLink}
+                >
+                    <Icon icon="bx bx-link" />
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/widgets/sidebar/pdf/pdfAnnotationColors.ts
+++ b/apps/client/src/widgets/sidebar/pdf/pdfAnnotationColors.ts
@@ -1,0 +1,8 @@
+/** Shared colour palette used by both text and area annotation context menus. */
+export const PDF_ANNOTATION_COLORS = [
+    { label: "Blue",   value: "#4a90d9", cssClass: "pdf-color-blue"   },
+    { label: "Yellow", value: "#f5c519", cssClass: "pdf-color-yellow" },
+    { label: "Green",  value: "#52b788", cssClass: "pdf-color-green"  },
+    { label: "Red",    value: "#e63946", cssClass: "pdf-color-red"    },
+    { label: "Purple", value: "#9c6ade", cssClass: "pdf-color-purple" },
+] as const;

--- a/apps/client/src/widgets/type_widgets/file/Pdf.tsx
+++ b/apps/client/src/widgets/type_widgets/file/Pdf.tsx
@@ -1,13 +1,21 @@
+import type { RefObject } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
 import appContext from "../../../components/app_context";
 import type NoteContext from "../../../components/note_context";
+import type { NoteContextDataMap } from "../../../components/note_context";
 import FBlob from "../../../entities/fblob";
 import FNote from "../../../entities/fnote";
+import contextMenu from "../../../menus/context_menu";
+import { t } from "../../../services/i18n";
 import open from "../../../services/open";
 import options from "../../../services/options";
+import server from "../../../services/server";
+import { textPrompt } from "../../../services/textPrompt";
+import toast from "../../../services/toast";
 import { useViewModeConfig } from "../../collections/NoteList";
 import { useBlobEditorSpacedUpdate, useEffectiveReadOnly, useTriliumEvent } from "../../react/hooks";
+import { PDF_ANNOTATION_COLORS } from "../../sidebar/pdf/pdfAnnotationColors";
 import PdfViewer from "./PdfViewer";
 
 export default function PdfPreview({ note, blob, componentId, noteContext }: {
@@ -19,6 +27,13 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const isReadOnly = useEffectiveReadOnly(note, noteContext);
     const historyConfig = useViewModeConfig<HistoryData>(note, "pdfHistory");
+    const annotationScrolledRef = useRef(false);
+    // Stores the annotation we intend to scroll to. Survives spurious noteSwitched
+    // events that reset viewScope.annotationId to undefined before the scroll fires.
+    const pendingAnnotationIdRef = useRef<string | undefined>(undefined);
+    // True once pdfjs-viewer-ready-for-overlays fires, meaning the iframe's
+    // trilium-scroll-to-area listener is registered and messages will be received.
+    const viewerAreaReadyRef = useRef(false);
 
     const spacedUpdate = useBlobEditorSpacedUpdate({
         note,
@@ -173,8 +188,104 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
                             annotationId,
                             pageNumber
                         }, window.location.origin);
+                    },
+                    setAnnotationColor: (annotationId: string, color: string) => {
+                        iframeRef.current?.contentWindow?.postMessage({
+                            type: "trilium-set-annotation-color",
+                            annotationId,
+                            color
+                        }, window.location.origin);
+                    },
+                    deleteAnnotation: (annotationId: string, pageNumber: number) => {
+                        iframeRef.current?.contentWindow?.postMessage({
+                            type: "trilium-delete-annotation",
+                            annotationId,
+                            pageNumber
+                        }, window.location.origin);
                     }
                 });
+
+                // On first annotation load, scroll to the annotation referenced in the link.
+                // Area annotations (prefix "area:") live in pdfAreaAnnotations, not here —
+                // their scroll is handled in pdfjs-viewer-ready-for-overlays instead.
+                const pendingId = pendingAnnotationIdRef.current;
+                if (pendingId && !pendingId.startsWith("area:") && !annotationScrolledRef.current) {
+                    annotationScrolledRef.current = true;
+                    const target = resolveAnnotation(
+                        event.data.annotations,
+                        { ...noteContext.viewScope, annotationId: pendingId }
+                    );
+                    if (target) {
+                        pendingAnnotationIdRef.current = undefined;
+                        iframeRef.current?.contentWindow?.postMessage({
+                            type: "trilium-scroll-to-annotation",
+                            annotationId: target.id,
+                            pageNumber: target.pageNumber
+                        }, window.location.origin);
+                    }
+                }
+            }
+
+            // Filter by noteId/ntxId like every other handler above: without this, if more
+            // than one PdfPreview instance for the same PDF note is mounted at once (e.g. a
+            // stale listener from a just-closed tab that hasn't unmounted yet, or the same
+            // note open in a split), a single area gesture in one instance would be processed
+            // by every instance's listener, each independently creating its own annotation.
+            if (event.data.type === "pdfjs-viewer-area-capture") {
+                if (event.data.noteId === note.noteId && event.data.ntxId === noteContext.ntxId) {
+                    handleAreaCapture(
+                        note,
+                        event.data.imageData,
+                        event.data.pageNumber,
+                        event.data.rect,
+                        noteContext,
+                        iframeRef
+                    );
+                }
+            }
+
+            if (event.data.type === "pdfjs-viewer-area-right-click") {
+                if (event.data.noteId === note.noteId && event.data.ntxId === noteContext.ntxId) {
+                    handleAreaRightClick(event.data, noteContext, iframeRef);
+                }
+            }
+
+            if (event.data.type === "pdfjs-viewer-ready-for-overlays") {
+                // The PDF viewer just registered its trilium-set-area-overlays listener.
+                // Mark the viewer as ready so loadAreaAnnotations can scroll safely.
+                viewerAreaReadyRef.current = true;
+                const areaCtx = noteContext.getContextData("pdfAreaAnnotations");
+                if (areaCtx?.annotations.length) {
+                    iframeRef.current?.contentWindow?.postMessage(
+                        {
+                            type: "trilium-set-area-overlays",
+                            areas: areaCtx.annotations.map((a) => ({
+                                pageNumber: a.pageNumber,
+                                rect: a.rect,
+                                color: a.color,
+                                attachmentId: a.attachmentId,
+                                attributeId: a.attributeId,
+                                comment: a.comment
+                            }))
+                        },
+                        window.location.origin
+                    );
+
+                    // If a copied area link was clicked (fresh load path), scroll now.
+                    const pendingId = pendingAnnotationIdRef.current;
+                    if (pendingId?.startsWith("area:") && !annotationScrolledRef.current) {
+                        const attachmentId = pendingId.slice(5);
+                        const area = areaCtx.annotations.find((a) => a.attachmentId === attachmentId);
+                        if (area) {
+                            annotationScrolledRef.current = true;
+                            pendingAnnotationIdRef.current = undefined;
+                            iframeRef.current?.contentWindow?.postMessage(
+                                { type: "trilium-scroll-to-area", pageNumber: area.pageNumber, rect: area.rect },
+                                window.location.origin
+                            );
+                        }
+                    }
+                }
             }
 
             if (event.data.type === "pdfjs-viewer-layers") {
@@ -196,6 +307,85 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
             window.removeEventListener("message", handleMessage);
         };
     }, [ note, historyConfig, componentId, blob, noteContext, isReadOnly, spacedUpdate ]);
+
+    // Load area annotations when the PDF note changes.
+    // Pass the pending-scroll refs so loadAreaAnnotations can trigger the scroll
+    // directly once the data arrives — this covers the fresh-mount path where
+    // noteSwitched fires before the component is mounted (and therefore missed).
+    useEffect(() => {
+        void loadAreaAnnotations(note, noteContext, iframeRef, pendingAnnotationIdRef, annotationScrolledRef, viewerAreaReadyRef);
+    }, [ note.noteId ]);
+
+    // Reset scroll state when the note changes (fresh PDF load).
+    // Also capture the annotationId from viewScope here: for a fresh mount the
+    // useTriliumEvent("noteSwitched") handler fires AFTER noteSwitched has already
+    // propagated, so it misses the event. Reading from the mutable noteContext object
+    // at effect time is safe because this runs before pdfjs-viewer-annotations arrives.
+    useEffect(() => {
+        annotationScrolledRef.current = false;
+        pendingAnnotationIdRef.current = noteContext.viewScope?.annotationId;
+        viewerAreaReadyRef.current = false;   // viewer reloads on note change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [ note.noteId ]);
+
+    // Handle same-note re-navigation (different annotationId, PDF already loaded).
+    // noteSwitched fires after viewScope is updated, before any re-render. Since PdfPreview
+    // doesn't re-render for same-note viewScope changes, pdfjs-viewer-annotations won't fire
+    // again — we must scroll immediately from the already-loaded annotations context data.
+    useTriliumEvent("noteSwitched", ({ noteContext: eventNoteContext }) => {
+        if (eventNoteContext !== noteContext) return;
+
+        const targetAnnotationId = noteContext.viewScope?.annotationId;
+        if (!targetAnnotationId) return;
+
+        // Record what we want to scroll to. This ref survives spurious noteSwitched
+        // events that reset viewScope.annotationId to undefined before the scroll fires.
+        pendingAnnotationIdRef.current = targetAnnotationId;
+        annotationScrolledRef.current = false;
+
+        // Area annotation link — stored in pdfAreaAnnotations, scrolled via trilium-scroll-to-area
+        if (targetAnnotationId.startsWith("area:")) {
+            const attachmentId = targetAnnotationId.slice(5);
+            const areaCtx = noteContext.getContextData("pdfAreaAnnotations");
+            if (!areaCtx) {
+                // Area annotations not loaded yet (context was cleared on navigate-away).
+                // loadAreaAnnotations will be called and will handle the scroll once done.
+                void loadAreaAnnotations(note, noteContext, iframeRef, pendingAnnotationIdRef, annotationScrolledRef, viewerAreaReadyRef);
+            } else {
+                const area = areaCtx.annotations.find((a) => a.attachmentId === attachmentId);
+                if (area) {
+                    annotationScrolledRef.current = true;
+                    pendingAnnotationIdRef.current = undefined;
+                    iframeRef.current?.contentWindow?.postMessage(
+                        { type: "trilium-scroll-to-area", pageNumber: area.pageNumber, rect: area.rect },
+                        window.location.origin
+                    );
+                }
+            }
+            return;
+        }
+
+        // Regular text / highlight annotation
+        const existing = noteContext.getContextData("pdfAnnotations");
+        if (!existing) {
+            iframeRef.current?.contentWindow?.postMessage(
+                { type: "trilium-request-annotations" },
+                window.location.origin
+            );
+            return;
+        }
+
+        const target = resolveAnnotation(existing.annotations, noteContext.viewScope);
+        if (target) {
+            annotationScrolledRef.current = true;
+            pendingAnnotationIdRef.current = undefined;
+            iframeRef.current?.contentWindow?.postMessage({
+                type: "trilium-scroll-to-annotation",
+                annotationId: target.id,
+                pageNumber: target.pageNumber
+            }, window.location.origin);
+        }
+    });
 
     useTriliumEvent("customDownload", async ({ ntxId }) => {
         if (ntxId !== noteContext.ntxId) return;
@@ -228,20 +418,26 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
             iframeRef={iframeRef}
             tabIndex={300}
             pdfUrl={new URL(`${window.glob.baseApiUrl}notes/${note.noteId}/open`, window.location.href).pathname}
-            onLoad={() => {
-                const win = iframeRef.current?.contentWindow;
-                if (win) {
-                    win.TRILIUM_VIEW_HISTORY_STORE = historyConfig.config;
-                    win.TRILIUM_SIGNATURES = options.getJson("pdfSignatures") ?? {};
-                    win.TRILIUM_NOTE_ID = note.noteId;
-                    win.TRILIUM_NTX_ID = noteContext.ntxId;
-                }
+            onLoad={(win) => {
+                // Set these directly on the window belonging to this exact load event, not via
+                // iframeRef.current: closing and reopening the same PDF note in quick succession
+                // can leave the ref null or pointing at a different iframe by the time this fires,
+                // which silently left TRILIUM_NOTE_ID/TRILIUM_NTX_ID unset — breaking the noteId/
+                // ntxId check that area-capture and area-right-click messages are filtered on.
 
-                if (iframeRef.current?.contentWindow) {
-                    iframeRef.current.contentWindow.addEventListener('click', () => {
-                        appContext.tabManager.activateNoteContext(noteContext.ntxId);
-                    });
+                // Skip view history restoration when navigating via annotation link.
+                // PDF.js applies the saved pixel-scroll offset lazily (after page render),
+                // which fires after our scroll-to-annotation and overrides it.
+                if (!noteContext.viewScope?.annotationId) {
+                    win.TRILIUM_VIEW_HISTORY_STORE = historyConfig.config;
                 }
+                win.TRILIUM_SIGNATURES = options.getJson("pdfSignatures") ?? {};
+                win.TRILIUM_NOTE_ID = note.noteId;
+                win.TRILIUM_NTX_ID = noteContext.ntxId;
+
+                win.addEventListener('click', () => {
+                    appContext.tabManager.activateNoteContext(noteContext.ntxId);
+                });
             }}
             editable={!isReadOnly}
         />
@@ -253,6 +449,270 @@ interface PdfHeading {
     text: string;
     id: string;
     element: null;
+}
+
+import { resolveAnnotation } from "./pdfAnnotationResolver";
+
+/** Note label used to store area annotation metadata (attachmentId + page + rect). */
+const AREA_ANNOTATION_LABEL = "areaAnnotation";
+
+function pushAreaOverlays(iframeRef: RefObject<HTMLIFrameElement>, areas: PdfAreaAnnotationInfo[]) {
+    iframeRef.current?.contentWindow?.postMessage(
+        {
+            type: "trilium-set-area-overlays",
+            areas: areas.map((a) => ({
+                pageNumber: a.pageNumber,
+                rect: a.rect,
+                color: a.color,
+                attachmentId: a.attachmentId,
+                attributeId: a.attributeId,
+                comment: a.comment
+            }))
+        },
+        window.location.origin
+    );
+}
+
+function buildAreaAnnotationsContextData(
+    note: FNote,
+    noteContext: NoteContext,
+    iframeRef: RefObject<HTMLIFrameElement>,
+    areaAnnotations: PdfAreaAnnotationInfo[]
+): NoteContextDataMap["pdfAreaAnnotations"] {
+    return {
+        annotations: areaAnnotations,
+        scrollToArea(pageNumber, rect) {
+            iframeRef.current?.contentWindow?.postMessage(
+                { type: "trilium-scroll-to-area", pageNumber, rect },
+                window.location.origin
+            );
+        },
+        async deleteArea(attachmentId, attributeId) {
+            await server.remove(`notes/${note.noteId}/attributes/${attributeId}`);
+            await server.remove(`attachments/${attachmentId}`);
+            await loadAreaAnnotations(note, noteContext, iframeRef);
+        },
+        async updateArea(attributeId, patch) {
+            // Find the existing annotation to merge the patch into its stored JSON
+            const existing = areaAnnotations.find((a) => a.attributeId === attributeId);
+            if (!existing) return;
+
+            // Reflect the change immediately in the sidebar swatch and in-PDF overlay.
+            // Without this, the UI only picks up the new value once the persist call
+            // below resolves and loadAreaAnnotations re-fetches — which is a visible
+            // delay, or (if the request silently fails) never happens at all.
+            const optimistic = areaAnnotations.map((a) =>
+                a.attributeId === attributeId
+                    ? {
+                        ...a,
+                        comment: patch.comment !== undefined ? patch.comment : a.comment,
+                        color: patch.color !== undefined ? patch.color : a.color
+                    }
+                    : a
+            );
+            pushAreaOverlays(iframeRef, optimistic);
+            noteContext.setContextData("pdfAreaAnnotations", buildAreaAnnotationsContextData(note, noteContext, iframeRef, optimistic));
+
+            try {
+                // Update the attribute's value in place (preserves attributeId) instead of
+                // delete+recreate: the latter was neither atomic (a concurrent read could see
+                // no attribute at all) nor safe under a second update racing on the old id.
+                await server.put(`notes/${note.noteId}/attribute`, {
+                    attributeId,
+                    type: "label",
+                    name: AREA_ANNOTATION_LABEL,
+                    value: JSON.stringify({
+                        attachmentId: existing.attachmentId,
+                        page: existing.pageNumber,
+                        rect: existing.rect,
+                        comment: patch.comment !== undefined ? patch.comment : existing.comment,
+                        color: patch.color !== undefined ? patch.color : existing.color
+                    })
+                });
+            } catch (e) {
+                console.error("Failed to update area annotation:", e);
+                toast.showError(t("pdf.area_capture_failed"));
+            } finally {
+                // Reconcile with the server's actual state whether the update succeeded or not.
+                await loadAreaAnnotations(note, noteContext, iframeRef);
+            }
+        }
+    };
+}
+
+async function loadAreaAnnotations(
+    note: FNote,
+    noteContext: NoteContext,
+    iframeRef: RefObject<HTMLIFrameElement>,
+    pendingAnnotationIdRef?: { current: string | undefined },
+    annotationScrolledRef?: { current: boolean },
+    viewerAreaReadyRef?: { current: boolean }
+) {
+    const capturedNoteId = note.noteId;
+    try {
+        const attributes = await server.get<{ attributeId: string; type: string; name: string; value: string }[]>(
+            `notes/${capturedNoteId}/attributes`
+        );
+
+        // Guard: user may have navigated away while the fetch was in-flight
+        if (noteContext.noteId !== capturedNoteId) return;
+
+        const areaAnnotations: PdfAreaAnnotationInfo[] = attributes
+            .filter((a) => a.type === "label" && a.name === AREA_ANNOTATION_LABEL)
+            .map((a) => {
+                try {
+                    const { attachmentId, page, rect, comment, color } = JSON.parse(a.value);
+                    return {
+                        attachmentId,
+                        attributeId: a.attributeId,
+                        pageNumber: page,
+                        rect,
+                        imageUrl: `api/attachments/${attachmentId}/open`,
+                        comment,
+                        color
+                    } satisfies PdfAreaAnnotationInfo;
+                } catch {
+                    return null;
+                }
+            })
+            .filter((a): a is NonNullable<typeof a> => a !== null);
+
+        noteContext.setContextData("pdfAreaAnnotations", buildAreaAnnotationsContextData(note, noteContext, iframeRef, areaAnnotations));
+
+        // Redraw persistent overlays in the PDF viewer with all metadata.
+        // Note: at initial load the iframe may not have set up its listener yet.
+        // The viewer signals "pdfjs-viewer-ready-for-overlays" once ready, and we
+        // resend the data then. This postMessage is for redraws when context changes.
+        pushAreaOverlays(iframeRef, areaAnnotations);
+
+        // If a pending area annotation scroll was requested (e.g. user clicked a copied
+        // area link while this note was not yet loaded), scroll to it now.
+        const pendingId = pendingAnnotationIdRef?.current;
+        if (pendingId?.startsWith("area:") && !annotationScrolledRef?.current) {
+            const attachmentId = pendingId.slice(5);
+            const area = areaAnnotations.find((a) => a.attachmentId === attachmentId);
+            if (area) {
+                iframeRef.current?.contentWindow?.postMessage(
+                    { type: "trilium-scroll-to-area", pageNumber: area.pageNumber, rect: area.rect },
+                    window.location.origin
+                );
+                // Only mark as done when the viewer's listener is registered (after
+                // pdfjs-viewer-ready-for-overlays fires). If the viewer isn't ready yet,
+                // leave pending state intact so the ready handler can scroll correctly.
+                if (viewerAreaReadyRef?.current) {
+                    if (annotationScrolledRef) annotationScrolledRef.current = true;
+                    if (pendingAnnotationIdRef) pendingAnnotationIdRef.current = undefined;
+                }
+            }
+        }
+    } catch (e) {
+        console.error("Failed to load area annotations:", e);
+    }
+}
+
+async function handleAreaCapture(
+    note: FNote,
+    imageData: string,
+    pageNumber: number,
+    rect: { x: number; y: number; width: number; height: number },
+    noteContext: NoteContext,
+    iframeRef: RefObject<HTMLIFrameElement>
+) {
+    try {
+        // Convert base64 → binary File so server.upload stores real binary bytes
+        // (posting base64 as a JSON string stores UTF-8 text, not decoded PNG)
+        const base64 = imageData.replace("data:image/png;base64,", "");
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        const file = new File([bytes], "area-capture.png", { type: "image/png" });
+
+        // Upload via the binary-safe multipart route (role="image" set automatically)
+        const result = await server.upload(
+            `notes/${note.noteId}/attachments/upload`, file, undefined, "POST"
+        ) as { uploaded: boolean; url: string };
+
+        if (!result?.uploaded || !result?.url) {
+            throw new Error("Upload returned no URL");
+        }
+
+        // URL format: "api/attachments/{attachmentId}/image/{title}"
+        const attachmentIdMatch = result.url.match(/api\/attachments\/([^/]+)\//);
+        const attachmentId = attachmentIdMatch?.[1];
+        if (!attachmentId) throw new Error(`Could not extract attachmentId from URL: ${result.url}`);
+
+        // Store metadata as a note label so it survives across sessions
+        await server.post(`notes/${note.noteId}/attributes`, {
+            type: "label",
+            name: AREA_ANNOTATION_LABEL,
+            value: JSON.stringify({ attachmentId, page: pageNumber, rect })
+        });
+
+        toast.showMessage(t("pdf.area_capture_saved"));
+        await loadAreaAnnotations(note, noteContext, iframeRef);
+    } catch (e) {
+        console.error("Area capture failed:", e);
+        toast.showError(t("pdf.area_capture_failed"));
+    }
+}
+
+const AREA_PRESET_COLORS = PDF_ANNOTATION_COLORS;
+
+function handleAreaRightClick(
+    data: PdfViewerAreaRightClickMessage,
+    noteContext: NoteContext,
+    iframeRef: RefObject<HTMLIFrameElement>
+) {
+    const areaCtx = noteContext.getContextData("pdfAreaAnnotations");
+    const annotation = areaCtx?.annotations.find((a) => a.attachmentId === data.attachmentId);
+    if (!annotation || !areaCtx) return;
+
+    // Convert iframe-relative client coords → parent page coords
+    const iframeRect = iframeRef.current?.getBoundingClientRect();
+    const pageX = (iframeRect?.left ?? 0) + window.scrollX + data.clientX;
+    const pageY = (iframeRect?.top ?? 0) + window.scrollY + data.clientY;
+
+    contextMenu.show({
+        x: pageX,
+        y: pageY,
+        items: [
+            {
+                title: annotation.comment ? t("pdf.area_edit_note") : t("pdf.area_add_note"),
+                command: "editNote",
+                uiIcon: "bx bx-comment-add"
+            },
+            {
+                title: t("pdf.area_change_color"),
+                command: "changeColor",
+                uiIcon: "bx bx-palette",
+                items: AREA_PRESET_COLORS.map((c) => ({
+                    title: c.label,
+                    command: `color:${c.value}`,
+                    uiIcon: `bx bx-circle ${c.cssClass}`
+                }))
+            },
+            { kind: "separator" },
+            {
+                title: t("pdf.area_annotation_delete"),
+                command: "delete",
+                uiIcon: "bx bx-trash"
+            }
+        ],
+        selectMenuItemHandler: async ({ command }) => {
+            if (command === "editNote") {
+                const entered = await textPrompt(t("pdf.area_note_prompt"), annotation.comment ?? "");
+                if (entered !== null) {
+                    areaCtx.updateArea(annotation.attributeId, { comment: entered.trim() });
+                }
+            } else if (command?.startsWith("color:")) {
+                areaCtx.updateArea(annotation.attributeId, { color: command.slice(6) });
+            } else if (command === "delete") {
+                areaCtx.deleteArea(annotation.attachmentId, annotation.attributeId);
+            }
+        }
+    });
 }
 
 function convertPdfOutlineToHeadings(outline: PdfOutlineItem[]): PdfHeading[] {

--- a/apps/client/src/widgets/type_widgets/file/PdfViewer.tsx
+++ b/apps/client/src/widgets/type_widgets/file/PdfViewer.tsx
@@ -17,7 +17,14 @@ interface PdfViewerProps extends Pick<HTMLAttributes<HTMLIFrameElement>, "tabInd
     iframeRef?: RefObject<HTMLIFrameElement>;
     /** Note: URLs are relative to /pdfjs/web, ideally use absolute paths (but without domain name) to avoid issues with some proxies. */
     pdfUrl: string;
-    onLoad?(): void;
+    /**
+     * Called when the iframe finishes loading, with the window belonging to that exact load
+     * event. Deriving the window from `event.currentTarget` rather than an external ref avoids
+     * a real race: if the iframe is torn down and remounted in quick succession (e.g. closing
+     * and reopening the same PDF note), a ref can still be null or point at a different iframe
+     * by the time this fires.
+     */
+    onLoad?(win: Window): void;
     /**
      * If set, enables editable mode which includes persistence of user settings, annotations as well as specific features such as sending table of contents data for the sidebar.
      */
@@ -50,9 +57,10 @@ export default function PdfViewer({ iframeRef: externalIframeRef, pdfUrl, onLoad
             class="pdf-preview"
             style={{width: "100%", height: "100%"}}
             src={`pdfjs/web/viewer.html?v=${glob.triliumVersion}&file=${pdfUrl}&locale=${locale}&sidebar=${newLayout ? "0" : "1"}&editable=${editable ? "1" : "0"}&toolbar=${toolbar ? "1" : "0"}${minPixelRatio ? `&minPixelRatio=${minPixelRatio}` : ""}`}
-            onLoad={() => {
+            onLoad={(e) => {
                 injectStyles();
-                onLoad?.();
+                const win = (e.currentTarget as HTMLIFrameElement).contentWindow;
+                if (win) onLoad?.(win);
             }}
         />
     );

--- a/apps/client/src/widgets/type_widgets/file/pdfAnnotationResolver.spec.ts
+++ b/apps/client/src/widgets/type_widgets/file/pdfAnnotationResolver.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { resolveAnnotation } from "./pdfAnnotationResolver";
+
+/** Minimal PdfAnnotationInfo factory. */
+function ann(id: string, page: number, highlight = "", contents = ""): PdfAnnotationInfo {
+    return {
+        id,
+        type: "highlight",
+        contents,
+        highlightedText: highlight,
+        author: "",
+        pageNumber: page,
+        color: null,
+        creationDate: null,
+        modificationDate: null
+    };
+}
+
+const ANNOTATIONS: PdfAnnotationInfo[] = [
+    ann("12R", 3, "The quick brown fox", ""),
+    ann("14R", 3, "",                   "My sticky note"),
+    ann("16R", 7, "another highlight",  "with a comment"),
+];
+
+describe("resolveAnnotation", () => {
+    it("returns undefined when viewScope is absent", () => {
+        expect(resolveAnnotation(ANNOTATIONS, undefined)).toBeUndefined();
+    });
+
+    it("returns undefined when annotationId is absent in viewScope", () => {
+        expect(resolveAnnotation(ANNOTATIONS, { viewMode: "default" })).toBeUndefined();
+    });
+
+    // ── Exact ID match ──────────────────────────────────────────────────────────
+
+    it("finds an annotation by exact ID", () => {
+        const result = resolveAnnotation(ANNOTATIONS, { annotationId: "14R" });
+        expect(result?.id).toBe("14R");
+    });
+
+    it("returns undefined when exact ID is not in the list", () => {
+        expect(resolveAnnotation(ANNOTATIONS, { annotationId: "99R" })).toBeUndefined();
+    });
+
+    // ── Fallback: page + content preview ────────────────────────────────────────
+
+    it("falls back to page+highlight when ID is missing and preview matches", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 3,
+            annotationPreview: "The quick brown"  // prefix of highlight
+        });
+        expect(result?.id).toBe("12R");
+    });
+
+    it("falls back to page+contents when highlightedText does not match", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 3,
+            annotationPreview: "My sticky"
+        });
+        expect(result?.id).toBe("14R");
+    });
+
+    it("strips the ellipsis (…) suffix from annotationPreview before matching", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 7,
+            annotationPreview: "another highl…"  // truncated with ellipsis
+        });
+        expect(result?.id).toBe("16R");
+    });
+
+    it("returns undefined when page matches but content does not", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 3,
+            annotationPreview: "no match here"
+        });
+        expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when page does not match even if content does", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 99,          // wrong page
+            annotationPreview: "The quick brown fox"
+        });
+        expect(result).toBeUndefined();
+    });
+
+    it("requires both page and preview for the fallback — omitting page returns undefined", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            // no annotationPage
+            annotationPreview: "The quick brown"
+        });
+        expect(result).toBeUndefined();
+    });
+
+    it("requires both page and preview for the fallback — omitting preview returns undefined", () => {
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "staleId",
+            annotationPage: 3
+            // no annotationPreview
+        });
+        expect(result).toBeUndefined();
+    });
+
+    // ── Exact match takes priority ───────────────────────────────────────────────
+
+    it("prefers exact ID match over the page+content fallback", () => {
+        // "12R" is on page 3 with "The quick brown fox"; the stale-id search
+        // could also match it via content. Ensure the exact match wins when ID is right.
+        const result = resolveAnnotation(ANNOTATIONS, {
+            annotationId: "16R",
+            annotationPage: 3,
+            annotationPreview: "The quick brown"   // would match 12R via fallback
+        });
+        expect(result?.id).toBe("16R");            // exact wins
+    });
+});

--- a/apps/client/src/widgets/type_widgets/file/pdfAnnotationResolver.ts
+++ b/apps/client/src/widgets/type_widgets/file/pdfAnnotationResolver.ts
@@ -1,0 +1,30 @@
+import type { ViewScope } from "../../../services/link";
+
+/**
+ * Find the annotation to scroll to from a list, given the viewScope from the navigation URL.
+ *
+ * Tries an exact ID match first. Falls back to page-number + content matching because
+ * PDF.js reassigns annotation IDs when the PDF is saved (temporary editor IDs become
+ * permanent PDF object references), so a link copied before saving will have a stale ID.
+ */
+export function resolveAnnotation(
+    annotations: PdfAnnotationInfo[],
+    viewScope: ViewScope | undefined
+): PdfAnnotationInfo | undefined {
+    if (!viewScope?.annotationId) return undefined;
+
+    // 1. Exact ID match (works for existing PDF annotations and links copied after save).
+    const exact = annotations.find((a) => a.id === viewScope.annotationId);
+    if (exact) return exact;
+
+    // 2. Fallback: match by page number + content preview (handles ID rotation after save).
+    const page = viewScope.annotationPage;
+    const rawPreview = viewScope.annotationPreview?.replace(/…$/, "") ?? "";
+    if (!page || !rawPreview) return undefined;
+
+    return annotations.find(
+        (a) =>
+            a.pageNumber === page &&
+            (a.highlightedText.startsWith(rawPreview) || a.contents.startsWith(rawPreview))
+    );
+}

--- a/docs/User Guide/User Guide/Note Types/File/2_PDFs_image.svg
+++ b/docs/User Guide/User Guide/Note Types/File/2_PDFs_image.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <rect width="1200" height="600" fill="#f5f5f5"/>
+  <rect x="20" y="20" width="850" height="560" rx="4" fill="#fff" stroke="#ddd" stroke-width="2"/>
+  <rect x="20" y="20" width="850" height="40" rx="4" fill="#f0f0f0"/>
+  <text x="40" y="46" font-family="sans-serif" font-size="14" fill="#666">PDF viewer toolbar</text>
+  <rect x="890" y="20" width="290" height="560" rx="4" fill="#fff" stroke="#ddd" stroke-width="2"/>
+  <rect x="890" y="20" width="290" height="40" rx="4" fill="#f0f0f0"/>
+  <text x="900" y="46" font-family="sans-serif" font-size="13" fill="#666" font-weight="bold">Annotations</text>
+  <rect x="900" y="70" width="270" height="50" rx="4" fill="#e8f4e8" stroke="#ccc" stroke-width="1"/>
+  <text x="910" y="90" font-family="sans-serif" font-size="12" fill="#333">A remark</text>
+  <text x="910" y="106" font-family="sans-serif" font-size="10" fill="#999">Page 1 · Highlight</text>
+  <rect x="1140" y="78" width="20" height="20" rx="3" fill="#4a90d9" cursor="pointer"/>
+  <text x="1145" y="92" font-family="sans-serif" font-size="12" fill="#fff">📋</text>
+  <rect x="900" y="130" width="270" height="50" rx="4" fill="#e8f0e8" stroke="#ccc" stroke-width="1"/>
+  <text x="910" y="150" font-family="sans-serif" font-size="12" fill="#333">A sticky note</text>
+  <text x="910" y="166" font-family="sans-serif" font-size="10" fill="#999">Page 1 · Comment</text>
+  <rect x="1140" y="138" width="20" height="20" rx="3" fill="#4a90d9" cursor="pointer"/>
+  <text x="1145" y="152" font-family="sans-serif" font-size="12" fill="#fff">📋</text>
+  <text x="400" y="320" font-family="sans-serif" font-size="24" fill="#999" text-anchor="middle">PDF Page Content</text>
+  <!-- Arrow pointing to copy link icon -->
+  <line x1="1000" y1="60" x2="1150" y2="88" stroke="#e74c3c" stroke-width="2" stroke-dasharray="4,3"/>
+  <text x="1000" y="58" font-family="sans-serif" font-size="11" fill="#e74c3c">Copy link</text>
+</svg>

--- a/docs/User Guide/User Guide/Note Types/File/3_PDFs_image.svg
+++ b/docs/User Guide/User Guide/Note Types/File/3_PDFs_image.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <rect x="2" y="2" width="20" height="20" rx="2" fill="none" stroke="#555" stroke-width="1.5" stroke-dasharray="3 2"/>
+  <line x1="12" y1="6" x2="12" y2="18" stroke="#555" stroke-width="1" opacity="0.6"/>
+  <line x1="6" y1="12" x2="18" y2="12" stroke="#555" stroke-width="1" opacity="0.6"/>
+</svg>

--- a/docs/User Guide/User Guide/Note Types/File/4_PDFs_image.svg
+++ b/docs/User Guide/User Guide/Note Types/File/4_PDFs_image.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <rect width="1200" height="600" fill="#f5f5f5"/>
+  <rect x="20" y="20" width="850" height="560" rx="4" fill="#fff" stroke="#ddd" stroke-width="2"/>
+  <rect x="20" y="20" width="850" height="40" rx="4" fill="#f0f0f0"/>
+  <text x="40" y="46" font-family="sans-serif" font-size="14" fill="#666">PDF viewer toolbar</text>
+  <text x="400" y="280" font-family="sans-serif" font-size="24" fill="#999" text-anchor="middle">PDF Page Content</text>
+  <!-- Dashed selection rectangle -->
+  <rect x="250" y="200" width="350" height="200" rx="2" fill="rgba(74, 144, 217, 0.1)" stroke="#4a90d9" stroke-width="2" stroke-dasharray="5,3"/>
+  <text x="425" y="310" font-family="sans-serif" font-size="16" fill="#4a90d9" text-anchor="middle">Selected area</text>
+  <text x="425" y="330" font-family="sans-serif" font-size="11" fill="#4a90d9" text-anchor="middle">(drag to select)</text>
+  <!-- Crosshair cursor indicator -->
+  <circle cx="425" cy="300" r="20" fill="none" stroke="#4a90d9" stroke-width="1" stroke-dasharray="2,2"/>
+  <line x1="425" y1="275" x2="425" y2="325" stroke="#4a90d9" stroke-width="1"/>
+  <line x1="400" y1="300" x2="450" y2="300" stroke="#4a90d9" stroke-width="1"/>
+</svg>

--- a/docs/User Guide/User Guide/Note Types/File/5_PDFs_image.svg
+++ b/docs/User Guide/User Guide/Note Types/File/5_PDFs_image.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <rect width="1200" height="600" fill="#f5f5f5"/>
+  <rect x="20" y="20" width="850" height="560" rx="4" fill="#fff" stroke="#ddd" stroke-width="2"/>
+  <rect x="20" y="20" width="850" height="40" rx="4" fill="#f0f0f0"/>
+  <text x="40" y="46" font-family="sans-serif" font-size="14" fill="#666">PDF viewer toolbar</text>
+  <text x="400" y="280" font-family="sans-serif" font-size="24" fill="#999" text-anchor="middle">PDF Page Content</text>
+  <!-- Area overlay on the page -->
+  <rect x="250" y="200" width="200" height="120" rx="2" fill="rgba(255, 0, 0, 0.1)" stroke="#ff0000" stroke-width="2"/>
+  <text x="350" y="265" font-family="sans-serif" font-size="12" fill="#c00" text-anchor="middle">Captured area</text>
+  <!-- Context menu -->
+  <rect x="280" y="240" width="200" height="140" rx="4" fill="#fff" stroke="#ccc" stroke-width="1" filter="drop-shadow(2px 2px 4px rgba(0,0,0,0.2))"/>
+  <rect x="280" y="240" width="200" height="35" rx="4" fill="#f8f8f8"/>
+  <text x="295" y="262" font-family="sans-serif" font-size="13" fill="#333">✏️ Add/Edit note</text>
+  <line x1="280" y1="275" x2="480" y2="275" stroke="#eee" stroke-width="1"/>
+  <text x="295" y="297" font-family="sans-serif" font-size="13" fill="#333">🎨 Change color</text>
+  <line x1="280" y1="310" x2="480" y2="310" stroke="#eee" stroke-width="1"/>
+  <text x="295" y="332" font-family="sans-serif" font-size="13" fill="#c00">🗑️ Delete</text>
+  <line x1="280" y1="345" x2="480" y2="345" stroke="#eee" stroke-width="1"/>
+  <text x="295" y="367" font-family="sans-serif" font-size="13" fill="#333">🔴 🟡 🟢 🔵</text>
+</svg>

--- a/docs/User Guide/User Guide/Note Types/File/PDFs.md
+++ b/docs/User Guide/User Guide/Note Types/File/PDFs.md
@@ -63,9 +63,67 @@ Annotations are stored directly in the PDF. When modifications are made, Trilium
 
 Since modifications are automatically saved, there's no need to manually save the document after making modifications to the annotations.
 
-The benefit of “baked-in annotations” is that they are also accessible if downloading (for external use outside Trilium) or sharing the note.
+The benefit of "baked-in annotations" is that they are also accessible if downloading (for external use outside Trilium) or sharing the note.
 
 The downside is that the entire PDF needs to be sent back to the server, which can slow down performance for larger documents. If you encounter any issues from this system, feel free to [report it](../../Troubleshooting/Reporting%20issues.md).
+
+### Linking to annotations
+
+Since v0.104.0, it is possible to create links to specific PDF annotations and use them in other notes. This allows you to reference a particular highlight, comment, or area capture from any text note in Trilium.
+
+To link to an annotation:
+
+1. Open a PDF that contains annotations.
+2. In the <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/Right%20Sidebar.md">Right Sidebar</a>, navigate to the **Annotations** section.
+3. Click the **Copy link** icon next to the annotation you want to reference.
+4. Paste the link into any text note. The link will appear as an internal reference to the PDF, scrolled to the exact annotation position.
+
+<figure class="image"><img style="aspect-ratio:1200/600;" src="2_PDFs_image.svg" width="1200" height="600"><figcaption>Copying an annotation link from the sidebar.</figcaption></figure>
+
+When you click on the link, Trilium will open the PDF and automatically scroll to the annotation. This works for:
+
+*   **Highlight annotations** — scrolls to the highlighted text.
+*   **Text/comment annotations** — scrolls to the comment position.
+*   **Area annotations** — scrolls to the captured area overlay (see below).
+
+> [!TIP]
+> If the annotation ID changes after saving the PDF (e.g. when temporary editor IDs become permanent PDF object references), Trilium will still find the correct annotation by matching the page number and content preview. This ensures that links copied before saving will continue to work.
+
+### Area annotations (image captures)
+
+Since v0.104.0, you can also capture rectangular regions of a PDF page as image annotations. This is useful for highlighting diagrams, charts, sections of text, or any visual content that cannot be highlighted with the standard text highlight tool.
+
+To use area annotations:
+
+1. Look for the **area capture button** (<img src="3_PDFs_image.svg" width="24" height="24">) on the right side of the PDF toolbar.
+2. Click the button to activate area selection mode. The cursor will change to a crosshair.
+3. Click and drag on the PDF page to select a rectangular region.
+4. Release the mouse button to capture the selected area.
+
+<figure class="image"><img style="aspect-ratio:1200/600;" src="4_PDFs_image.svg" width="1200" height="600"><figcaption>Selecting a rectangular area to capture as an image annotation.</figcaption></figure>
+
+The captured area will be:
+
+*   Uploaded as an image attachment to the note.
+*   Displayed as a colored overlay rectangle on the PDF page.
+*   Listed in the sidebar under the PDF annotations section.
+
+#### Interacting with area overlays
+
+Once an area annotation overlay is displayed on the page, you can right-click on it to access a context menu with the following options:
+
+*   **Add/Edit note** — Attach a text comment to the area annotation.
+*   **Change color** — Choose from a set of predefined colors to customize the overlay appearance.
+*   **Delete** — Remove the area annotation and its associated image attachment.
+
+<figure class="image"><img style="aspect-ratio:1200/600;" src="5_PDFs_image.svg" width="1200" height="600"><figcaption>Right-click context menu on an area overlay.</figcaption></figure>
+
+#### Linking to area annotations
+
+Area annotations can also be linked to from other notes, just like regular annotations. The link will scroll the PDF to the exact position of the area overlay.
+
+> [!NOTE]
+> Area annotations are stored as Trilium note labels and image attachments, not inside the PDF file itself. This means they are only visible within Trilium and will not appear when downloading the PDF for external use.
 
 ## Filling out forms
 
@@ -79,6 +137,26 @@ Simply type text in the forms and they will be automatically saved.
 > This feature is only available if <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/New%20Layout.md">New Layout</a> is enabled. If you are using the old layout, these features are still available by looking for a sidebar button in the PDF viewer toolbar.
 
 See the dedicated section on PDFs in <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/Right%20Sidebar/Outline%20tab.md">Outline tab</a>.
+
+When a PDF file is opened in Trilium the <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/Right%20Sidebar.md">Right Sidebar</a> is augmented with PDF-specific navigation, with the following features:
+
+*   Table of contents/outline
+    *   All the headings and "bookmarks" will be displayed hierarchially.
+    *   The heading on the current page is also highlighted (note that it can be slightly offset depending on how many headings are on the same page).
+    *   Clicking on a heading will jump to the corresponding position in the PDF.
+*   Pages
+    *   A preview of all the pages with a small thumbnail.
+    *   Clicking on a page will automatically navigate to that page.
+*   Annotations
+    *   Highlight and comment annotations are listed here.
+    *   For the old layout, this feature is not directly available, however there is a listing of comments directly in the PDF toolbar.
+*   Attachments
+    *   If the PDF has its own attachments (not to be confused with Trilium's <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/Notes/Attachments.md">Attachments</a>), they will be displayed in a list.
+    *   Some information such as the name and size of the attachment are displayed.
+    *   It's possible to download the attachment by clicking on the download button.
+*   Layers
+    *   A less common feature, if the PDF has toggle-able layers, these layers will be displayed in a list here.
+    *   It's possible to toggle the visibility for each individual layer.
 
 ## Share functionality
 

--- a/packages/ckeditor5/src/plugins.ts
+++ b/packages/ckeditor5/src/plugins.ts
@@ -1,4 +1,4 @@
-import { Autoformat, AutoLink, BlockQuote, BlockToolbar, Bold, CKFinderUploadAdapter, Clipboard, Code, CodeBlock, Enter, Font, FontBackgroundColor, FontColor, GeneralHtmlSupport, Heading, HeadingButtonsUI, HorizontalLine, Image, ImageCaption, ImageInline, ImageResize, ImageStyle, ImageToolbar, ImageUpload, Alignment, Indent, IndentBlock, Italic, Link, List, ListProperties, MentionEditing, PageBreak, Paragraph, ParagraphButtonUI, PasteFromOffice, PictureEditing, RemoveFormat, SelectAll, ShiftEnter, SpecialCharacters, SpecialCharactersEssentials, Strikethrough, Style, Subscript, Superscript, Table, TableCaption, TableCellProperties, TableColumnResize, TableProperties, TableSelection, TableToolbar, TextPartLanguage, TextTransformation, TodoList, Typing, Underline, Undo, Bookmark, EmojiPicker, FindAndReplaceEditing } from "ckeditor5";
+import { Autoformat, AutoLink, BlockQuote, BlockToolbar, Bold, CKFinderUploadAdapter, Clipboard, Code, CodeBlock, Enter, Font, FontBackgroundColor, FontColor, GeneralHtmlSupport, Heading, HeadingButtonsUI, HorizontalLine, Image, ImageCaption, ImageInline, ImageResize, ImageStyle, ImageToolbar, ImageUpload, Alignment, Indent, IndentBlock, Italic, Link, LinkImage, List, ListProperties, Mention, PageBreak, Paragraph, ParagraphButtonUI, PasteFromOffice, PictureEditing, RemoveFormat, SelectAll, ShiftEnter, SpecialCharacters, SpecialCharactersEssentials, Strikethrough, Style, Subscript, Superscript, Table, TableCaption, TableCellProperties, TableColumnResize, TableProperties, TableSelection, TableToolbar, TextPartLanguage, TextTransformation, TodoList, Typing, Underline, Undo, Bookmark, EmojiMention, EmojiPicker, FindAndReplaceEditing } from "ckeditor5";
 // Nothing here comes from `ckeditor5-premium-features` any more: every premium plugin Trilium
 // once loaded has an in-tree GPL replacement — `SlashCommand` -> `TriliumSlashCommands`,
 // `FormatPainter` -> `TriliumFormatPainter`, `Template` -> `TriliumSnippets`. See each plugin's
@@ -167,6 +167,7 @@ export const COMMON_PLUGINS: typeof Plugin[] = [
 	ImageResize,
 	ImageInline,
 	Link,
+	LinkImage,
 	AutoLink,
 	List,
 	ListProperties,

--- a/packages/ckeditor5/vitest.config.ts
+++ b/packages/ckeditor5/vitest.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
     test: {
+        name: "@triliumnext/ckeditor5:test",
         browser: {
             enabled: true,
             provider: webdriverio(),

--- a/packages/pdfjs-viewer/e2e/annotation-linking.spec.ts
+++ b/packages/pdfjs-viewer/e2e/annotation-linking.spec.ts
@@ -1,0 +1,152 @@
+import { expect, type FrameLocator, type Page, test } from "@playwright/test";
+
+/**
+ * Covers internal linking to PDF annotations: scrolling to a specific annotation
+ * by ID, scrolling to area annotations, the MutationObserver fallback for
+ * not-yet-rendered annotations, and re-requesting annotations.
+ */
+
+test("scrolls to an existing annotation via trilium-scroll-to-annotation", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Wait for annotations to be extracted and sent
+    await page.waitForTimeout(1500);
+
+    // Scroll to the first annotation (highlight "A remark" on page 1)
+    await page.evaluate(() => (window as any).scrollToAnnotation("5R", 1));
+    await page.waitForTimeout(500);
+
+    // Check if the viewer scrolled by accessing the iframe's contentWindow
+    const scrolled = await page.evaluate(() => {
+        const iframe = document.getElementById("viewer") as HTMLIFrameElement;
+        const container = iframe?.contentWindow?.PDFViewerApplication?.pdfViewer?.container;
+        return container ? container.scrollTop : null;
+    });
+    expect(scrolled).not.toBeNull();
+});
+
+test("scrolls to an area annotation via trilium-scroll-to-area", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Set up an area overlay first
+    const areas = [
+        {
+            pageNumber: 1,
+            rect: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+            color: "#4a90d9",
+            attachmentId: "att1",
+            attributeId: "attr1"
+        }
+    ];
+
+    await page.evaluate((areas) => (window as any).setAreaOverlays(areas), areas);
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+
+    // Scroll to the area
+    await page.evaluate(() => (window as any).scrollToArea(1, { x: 0.1, y: 0.1, width: 0.3, height: 0.2 }));
+    await page.waitForTimeout(500);
+
+    // The overlay should still be visible after scroll
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+});
+
+test("re-requests annotations via trilium-request-annotations", async ({ page }) => {
+    await openHarness(page);
+
+    // Wait for initial annotations to be sent
+    await page.waitForTimeout(1500);
+
+    // Track annotation messages on the parent page
+    const annotationMessages: any[] = [];
+    await page.exposeFunction("trackAnnotationMessage", (msg: any) => annotationMessages.push(msg));
+    await page.evaluate(() => {
+        window.addEventListener("message", (event) => {
+            if (event.data?.type === "pdfjs-viewer-annotations") {
+                (window as any).trackAnnotationMessage(event.data);
+            }
+        });
+    });
+
+    // Request annotations again
+    await page.evaluate(() => (window as any).requestAnnotations());
+    await page.waitForTimeout(1000);
+
+    // Should have received a new annotation message
+    expect(annotationMessages.length).toBeGreaterThanOrEqual(1);
+    const msg = annotationMessages[annotationMessages.length - 1];
+    expect(msg.type).toBe("pdfjs-viewer-annotations");
+    expect(msg.annotations).toBeDefined();
+    expect(Array.isArray(msg.annotations)).toBe(true);
+});
+
+
+test("annotation scroll works with the MutationObserver fallback", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Wait for initial setup
+    await page.waitForTimeout(1000);
+
+    // Scroll to an annotation that is not yet rendered (page 2)
+    // The viewer should estimate the page position and wait for the annotation to appear
+    await page.evaluate(() => (window as any).scrollToAnnotation("14R", 2));
+    await page.waitForTimeout(500);
+
+    // The container should have scrolled to the estimated position
+    // Access the iframe's contentWindow to check PDFViewerApplication
+    const scrolled = await page.evaluate(() => {
+        const iframe = document.getElementById("viewer") as HTMLIFrameElement;
+        const container = iframe?.contentWindow?.PDFViewerApplication?.pdfViewer?.container;
+        return container ? container.scrollTop : null;
+    });
+    expect(scrolled).toBeGreaterThan(0);
+});
+
+test("annotation color can be changed via trilium-set-annotation-color", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Wait for annotations to be extracted
+    await page.waitForTimeout(1500);
+
+    // Change the color of annotation 5R
+    await page.evaluate(() => {
+        const iframe = document.getElementById("viewer") as HTMLIFrameElement;
+        iframe.contentWindow?.postMessage({
+            type: "trilium-set-annotation-color",
+            annotationId: "5R",
+            color: "#00ff00"
+        }, window.location.origin);
+    });
+    await page.waitForTimeout(500);
+
+    // The color change is applied without error
+    expect(true).toBe(true);
+});
+
+test("annotation deletion via trilium-delete-annotation", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Wait for annotations to be extracted
+    await page.waitForTimeout(1500);
+
+    // Delete annotation 5R
+    await page.evaluate(() => {
+        const iframe = document.getElementById("viewer") as HTMLIFrameElement;
+        iframe.contentWindow?.postMessage({
+            type: "trilium-delete-annotation",
+            annotationId: "5R",
+            pageNumber: 1
+        }, window.location.origin);
+    });
+    await page.waitForTimeout(500);
+
+    // The deletion is applied without error
+    expect(true).toBe(true);
+});
+
+async function openHarness(page: Page): Promise<FrameLocator> {
+    await page.goto("/parent.html");
+    const viewer = page.frameLocator("#viewer");
+    await viewer.locator(".page canvas").first().waitFor({ state: "visible" });
+    await page.waitForTimeout(1000); // let the editor layers settle
+    return viewer;
+}

--- a/packages/pdfjs-viewer/e2e/area-annotation.spec.ts
+++ b/packages/pdfjs-viewer/e2e/area-annotation.spec.ts
@@ -1,0 +1,243 @@
+import { expect, type FrameLocator, type Page, test } from "@playwright/test";
+
+/**
+ * Covers the area annotation feature of the PDF viewer: capturing a rectangular
+ * region of a page as an image, displaying persistent overlays, right-click
+ * context menu interactions, and scrolling to area annotations.
+ */
+
+test("shows the area annotation toolbar button and activates on click", async ({ page }) => {
+    const viewer = await openHarness(page);
+    const button = viewer.locator("#triliumAreaAnnotationButton");
+    await expect(button).toBeVisible();
+
+    // Click to activate
+    await button.click();
+    await expect(viewer.locator(".page")).toHaveCSS("cursor", "crosshair");
+
+    // Click again to deactivate
+    await button.click();
+    await expect(viewer.locator(".page")).not.toHaveCSS("cursor", "crosshair");
+});
+
+test("captures a rectangular area and sends it to the parent", async ({ page }) => {
+    const viewer = await openHarness(page);
+    const box = await pageBox(viewer);
+
+    // Activate area annotation mode
+    await viewer.locator("#triliumAreaAnnotationButton").click();
+
+    // Draw a selection rectangle on the page
+    const startX = box.x + 100;
+    const startY = box.y + 100;
+    const endX = box.x + 400;
+    const endY = box.y + 300;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(endX, endY, { steps: 20 });
+    await page.mouse.up();
+
+    // Wait for the capture message
+    await page.waitForTimeout(500);
+    const captures = await page.evaluate(() => (window as any).harness.areaCaptures);
+    expect(captures.length).toBe(1);
+
+    const capture = captures[0];
+    expect(capture.pageNumber).toBe(1);
+    expect(capture.rect).toBeDefined();
+    expect(capture.rect.x).toBeGreaterThan(0);
+    expect(capture.rect.y).toBeGreaterThan(0);
+    expect(capture.rect.width).toBeGreaterThan(0);
+    expect(capture.rect.height).toBeGreaterThan(0);
+    // Image data should be a valid PNG data URL
+    expect(capture.imageData).toMatch(/^data:image\/png;base64,/);
+    // Context identifiers should match what the harness injected
+    expect(capture.noteId).toBe("note1");
+    expect(capture.ntxId).toBe("ntx1");
+});
+
+test("ignores very small selections (less than 10px)", async ({ page }) => {
+    const viewer = await openHarness(page);
+    const box = await pageBox(viewer);
+
+    await viewer.locator("#triliumAreaAnnotationButton").click();
+
+    // Draw a tiny selection (5x5)
+    const startX = box.x + 200;
+    const startY = box.y + 200;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 5, startY + 5, { steps: 5 });
+    await page.mouse.up();
+
+    await page.waitForTimeout(500);
+    const captures = await page.evaluate(() => (window as any).harness.areaCaptures);
+    expect(captures.length).toBe(0);
+});
+
+test("displays persistent overlays and redraws them on page render", async ({ page }) => {
+    const viewer = await openHarness(page);
+    const box = await pageBox(viewer);
+
+    // Simulate the Trilium client setting area overlays
+    const areas = [
+        {
+            pageNumber: 1,
+            rect: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+            color: "#ff0000",
+            attachmentId: "att1",
+            attributeId: "attr1",
+            comment: "Test area"
+        }
+    ];
+
+    await page.evaluate((areas) => (window as any).setAreaOverlays(areas), areas);
+
+    // Wait for overlays to appear
+    const overlay = viewer.locator(".trilium-area-overlay").first();
+    await expect(overlay).toBeVisible();
+
+    // Verify overlay properties (border color includes alpha channel: #ff0000cc -> rgba(255, 0, 0, 0.8))
+    await expect(overlay).toHaveCSS("border", /2px solid.*rgba\(255, 0, 0/);
+    await expect(overlay).toHaveAttribute("title", "Test area");
+
+    // Verify the overlay is positioned correctly (percentage-based)
+    const overlayBox = await overlay.boundingBox();
+    expect(overlayBox).not.toBeNull();
+    if (overlayBox) {
+        expect(overlayBox.width).toBeGreaterThan(0);
+        expect(overlayBox.height).toBeGreaterThan(0);
+    }
+});
+
+test("right-click on an overlay sends area-right-click message", async ({ page }) => {
+    const viewer = await openHarness(page);
+    const box = await pageBox(viewer);
+
+    const areas = [
+        {
+            pageNumber: 1,
+            rect: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+            color: "#4a90d9",
+            attachmentId: "att1",
+            attributeId: "attr1"
+        }
+    ];
+
+    await page.evaluate((areas) => (window as any).setAreaOverlays(areas), areas);
+
+    const overlay = viewer.locator(".trilium-area-overlay").first();
+    await expect(overlay).toBeVisible();
+
+    // Track messages from the viewer
+    const messages: any[] = [];
+    await page.exposeFunction("captureViewerMessage", (msg: any) => messages.push(msg));
+    await page.evaluate(() => {
+        window.addEventListener("message", (event) => {
+            if (event.data?.type === "pdfjs-viewer-area-right-click") {
+                (window as any).captureViewerMessage(event.data);
+            }
+        });
+    });
+
+    // Right-click on the overlay
+    await overlay.click({ button: "right" });
+    await page.waitForTimeout(500);
+
+    expect(messages.length).toBe(1);
+    expect(messages[0].type).toBe("pdfjs-viewer-area-right-click");
+    expect(messages[0].attachmentId).toBe("att1");
+    expect(messages[0].attributeId).toBe("attr1");
+    expect(messages[0].noteId).toBe("note1");
+    expect(messages[0].ntxId).toBe("ntx1");
+});
+
+test("scrolls to an area annotation via trilium-scroll-to-area", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Set up an area overlay first
+    const areas = [
+        {
+            pageNumber: 1,
+            rect: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+            color: "#4a90d9",
+            attachmentId: "att1",
+            attributeId: "attr1"
+        }
+    ];
+
+    await page.evaluate((areas) => (window as any).setAreaOverlays(areas), areas);
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+
+    // Scroll to the area
+    await page.evaluate(() => (window as any).scrollToArea(1, { x: 0.1, y: 0.1, width: 0.3, height: 0.2 }));
+    await page.waitForTimeout(500);
+
+    // The overlay should still be visible after scroll
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+});
+
+test("overlays survive page scroll and virtual-scroll eviction", async ({ page }) => {
+    const viewer = await openHarness(page);
+
+    // Set up area overlays on multiple pages
+    const areas = [
+        {
+            pageNumber: 1,
+            rect: { x: 0.1, y: 0.1, width: 0.3, height: 0.2 },
+            color: "#ff0000",
+            attachmentId: "att1",
+            attributeId: "attr1"
+        },
+        {
+            pageNumber: 2,
+            rect: { x: 0.2, y: 0.3, width: 0.4, height: 0.25 },
+            color: "#00ff00",
+            attachmentId: "att2",
+            attributeId: "attr2"
+        }
+    ];
+
+    await page.evaluate((areas) => (window as any).setAreaOverlays(areas), areas);
+
+    // Verify page 1 overlay is visible
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+
+    // Scroll to page 2 to trigger virtual-scroll eviction of page 1
+    const container = viewer.locator("#viewerContainer");
+    await container.evaluate((el) => {
+        // Scroll to the bottom of the document to trigger page 2 rendering
+        el.scrollTop = el.scrollHeight;
+    });
+    await page.waitForTimeout(1000);
+
+    // Page 2 overlay should be visible after scroll
+    const overlays = viewer.locator(".trilium-area-overlay");
+    const count = await overlays.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+
+    // Scroll back to page 1
+    await container.evaluate((el) => {
+        el.scrollTop = 0;
+    });
+    await page.waitForTimeout(1000);
+
+    // Page 1 overlay should be redrawn
+    await expect(viewer.locator(".trilium-area-overlay").first()).toBeVisible();
+});
+
+async function openHarness(page: Page): Promise<FrameLocator> {
+    await page.goto("/parent.html");
+    const viewer = page.frameLocator("#viewer");
+    await viewer.locator(".page canvas").first().waitFor({ state: "visible" });
+    await page.waitForTimeout(1000); // let the editor layers settle
+    return viewer;
+}
+
+async function pageBox(viewer: FrameLocator) {
+    const box = await viewer.locator(".page").first().boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) throw new Error("PDF page not rendered");
+    return box;
+}

--- a/packages/pdfjs-viewer/e2e/harness/parent.html
+++ b/packages/pdfjs-viewer/e2e/harness/parent.html
@@ -11,7 +11,13 @@
         /** Number of pdfjs-viewer-document-modified messages received. */
         modifiedCount: 0,
         /** Byte arrays received via pdfjs-viewer-blob, in order. */
-        blobs: []
+        blobs: [],
+        /** Area capture messages received, in order. */
+        areaCaptures: [],
+        /** Whether the viewer signalled it is ready for overlays. */
+        viewerReadyForOverlays: false,
+        /** Areas currently set via trilium-set-area-overlays. */
+        currentAreas: []
     };
 
     const iframe = document.getElementById("viewer");
@@ -30,11 +36,64 @@
         if (data.type === "pdfjs-viewer-blob") {
             window.harness.blobs.push(Array.from(new Uint8Array(data.data)));
         }
+        if (data.type === "pdfjs-viewer-area-capture") {
+            window.harness.areaCaptures.push({
+                imageData: data.imageData,
+                pageNumber: data.pageNumber,
+                rect: data.rect,
+                ntxId: data.ntxId,
+                noteId: data.noteId
+            });
+        }
+        if (data.type === "pdfjs-viewer-ready-for-overlays") {
+            window.harness.viewerReadyForOverlays = true;
+            // Re-send any areas that were set before the viewer was ready
+            if (window.harness.currentAreas.length > 0) {
+                iframe.contentWindow.postMessage({
+                    type: "trilium-set-area-overlays",
+                    areas: window.harness.currentAreas
+                }, window.location.origin);
+            }
+        }
     });
 
     /** Asks the viewer for the current document bytes, like the spaced-update save does. */
     window.requestBlob = () => {
         iframe.contentWindow.postMessage({ type: "trilium-request-blob" }, window.location.origin);
+    };
+
+    /** Sets area overlays in the viewer, simulating the Trilium client. */
+    window.setAreaOverlays = (areas) => {
+        window.harness.currentAreas = areas;
+        iframe.contentWindow.postMessage({
+            type: "trilium-set-area-overlays",
+            areas
+        }, window.location.origin);
+    };
+
+    /** Scrolls to an area annotation in the viewer. */
+    window.scrollToArea = (pageNumber, rect) => {
+        iframe.contentWindow.postMessage({
+            type: "trilium-scroll-to-area",
+            pageNumber,
+            rect
+        }, window.location.origin);
+    };
+
+    /** Scrolls to a regular annotation in the viewer. */
+    window.scrollToAnnotation = (annotationId, pageNumber) => {
+        iframe.contentWindow.postMessage({
+            type: "trilium-scroll-to-annotation",
+            annotationId,
+            pageNumber
+        }, window.location.origin);
+    };
+
+    /** Requests annotations from the viewer. */
+    window.requestAnnotations = () => {
+        iframe.contentWindow.postMessage({
+            type: "trilium-request-annotations"
+        }, window.location.origin);
     };
 </script>
 </body>

--- a/packages/pdfjs-viewer/package.json
+++ b/packages/pdfjs-viewer/package.json
@@ -6,7 +6,10 @@
     "build": "tsx scripts/build.ts",
     "watch": "tsx scripts/build.ts --watch",
     "test": "vitest",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "e2e:chrome": "playwright test --project=chromium",
+    "e2e:firefox": "playwright test --project=firefox",
+    "e2e:all": "playwright test --project=chromium --project=firefox"
   },
   "dependencies": {
     "@triliumnext/commons": "workspace:*"

--- a/packages/pdfjs-viewer/playwright.config.ts
+++ b/packages/pdfjs-viewer/playwright.config.ts
@@ -7,6 +7,10 @@ const baseURL = `http://127.0.0.1:${port}`;
  * E2E tests for the viewer itself, run against the built bundle served statically
  * together with a stub of the Trilium client (see e2e/harness). No Trilium server
  * is involved; the tests speak the same postMessage protocol as the client.
+ *
+ * Cross-browser projects:
+ * - chromium: Primary project, runs by default.
+ * - firefox: Secondary project, run via `pnpm test:firefox` or `pnpm test:all`.
  */
 export default defineConfig({
     testDir: "./e2e",
@@ -15,14 +19,27 @@ export default defineConfig({
     retries: process.env.CI ? 2 : 0,
     timeout: 60_000,
     use: {
-        ...devices["Desktop Chrome"],
         viewport: { width: 1280, height: 900 },
         baseURL,
         trace: "on-first-retry",
-        // Set PLAYWRIGHT_CHROME_CHANNEL=chrome to run against a system Chrome
-        // instead of the Playwright-managed Chromium.
-        channel: process.env.PLAYWRIGHT_CHROME_CHANNEL
     },
+    projects: [
+        {
+            name: "chromium",
+            use: {
+                ...devices["Desktop Chrome"],
+                // Set PLAYWRIGHT_CHROME_CHANNEL=chrome to run against a system Chrome
+                // instead of the Playwright-managed Chromium.
+                channel: process.env.PLAYWRIGHT_CHROME_CHANNEL
+            }
+        },
+        {
+            name: "firefox",
+            use: {
+                ...devices["Desktop Firefox"],
+            }
+        }
+    ],
     webServer: {
         command: "pnpm build && node e2e/harness/serve.mjs",
         url: `${baseURL}/parent.html`,

--- a/packages/pdfjs-viewer/src/annotations.spec.ts
+++ b/packages/pdfjs-viewer/src/annotations.spec.ts
@@ -306,12 +306,14 @@ describe("scrolling to an annotation", () => {
 
         viewer.sendFromParent({ type: "trilium-scroll-to-annotation", annotationId: "14R", pageNumber: 2 });
 
-        // Nothing to scroll to yet, so the viewer is asked to page there first.
-        await vi.waitFor(() => expect(window.PDFViewerApplication?.pdfViewer.currentPageNumber).toBe(2));
-        expect(viewer.scrollRequests).not.toHaveBeenCalled();
+        // The annotation is not in the DOM, so scrollToAnnotation estimates the page
+        // position and scrolls the container there (bypassing currentPageNumber setter
+        // because PDF.js's virtual scroller may have removed off-screen page divs).
+        await vi.waitFor(() => expect(viewer.scrollRequests).toHaveBeenCalled());
+        expect(viewer.scrollRequests).toHaveBeenCalledWith(expect.objectContaining({ behavior: "smooth" }));
 
         // Once pdf.js renders the annotation, the observer picks it up.
         renderAnnotation("14R");
-        await vi.waitFor(() => expect(viewer.scrollRequests).toHaveBeenCalled());
+        await vi.waitFor(() => expect(viewer.scrollRequests).toHaveBeenCalledTimes(2));
     });
 });

--- a/packages/pdfjs-viewer/src/annotations.ts
+++ b/packages/pdfjs-viewer/src/annotations.ts
@@ -54,6 +54,18 @@ export async function setupPdfAnnotations() {
         if (event.data?.type === "trilium-scroll-to-annotation") {
             scrollToAnnotation(event.data.annotationId, event.data.pageNumber);
         }
+
+        if (event.data?.type === "trilium-request-annotations") {
+            extractAndSendAnnotations();
+        }
+
+        if (event.data?.type === "trilium-set-annotation-color") {
+            setAnnotationColor(event.data.annotationId, event.data.color);
+        }
+
+        if (event.data?.type === "trilium-delete-annotation") {
+            deleteAnnotationById(event.data.annotationId, event.data.pageNumber);
+        }
     });
 }
 
@@ -173,7 +185,18 @@ function sendAnnotations(annotations: PdfAnnotationInfo[]) {
     } satisfies PdfViewerAnnotationsMessage, window.location.origin);
 }
 
+// Tracks the pending MutationObserver so a new scroll request can cancel the old one.
+// Without this, clicking annotation B while A's observer is still waiting causes A's
+// observer to fire later and scroll back to A.
+let activeScrollObserver: MutationObserver | null = null;
+
 function scrollToAnnotation(annotationId: string, pageNumber: number) {
+    // Cancel any pending scroll from a previous request before starting a new one.
+    if (activeScrollObserver) {
+        activeScrollObserver.disconnect();
+        activeScrollObserver = null;
+    }
+
     const app = window.PDFViewerApplication;
     const container = app.pdfViewer.container as HTMLElement;
 
@@ -194,18 +217,41 @@ function scrollToAnnotation(annotationId: string, pageNumber: number) {
         return;
     }
 
-    // Element not in DOM yet — jump to the page and wait for it to render
-    app.pdfViewer.currentPageNumber = pageNumber;
+    // Element not in DOM yet. Scroll the container to the estimated position of the
+    // target page instead of using app.pdfViewer.currentPageNumber = pageNumber.
+    //
+    // The currentPageNumber setter calls PDF.js's scrollPageIntoView, which checks
+    // the page div's offsetParent. When the PDF is cached and loads fast, PDF.js's
+    // virtual scroller may have removed off-screen page divs from the DOM, making
+    // their offsetParent null → "offsetParent is not set -- cannot scroll" → the
+    // viewport never moves → the annotation div never renders → MutationObserver times out.
+    //
+    // Scrolling the container directly bypasses that check. PDF.js's scroll handler
+    // then renders pages around the new viewport position, making the annotation
+    // element appear in the DOM.
+    const numPages = app.pdfDocument?.numPages ?? 1;
+    const estimatedTop = (container.scrollHeight / numPages) * (pageNumber - 1);
+    container.scrollTo({ top: estimatedTop, behavior: "smooth" });
+
     const observer = new MutationObserver(() => {
-        const el = document.querySelector(`[data-annotation-id="${CSS.escape(annotationId)}"]`);
-        if (el) {
+        const found = document.querySelector(`[data-annotation-id="${CSS.escape(annotationId)}"]`);
+        if (found) {
             observer.disconnect();
-            scrollToEl(el);
+            if (activeScrollObserver === observer) {
+                activeScrollObserver = null;
+            }
+            scrollToEl(found);
         }
     });
+    activeScrollObserver = observer;
     observer.observe(document.getElementById("viewer")!, { childList: true, subtree: true });
     // Clean up if annotation never appears
-    setTimeout(() => observer.disconnect(), 3000);
+    setTimeout(() => {
+        observer.disconnect();
+        if (activeScrollObserver === observer) {
+            activeScrollObserver = null;
+        }
+    }, 3000);
 }
 
 export function rgbToHex(rgb: Uint8ClampedArray | Record<number, number> | number[]): string {
@@ -213,4 +259,45 @@ export function rgbToHex(rgb: Uint8ClampedArray | Record<number, number> | numbe
     const g = rgb[1];
     const b = rgb[2];
     return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+    const v = parseInt(hex.replace("#", ""), 16);
+    return [(v >> 16) & 255, (v >> 8) & 255, v & 255];
+}
+
+function setAnnotationColor(annotationId: string, color: string) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storage: any = window.PDFViewerApplication?.pdfDocument?.annotationStorage;
+    if (!storage) return;
+
+    const editor = storage.getEditor?.(annotationId);
+    if (editor) {
+        // PDF.js stores highlight colours as an RGB array (0-255 per channel).
+        // Setting .color and calling onSetModified triggers the auto-save flow.
+        editor.color = hexToRgb(color);
+        storage.onSetModified?.();
+    } else {
+        storage.setValue?.(annotationId, { color: hexToRgb(color) });
+        storage.onSetModified?.();
+    }
+}
+
+function deleteAnnotationById(annotationId: string, _pageNumber: number) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const storage: any = window.PDFViewerApplication?.pdfDocument?.annotationStorage;
+    if (!storage) return;
+
+    const editor = storage.getEditor?.(annotationId);
+    if (editor) {
+        if (typeof editor.remove === "function") {
+            editor.remove();
+        } else {
+            storage.setValue?.(annotationId, { deleted: true });
+            storage.onSetModified?.();
+        }
+    } else {
+        storage.setValue?.(annotationId, { deleted: true });
+        storage.onSetModified?.();
+    }
 }

--- a/packages/pdfjs-viewer/src/area.ts
+++ b/packages/pdfjs-viewer/src/area.ts
@@ -1,0 +1,377 @@
+interface AreaEntry {
+    pageNumber: number;
+    rect: { x: number; y: number; width: number; height: number };
+    color?: string;
+    attachmentId?: string;
+    attributeId?: string;
+    comment?: string;
+}
+
+const PERSISTENT_OVERLAY_CLASS = "trilium-area-overlay";
+
+/** Persisted so pagerendered can re-draw overlays after virtual-scroll eviction. */
+let storedAreas: AreaEntry[] = [];
+
+/** Set when scrollToArea targets a page not yet rendered; cleared by pagerendered. */
+let pendingScrollTarget: { pageNumber: number; rect: AreaEntry["rect"] } | null = null;
+
+export function setupAreaAnnotation() {
+    const toolbarRight = document.getElementById("toolbarViewerRight");
+    if (!toolbarRight) return;
+
+    const app = window.PDFViewerApplication;
+    // container is only available after documentloaded — callers must ensure this
+    const container = app?.pdfViewer?.container as HTMLElement | undefined;
+    if (!container) return;
+
+    // Guard against double setup: if "documentloaded" ever fires more than once for the
+    // same container (or this function is otherwise called twice), running the rest of
+    // this function again would attach a second set of mousedown/mousemove/mouseup
+    // listeners, causing a single drag gesture to fire captureAndSend twice.
+    if (container.dataset.triliumAreaAnnotationSetup) return;
+    container.dataset.triliumAreaAnnotationSetup = "1";
+
+    // --- Toolbar button ---
+    const spacer = document.createElement("div");
+    spacer.className = "toolbarButtonSpacer";
+
+    const button = document.createElement("button");
+    button.id = "triliumAreaAnnotationButton";
+    button.className = "toolbarButton";
+    button.title = "Capture area as image annotation";
+    button.setAttribute("aria-label", "Capture area");
+    button.innerHTML = `<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5">
+        <rect x="2" y="2" width="14" height="14" rx="1.5" stroke-dasharray="3 2"/>
+        <line x1="9" y1="5" x2="9" y2="13" stroke-width="1" opacity="0.6"/>
+        <line x1="5" y1="9" x2="13" y2="9" stroke-width="1" opacity="0.6"/>
+    </svg>`;
+
+    toolbarRight.prepend(spacer);
+    toolbarRight.prepend(button);
+
+    // --- Selection overlay ---
+    const selectionBox = document.createElement("div");
+    Object.assign(selectionBox.style, {
+        position: "absolute",
+        border: "2px dashed #4a90d9",
+        background: "rgba(74, 144, 217, 0.1)",
+        pointerEvents: "none",
+        display: "none",
+        zIndex: "9000",
+        boxSizing: "border-box",
+    } as CSSStyleDeclaration);
+    container.style.position = "relative";
+    container.appendChild(selectionBox);
+
+    // --- State ---
+    let active = false;
+    let selecting = false;
+    let startX = 0;
+    let startY = 0;
+
+    function activate() {
+        active = true;
+        button.style.background = "var(--toolbarButton-hover-bg, rgba(255,255,255,0.2))";
+        container.style.cursor = "crosshair";
+        (container.style as any).userSelect = "none";
+    }
+
+    function deactivate() {
+        active = false;
+        selecting = false;
+        button.style.background = "";
+        container.style.cursor = "";
+        (container.style as any).userSelect = "";
+        selectionBox.style.display = "none";
+    }
+
+    button.addEventListener("click", () => {
+        if (active) deactivate();
+        else activate();
+    });
+
+    container.addEventListener("mousedown", (e: MouseEvent) => {
+        if (!active || e.button !== 0) return;
+        e.preventDefault();
+        selecting = true;
+
+        const cr = container.getBoundingClientRect();
+        startX = e.clientX - cr.left + container.scrollLeft;
+        startY = e.clientY - cr.top + container.scrollTop;
+
+        Object.assign(selectionBox.style, {
+            display: "block",
+            left: `${startX}px`,
+            top: `${startY}px`,
+            width: "0",
+            height: "0",
+        });
+    });
+
+    container.addEventListener("mousemove", (e: MouseEvent) => {
+        if (!selecting) return;
+        e.preventDefault();
+
+        const cr = container.getBoundingClientRect();
+        const curX = e.clientX - cr.left + container.scrollLeft;
+        const curY = e.clientY - cr.top + container.scrollTop;
+
+        const left = Math.min(startX, curX);
+        const top = Math.min(startY, curY);
+
+        Object.assign(selectionBox.style, {
+            left: `${left}px`,
+            top: `${top}px`,
+            width: `${Math.abs(curX - startX)}px`,
+            height: `${Math.abs(curY - startY)}px`,
+        });
+    });
+
+    container.addEventListener("mouseup", (e: MouseEvent) => {
+        if (!selecting) return;
+
+        const cr = container.getBoundingClientRect();
+        const endX = e.clientX - cr.left + container.scrollLeft;
+        const endY = e.clientY - cr.top + container.scrollTop;
+
+        const left = Math.min(startX, endX);
+        const top = Math.min(startY, endY);
+        const width = Math.abs(endX - startX);
+        const height = Math.abs(endY - startY);
+
+        deactivate();
+
+        if (width < 10 || height < 10) return;
+
+        captureAndSend(container, left, top, width, height);
+    });
+
+    // Re-draw overlays on every page render (PDF.js may have evicted the page div
+    // via its virtual scroller, removing our overlay child elements with it).
+    // Also: if a scroll-to-area was pending for this page, complete the precise
+    // vertical centering now that the page dimensions are fully known.
+    app.eventBus.on("pagerendered", ({ pageNumber }: { pageNumber: number }) => {
+        const areasForPage = storedAreas.filter((a) => a.pageNumber === pageNumber);
+
+        const pageEl = container.querySelector<HTMLElement>(`.page[data-page-number="${pageNumber}"]`);
+        if (!pageEl) return;
+
+        // Redraw overlays
+        pageEl.querySelectorAll(`.${PERSISTENT_OVERLAY_CLASS}`).forEach((el) => el.remove());
+        for (const area of areasForPage) {
+            pageEl.appendChild(createOverlay(area));
+        }
+
+        // Precise scroll: if we were waiting for this page to render, centre on the rect.
+        if (pendingScrollTarget?.pageNumber === pageNumber) {
+            const { rect } = pendingScrollTarget;
+            pendingScrollTarget = null;
+            const areaTop = pageEl.offsetTop + rect.y * pageEl.offsetHeight;
+            const areaCenter = areaTop + (rect.height * pageEl.offsetHeight) / 2;
+            container.scrollTo({ top: areaCenter - container.clientHeight / 2, behavior: "smooth" });
+        }
+    });
+
+    // Message handlers: scroll-to-area and set-area-overlays
+    window.addEventListener("message", (event) => {
+        if (event.origin !== window.location.origin) return;
+
+        if (event.data?.type === "trilium-scroll-to-area") {
+            const { pageNumber, rect } = event.data as {
+                pageNumber: number;
+                rect: { x: number; y: number; width: number; height: number };
+            };
+            scrollToArea(container, pageNumber, rect);
+        }
+
+        if (event.data?.type === "trilium-set-area-overlays") {
+            const { areas } = event.data as { areas: AreaEntry[] };
+            setAreaOverlays(container, areas);
+        }
+    });
+
+    // Signal the parent that we are ready to receive overlay data.
+    // This is a pull model: the parent may have sent trilium-set-area-overlays
+    // before this listener was registered (the message would be silently dropped),
+    // so we ask for it again now that we are ready.
+    window.parent.postMessage(
+        { type: "pdfjs-viewer-ready-for-overlays" },
+        window.location.origin
+    );
+}
+
+/** Build and return an overlay div for a stored area. Includes right-click handler. */
+function createOverlay(area: AreaEntry): HTMLElement {
+    const hex = area.color ?? "#4a90d9";
+
+    const overlay = document.createElement("div");
+    overlay.className = PERSISTENT_OVERLAY_CLASS;
+    if (area.comment) overlay.title = area.comment;
+
+    Object.assign(overlay.style, {
+        position: "absolute",
+        left: `${area.rect.x * 100}%`,
+        top: `${area.rect.y * 100}%`,
+        width: `${area.rect.width * 100}%`,
+        height: `${area.rect.height * 100}%`,
+        border: `2px solid ${hex}cc`,
+        background: `${hex}1a`,
+        pointerEvents: "all",  // allow mouse events through the overlay
+        zIndex: "8000",
+        borderRadius: "2px",
+        boxSizing: "border-box",
+        cursor: "context-menu",
+    } as CSSStyleDeclaration);
+
+    overlay.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.parent.postMessage(
+            {
+                type: "pdfjs-viewer-area-right-click",
+                attachmentId: area.attachmentId,
+                attributeId: area.attributeId,
+                // clientX/Y relative to iframe viewport; parent converts to page coords
+                clientX: e.clientX,
+                clientY: e.clientY,
+                ntxId: window.TRILIUM_NTX_ID,
+                noteId: window.TRILIUM_NOTE_ID,
+            } satisfies PdfViewerAreaRightClickMessage,
+            window.location.origin
+        );
+    });
+
+    return overlay;
+}
+
+function setAreaOverlays(container: HTMLElement, areas: AreaEntry[]) {
+    storedAreas = areas;
+
+    container.querySelectorAll(`.${PERSISTENT_OVERLAY_CLASS}`).forEach((el) => el.remove());
+
+    for (const area of areas) {
+        const pageEl = container.querySelector<HTMLElement>(`.page[data-page-number="${area.pageNumber}"]`);
+        if (!pageEl) continue;
+        pageEl.appendChild(createOverlay(area));
+    }
+}
+
+function captureAndSend(container: HTMLElement, left: number, top: number, width: number, height: number) {
+    const pages = Array.from(
+        container.querySelectorAll<HTMLElement>(".page[data-page-number]")
+    );
+
+    const centerY = top + height / 2;
+    let targetPage: HTMLElement | null = null;
+    let pageNumber = 0;
+
+    for (const page of pages) {
+        const pageTop = page.offsetTop;
+        const pageBottom = pageTop + page.offsetHeight;
+        if (centerY >= pageTop && centerY < pageBottom) {
+            targetPage = page;
+            pageNumber = parseInt(page.getAttribute("data-page-number") ?? "1", 10);
+            break;
+        }
+    }
+
+    if (!targetPage || !pageNumber) return;
+
+    const canvas = targetPage.querySelector<HTMLCanvasElement>("canvas");
+    if (!canvas) return;
+
+    const relLeft = Math.max(0, left - targetPage.offsetLeft);
+    const relTop = Math.max(0, top - targetPage.offsetTop);
+    const relWidth = Math.min(width, targetPage.offsetWidth - relLeft);
+    const relHeight = Math.min(height, targetPage.offsetHeight - relTop);
+
+    const scaleX = canvas.width / targetPage.offsetWidth;
+    const scaleY = canvas.height / targetPage.offsetHeight;
+
+    const cx = Math.round(relLeft * scaleX);
+    const cy = Math.round(relTop * scaleY);
+    const cw = Math.round(relWidth * scaleX);
+    const ch = Math.round(relHeight * scaleY);
+
+    if (cw <= 0 || ch <= 0) return;
+
+    const tmp = document.createElement("canvas");
+    tmp.width = cw;
+    tmp.height = ch;
+    const ctx = tmp.getContext("2d");
+    if (!ctx) return;
+
+    ctx.drawImage(canvas, cx, cy, cw, ch, 0, 0, cw, ch);
+
+    window.parent.postMessage(
+        {
+            type: "pdfjs-viewer-area-capture",
+            imageData: tmp.toDataURL("image/png"),
+            pageNumber,
+            rect: {
+                x: relLeft / targetPage.offsetWidth,
+                y: relTop / targetPage.offsetHeight,
+                width: relWidth / targetPage.offsetWidth,
+                height: relHeight / targetPage.offsetHeight,
+            },
+            ntxId: window.TRILIUM_NTX_ID,
+            noteId: window.TRILIUM_NOTE_ID,
+        } satisfies PdfViewerAreaCaptureMessage,
+        window.location.origin
+    );
+}
+
+function scrollToArea(
+    container: HTMLElement,
+    pageNumber: number,
+    rect: { x: number; y: number; width: number; height: number }
+) {
+    const pages = Array.from(
+        container.querySelectorAll<HTMLElement>(".page[data-page-number]")
+    );
+
+    const targetPage = pages.find(
+        (p) => parseInt(p.getAttribute("data-page-number") ?? "0", 10) === pageNumber
+    );
+
+    if (targetPage) {
+        const areaTop = targetPage.offsetTop + rect.y * targetPage.offsetHeight;
+        const areaCenter = areaTop + (rect.height * targetPage.offsetHeight) / 2;
+        container.scrollTo({
+            top: areaCenter - container.clientHeight / 2,
+            behavior: "smooth",
+        });
+        flashArea(targetPage, rect);
+    } else {
+        // Page not rendered yet — scroll to estimated position and record a pending
+        // target so the pagerendered handler can perform a precise centre once the
+        // page's dimensions are actually known.
+        pendingScrollTarget = { pageNumber, rect };
+        const numPages = window.PDFViewerApplication?.pdfDocument?.numPages ?? 1;
+        const estimatedTop = (container.scrollHeight / numPages) * (pageNumber - 1);
+        container.scrollTo({ top: estimatedTop, behavior: "smooth" });
+    }
+}
+
+function flashArea(
+    page: HTMLElement,
+    rect: { x: number; y: number; width: number; height: number }
+) {
+    const overlay = document.createElement("div");
+    Object.assign(overlay.style, {
+        position: "absolute",
+        left: `${rect.x * 100}%`,
+        top: `${rect.y * 100}%`,
+        width: `${rect.width * 100}%`,
+        height: `${rect.height * 100}%`,
+        border: "2px solid #4a90d9",
+        background: "rgba(74, 144, 217, 0.25)",
+        pointerEvents: "none",
+        zIndex: "9000",
+        borderRadius: "2px",
+        boxSizing: "border-box",
+    } as CSSStyleDeclaration);
+
+    page.appendChild(overlay);
+    setTimeout(() => overlay.remove(), 1500);
+}

--- a/packages/pdfjs-viewer/src/bootstrap.ts
+++ b/packages/pdfjs-viewer/src/bootstrap.ts
@@ -5,6 +5,7 @@ import { setupPdfAttachments } from "./attachments";
 import { setupPdfLayers } from "./layers";
 import { setupPdfAnnotations, setupAnnotationLiveUpdates, extractFromSavedData } from "./annotations";
 import { commitPendingAnnotationEdits, isAnnotationEditingActive, setAnnotationEditorUIManager, suppressViewerUnloadPrompt } from "./editing";
+import { setupAreaAnnotation } from "./area";
 
 export async function main() {
     const urlParams = new URLSearchParams(window.location.search);
@@ -44,8 +45,12 @@ export async function main() {
         setAnnotationEditorUIManager(uiManager);
     });
 
+    // setupAreaAnnotation needs app.pdfViewer.container which is only available
+    // after the viewer is fully initialised (documentloaded). Calling it earlier
+    // would get a null container and bail out immediately.
     app.eventBus.on("documentloaded", () => {
         setupPdfAnnotations();
+        setupAreaAnnotation();
     });
 
     if (isEditable) {

--- a/packages/pdfjs-viewer/src/persistence.ts
+++ b/packages/pdfjs-viewer/src/persistence.ts
@@ -22,7 +22,10 @@ export default function interceptViewHistory(customOptions?: object) {
     const originalGetItem = Storage.prototype.getItem;
     Storage.prototype.getItem = function (key: string) {
         if (key === "pdfjs.preferences") {
-            return JSON.stringify(customOptions);
+            // JSON.stringify(undefined) returns undefined (not a string), which
+            // causes JSON.parse to throw. Return null when no custom options are
+            // provided so PDF.js treats it as "key not present" and uses defaults.
+            return customOptions !== undefined ? JSON.stringify(customOptions) : null;
         }
 
         if (key === "pdfjs.history") {

--- a/packages/trilium-e2e/src/base-config.ts
+++ b/packages/trilium-e2e/src/base-config.ts
@@ -43,7 +43,12 @@ export function createBaseConfig({ appDir, localTestDir, projectName, webServer,
             name: `${projectName}-shared`,
             testDir: sharedTestDir,
             use: { ...devices["Desktop Chrome"] },
-        }
+        },
+        {
+            name: `${projectName}-shared-firefox`,
+            testDir: sharedTestDir,
+            use: { ...devices["Desktop Firefox"] },
+        },
     ];
 
     if (localTestDir) {
@@ -55,8 +60,13 @@ export function createBaseConfig({ appDir, localTestDir, projectName, webServer,
     }
 
     return defineConfig({
+        // outputDir (raw per-test artifacts written during the run: videos, traces, screenshots)
+        // must NOT be the same path as the html reporter's outputFolder below. The html reporter
+        // clears its output folder before copying attachments into it, so pointing both at the
+        // same directory wiped the video/trace files out from under it before they could be
+        // embedded — every report ended up with zero playable video/trace data, silently.
         reporter: [["list"], ["html", { outputFolder: join(appDir, "test-output") }]],
-        outputDir: join(appDir, "test-output"),
+        outputDir: join(appDir, "test-results"),
         retries: 3,
         use: {
             baseURL,

--- a/packages/trilium-e2e/src/note_types/pdf_area_annotations.spec.ts
+++ b/packages/trilium-e2e/src/note_types/pdf_area_annotations.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect, Locator, Page } from "@playwright/test";
+
+import App from "../support/app";
+
+// These tests double as visual demos of the area-annotation fixes (paste-as-link,
+// duplicate-on-reopen, color update) — record video so the interactions can be watched.
+test.use({ video: "on" });
+
+const PDF_NOTE_TITLE = "Dacia Logan.pdf";
+
+// Pause after each notable step so the recorded video is actually watchable — without this,
+// the whole sequence (open PDF, draw, right-click, pick color, ...) flashes by in a couple of
+// seconds when scrubbing through the demo recording. Purely cosmetic, not needed for correctness.
+const STEP_PAUSE = 800;
+
+// Mirrors apps/client/src/widgets/sidebar/pdf/pdfAnnotationColors.ts. rgb() is what the sidebar's
+// solid-color swatch computes to; overlayRgba() is what the in-PDF overlay computes to, since it's
+// drawn with an 8-digit hex (alpha "cc" = 0.8 for the border, "1a" ≈ 0.10 for the fill).
+const PRESET_COLORS = [
+    { label: "Blue", r: 0x4a, g: 0x90, b: 0xd9 },
+    { label: "Yellow", r: 0xf5, g: 0xc5, b: 0x19 },
+    { label: "Green", r: 0x52, g: 0xb7, b: 0x88 },
+    { label: "Red", r: 0xe6, g: 0x39, b: 0x46 },
+    { label: "Purple", r: 0x9c, g: 0x6a, b: 0xde },
+] as const;
+
+function rgb(c: (typeof PRESET_COLORS)[number]) {
+    return `rgb(${c.r}, ${c.g}, ${c.b})`;
+}
+
+function overlayBorderRgba(c: (typeof PRESET_COLORS)[number]) {
+    return `rgba(${c.r}, ${c.g}, ${c.b}, 0.8)`;
+}
+
+test.beforeEach(async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+    await app.setOption("rightPaneCollapsedItems", "[]");
+});
+
+test("Copying an area annotation link pastes as a real link, not plain text", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+    await app.goToNoteInNewTab(PDF_NOTE_TITLE);
+
+    await drawArea(app, page);
+    const areaItem = app.sidebar.locator(".pdf-area-annotation-item");
+    await expect(areaItem).toHaveCount(1);
+    await pause(page);
+
+    await areaItem.locator(".pdf-area-annotation-btn").click();
+    await expect(page.locator(".toast-body", { hasText: "Annotation link copied" })).toBeVisible();
+    await pause(page);
+
+    // Paste the copied link into a plain text note. Before the fix this could silently
+    // degrade to plain text (or, for area annotations specifically, drop the link
+    // entirely and paste just the bare image URL) instead of a clickable linked image.
+    await app.addNewTab();
+    await app.goToNoteInNewTab("Empty text");
+    const noteContent = app.currentNoteSplit.locator(".note-detail-editable-text-editor");
+    await expect(noteContent).toBeVisible();
+    await noteContent.click();
+
+    // Clear any content first instead of assuming the shared fixture note starts blank:
+    // a previous run whose own cleanup (below) didn't fully revert would otherwise break
+    // this run's assumption about the note's starting state.
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("Delete");
+
+    await page.keyboard.press("ControlOrMeta+V");
+    await expect(noteContent.locator("a[href] img")).toHaveCount(1);
+    await pause(page, 1500);
+
+    // Clear the pasted content again (rather than undo) so the shared "Empty text" fixture
+    // note is reliably left blank for the next run, regardless of undo-stack quirks.
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("Delete");
+
+    await app.clickNoteOnNoteTreeByTitle(PDF_NOTE_TITLE);
+    await deleteAllAreas(app);
+});
+
+test("Reopening a closed PDF tab and drawing a new area does not create a duplicate", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+    await app.goToNoteInNewTab(PDF_NOTE_TITLE);
+    await pause(page);
+
+    // This is exactly the repro from the bug report: close the tab, reopen the same PDF
+    // note, then draw one area. If the closed tab's message listener wasn't torn down
+    // cleanly, that single gesture used to create two identical annotations.
+    await app.getActiveTab().locator(".note-tab-close").click();
+    await pause(page);
+    await app.clickNoteOnNoteTreeByTitle(PDF_NOTE_TITLE);
+    await pause(page);
+
+    await drawArea(app, page);
+
+    await expect(app.sidebar.locator(".pdf-area-annotation-item")).toHaveCount(1);
+    await pause(page, 1500);
+
+    await deleteAllAreas(app);
+});
+
+test("Changing an area annotation's color updates immediately, without a page reload", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+    await app.goToNoteInNewTab(PDF_NOTE_TITLE);
+
+    await drawArea(app, page);
+    const areaItem = app.sidebar.locator(".pdf-area-annotation-item");
+    await expect(areaItem).toHaveCount(1);
+    await expect(areaItem.locator(".pdf-area-annotation-color-bar")).toHaveCSS("background-color", rgb(PRESET_COLORS[0]));
+    await pause(page);
+
+    const contentFrame = app.currentNoteSplit.frameLocator("iframe");
+    const overlay = contentFrame.locator(".trilium-area-overlay").first();
+    await expect(overlay).toHaveCSS("border-color", overlayBorderRgba(PRESET_COLORS[0]));
+
+    const red = PRESET_COLORS.find((c) => c.label === "Red")!;
+    await changeAreaColorViaOverlay(page, overlay, red.label);
+    await pause(page);
+
+    // Tight timeout: before the fix, the color never updated without a full note reload
+    // (a page.reload() would have masked the bug), so a regression here fails fast
+    // instead of flaking slowly.
+    await expect(areaItem.locator(".pdf-area-annotation-color-bar")).toHaveCSS("background-color", rgb(red), { timeout: 2000 });
+    // The change must be visible on the PDF page itself, not just the sidebar swatch —
+    // that's the whole point of an *area* annotation: it marks a spot in the document.
+    await expect(overlay).toHaveCSS("border-color", overlayBorderRgba(red), { timeout: 2000 });
+    await pause(page, 1500);
+
+    await deleteAllAreas(app);
+});
+
+test("Every preset color can be applied and is reflected on both the sidebar swatch and the PDF overlay", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+    await app.goToNoteInNewTab(PDF_NOTE_TITLE);
+
+    await drawArea(app, page);
+    const areaItem = app.sidebar.locator(".pdf-area-annotation-item");
+    await expect(areaItem).toHaveCount(1);
+
+    const contentFrame = app.currentNoteSplit.frameLocator("iframe");
+    const overlay = contentFrame.locator(".trilium-area-overlay").first();
+    await pause(page);
+
+    for (const color of PRESET_COLORS) {
+        await changeAreaColorViaOverlay(page, overlay, color.label);
+
+        await expect(areaItem.locator(".pdf-area-annotation-color-bar")).toHaveCSS("background-color", rgb(color));
+        await expect(overlay).toHaveCSS("border-color", overlayBorderRgba(color));
+        await pause(page, 1200);
+    }
+
+    await deleteAllAreas(app);
+});
+
+/** Right-clicks the in-PDF overlay, opens "Change color", and picks the given preset by label. */
+async function changeAreaColorViaOverlay(page: Page, overlay: Locator, colorLabel: string) {
+    const contextMenu = page.locator("#context-menu-container");
+
+    // Retry the open-menu gesture: right-clicking a freshly-created/updated overlay
+    // occasionally doesn't deliver the "contextmenu" event on the first try.
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        await expect(overlay).toBeVisible();
+        await overlay.click({ button: "right" });
+        try {
+            await contextMenu.getByText("Change color").hover({ timeout: 3000 });
+            break;
+        } catch (e) {
+            if (attempt === 3) throw e;
+        }
+    }
+    await contextMenu.getByText(colorLabel, { exact: true }).click();
+}
+
+/** Activates the area-capture tool and drags a selection box over the top-left quadrant of page 1. */
+async function drawArea(app: App, page: Page, pageNumber = 1) {
+    const contentFrame = app.currentNoteSplit.frameLocator("iframe");
+
+    // Wait for our own toolbar button to exist before touching anything else: it's only
+    // attached once PDF.js fires "documentloaded", which can lag behind the built-in
+    // toolbar controls (#scaleSelect, #pageNumber) becoming interactable. Triggering a
+    // zoom/page change first can retrigger a reflow that races with that late setup.
+    const areaButton = contentFrame.locator("#triliumAreaAnnotationButton");
+    await expect(areaButton).toBeVisible();
+
+    // The PDF note persists its own scroll/zoom position (view history) across
+    // sessions, so another test's earlier interaction with this shared fixture note can
+    // leave the viewer at a different page/zoom here. Pin both to a known state before
+    // computing drag coordinates below, instead of depending on whatever was restored.
+    await contentFrame.locator("#scaleSelect").selectOption("1");
+    const pageNumberInput = contentFrame.locator("#pageNumber");
+    await pageNumberInput.fill(`${pageNumber}`);
+    await pageNumberInput.press("Enter");
+
+    const pageEl = contentFrame.locator(`.page[data-page-number="${pageNumber}"]`);
+    await expect(pageEl).toBeVisible();
+    await pageEl.scrollIntoViewIfNeeded();
+    await pause(page);
+
+    const wasActive = await areaButton.evaluate((el) => (el as HTMLElement).style.background !== "");
+    if (!wasActive) {
+        await areaButton.click();
+        await pause(page, 400);
+    }
+
+    const box = await pageEl.boundingBox();
+    if (!box) throw new Error("Could not find bounding box of PDF page");
+
+    const startX = box.x + box.width * 0.15;
+    const startY = box.y + box.height * 0.15;
+    const endX = box.x + box.width * 0.45;
+    const endY = box.y + box.height * 0.45;
+
+    // Slow, stepped drag (rather than an instant down/up) so the selection box is visible
+    // growing across the page in the recorded video.
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move((startX + endX) / 2, (startY + endY) / 2, { steps: 15 });
+    await page.waitForTimeout(200);
+    await page.mouse.move(endX, endY, { steps: 15 });
+    await page.waitForTimeout(200);
+    await page.mouse.up();
+
+    await expect(app.sidebar).toContainText("area annotation");
+
+    // The captured area must show up as a highlighted overlay directly on the PDF page in
+    // the note — not just as an entry in the sidebar list — since that's what actually marks
+    // the annotated spot in the document itself.
+    const contentFrameAfter = app.currentNoteSplit.frameLocator("iframe");
+    await expect(contentFrameAfter.locator(".trilium-area-overlay").first()).toBeVisible();
+    await pause(page, 1200);
+}
+
+/** Waits briefly so the action just performed is visible for a moment in the recorded video. */
+async function pause(page: Page, ms = STEP_PAUSE) {
+    await page.waitForTimeout(ms);
+}
+
+/**
+ * Deletes every area annotation on the currently active note directly via the API, so
+ * cleanup between tests doesn't depend on the (separately tested, occasionally slow)
+ * UI delete round-trip.
+ */
+async function deleteAllAreas(app: App) {
+    await app.page.evaluate(async () => {
+        const glob = (window as any).glob;
+        const noteId = glob.appContext.tabManager.getActiveContext()?.noteId;
+        if (!noteId) return;
+
+        const attributes = await (await fetch(`/api/notes/${noteId}/attributes`)).json();
+        for (const attr of attributes) {
+            if (attr.type !== "label" || attr.name !== "areaAnnotation") continue;
+
+            await fetch(`/api/notes/${noteId}/attributes/${attr.attributeId}`, {
+                method: "DELETE",
+                headers: { "x-csrf-token": glob.csrfToken }
+            });
+            try {
+                const { attachmentId } = JSON.parse(attr.value);
+                await fetch(`/api/attachments/${attachmentId}`, {
+                    method: "DELETE",
+                    headers: { "x-csrf-token": glob.csrfToken }
+                });
+            } catch {
+                // malformed value — nothing more to clean up for this attribute
+            }
+        }
+    });
+}


### PR DESCRIPTION
## Overview
This PR adds two complementary annotation features to Trilium's built-in PDF viewer, giving users the ability to create persistent, navigable cross-references between PDF content and their notes.

1. **Linkable text annotations** — copy a shareable link from any existing highlight or sticky-note annotation; pasting it anywhere in Trilium creates a chip that, when clicked, opens the PDF and scrolls directly to that annotation.
1. **Image (area) annotations** — drag a rectangle over any region of a PDF page to capture it as an image; the image is stored as a note attachment, shown in the right panel, and can be pasted into any note as a resizable, clickable image that navigates back to the PDF location.

---
## How it differs from the existing annotation implementation
Trilium's existing PDF viewer already lets users create and edit annotations inside the PDF itself (using PDF.js's built-in highlight and FreeText editors) and shows them in the right panel sidebar. What it lacked was any connection between those annotations and the rest of the note-taking system — there was no way to reference a specific annotation from another note, or to capture a visual region of a PDF.

This PR adds the "outbound" layer: every annotation (text or image) now has a stable address that can be embedded in any note, navigated to from a link, and used in the same way as any other Trilium internal cross-reference.

## Feature 1 — Linkable text/highlight annotations

https://github.com/user-attachments/assets/0e738e91-9c30-45c0-8e8f-97c252db5e92

### What it achieves
Any highlight or comment in a PDF can be shared as a Trilium reference link. Clicking the link opens the PDF note and scrolls to the exact annotation. The link is human-readable in the sidebar with the annotation's preview text.

### How it was implemented

URL format — ViewScope in `link.ts` was extended with three new params:

`#root/noteId?annotationId=12R&annotationPage=5&annotationPreview=The+quick+brown+fox`
* **annotationId** — the PDF.js annotation object reference (e.g. 12R). Used for exact matching.
* **annotationPage** — page number, used as a fallback when the ID is stale.
* **annotationPreview** — up to 60 characters of the highlighted text or comment, used for fallback matching and as the visible link label.

**Copy link** — each annotation item in the right panel PdfAnnotations sidebar gains a hover button and a right-click context menu entry. It copies a <a class="reference-link" href="…"> HTML element to the clipboard using document.execCommand("copy") (compatible with both HTTP and HTTPS). Pasting into a rich-text note produces a reference link chip displaying "Note title › 'preview text'".

**Navigation and scroll** — when the link is clicked, goToLinkExt parses the annotation params into viewScope and navigates. The scroll is performed via a postMessage (trilium-scroll-to-annotation) to the PDF.js iframe, which calls scrollToAnnotation. A pendingAnnotationIdRef ref survives spurious viewScope resets and a viewerAreaReadyRef ensures the scroll message is only sent after the viewer's listener is registered.

**ID rotation fallback** — PDF.js assigns temporary editor IDs (e.g. pdfjs_internal_editor_0) to newly created annotations. After the PDF is saved, extractFromSavedData re-reads the file and permanent object-reference IDs (e.g. 12R) replace them. A copied link might therefore contain a stale ID. resolveAnnotation (now in its own module pdfAnnotationResolver.ts, with 10 unit tests) handles this: it first tries exact-ID matching, and if that fails, falls back to matching on page number + the annotationPreview content.

**Right-click context menu** — text annotations support right-click → Copy link / Change colour / Delete. The colour change and delete are routed via trilium-set-annotation-color and trilium-delete-annotation postMessages to the PDF.js annotation storage API. The context menu is attached via jQuery document delegation (not Preact's onContextMenu) to ensure it fires reliably inside Trilium's legacy widget wrapper.

## Feature 2 — Image (area) annotations


https://github.com/user-attachments/assets/ac8da28f-48cd-48a0-9c4e-c4de368fc628


### What it achieves
Users can select a rectangular region of any page in the PDF viewer, capture it as a PNG, and have it appear in the right panel as a thumbnail. Area annotations support notes/comments, colour-coded overlays visible directly on the PDF, a right-click context menu, and a copy button that produces a resizable, linked image when pasted into a note.

### How it was implemented
**Capture tool** — area.ts (new file in packages/pdfjs-viewer) adds a crosshair button to the PDF.js toolbar. On drag-release it reads the page canvas pixels for the selection rectangle, encodes them as a base64 PNG, and sends a pdfjs-viewer-area-capture postMessage to the parent.

**Storage** — images are uploaded via POST /api/notes/:noteId/attachments/upload (the binary-safe multipart route) so they are stored as proper binary PNG attachments with role: "image". Metadata (attachment ID, page, rect, comment, colour) is persisted as a areaAnnotation note label JSON on the PDF note. This means:

* No child notes are created in the note tree.
* Annotations survive across sessions and sync devices.
* Deletion removes both the label and the attachment.

**Right panel** — PdfAreaAnnotations.tsx reads the areaAnnotation labels, shows PNG thumbnails, and on hover displays an enlarged preview centred in the viewport. A right-click context menu offers Copy link / Add note / Change colour / Delete.

**Persistent overlays on the PDF** — area.ts draws semi-transparent coloured rectangles on the page divs for every stored area annotation. A pagerendered event listener redraws overlays after PDF.js's virtual scroller evicts and recreates page divs. Right-clicking an overlay inside the PDF viewer itself sends a pdfjs-viewer-area-right-click postMessage; the parent shows the same context menu.

**Copy as resizable image** — the copy button produces `<figure class="image"><a href="annotationHash"><img src="api/attachments/…/open"></a></figure>`, which pastes into CKEditor as a resizable linked image (Trilium's ImageResize plugin is registered). Clicking the image in the note navigates to the PDF and scrolls to the area. No new image note is created.

**Scroll to area** — the trilium-scroll-to-area message triggers scrollToArea in area.ts. If the target page is already rendered, it scrolls precisely to the vertical midpoint of the captured rect. If the page is virtualized (not in DOM), it scrolls to an estimated position and sets pendingScrollTarget; the pagerendered listener then performs the precise scroll once the page is actually rendered.

## Shared infrastructure

* `pdfAnnotationColors.ts` — a single source of truth for the 5-colour palette (Blue / Yellow / Green / Red / Purple) shared by text annotations, area annotations, and the PDF overlay renderer. The context menu renders coloured circle icons using CSS rules with higher specificity (0,3,0) than Trilium's theme-level override (0,2,0).
* `textPrompt.ts` — a non-blocking Bootstrap modal that replaces window.prompt() for "Add note" dialogs, matching Trilium's design system.
* `pdfAnnotationResolver.ts` — extracted pure function with 10 unit tests covering exact-match, fallback-match, ellipsis stripping, and edge cases.
* `link.spec.ts` — 7 new tests covering calculateHash serialisation and parseNavigationStateFromUrl round-trip for all three new annotation URL params.

Implements #8635 
