### PR TITLE
feat(spreadsheet): image support in the editor, share view, and XLSX import/export

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -38,6 +38,7 @@
     "@univerjs/preset-sheets-conditional-formatting": "0.24.0",
     "@univerjs/preset-sheets-core": "0.24.0",
     "@univerjs/preset-sheets-data-validation": "0.24.0",
+    "@univerjs/preset-sheets-drawing": "0.24.0",
     "@univerjs/preset-sheets-filter": "0.24.0",
     "@univerjs/preset-sheets-find-replace": "0.24.0",
     "@univerjs/preset-sheets-note": "0.24.0",

--- a/apps/client/src/services/image_upload.spec.ts
+++ b/apps/client/src/services/image_upload.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { dataUrlToImageFile, parseImageDataUrl, uploadImageAttachment } from "./image_upload";
+import server from "./server";
+
+vi.mock("./server", () => ({ default: { upload: vi.fn() } }));
+
+const serverUpload = vi.mocked(server.upload);
+
+describe("parseImageDataUrl", () => {
+    it("splits a base64 data URL into its mime, raw base64 and extension", () => {
+        expect(parseImageDataUrl("data:image/png;base64,AAAA")).toEqual({ mime: "image/png", base64: "AAAA", ext: "png" });
+        expect(parseImageDataUrl("data:image/jpeg;base64,BBBB")?.ext).toBe("jpeg");
+    });
+
+    it("maps svg+xml to a clean 'svg' extension", () => {
+        expect(parseImageDataUrl("data:image/svg+xml;base64,Q0M=")?.ext).toBe("svg");
+    });
+
+    it("returns null for non-base64 data URLs and plain URLs", () => {
+        expect(parseImageDataUrl("api/attachments/x/image/x.png")).toBeNull();
+        expect(parseImageDataUrl("data:image/png,notbase64")).toBeNull();
+    });
+});
+
+describe("dataUrlToImageFile", () => {
+    it("decodes the base64 payload into a File with the parsed mime and extension", async () => {
+        const file = dataUrlToImageFile("data:image/png;base64,QUJD"); // "ABC"
+        expect(file).not.toBeNull();
+        expect(file?.type).toBe("image/png");
+        expect(file?.name).toBe("image.png");
+        expect(await file?.text()).toBe("ABC");
+    });
+
+    it("returns null when the input is not a base64 data URL", () => {
+        expect(dataUrlToImageFile("https://example.com/a.png")).toBeNull();
+    });
+});
+
+describe("uploadImageAttachment", () => {
+    afterEach(() => vi.clearAllMocks());
+
+    it("uploads the decoded image and returns the attachment URL on success", async () => {
+        serverUpload.mockResolvedValue({ uploaded: true, url: "api/attachments/new1/image/image.png" });
+
+        const url = await uploadImageAttachment("note1", "data:image/png;base64,QUJD");
+
+        expect(url).toBe("api/attachments/new1/image/image.png");
+        expect(serverUpload).toHaveBeenCalledWith("notes/note1/attachments/upload", expect.any(File), undefined, "POST");
+    });
+
+    it("returns null when the server reports the upload did not succeed", async () => {
+        serverUpload.mockResolvedValue({ uploaded: false });
+        expect(await uploadImageAttachment("note1", "data:image/png;base64,QUJD")).toBeNull();
+    });
+
+    it("returns null without uploading when the data URL cannot be parsed", async () => {
+        expect(await uploadImageAttachment("note1", "not-a-data-url")).toBeNull();
+        expect(serverUpload).not.toHaveBeenCalled();
+    });
+
+    it("returns null when the upload throws", async () => {
+        serverUpload.mockRejectedValue(new Error("network"));
+        expect(await uploadImageAttachment("note1", "data:image/png;base64,QUJD")).toBeNull();
+    });
+});

--- a/apps/client/src/services/image_upload.spec.ts
+++ b/apps/client/src/services/image_upload.spec.ts
@@ -35,6 +35,11 @@ describe("dataUrlToImageFile", () => {
     it("returns null when the input is not a base64 data URL", () => {
         expect(dataUrlToImageFile("https://example.com/a.png")).toBeNull();
     });
+
+    it("returns null for a malformed base64 payload instead of throwing", () => {
+        // atob throws a DOMException on invalid base64; the decode must be guarded.
+        expect(dataUrlToImageFile("data:image/png;base64,@@@not-base64@@@")).toBeNull();
+    });
 });
 
 describe("uploadImageAttachment", () => {

--- a/apps/client/src/services/image_upload.ts
+++ b/apps/client/src/services/image_upload.ts
@@ -27,7 +27,12 @@ export function dataUrlToImageFile(dataUrl: string): File | null {
     const parsed = parseImageDataUrl(dataUrl);
     if (!parsed) return null;
 
-    const binary = atob(parsed.base64);
+    let binary: string;
+    try {
+        binary = atob(parsed.base64);
+    } catch {
+        return null; // malformed base64 — atob throws a DOMException
+    }
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
         bytes[i] = binary.charCodeAt(i);

--- a/apps/client/src/services/image_upload.ts
+++ b/apps/client/src/services/image_upload.ts
@@ -1,0 +1,54 @@
+import server from "./server.js";
+
+/**
+ * Uploads a base64 `data:` image to a note as an attachment via the standard attachment-upload
+ * endpoint (the server assigns the id, compresses the image, and returns the reference URL).
+ * Resolves to the `api/attachments/...` URL, or `null` on failure (caller decides how to fall back,
+ * e.g. keep the image inline as base64 so it still persists/renders).
+ *
+ * Format-agnostic: used by any rich note type that needs to offload inline base64 images to
+ * attachments (e.g. the spreadsheet drawing layer).
+ */
+export async function uploadImageAttachment(noteId: string, dataUrl: string): Promise<string | null> {
+    const file = dataUrlToImageFile(dataUrl);
+    if (!file) return null;
+
+    try {
+        const response = await server.upload(`notes/${noteId}/attachments/upload`, file, undefined, "POST") as { uploaded?: boolean; url?: string };
+        return response?.uploaded && response.url ? response.url : null;
+    } catch (e) {
+        console.error("Failed to upload image attachment", e);
+        return null;
+    }
+}
+
+/** Decodes a `data:<mime>;base64,<data>` URL into a {@link File} suitable for upload. */
+export function dataUrlToImageFile(dataUrl: string): File | null {
+    const parsed = parseImageDataUrl(dataUrl);
+    if (!parsed) return null;
+
+    const binary = atob(parsed.base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return new File([ bytes ], `image.${parsed.ext}`, { type: parsed.mime });
+}
+
+export interface ParsedImageDataUrl {
+    mime: string;
+    base64: string;
+    ext: string;
+}
+
+/** Splits a `data:<mime>;base64,<data>` URL into its mime, raw base64 and a file extension. */
+export function parseImageDataUrl(dataUrl: string): ParsedImageDataUrl | null {
+    const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
+    if (!match) return null;
+
+    const mime = match[1];
+    const base64 = match[2];
+    const subtype = mime.split("/")[1] ?? "png";
+    const ext = subtype === "svg+xml" ? "svg" : (subtype.replace(/[^a-z0-9]/gi, "") || "png");
+    return { mime, base64, ext };
+}

--- a/apps/client/src/widgets/type_widgets/Attachment.tsx
+++ b/apps/client/src/widgets/type_widgets/Attachment.tsx
@@ -146,6 +146,10 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
     const imageViewerWrapper = useRef<HTMLDivElement>(null);
     const [ title, setTitle ] = useState(attachment.title);
     const [ textContent, setTextContent ] = useState<string | null>(null);
+    // Tracked in state so the deletion warning reacts to entity reloads. The FAttachment is mutated
+    // in place by froca, so reading it directly during render wouldn't re-render an image attachment
+    // (whose title/content don't change when only the erasure schedule does).
+    const [ scheduledForErasureSince, setScheduledForErasureSince ] = useState(attachment.utcDateScheduledForErasureSince);
     // "importSource" attachments (e.g. OneNote debug source) behave like ordinary files for
     // preview, OCR and link-copying purposes.
     const isFileLike = attachment.role === "file" || attachment.role === "importSource";
@@ -169,6 +173,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
         }
 
         setTitle(attachment.title);
+        setScheduledForErasureSince(attachment.utcDateScheduledForErasureSince);
     }
 
     useEffect(refresh, [ attachment, isZoomableImage ]);
@@ -208,7 +213,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
 
     return (
         <div className="attachment-detail-widget">
-            <div className={`attachment-detail-wrapper ${isFullDetail ? "full-detail" : "list-view"} ${attachment.utcDateScheduledForErasureSince ? "scheduled-for-deletion" : ""}`}>
+            <div className={`attachment-detail-wrapper ${isFullDetail ? "full-detail" : "list-view"} ${scheduledForErasureSince ? "scheduled-for-deletion" : ""}`}>
                 <div className="attachment-title-line">
                     <AttachmentActions
                         attachment={attachment}
@@ -240,7 +245,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
                     <div style="flex: 1 1;" />
                 </div>
 
-                {attachment.utcDateScheduledForErasureSince && <DeletionAlert utcDateScheduledForErasureSince={attachment.utcDateScheduledForErasureSince} />}
+                {scheduledForErasureSince && <DeletionAlert utcDateScheduledForErasureSince={scheduledForErasureSince} />}
                 {textContent && <TextPreview content={textContent} />}
                 {isZoomableImage ? (
                     <div key="image-viewer" ref={imageViewerWrapper} className="attachment-content-wrapper attachment-image-viewer">

--- a/apps/client/src/widgets/type_widgets/canvas/image_attachments.spec.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/image_attachments.spec.ts
@@ -1,0 +1,118 @@
+import { BinaryFileData } from "@excalidraw/excalidraw/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type FNote from "../../../entities/fnote";
+import { buildNewImageAttachments, findOrphanImageAttachments, loadImageAttachments } from "./image_attachments";
+
+function file(dataURL: string, mimeType = "image/png"): BinaryFileData {
+    return { id: "x", dataURL, mimeType, created: 0 } as BinaryFileData;
+}
+
+describe("buildNewImageAttachments", () => {
+    it("emits a base64 image attachment titled with the fileId for each new image", () => {
+        const activeFiles = {
+            a: file("data:image/png;base64,AAAA"),
+            b: file("data:image/jpeg;base64,BBBB", "image/jpeg")
+        };
+
+        const attachments = buildNewImageAttachments(activeFiles, new Set());
+
+        expect(attachments).toEqual([
+            { role: "image", title: "a", mime: "image/png", content: "AAAA", position: 10, encoding: "base64" },
+            { role: "image", title: "b", mime: "image/jpeg", content: "BBBB", position: 20, encoding: "base64" }
+        ]);
+    });
+
+    it("skips files already persisted (loaded at start or uploaded earlier this session)", () => {
+        const activeFiles = {
+            old: file("data:image/png;base64,AAAA"),
+            new: file("data:image/png;base64,CCCC")
+        };
+
+        const attachments = buildNewImageAttachments(activeFiles, new Set([ "old" ]));
+
+        expect(attachments).toEqual([
+            { role: "image", title: "new", mime: "image/png", content: "CCCC", position: 10, encoding: "base64" }
+        ]);
+    });
+
+    it("skips files whose source is not an inline data URL (nothing to upload)", () => {
+        const activeFiles = { a: file("api/attachments/x/image/x.png") };
+        expect(buildNewImageAttachments(activeFiles, new Set())).toEqual([]);
+    });
+
+    it("migrates a legacy note's inline base64 images to attachments, preserving the exact bytes", () => {
+        // A legacy note loads its images inline (content.files) into memory, so on the first save
+        // every active file is unseen (empty persisted set) and must be written out verbatim — the
+        // stored content is the original base64, not a recompressed copy.
+        const activeFiles = { legacy: file("data:image/png;base64,iVBORw0KGgoAAAA=") };
+
+        const attachments = buildNewImageAttachments(activeFiles, new Set());
+
+        expect(attachments).toEqual([
+            { role: "image", title: "legacy", mime: "image/png", content: "iVBORw0KGgoAAAA=", position: 10, encoding: "base64" }
+        ]);
+    });
+});
+
+describe("findOrphanImageAttachments", () => {
+    it("splits loaded attachments into removed (orphan) and still-referenced (remaining)", () => {
+        const loaded = [
+            { fileId: "a", attachmentId: "att-a" },
+            { fileId: "b", attachmentId: "att-b" },
+            { fileId: "c", attachmentId: "att-c" }
+        ];
+
+        const { orphans, remaining } = findOrphanImageAttachments(loaded, new Set([ "a", "c" ]));
+
+        expect(orphans).toEqual([ { fileId: "b", attachmentId: "att-b" } ]);
+        expect(remaining).toEqual([
+            { fileId: "a", attachmentId: "att-a" },
+            { fileId: "c", attachmentId: "att-c" }
+        ]);
+    });
+
+    it("returns no orphans when every loaded image is still on the canvas", () => {
+        const loaded = [ { fileId: "a", attachmentId: "att-a" } ];
+        const { orphans, remaining } = findOrphanImageAttachments(loaded, new Set([ "a" ]));
+
+        expect(orphans).toEqual([]);
+        expect(remaining).toEqual(loaded);
+    });
+});
+
+describe("loadImageAttachments", () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    function noteWithAttachments(attachments: { attachmentId: string; title: string }[]) {
+        return { getAttachmentsByRole: vi.fn(async () => attachments) } as unknown as FNote;
+    }
+
+    it("fetches each image attachment, rebuilds its data URL and maps it to its fileId, ignoring the SVG export", async () => {
+        const note = noteWithAttachments([
+            { attachmentId: "att-export", title: "canvas-export.svg" },
+            { attachmentId: "att-1", title: "fileId-1" }
+        ]);
+        const fetchMock = vi.fn(async () => ({ ok: true, blob: async () => new Blob([ "ABC" ], { type: "image/png" }) }));
+        vi.stubGlobal("fetch", fetchMock);
+
+        const { files, metadata } = await loadImageAttachments(note);
+
+        // Only the image is fetched (the export is filtered out by title), via the attachment image endpoint.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith("api/attachments/att-1/image/fileId-1");
+        // "ABC" base64-encodes to "QUJD" — the bytes survive the round-trip unchanged.
+        expect(files).toEqual([ { id: "fileId-1", dataURL: "data:image/png;base64,QUJD", mimeType: "image/png", created: expect.any(Number) } ]);
+        expect(metadata).toEqual([ { fileId: "fileId-1", attachmentId: "att-1" } ]);
+    });
+
+    it("skips attachments whose fetch fails without rejecting", async () => {
+        const note = noteWithAttachments([ { attachmentId: "att-1", title: "fileId-1" } ]);
+        vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, blob: async () => new Blob() })));
+
+        const { files, metadata } = await loadImageAttachments(note);
+
+        expect(files).toEqual([]);
+        expect(metadata).toEqual([]);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/canvas/image_attachments.spec.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/image_attachments.spec.ts
@@ -2,7 +2,7 @@ import { BinaryFileData } from "@excalidraw/excalidraw/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type FNote from "../../../entities/fnote";
-import { buildNewImageAttachments, findOrphanImageAttachments, loadImageAttachments } from "./image_attachments";
+import { buildNewImageAttachments, loadImageAttachments } from "./image_attachments";
 
 function file(dataURL: string, mimeType = "image/png"): BinaryFileData {
     return { id: "x", dataURL, mimeType, created: 0 } as BinaryFileData;
@@ -52,32 +52,6 @@ describe("buildNewImageAttachments", () => {
         expect(attachments).toEqual([
             { role: "image", title: "legacy", mime: "image/png", content: "iVBORw0KGgoAAAA=", position: 10, encoding: "base64" }
         ]);
-    });
-});
-
-describe("findOrphanImageAttachments", () => {
-    it("splits loaded attachments into removed (orphan) and still-referenced (remaining)", () => {
-        const loaded = [
-            { fileId: "a", attachmentId: "att-a" },
-            { fileId: "b", attachmentId: "att-b" },
-            { fileId: "c", attachmentId: "att-c" }
-        ];
-
-        const { orphans, remaining } = findOrphanImageAttachments(loaded, new Set([ "a", "c" ]));
-
-        expect(orphans).toEqual([ { fileId: "b", attachmentId: "att-b" } ]);
-        expect(remaining).toEqual([
-            { fileId: "a", attachmentId: "att-a" },
-            { fileId: "c", attachmentId: "att-c" }
-        ]);
-    });
-
-    it("returns no orphans when every loaded image is still on the canvas", () => {
-        const loaded = [ { fileId: "a", attachmentId: "att-a" } ];
-        const { orphans, remaining } = findOrphanImageAttachments(loaded, new Set([ "a" ]));
-
-        expect(orphans).toEqual([]);
-        expect(remaining).toEqual(loaded);
     });
 });
 

--- a/apps/client/src/widgets/type_widgets/canvas/image_attachments.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/image_attachments.ts
@@ -26,7 +26,7 @@ export const CANVAS_EXPORT_TITLE = "canvas-export.svg";
  * data URL, since Excalidraw renders only from inline data URLs (it has no external-URL provider).
  */
 export async function loadImageAttachments(note: FNote): Promise<{ files: BinaryFileData[]; metadata: ImageAttachmentMetadata[] }> {
-    const attachments = (await note.getAttachmentsByRole(IMAGE_ROLE)).filter((attachment) => attachment.title !== CANVAS_EXPORT_TITLE);
+    const attachments = await getCanvasImageAttachments(note);
 
     const files: BinaryFileData[] = [];
     const metadata: ImageAttachmentMetadata[] = [];
@@ -83,18 +83,12 @@ export function buildNewImageAttachments(activeFiles: Record<string, BinaryFileD
 }
 
 /**
- * Partitions previously-loaded image attachments into those whose image is gone from the canvas
- * (`orphans`, to be deleted) and those still referenced (`remaining`).
+ * Returns the note's `image`-role attachments that back canvas images (i.e. excluding the SVG
+ * export), used to reload images on open. Orphan cleanup of removed images is handled server-side
+ * (saveLinks/checkImageAttachments scanning the scene JSON), not here.
  */
-export function findOrphanImageAttachments(loaded: readonly ImageAttachmentMetadata[], activeFileIds: ReadonlySet<string>) {
-    const orphans: ImageAttachmentMetadata[] = [];
-    const remaining: ImageAttachmentMetadata[] = [];
-
-    for (const entry of loaded) {
-        (activeFileIds.has(entry.fileId) ? remaining : orphans).push(entry);
-    }
-
-    return { orphans, remaining };
+async function getCanvasImageAttachments(note: FNote) {
+    return (await note.getAttachmentsByRole(IMAGE_ROLE)).filter((attachment) => attachment.title !== CANVAS_EXPORT_TITLE);
 }
 
 /** Reads a blob as a base64 `data:` URL. */

--- a/apps/client/src/widgets/type_widgets/canvas/image_attachments.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/image_attachments.ts
@@ -1,0 +1,108 @@
+import type { BinaryFileData } from "@excalidraw/excalidraw/types";
+
+import type FNote from "../../../entities/fnote";
+import { parseImageDataUrl } from "../../../services/image_upload";
+import type { SavedData } from "../../react/hooks";
+
+/** Maps a canvas image's Excalidraw `fileId` to the attachment it is stored in. */
+export interface ImageAttachmentMetadata {
+    fileId: string;
+    attachmentId: string;
+}
+
+/**
+ * Attachment role under which both the SVG export and the canvas images are stored. Images are
+ * served back via the `api/attachments/:id/image/...` endpoint, which only accepts the `image`
+ * role — so they must share it with the export and are told apart by title (see below).
+ */
+export const IMAGE_ROLE = "image";
+/** Fixed title of the SVG export attachment; canvas images are titled with their `fileId` instead. */
+export const CANVAS_EXPORT_TITLE = "canvas-export.svg";
+
+/**
+ * Loads the note's image attachments (every `image`-role attachment except the SVG export) and
+ * rebuilds them into Excalidraw {@link BinaryFileData}, keyed by the `fileId` stored as the
+ * attachment title. The bytes are fetched from the attachment image endpoint and re-encoded as a
+ * data URL, since Excalidraw renders only from inline data URLs (it has no external-URL provider).
+ */
+export async function loadImageAttachments(note: FNote): Promise<{ files: BinaryFileData[]; metadata: ImageAttachmentMetadata[] }> {
+    const attachments = (await note.getAttachmentsByRole(IMAGE_ROLE)).filter((attachment) => attachment.title !== CANVAS_EXPORT_TITLE);
+
+    const files: BinaryFileData[] = [];
+    const metadata: ImageAttachmentMetadata[] = [];
+
+    await Promise.all(attachments.map(async (attachment) => {
+        try {
+            const response = await fetch(`api/attachments/${attachment.attachmentId}/image/${encodeURIComponent(attachment.title)}`);
+            if (!response.ok) return;
+
+            const blob = await response.blob();
+            const dataURL = await blobToDataURL(blob);
+            files.push({
+                id: attachment.title,
+                dataURL,
+                mimeType: blob.type || "image/png",
+                created: Date.now()
+            } as BinaryFileData);
+            metadata.push({ fileId: attachment.title, attachmentId: attachment.attachmentId });
+        } catch (e) {
+            console.error(`Failed to load canvas image attachment '${attachment.attachmentId}'`, e);
+        }
+    }));
+
+    return { files, metadata };
+}
+
+/**
+ * Builds attachment payloads for canvas images not yet persisted. Each is titled with its `fileId`
+ * so the server matches and updates it in place across saves (rather than duplicating). The bytes
+ * are stored as exact base64 (no compression), preserving PNG transparency.
+ */
+export function buildNewImageAttachments(activeFiles: Record<string, BinaryFileData>, persistedFileIds: ReadonlySet<string>): NonNullable<SavedData["attachments"]> {
+    const attachments: NonNullable<SavedData["attachments"]> = [];
+    let position = 10;
+
+    for (const [ fileId, file ] of Object.entries(activeFiles)) {
+        if (!file || persistedFileIds.has(fileId)) continue;
+
+        const parsed = parseImageDataUrl(file.dataURL);
+        if (!parsed) continue; // not an inline data URL — nothing to upload
+
+        attachments.push({
+            role: IMAGE_ROLE,
+            title: fileId,
+            mime: file.mimeType,
+            content: parsed.base64,
+            position,
+            encoding: "base64"
+        });
+        position += 10;
+    }
+
+    return attachments;
+}
+
+/**
+ * Partitions previously-loaded image attachments into those whose image is gone from the canvas
+ * (`orphans`, to be deleted) and those still referenced (`remaining`).
+ */
+export function findOrphanImageAttachments(loaded: readonly ImageAttachmentMetadata[], activeFileIds: ReadonlySet<string>) {
+    const orphans: ImageAttachmentMetadata[] = [];
+    const remaining: ImageAttachmentMetadata[] = [];
+
+    for (const entry of loaded) {
+        (activeFileIds.has(entry.fileId) ? remaining : orphans).push(entry);
+    }
+
+    return { orphans, remaining };
+}
+
+/** Reads a blob as a base64 `data:` URL. */
+function blobToDataURL(blob: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(blob);
+    });
+}

--- a/apps/client/src/widgets/type_widgets/canvas/persistence.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/persistence.ts
@@ -8,6 +8,7 @@ import NoteContext from "../../../components/note_context";
 import FNote from "../../../entities/fnote";
 import server from "../../../services/server";
 import { SavedData, useEditorSpacedUpdate } from "../../react/hooks";
+import { buildNewImageAttachments, CANVAS_EXPORT_TITLE, findOrphanImageAttachments, IMAGE_ROLE, ImageAttachmentMetadata, loadImageAttachments } from "./image_attachments";
 
 interface AttachmentMetadata {
     title: string;
@@ -40,6 +41,13 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
     const libraryCache = useRef<LibraryItem[]>([]);
     const attachmentMetadata = useRef<AttachmentMetadata[]>([]);
 
+    // Image attachments present at load (fileId -> attachmentId), used to delete attachments whose
+    // image was removed from the canvas this session (mirrors the library-item cleanup above).
+    const loadedImageAttachments = useRef<ImageAttachmentMetadata[]>([]);
+    // fileIds already persisted as attachments (loaded at start + uploaded this session), so each
+    // image is written once rather than re-encoded into every save.
+    const persistedImageFileIds = useRef<Set<string>>(new Set());
+
     const appStateToCompare = useRef<Partial<ImportantAppState>>({});
 
     const spacedUpdate = useEditorSpacedUpdate({
@@ -52,6 +60,8 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
 
             libraryCache.current = [];
             attachmentMetadata.current = [];
+            loadedImageAttachments.current = [];
+            persistedImageFileIds.current = new Set();
 
             // load saved content into excalidraw canvas
             let content: CanvasContent = {
@@ -69,6 +79,17 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
 
             loadData(api, content, theme);
 
+            // Images live as attachments (titled with their fileId); fetch them, rebuild their
+            // data URLs and inject them so elements referencing those fileIds render. Legacy notes
+            // that still carry inline images in `content.files` were already loaded by loadData().
+            loadImageAttachments(note).then(({ files, metadata }) => {
+                if (files.length > 0) {
+                    api.addFiles(files);
+                }
+                loadedImageAttachments.current = metadata;
+                persistedImageFileIds.current = new Set(metadata.map((m) => m.fileId));
+            });
+
             // Initialize tracking state after loading to prevent redundant updates from initial onChange events
             currentSceneVersion.current = getSceneVersion(api.getSceneElements());
 
@@ -85,8 +106,23 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
         async getData() {
             const api = apiRef.current;
             if (!api) return;
-            const { content, svg } = await getData(api, appStateToCompare);
-            const attachments: SavedData["attachments"] = [{ role: "image", title: "canvas-export.svg", mime: "image/svg+xml", content: svg, position: 0 }];
+            const { content, svg, activeFiles } = await getData(api, appStateToCompare);
+            const attachments: SavedData["attachments"] = [{ role: IMAGE_ROLE, title: CANVAS_EXPORT_TITLE, mime: "image/svg+xml", content: svg, position: 0 }];
+
+            // Persist newly inserted images as attachments and drop the ones whose image was removed.
+            // `content` carries only the fileId references (see getData), so the bytes live here.
+            const activeFileIds = new Set(Object.keys(activeFiles));
+            for (const attachment of buildNewImageAttachments(activeFiles, persistedImageFileIds.current)) {
+                attachments.push(attachment);
+                persistedImageFileIds.current.add(attachment.title);
+            }
+
+            const { orphans, remaining } = findOrphanImageAttachments(loadedImageAttachments.current, activeFileIds);
+            for (const { attachmentId, fileId } of orphans) {
+                await server.remove(`attachments/${attachmentId}`);
+                persistedImageFileIds.current.delete(fileId);
+            }
+            loadedImageAttachments.current = remaining;
 
             // libraryChanged is unset in dataSaved()
             if (libraryChanged.current) {
@@ -231,7 +267,10 @@ async function getData(api: ExcalidrawImperativeAPI, appStateToCompare: RefObjec
         type: "excalidraw",
         version: 2,
         elements,
-        files: activeFiles,
+        // Images are persisted as attachments (keyed by fileId), not inline, so the content stays
+        // small. Elements keep their `fileId`; the bytes are reattached on load. Kept as an empty
+        // object for shape compatibility with loadData() and legacy content.
+        files: {} as Record<string, BinaryFileData>,
         appState: {
             scrollX: appState.scrollX,
             scrollY: appState.scrollY,
@@ -242,7 +281,8 @@ async function getData(api: ExcalidrawImperativeAPI, appStateToCompare: RefObjec
 
     return {
         content,
-        svg: svgString
+        svg: svgString,
+        activeFiles
     };
 }
 
@@ -254,14 +294,11 @@ function loadData(api: ExcalidrawImperativeAPI, content: CanvasContent, theme: A
     // files are expected in an array when loading. they are stored as a key-index object
     // see example for loading here:
     // https://github.com/excalidraw/excalidraw/blob/c5a7723185f6ca05e0ceb0b0d45c4e3fbcb81b2a/src/packages/excalidraw/example/App.js#L68
+    // Only legacy notes still carry inline images here; new saves persist images as attachments
+    // (loaded separately via loadImageAttachments) and leave `content.files` empty.
     const fileArray: BinaryFileData[] = [];
     for (const fileId in files) {
-        const file = files[fileId];
-        // TODO: dataURL is replaceable with a trilium image url
-        //       maybe we can save normal images (pasted) with base64 data url, and trilium images
-        //       with their respective url! nice
-        // file.dataURL = "http://localhost:8080/api/images/ltjOiU8nwoZx/start.png";
-        fileArray.push(file);
+        fileArray.push(files[fileId]);
     }
 
     // Update the scene

--- a/apps/client/src/widgets/type_widgets/canvas/persistence.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/persistence.ts
@@ -8,7 +8,7 @@ import NoteContext from "../../../components/note_context";
 import FNote from "../../../entities/fnote";
 import server from "../../../services/server";
 import { SavedData, useEditorSpacedUpdate } from "../../react/hooks";
-import { buildNewImageAttachments, CANVAS_EXPORT_TITLE, findOrphanImageAttachments, IMAGE_ROLE, ImageAttachmentMetadata, loadImageAttachments } from "./image_attachments";
+import { buildNewImageAttachments, CANVAS_EXPORT_TITLE, IMAGE_ROLE, loadImageAttachments } from "./image_attachments";
 
 interface AttachmentMetadata {
     title: string;
@@ -41,11 +41,9 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
     const libraryCache = useRef<LibraryItem[]>([]);
     const attachmentMetadata = useRef<AttachmentMetadata[]>([]);
 
-    // Image attachments present at load (fileId -> attachmentId), used to delete attachments whose
-    // image was removed from the canvas this session (mirrors the library-item cleanup above).
-    const loadedImageAttachments = useRef<ImageAttachmentMetadata[]>([]);
-    // fileIds already persisted as attachments (loaded at start + uploaded this session), so each
-    // image is written once rather than re-encoded into every save.
+    // fileIds of images this session owns as attachments (loaded at start + uploaded this session).
+    // Drives both skip-reupload and orphan cleanup: an owned fileId no longer on the canvas marks
+    // its attachment for deletion (mirrors the library-item cleanup above).
     const persistedImageFileIds = useRef<Set<string>>(new Set());
 
     const appStateToCompare = useRef<Partial<ImportantAppState>>({});
@@ -60,7 +58,6 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
 
             libraryCache.current = [];
             attachmentMetadata.current = [];
-            loadedImageAttachments.current = [];
             persistedImageFileIds.current = new Set();
 
             // load saved content into excalidraw canvas
@@ -86,7 +83,6 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
                 if (files.length > 0) {
                     api.addFiles(files);
                 }
-                loadedImageAttachments.current = metadata;
                 persistedImageFileIds.current = new Set(metadata.map((m) => m.fileId));
             });
 
@@ -109,20 +105,14 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
             const { content, svg, activeFiles } = await getData(api, appStateToCompare);
             const attachments: SavedData["attachments"] = [{ role: IMAGE_ROLE, title: CANVAS_EXPORT_TITLE, mime: "image/svg+xml", content: svg, position: 0 }];
 
-            // Persist newly inserted images as attachments and drop the ones whose image was removed.
-            // `content` carries only the fileId references (see getData), so the bytes live here.
-            const activeFileIds = new Set(Object.keys(activeFiles));
+            // Persist newly inserted images as attachments. `content` carries only the fileId
+            // references (see getData), so the bytes live here. Removed images are not deleted from
+            // the client: the server's saveLinks/checkImageAttachments scans the saved scene JSON and
+            // schedules now-unreferenced image attachments for erasure (same as the spreadsheet).
             for (const attachment of buildNewImageAttachments(activeFiles, persistedImageFileIds.current)) {
                 attachments.push(attachment);
                 persistedImageFileIds.current.add(attachment.title);
             }
-
-            const { orphans, remaining } = findOrphanImageAttachments(loadedImageAttachments.current, activeFileIds);
-            for (const { attachmentId, fileId } of orphans) {
-                await server.remove(`attachments/${attachmentId}`);
-                persistedImageFileIds.current.delete(fileId);
-            }
-            loadedImageAttachments.current = remaining;
 
             // libraryChanged is unset in dataSaved()
             if (libraryChanged.current) {

--- a/apps/client/src/widgets/type_widgets/canvas/persistence.ts
+++ b/apps/client/src/widgets/type_widgets/canvas/persistence.ts
@@ -46,6 +46,11 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
     // its attachment for deletion (mirrors the library-item cleanup above).
     const persistedImageFileIds = useRef<Set<string>>(new Set());
 
+    // The note being loaded by the latest onContentChange. Async loads below capture the id they
+    // started for and bail if the user switched notes before they resolved, so a stale load can't
+    // inject the previous note's images or overwrite the new note's owned-fileId set.
+    const activeNoteIdRef = useRef<string | null>(null);
+
     const appStateToCompare = useRef<Partial<ImportantAppState>>({});
 
     const spacedUpdate = useEditorSpacedUpdate({
@@ -59,6 +64,10 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
             libraryCache.current = [];
             attachmentMetadata.current = [];
             persistedImageFileIds.current = new Set();
+
+            // The note this load run belongs to; async results below are ignored if it's superseded.
+            const loadedNoteId = note.noteId;
+            activeNoteIdRef.current = loadedNoteId;
 
             // load saved content into excalidraw canvas
             let content: CanvasContent = {
@@ -80,6 +89,7 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
             // data URLs and inject them so elements referencing those fileIds render. Legacy notes
             // that still carry inline images in `content.files` were already loaded by loadData().
             loadImageAttachments(note).then(({ files, metadata }) => {
+                if (activeNoteIdRef.current !== loadedNoteId) return; // note switched mid-load
                 if (files.length > 0) {
                     api.addFiles(files);
                 }
@@ -91,6 +101,7 @@ export default function useCanvasPersistence(note: FNote, noteContext: NoteConte
 
             // load the library state
             loadLibrary(note).then(({ libraryItems, metadata }) => {
+                if (activeNoteIdRef.current !== loadedNoteId) return; // note switched mid-load
                 // Update the library and save to independent variables
                 api.updateLibrary({ libraryItems, merge: false });
 

--- a/apps/client/src/widgets/type_widgets/spreadsheet/Spreadsheet.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/Spreadsheet.tsx
@@ -1,5 +1,6 @@
 import "./Spreadsheet.css";
 import "@univerjs/preset-sheets-core/lib/index.css";
+import "@univerjs/preset-sheets-drawing/lib/index.css";
 import "@univerjs/preset-sheets-sort/lib/index.css";
 import "@univerjs/preset-sheets-conditional-formatting/lib/index.css";
 import "@univerjs/preset-sheets-find-replace/lib/index.css";
@@ -12,6 +13,7 @@ import { DEFAULT_STYLES } from '@univerjs/core';
 import { UniverSheetsConditionalFormattingPreset } from '@univerjs/preset-sheets-conditional-formatting';
 import { UniverSheetsCorePreset } from '@univerjs/preset-sheets-core';
 import { UniverSheetsDataValidationPreset } from '@univerjs/preset-sheets-data-validation';
+import { UniverSheetsDrawingPreset } from '@univerjs/preset-sheets-drawing';
 import { UniverSheetsFilterPreset } from '@univerjs/preset-sheets-filter';
 import { UniverSheetsFindReplacePreset } from '@univerjs/preset-sheets-find-replace';
 import { UniverSheetsHyperLinkPreset } from '@univerjs/preset-sheets-hyper-link';
@@ -243,6 +245,11 @@ function useInitializeSpreadsheet(containerRef: MutableRef<HTMLDivElement | null
                         "sheet.command.set-range-font-family": { hidden: true },
                     },
                 }),
+                // Floating images stored inline as base64 in the workbook's SHEET_DRAWING_PLUGIN
+                // resource (Univer's default ImageIoService), so they persist through the normal
+                // content save path. The insert-image toolbar button is hidden in read-only mode
+                // (toolbar is disabled above); the preset stays registered so existing images render.
+                UniverSheetsDrawingPreset(),
                 UniverSheetsFindReplacePreset(),
                 UniverSheetsNotePreset(),
                 UniverSheetsFilterPreset(),

--- a/apps/client/src/widgets/type_widgets/spreadsheet/Spreadsheet.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/Spreadsheet.tsx
@@ -9,12 +9,12 @@ import "@univerjs/preset-sheets-filter/lib/index.css";
 import "@univerjs/preset-sheets-hyper-link/lib/index.css";
 import "@univerjs/preset-sheets-data-validation/lib/index.css";
 
-import { DEFAULT_STYLES } from '@univerjs/core';
-import { UniverSheetsConditionalFormattingPreset } from '@univerjs/preset-sheets-conditional-formatting';
-import { UniverSheetsCorePreset } from '@univerjs/preset-sheets-core';
-import { UniverSheetsDataValidationPreset } from '@univerjs/preset-sheets-data-validation';
+import { DEFAULT_STYLES, type Plugin, type PluginCtor } from '@univerjs/core';
+import { UniverSheetsConditionalFormattingMobileUIPlugin, UniverSheetsConditionalFormattingPreset, UniverSheetsConditionalFormattingUIPlugin } from '@univerjs/preset-sheets-conditional-formatting';
+import { UniverMobileUIPlugin, UniverSheetsCorePreset, UniverSheetsMobileUIPlugin, UniverSheetsUIPlugin, UniverUIPlugin } from '@univerjs/preset-sheets-core';
+import { UniverSheetsDataValidationMobileUIPlugin, UniverSheetsDataValidationPreset, UniverSheetsDataValidationUIPlugin } from '@univerjs/preset-sheets-data-validation';
 import { UniverSheetsDrawingPreset } from '@univerjs/preset-sheets-drawing';
-import { UniverSheetsFilterPreset } from '@univerjs/preset-sheets-filter';
+import { UniverSheetsFilterMobileUIPlugin, UniverSheetsFilterPreset, UniverSheetsFilterUIPlugin } from '@univerjs/preset-sheets-filter';
 import { UniverSheetsFindReplacePreset } from '@univerjs/preset-sheets-find-replace';
 import { UniverSheetsHyperLinkPreset } from '@univerjs/preset-sheets-hyper-link';
 import { UniverSheetsNotePreset } from '@univerjs/preset-sheets-note';
@@ -26,6 +26,7 @@ import { MutableRef, useEffect, useRef, useState } from "preact/hooks";
 
 import type NoteContext from "../../../components/note_context";
 import { t } from "../../../services/i18n";
+import { isMobile } from "../../../services/utils";
 import { useColorScheme, useEffectiveReadOnly, useTriliumEvent, useTriliumEvents } from "../../react/hooks";
 import { TypeWidgetProps } from "../type_widget";
 import useSpreadsheetExport from "./export";
@@ -214,17 +215,7 @@ function useInitializeSpreadsheet(containerRef: MutableRef<HTMLDivElement | null
             DEFAULT_STYLES.ff = ff;
         }
 
-        const { univerAPI } = createUniver({
-            // Inherit the spreadsheet language (and locale-dependent defaults such as the currency
-            // symbol) from Trilium's UI language instead of hardcoding US English.
-            locale: locale.type,
-            locales: {
-                [locale.type]: mergeLocales(
-                    locale.data,
-                    readOnly ? buildReadOnlyLocaleOverrides() : {},
-                ),
-            },
-            presets: [
+        const presets = [
                 UniverSheetsCorePreset({
                     container: containerRef.current,
                     toolbar: !readOnly,
@@ -257,7 +248,22 @@ function useInitializeSpreadsheet(containerRef: MutableRef<HTMLDivElement | null
                 UniverSheetsDataValidationPreset(),
                 UniverSheetsConditionalFormattingPreset(),
                 UniverSheetsHyperLinkPreset()
-            ]
+            ];
+
+        const { univerAPI } = createUniver({
+            // Inherit the spreadsheet language (and locale-dependent defaults such as the currency
+            // symbol) from Trilium's UI language instead of hardcoding US English.
+            locale: locale.type,
+            locales: {
+                [locale.type]: mergeLocales(
+                    locale.data,
+                    readOnly ? buildReadOnlyLocaleOverrides() : {},
+                ),
+            },
+            // Univer ships no "mobile preset" — the presets above register the desktop UI shells.
+            // On Trilium's mobile layout, swap those shells for their touch-optimised variants
+            // (see toMobilePresets); the remaining feature plugins are platform-agnostic.
+            presets: isMobile() ? toMobilePresets(presets) : presets,
         });
         if (readOnly) {
             univerAPI.addEvent(univerAPI.Event.LifeCycleChanged, ({ stage }) => {
@@ -274,6 +280,38 @@ function useInitializeSpreadsheet(containerRef: MutableRef<HTMLDivElement | null
         apiRef.current = univerAPI;
         return () => univerAPI.dispose();
     }, [ apiRef, containerRef, readOnly, locale ]);
+}
+
+type PluginEntry = PluginCtor<Plugin> | [PluginCtor<Plugin>, ConstructorParameters<PluginCtor<Plugin>>[0]];
+interface UniverPreset { plugins: PluginEntry[]; }
+
+// Desktop UI shell plugins (registered by the presets) mapped to their touch-optimised
+// counterparts. Only these five Univer plugins ship a mobile variant; every other plugin
+// the presets register is platform-agnostic and is left untouched.
+const DESKTOP_TO_MOBILE_UI = new Map<PluginCtor<Plugin>, PluginCtor<Plugin>>([
+    [UniverUIPlugin, UniverMobileUIPlugin],
+    [UniverSheetsUIPlugin, UniverSheetsMobileUIPlugin],
+    [UniverSheetsConditionalFormattingUIPlugin, UniverSheetsConditionalFormattingMobileUIPlugin],
+    [UniverSheetsDataValidationUIPlugin, UniverSheetsDataValidationMobileUIPlugin],
+    [UniverSheetsFilterUIPlugin, UniverSheetsFilterMobileUIPlugin],
+]);
+
+/**
+ * Rewrite a list of Univer presets so their desktop UI shells are replaced by the mobile
+ * equivalents, preserving each plugin's configuration. A preset is just a `{ plugins }` data
+ * object whose entries are either a plugin constructor or a `[constructor, options]` tuple, so
+ * we can swap the constructor in place without re-running the preset factories.
+ */
+function toMobilePresets(presets: UniverPreset[]): UniverPreset[] {
+    return presets.map((preset) => ({
+        ...preset,
+        plugins: preset.plugins.map((entry) => {
+            const [ctor, options] = Array.isArray(entry) ? entry : [entry, undefined];
+            const mobileCtor = DESKTOP_TO_MOBILE_UI.get(ctor);
+            if (!mobileCtor) return entry;
+            return options === undefined ? mobileCtor : [mobileCtor, options];
+        }),
+    }));
 }
 
 function useDarkMode(apiRef: MutableRef<FUniver | undefined>) {

--- a/apps/client/src/widgets/type_widgets/spreadsheet/export.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/export.tsx
@@ -1,3 +1,4 @@
+import type { ResolvedImage } from "@triliumnext/commons/src/lib/spreadsheet/render_to_xlsx";
 import { FUniver } from "@univerjs/presets";
 import { MutableRef } from "preact/hooks";
 
@@ -40,7 +41,7 @@ async function exportToXlsx(univerAPI: FUniver | undefined, note: FNote) {
     try {
         // Dynamic import keeps exceljs out of the main bundle (and out of standalone/core).
         const { renderSpreadsheetToXlsx } = await import("@triliumnext/commons/src/lib/spreadsheet/render_to_xlsx");
-        const buffer = await renderSpreadsheetToXlsx(json);
+        const buffer = await renderSpreadsheetToXlsx(json, { resolveImage: resolveSpreadsheetImage });
         await download(note, "xlsx", new Blob([buffer as BlobPart], { type: XLSX_MIME }));
     } catch (e) {
         console.error("[spreadsheet-export] xlsx failed", e);
@@ -104,4 +105,41 @@ function blobToDataUrl(blob: Blob): Promise<string> {
         reader.onerror = () => reject(reader.error);
         reader.readAsDataURL(blob);
     });
+}
+
+/**
+ * Resolves a spreadsheet image source to embeddable bytes for the XLSX exporter. Images are stored
+ * as `api/attachments/<id>/image/...` URLs (fetched here) or inline `data:` URLs; both are reduced
+ * to a base64 payload and an exceljs-supported extension. Returns null (image skipped) on a fetch
+ * failure or an unsupported format — exceljs only embeds png/jpeg/gif.
+ */
+async function resolveSpreadsheetImage(source: string): Promise<ResolvedImage | null> {
+    try {
+        const dataUrl = source.startsWith("data:") ? source : await fetchAsDataUrl(source);
+        if (!dataUrl) return null;
+
+        const match = /^data:([^;,]+)(?:;[^,]*)*;base64,(.*)$/s.exec(dataUrl);
+        if (!match) return null;
+
+        const extension = imageExtensionForMime(match[1]);
+        return extension ? { base64: match[2], extension } : null;
+    } catch {
+        return null;
+    }
+}
+
+async function fetchAsDataUrl(url: string): Promise<string | null> {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    return blobToDataUrl(await response.blob());
+}
+
+function imageExtensionForMime(mime: string): ResolvedImage["extension"] | null {
+    switch (mime.toLowerCase()) {
+        case "image/png": return "png";
+        case "image/jpeg":
+        case "image/jpg": return "jpeg";
+        case "image/gif": return "gif";
+        default: return null; // svg/webp/bmp etc. — exceljs can't embed these
+    }
 }

--- a/apps/client/src/widgets/type_widgets/spreadsheet/export.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/export.tsx
@@ -118,11 +118,16 @@ async function resolveSpreadsheetImage(source: string): Promise<ResolvedImage | 
         const dataUrl = source.startsWith("data:") ? source : await fetchAsDataUrl(source);
         if (!dataUrl) return null;
 
-        const match = /^data:([^;,]+)(?:;[^,]*)*;base64,(.*)$/s.exec(dataUrl);
-        if (!match) return null;
+        // Parse `data:<mime>;base64,<payload>` with plain string ops — a regex with a nested
+        // quantifier over the `;` parameters can backtrack exponentially (ReDoS).
+        const comma = dataUrl.indexOf(",");
+        if (comma < 0) return null;
+        const header = dataUrl.slice(0, comma);
+        if (!/;base64$/i.test(header)) return null; // only base64 payloads
 
-        const extension = imageExtensionForMime(match[1]);
-        return extension ? { base64: match[2], extension } : null;
+        const mime = header.slice("data:".length).split(";")[0];
+        const extension = imageExtensionForMime(mime);
+        return extension ? { base64: dataUrl.slice(comma + 1), extension } : null;
     } catch {
         return null;
     }

--- a/apps/client/src/widgets/type_widgets/spreadsheet/locales.ts
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/locales.ts
@@ -24,6 +24,7 @@ interface UniverLocaleSource {
  */
 export const SPREADSHEET_PRESET_PACKAGES = [
     "@univerjs/preset-sheets-core",
+    "@univerjs/preset-sheets-drawing",
     "@univerjs/preset-sheets-find-replace",
     "@univerjs/preset-sheets-note",
     "@univerjs/preset-sheets-filter",
@@ -42,6 +43,7 @@ const ENGLISH_LOCALE: UniverLocaleSource = {
     type: LocaleType.EN_US,
     load: () => Promise.all([
         import('@univerjs/preset-sheets-core/locales/en-US'),
+        import('@univerjs/preset-sheets-drawing/locales/en-US'),
         import('@univerjs/preset-sheets-find-replace/locales/en-US'),
         import('@univerjs/preset-sheets-note/locales/en-US'),
         import('@univerjs/preset-sheets-filter/locales/en-US'),
@@ -70,6 +72,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.ZH_CN,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/zh-CN'),
+            import('@univerjs/preset-sheets-drawing/locales/zh-CN'),
             import('@univerjs/preset-sheets-find-replace/locales/zh-CN'),
             import('@univerjs/preset-sheets-note/locales/zh-CN'),
             import('@univerjs/preset-sheets-filter/locales/zh-CN'),
@@ -89,6 +92,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.ES_ES,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/es-ES'),
+            import('@univerjs/preset-sheets-drawing/locales/es-ES'),
             import('@univerjs/preset-sheets-find-replace/locales/es-ES'),
             import('@univerjs/preset-sheets-note/locales/es-ES'),
             import('@univerjs/preset-sheets-filter/locales/es-ES'),
@@ -102,6 +106,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.FR_FR,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/fr-FR'),
+            import('@univerjs/preset-sheets-drawing/locales/fr-FR'),
             import('@univerjs/preset-sheets-find-replace/locales/fr-FR'),
             import('@univerjs/preset-sheets-note/locales/fr-FR'),
             import('@univerjs/preset-sheets-filter/locales/fr-FR'),
@@ -119,6 +124,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.JA_JP,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/ja-JP'),
+            import('@univerjs/preset-sheets-drawing/locales/ja-JP'),
             import('@univerjs/preset-sheets-find-replace/locales/ja-JP'),
             import('@univerjs/preset-sheets-note/locales/ja-JP'),
             import('@univerjs/preset-sheets-filter/locales/ja-JP'),
@@ -136,6 +142,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.RU_RU,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/ru-RU'),
+            import('@univerjs/preset-sheets-drawing/locales/ru-RU'),
             import('@univerjs/preset-sheets-find-replace/locales/ru-RU'),
             import('@univerjs/preset-sheets-note/locales/ru-RU'),
             import('@univerjs/preset-sheets-filter/locales/ru-RU'),
@@ -149,6 +156,7 @@ export const UNIVER_LOCALES: Record<DISPLAYABLE_LOCALE_IDS, UniverLocaleSource |
         type: LocaleType.ZH_TW,
         load: () => Promise.all([
             import('@univerjs/preset-sheets-core/locales/zh-TW'),
+            import('@univerjs/preset-sheets-drawing/locales/zh-TW'),
             import('@univerjs/preset-sheets-find-replace/locales/zh-TW'),
             import('@univerjs/preset-sheets-note/locales/zh-TW'),
             import('@univerjs/preset-sheets-filter/locales/zh-TW'),

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
@@ -33,6 +33,23 @@ describe("slimWorkbookData", () => {
         ]);
     });
 
+    it("keeps the drawing resource carrying an inline base64 image, but drops it when empty", () => {
+        // Images are stored as base64 inside the SHEET_DRAWING_PLUGIN resource, so slimming must
+        // preserve a populated drawing resource (otherwise inserted images would vanish on save)
+        // while still discarding the empty "{}" the plugin emits for a sheet with no drawings.
+        const drawingData = "{\"sheet1\":{\"data\":{\"img1\":{\"source\":\"data:image/png;base64,iVBORw0KGgo=\"}}}}";
+        const result = slimWorkbookData(makeWorkbook({
+            resources: [
+                { name: "SHEET_DRAWING_PLUGIN", data: drawingData },
+                { name: "SHEET_NOTE_PLUGIN", data: "{}" }
+            ]
+        }));
+
+        expect(result.resources).toEqual([
+            { name: "SHEET_DRAWING_PLUGIN", data: drawingData }
+        ]);
+    });
+
     it("leaves an all-empty resource list as an empty array and tolerates absent resources", () => {
         expect(slimWorkbookData(makeWorkbook({
             resources: [

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
@@ -19,6 +19,27 @@ function readDrawing(workbook: IWorkbookData) {
     return JSON.parse(workbook.resources?.[0]?.data ?? "{}")["sheet-1"].data;
 }
 
+/**
+ * Builds a workbook holding the given drawing nodes inside a single cell's rich-text document
+ * (`sheets["sheet-1"].cellData[2][1].p.drawings`), as Univer stores cell-embedded (in-cell) images.
+ */
+function cellDrawingWorkbook(drawings: Record<string, { imageSourceType: string; source: string }>) {
+    return makeWorkbook({
+        sheets: {
+            "sheet-1": {
+                cellData: {
+                    2: { 1: { p: { drawings } } }
+                }
+            }
+        } as unknown as IWorkbookData["sheets"]
+    });
+}
+
+function readCellDrawings(workbook: IWorkbookData) {
+    const sheet = workbook.sheets?.["sheet-1"] as { cellData?: Record<string, Record<string, { p?: { drawings?: Record<string, { imageSourceType: string; source: string }> } }>> } | undefined;
+    return sheet?.cellData?.["2"]?.["1"]?.p?.drawings ?? {};
+}
+
 describe("slimWorkbookData", () => {
     it("drops the top-level workbook id and locale (both reassigned on load)", () => {
         const result = slimWorkbookData(makeWorkbook({ id: "abc123", locale: LocaleType.ZH_CN, name: "Sheet" }));
@@ -143,6 +164,46 @@ describe("uploadNewDrawingImages", () => {
         await uploadNewDrawingImages(workbook, new Set(), new Map(), upload("api/attachments/x/image/x.png"));
         expect(workbook.resources).toBeUndefined();
     });
+
+    it("uploads a base64 image embedded in a cell and rewrites it in place", async () => {
+        const workbook = cellDrawingWorkbook({
+            d1: { imageSourceType: "BASE64", source: "data:image/png;base64,EEEE" },
+            // An already-URL cell image must be left alone.
+            d2: { imageSourceType: "URL", source: "api/attachments/existing/image/existing.png" }
+        });
+
+        const uploaded: string[] = [];
+        await uploadNewDrawingImages(workbook, new Set(), new Map(), async (source) => {
+            uploaded.push(source);
+            return "api/attachments/cell1/image/image.png";
+        });
+
+        expect(uploaded).toEqual([ "data:image/png;base64,EEEE" ]);
+        const drawings = readCellDrawings(workbook);
+        expect(drawings.d1).toEqual({ imageSourceType: "URL", source: "api/attachments/cell1/image/image.png" });
+        expect(drawings.d2.source).toBe("api/attachments/existing/image/existing.png");
+    });
+
+    it("uploads cell images even when there is no floating-image drawing resource", async () => {
+        // Cell drawings live directly in the workbook (not in a SHEET_DRAWING_PLUGIN resource), so a
+        // workbook with only cell images and no resource must still trigger uploads.
+        const workbook = cellDrawingWorkbook({ d1: { imageSourceType: "BASE64", source: "data:image/png;base64,FFFF" } });
+
+        await uploadNewDrawingImages(workbook, new Set(), new Map(), upload("api/attachments/cell2/image/image.png"));
+
+        expect(readCellDrawings(workbook).d1).toEqual({ imageSourceType: "URL", source: "api/attachments/cell2/image/image.png" });
+    });
+
+    it("leaves a preexisting cell image as base64, uploading nothing", async () => {
+        const source = "data:image/png;base64,GGGG";
+        const workbook = cellDrawingWorkbook({ d1: { imageSourceType: "BASE64", source } });
+
+        await uploadNewDrawingImages(workbook, new Set([ source ]), new Map(), async () => {
+            throw new Error("should not upload a preexisting image");
+        });
+
+        expect(readCellDrawings(workbook).d1).toEqual({ imageSourceType: "BASE64", source });
+    });
 });
 
 describe("collectBase64DrawingSources", () => {
@@ -156,5 +217,14 @@ describe("collectBase64DrawingSources", () => {
 
         expect(collectBase64DrawingSources(workbook)).toEqual(new Set([ "data:image/png;base64,DDDD" ]));
         expect(collectBase64DrawingSources(makeWorkbook({}))).toEqual(new Set());
+    });
+
+    it("includes base64 sources from cell-embedded drawings", () => {
+        const workbook = cellDrawingWorkbook({
+            x: { imageSourceType: "BASE64", source: "data:image/png;base64,HHHH" },
+            y: { imageSourceType: "URL", source: "api/attachments/z/image/z.png" }
+        });
+
+        expect(collectBase64DrawingSources(workbook)).toEqual(new Set([ "data:image/png;base64,HHHH" ]));
     });
 });

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.spec.ts
@@ -1,10 +1,22 @@
 import { IWorkbookData, LocaleType } from "@univerjs/presets";
 import { describe, expect, it } from "vitest";
 
-import { slimWorkbookData } from "./persistence";
+import { collectBase64DrawingSources, slimWorkbookData, uploadNewDrawingImages } from "./persistence";
 
 function makeWorkbook(workbook: Partial<IWorkbookData>): IWorkbookData {
     return workbook as IWorkbookData;
+}
+
+/** Builds a SHEET_DRAWING_PLUGIN resource holding the given drawing nodes on a single sheet. */
+function drawingResource(images: Record<string, { imageSourceType: string; source: string }>) {
+    return {
+        name: "SHEET_DRAWING_PLUGIN",
+        data: JSON.stringify({ "sheet-1": { data: images, order: Object.keys(images) } })
+    };
+}
+
+function readDrawing(workbook: IWorkbookData) {
+    return JSON.parse(workbook.resources?.[0]?.data ?? "{}")["sheet-1"].data;
 }
 
 describe("slimWorkbookData", () => {
@@ -59,5 +71,90 @@ describe("slimWorkbookData", () => {
         })).resources).toEqual([]);
 
         expect(slimWorkbookData(makeWorkbook({})).resources).toBeUndefined();
+    });
+});
+
+describe("uploadNewDrawingImages", () => {
+    const upload = (url: string) => async () => url;
+
+    it("uploads a newly inserted base64 image and rewrites its source to the returned URL", async () => {
+        const workbook = makeWorkbook({
+            resources: [drawingResource({
+                img1: { imageSourceType: "BASE64", source: "data:image/png;base64,AAAA" },
+                // An already-URL image (e.g. saved on an earlier session) must be left alone.
+                img2: { imageSourceType: "URL", source: "api/attachments/existing1/image/existing1.png" }
+            })]
+        });
+
+        const uploaded: string[] = [];
+        await uploadNewDrawingImages(workbook, new Set(), new Map(), async (source) => {
+            uploaded.push(source);
+            return "api/attachments/new1/image/image.png";
+        });
+
+        expect(uploaded).toEqual([ "data:image/png;base64,AAAA" ]);
+        const drawing = readDrawing(workbook);
+        expect(drawing.img1).toEqual({ imageSourceType: "URL", source: "api/attachments/new1/image/image.png" });
+        expect(drawing.img2.source).toBe("api/attachments/existing1/image/existing1.png");
+    });
+
+    it("leaves images that were already present at load (preexisting) as base64, uploading nothing", async () => {
+        const source = "data:image/png;base64,BBBB";
+        const workbook = makeWorkbook({ resources: [drawingResource({ old: { imageSourceType: "BASE64", source } })] });
+
+        await uploadNewDrawingImages(workbook, new Set([ source ]), new Map(), async () => {
+            throw new Error("should not upload a preexisting image");
+        });
+
+        expect(readDrawing(workbook).old).toEqual({ imageSourceType: "BASE64", source });
+    });
+
+    it("uploads each distinct image once across repeated saves (caches the URL by source)", async () => {
+        const source = "data:image/jpeg;base64,CCCC";
+        const cache = new Map<string, string>();
+        let count = 0;
+        const countingUpload = async () => {
+            count++;
+            return "api/attachments/cached/image/image.jpeg";
+        };
+
+        // `workbook.save()` hands back a fresh snapshot each save, but the live base64 source is
+        // unchanged, so the shared cache must map it to the same URL without re-uploading.
+        await uploadNewDrawingImages(
+            makeWorkbook({ resources: [drawingResource({ a: { imageSourceType: "BASE64", source } })] }), new Set(), cache, countingUpload);
+        const second = makeWorkbook({ resources: [drawingResource({ a: { imageSourceType: "BASE64", source } })] });
+        await uploadNewDrawingImages(second, new Set(), cache, countingUpload);
+
+        expect(count).toBe(1);
+        expect(readDrawing(second).a.source).toBe("api/attachments/cached/image/image.jpeg");
+    });
+
+    it("leaves an image as base64 when its upload fails (returns null)", async () => {
+        const source = "data:image/png;base64,DDDD";
+        const workbook = makeWorkbook({ resources: [drawingResource({ a: { imageSourceType: "BASE64", source } })] });
+
+        await uploadNewDrawingImages(workbook, new Set(), new Map(), async () => null);
+
+        expect(readDrawing(workbook).a).toEqual({ imageSourceType: "BASE64", source });
+    });
+
+    it("does nothing when there is no drawing resource", async () => {
+        const workbook = makeWorkbook({});
+        await uploadNewDrawingImages(workbook, new Set(), new Map(), upload("api/attachments/x/image/x.png"));
+        expect(workbook.resources).toBeUndefined();
+    });
+});
+
+describe("collectBase64DrawingSources", () => {
+    it("returns base64 sources, ignoring URL sources and absent drawing resources", () => {
+        const workbook = makeWorkbook({
+            resources: [drawingResource({
+                x: { imageSourceType: "BASE64", source: "data:image/png;base64,DDDD" },
+                y: { imageSourceType: "URL", source: "api/attachments/z/image/z.png" }
+            })]
+        });
+
+        expect(collectBase64DrawingSources(workbook)).toEqual(new Set([ "data:image/png;base64,DDDD" ]));
+        expect(collectBase64DrawingSources(makeWorkbook({}))).toEqual(new Set());
     });
 });

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
@@ -332,7 +332,9 @@ export async function uploadNewDrawingImages(
             targets.push({ node, source });
         }
     });
-    if (!walked || targets.length === 0) return;
+    // `walked` may be null when there are only cell-embedded images (no drawing resource); those are
+    // mutated in place and need no re-serialization, so only `targets` gates whether there's work.
+    if (targets.length === 0) return;
 
     let mutated = false;
     for (const { node, source } of targets) {
@@ -348,7 +350,9 @@ export async function uploadNewDrawingImages(
         mutated = true;
     }
 
-    if (mutated) {
+    // Re-serialize the drawing resource if it carried any mutated node. Cell-embedded images live in
+    // the workbook object and are already mutated in place, so they need no re-serialization.
+    if (mutated && walked) {
         walked.resource.data = JSON.stringify(walked.drawingData);
     }
 }
@@ -366,25 +370,22 @@ interface DrawingResource {
 }
 
 /**
- * Walks the drawing resource of a saved workbook, invoking `callback` for every base64 image node
- * (an object with `imageSourceType === "BASE64"` and a `data:` `source`). The callback may mutate
- * the node in place. Returns the parsed drawing data and its resource so callers can re-serialize
- * after mutating, or `null` when there is no drawing resource / it fails to parse.
+ * Walks every base64 image node of a saved workbook, invoking `callback` for each (an object with
+ * `imageSourceType === "BASE64"` and a `data:` `source`). The callback may mutate the node in place.
+ *
+ * Two locations carry images:
+ * - **Floating images** are serialized in the `SHEET_DRAWING_PLUGIN` resource (a JSON string); the
+ *   returned `{ resource, drawingData }` lets callers re-serialize after mutating.
+ * - **Cell-embedded images** live directly in the workbook object under
+ *   `sheets[*].cellData[row][col].p.drawings`; mutating those nodes in place is enough — they need
+ *   no re-serialization, which is why this returns `null` when only cell images are present.
+ *
+ * Returns `null` when there is no (parsable) drawing resource, regardless of cell images.
  */
 function forEachBase64DrawingImage(
     workbookData: Partial<IWorkbookData>,
     callback: (node: Record<string, unknown>, source: string) => void
 ): DrawingResource | null {
-    const resource = workbookData.resources?.find((r) => r.name === DRAWING_RESOURCE_NAME);
-    if (!resource?.data) return null;
-
-    let drawingData: unknown;
-    try {
-        drawingData = JSON.parse(resource.data);
-    } catch {
-        return null;
-    }
-
     const visit = (value: unknown) => {
         if (Array.isArray(value)) {
             value.forEach(visit);
@@ -401,6 +402,28 @@ function forEachBase64DrawingImage(
             visit(node[key]);
         }
     };
+
+    // Cell-embedded images: sheets[*].cellData[row][col].p.drawings (live objects, mutated in place).
+    for (const sheet of Object.values(workbookData.sheets ?? {})) {
+        for (const row of Object.values(sheet?.cellData ?? {})) {
+            if (!row || typeof row !== "object") continue;
+            for (const cell of Object.values(row)) {
+                const drawings = (cell as { p?: { drawings?: unknown } } | undefined)?.p?.drawings;
+                if (drawings) visit(drawings);
+            }
+        }
+    }
+
+    // Floating images: serialized in the SHEET_DRAWING_PLUGIN resource.
+    const resource = workbookData.resources?.find((r) => r.name === DRAWING_RESOURCE_NAME);
+    if (!resource?.data) return null;
+
+    let drawingData: unknown;
+    try {
+        drawingData = JSON.parse(resource.data);
+    } catch {
+        return null;
+    }
     visit(drawingData);
 
     return { resource, drawingData };

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
@@ -3,7 +3,7 @@ import { MutableRef, useEffect, useRef } from "preact/hooks";
 
 import NoteContext from "../../../components/note_context";
 import FNote from "../../../entities/fnote";
-import server from "../../../services/server";
+import { uploadImageAttachment } from "../../../services/image_upload";
 import { randomString } from "../../../services/utils";
 import { SavedData, useEditorSpacedUpdate } from "../../react/hooks";
 
@@ -202,7 +202,7 @@ export default function usePersistence(note: FNote, noteContext: NoteContext | n
                 slimmed,
                 preexistingImageSources.current,
                 uploadedImageUrls.current,
-                (source) => uploadDrawingImage(note.noteId, source)
+                (source) => uploadImageAttachment(note.noteId, source)
             );
 
             const content = {
@@ -353,37 +353,6 @@ export async function uploadNewDrawingImages(
     }
 }
 
-/**
- * Uploads a base64 image to the note as an attachment via the standard attachment-upload endpoint
- * (the server assigns the id and returns the reference URL). Resolves to the URL, or `null` on
- * failure.
- */
-async function uploadDrawingImage(noteId: string, source: string): Promise<string | null> {
-    const file = dataUrlToImageFile(source);
-    if (!file) return null;
-
-    try {
-        const response = await server.upload(`notes/${noteId}/attachments/upload`, file, undefined, "POST") as { uploaded?: boolean; url?: string };
-        return response?.uploaded && response.url ? response.url : null;
-    } catch (e) {
-        console.error("Failed to upload spreadsheet image", e);
-        return null;
-    }
-}
-
-/** Decodes a `data:<mime>;base64,<data>` URL into a {@link File} for upload. */
-function dataUrlToImageFile(dataUrl: string): File | null {
-    const parsed = parseImageDataUrl(dataUrl);
-    if (!parsed) return null;
-
-    const binary = atob(parsed.base64);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        bytes[i] = binary.charCodeAt(i);
-    }
-    return new File([ bytes ], `image.${parsed.ext}`, { type: parsed.mime });
-}
-
 /** Collects the base64 image sources currently present in a workbook's drawing resource. */
 export function collectBase64DrawingSources(workbookData: Partial<IWorkbookData>): Set<string> {
     const sources = new Set<string>();
@@ -435,22 +404,4 @@ function forEachBase64DrawingImage(
     visit(drawingData);
 
     return { resource, drawingData };
-}
-
-interface ParsedImageDataUrl {
-    mime: string;
-    base64: string;
-    ext: string;
-}
-
-/** Splits a `data:<mime>;base64,<data>` URL into its mime, raw base64 and a file extension. */
-function parseImageDataUrl(dataUrl: string): ParsedImageDataUrl | null {
-    const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
-    if (!match) return null;
-
-    const mime = match[1];
-    const base64 = match[2];
-    const subtype = mime.split("/")[1] ?? "png";
-    const ext = subtype === "svg+xml" ? "svg" : (subtype.replace(/[^a-z0-9]/gi, "") || "png");
-    return { mime, base64, ext };
 }

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
@@ -3,6 +3,7 @@ import { MutableRef, useEffect, useRef } from "preact/hooks";
 
 import NoteContext from "../../../components/note_context";
 import FNote from "../../../entities/fnote";
+import server from "../../../services/server";
 import { randomString } from "../../../services/utils";
 import { SavedData, useEditorSpacedUpdate } from "../../react/hooks";
 
@@ -26,6 +27,12 @@ export default function usePersistence(note: FNote, noteContext: NoteContext | n
     // applied yet. getData() waits for that pending recalc before serializing, so a
     // save can't persist pre-recalc (stale) formula results.
     const recalcPending = useRef(false);
+    // Maps an inserted image's base64 source to the attachment URL it was uploaded to, so each image
+    // is uploaded once and reused across the repeated saves of one editing session. Reset on load.
+    const uploadedImageUrls = useRef<Map<string, string>>(new Map());
+    // Base64 images already present in the loaded content. Left as-is on save (we only convert newly
+    // inserted images to attachments — existing notes are not migrated).
+    const preexistingImageSources = useRef<Set<string>>(new Set());
 
     function saveViewState(univerAPI: FUniver): SpreadsheetViewState {
         const state: SpreadsheetViewState = {};
@@ -88,6 +95,12 @@ export default function usePersistence(note: FNote, noteContext: NoteContext | n
                 console.error("Failed to parse spreadsheet content", e);
             }
         }
+
+        // Snapshot the base64 images already in the loaded content so the save-time upload leaves them
+        // untouched (only newly inserted images become attachments), and start the per-session
+        // base64 -> attachment-URL map fresh for this workbook.
+        preexistingImageSources.current = collectBase64DrawingSources(workbookData);
+        uploadedImageUrls.current = new Map();
 
         // Always assign a fresh unit id. The persisted id is reused verbatim, but the
         // new workbook is created below BEFORE the old one is disposed, so a stale or
@@ -165,11 +178,7 @@ export default function usePersistence(note: FNote, noteContext: NoteContext | n
             }
 
             const saved = workbook.save();
-
-            const content = {
-                version: 1,
-                workbook: slimWorkbookData(saved)
-            };
+            const slimmed = slimWorkbookData(saved);
 
             const attachments: SavedData["attachments"] = [];
             const canvasEl = containerRef.current?.querySelector<HTMLCanvasElement>("canvas[id]");
@@ -185,6 +194,21 @@ export default function usePersistence(note: FNote, noteContext: NoteContext | n
                     encoding: "base64"
                 });
             }
+
+            // Upload newly inserted base64 images as attachments and rewrite their workbook sources
+            // to the returned api/attachments/... URLs (mutates `slimmed`) so they no longer bloat
+            // the note content. Existing base64 images are left in place (see preexistingImageSources).
+            await uploadNewDrawingImages(
+                slimmed,
+                preexistingImageSources.current,
+                uploadedImageUrls.current,
+                (source) => uploadDrawingImage(note.noteId, source)
+            );
+
+            const content = {
+                version: 1,
+                workbook: slimmed
+            };
 
             return {
                 content: JSON.stringify(content),
@@ -276,4 +300,157 @@ export function slimWorkbookData(workbookData: IWorkbookData): Partial<IWorkbook
         );
     }
     return slimmed;
+}
+
+/** Univer's resource key under which the sheet drawing (image) layer is serialized in the workbook. */
+const DRAWING_RESOURCE_NAME = "SHEET_DRAWING_PLUGIN";
+
+/**
+ * Uploads newly inserted base64 images in a saved workbook as Trilium attachments and rewrites their
+ * drawing-resource `source` from the inline data URL to the returned `api/attachments/...` URL (with
+ * `imageSourceType` switched to `URL`), so images live as attachments instead of bloating the note
+ * content.
+ *
+ * - `preexisting` holds base64 sources already in the loaded content; those are left untouched so
+ *   existing notes are not migrated.
+ * - `uploadedUrls` caches each base64 source's resulting URL, so an image is uploaded once and
+ *   reused across the session's repeated saves rather than re-uploaded each time.
+ * - `upload` performs the actual upload and resolves to the attachment URL, or `null` on failure
+ *   (in which case the image is left as base64 so it still persists and renders).
+ *
+ * Mutates `workbookData` (re-serializing the drawing resource) when any source changed.
+ */
+export async function uploadNewDrawingImages(
+    workbookData: Partial<IWorkbookData>,
+    preexisting: ReadonlySet<string>,
+    uploadedUrls: Map<string, string>,
+    upload: (source: string) => Promise<string | null>
+): Promise<void> {
+    const targets: { node: Record<string, unknown>; source: string }[] = [];
+    const walked = forEachBase64DrawingImage(workbookData, (node, source) => {
+        if (!preexisting.has(source)) {
+            targets.push({ node, source });
+        }
+    });
+    if (!walked || targets.length === 0) return;
+
+    let mutated = false;
+    for (const { node, source } of targets) {
+        let url = uploadedUrls.get(source);
+        if (!url) {
+            const uploaded = await upload(source);
+            if (!uploaded) continue; // upload failed — leave as base64 so it still persists/renders
+            url = uploaded;
+            uploadedUrls.set(source, url);
+        }
+        node.source = url;
+        node.imageSourceType = "URL";
+        mutated = true;
+    }
+
+    if (mutated) {
+        walked.resource.data = JSON.stringify(walked.drawingData);
+    }
+}
+
+/**
+ * Uploads a base64 image to the note as an attachment via the standard attachment-upload endpoint
+ * (the server assigns the id and returns the reference URL). Resolves to the URL, or `null` on
+ * failure.
+ */
+async function uploadDrawingImage(noteId: string, source: string): Promise<string | null> {
+    const file = dataUrlToImageFile(source);
+    if (!file) return null;
+
+    try {
+        const response = await server.upload(`notes/${noteId}/attachments/upload`, file, undefined, "POST") as { uploaded?: boolean; url?: string };
+        return response?.uploaded && response.url ? response.url : null;
+    } catch (e) {
+        console.error("Failed to upload spreadsheet image", e);
+        return null;
+    }
+}
+
+/** Decodes a `data:<mime>;base64,<data>` URL into a {@link File} for upload. */
+function dataUrlToImageFile(dataUrl: string): File | null {
+    const parsed = parseImageDataUrl(dataUrl);
+    if (!parsed) return null;
+
+    const binary = atob(parsed.base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return new File([ bytes ], `image.${parsed.ext}`, { type: parsed.mime });
+}
+
+/** Collects the base64 image sources currently present in a workbook's drawing resource. */
+export function collectBase64DrawingSources(workbookData: Partial<IWorkbookData>): Set<string> {
+    const sources = new Set<string>();
+    forEachBase64DrawingImage(workbookData, (_node, source) => sources.add(source));
+    return sources;
+}
+
+interface DrawingResource {
+    resource: { name: string; data: string };
+    drawingData: unknown;
+}
+
+/**
+ * Walks the drawing resource of a saved workbook, invoking `callback` for every base64 image node
+ * (an object with `imageSourceType === "BASE64"` and a `data:` `source`). The callback may mutate
+ * the node in place. Returns the parsed drawing data and its resource so callers can re-serialize
+ * after mutating, or `null` when there is no drawing resource / it fails to parse.
+ */
+function forEachBase64DrawingImage(
+    workbookData: Partial<IWorkbookData>,
+    callback: (node: Record<string, unknown>, source: string) => void
+): DrawingResource | null {
+    const resource = workbookData.resources?.find((r) => r.name === DRAWING_RESOURCE_NAME);
+    if (!resource?.data) return null;
+
+    let drawingData: unknown;
+    try {
+        drawingData = JSON.parse(resource.data);
+    } catch {
+        return null;
+    }
+
+    const visit = (value: unknown) => {
+        if (Array.isArray(value)) {
+            value.forEach(visit);
+            return;
+        }
+        if (!value || typeof value !== "object") return;
+
+        const node = value as Record<string, unknown>;
+        if (node.imageSourceType === "BASE64" && typeof node.source === "string" && node.source.startsWith("data:")) {
+            callback(node, node.source);
+            return;
+        }
+        for (const key of Object.keys(node)) {
+            visit(node[key]);
+        }
+    };
+    visit(drawingData);
+
+    return { resource, drawingData };
+}
+
+interface ParsedImageDataUrl {
+    mime: string;
+    base64: string;
+    ext: string;
+}
+
+/** Splits a `data:<mime>;base64,<data>` URL into its mime, raw base64 and a file extension. */
+function parseImageDataUrl(dataUrl: string): ParsedImageDataUrl | null {
+    const match = /^data:([^;,]+);base64,(.*)$/.exec(dataUrl);
+    if (!match) return null;
+
+    const mime = match[1];
+    const base64 = match[2];
+    const subtype = mime.split("/")[1] ?? "png";
+    const ext = subtype === "svg+xml" ? "svg" : (subtype.replace(/[^a-z0-9]/gi, "") || "png");
+    return { mime, base64, ext };
 }

--- a/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
+++ b/apps/client/src/widgets/type_widgets/spreadsheet/persistence.tsx
@@ -1,3 +1,4 @@
+import { SHEET_DRAWING_RESOURCE } from "@triliumnext/commons/src/lib/spreadsheet/workbook_model";
 import { CommandType, FUniver, IDisposable, IWorkbookData, LocaleType } from "@univerjs/presets";
 import { MutableRef, useEffect, useRef } from "preact/hooks";
 
@@ -302,9 +303,6 @@ export function slimWorkbookData(workbookData: IWorkbookData): Partial<IWorkbook
     return slimmed;
 }
 
-/** Univer's resource key under which the sheet drawing (image) layer is serialized in the workbook. */
-const DRAWING_RESOURCE_NAME = "SHEET_DRAWING_PLUGIN";
-
 /**
  * Uploads newly inserted base64 images in a saved workbook as Trilium attachments and rewrites their
  * drawing-resource `source` from the inline data URL to the returned `api/attachments/...` URL (with
@@ -415,7 +413,7 @@ function forEachBase64DrawingImage(
     }
 
     // Floating images: serialized in the SHEET_DRAWING_PLUGIN resource.
-    const resource = workbookData.resources?.find((r) => r.name === DRAWING_RESOURCE_NAME);
+    const resource = workbookData.resources?.find((r) => r.name === SHEET_DRAWING_RESOURCE);
     if (!resource?.data) return null;
 
     let drawingData: unknown;

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export.html
@@ -6,11 +6,10 @@
         to represent basic formatting and layout (e.g. <code spellcheck="false">&lt;strong&gt;</code>,
         <code
         spellcheck="false">&lt;table&gt;</code>, <code spellcheck="false">&lt;pre&gt;</code>).</li>
-      <li
-     >Note that HTML is not a standardized format so some more specific features
+      <li>Note that HTML is not a standardized format so some more specific features
         such as admonitions or&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;might
         not be supported by other applications.</li>
-  </ul>
+    </ul>
   </li>
   <li><a class="reference-link" href="#root/_help_Oau6X9rCuegd">Markdown</a>
     <ul>
@@ -25,4 +24,4 @@
   </li>
 </ul>
 <p>To import from other applications, see&nbsp;<a class="reference-link"
-  href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/mHbBMPDPkVV5/_help_ckZ2uNWQmVeX">Importing data from other applications</a>.</p>
+  href="#root/_help_ckZ2uNWQmVeX">Importing data from other applications</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Evernote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Evernote.html
@@ -28,17 +28,16 @@
   <li>Attachments</li>
   <li>The hierarchy of headings (these are shifted to start with H2 because
     H1 is reserved for note title, see&nbsp;<a href="#root/_help_Gr6xFaF6ioJ5">Headings</a>)</li>
-  <li
- >Tables</li>
-    <li>Bulleted lists</li>
-    <li>Numbered lists</li>
-    <li>Bold</li>
-    <li>Italics</li>
-    <li>Strikethrough</li>
-    <li>Highlights</li>
-    <li>Font colors</li>
-    <li>Soft line breaks</li>
-    <li>External links</li>
+  <li>Tables</li>
+  <li>Bulleted lists</li>
+  <li>Numbered lists</li>
+  <li>Bold</li>
+  <li>Italics</li>
+  <li>Strikethrough</li>
+  <li>Highlights</li>
+  <li>Font colors</li>
+  <li>Soft line breaks</li>
+  <li>External links</li>
 </ul>
 <p>However, we do not guarantee that all of your formatting will be imported
   100% correctly.</p>
@@ -47,11 +46,9 @@
   <li>The size limit of one import is 250Mb. If the total size of your files
     is larger, you can increase the&nbsp;<a href="#root/_help_WOcw2SLH6tbX">upload limit</a>,
     or divide your files, and run the import as many times as necessary.</li>
-  <li
- >All resources (except for images) are created as notes’ attachments.</li>
-    <li
-   >If you have HTML inside ENEX files, the HTML formatting may be broken
-      or lost after import in Trilium. See&nbsp;<a class="reference-link" href="#root/_help_wy8So3yZZlH9">Reporting issues</a>.</li>
+  <li>All resources (except for images) are created as notes’ attachments.</li>
+  <li>If you have HTML inside ENEX files, the HTML formatting may be broken
+    or lost after import in Trilium. See&nbsp;<a class="reference-link" href="#root/_help_wy8So3yZZlH9">Reporting issues</a>.</li>
 </ul>
 <h3>Internal links</h3>
 <p>The importer cannot transform Evernote internal links into Trilium internal

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Google Keep.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Google Keep.html
@@ -25,18 +25,10 @@
     <p>In <em>Choose file type, frequency &amp; destination</em> make sure the
       following options are set:</p>
     <ol>
-      <li>
-        <p><em>Transfer to</em> is set to <em>Send download link via email</em>.</p>
-      </li>
-      <li>
-        <p><em>Frequency</em> is set to <em>Export once</em>.</p>
-      </li>
-      <li>
-        <p><em>File type</em> is set to <em>.zip</em>.</p>
-      </li>
-      <li>
-        <p><em>File size</em> can remain set to <em>2 GB</em>.</p>
-      </li>
+      <li><em>Transfer to</em> is set to <em>Send download link via email</em>.</li>
+      <li><em>Frequency</em> is set to <em>Export once</em>.</li>
+      <li><em>File type</em> is set to <em>.zip</em>.</li>
+      <li><em>File size</em> can remain set to <em>2 GB</em>.</li>
     </ol>
   </li>
   <li>
@@ -50,7 +42,7 @@
   <li>From&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>,
     select <em>Import from a service…</em>
   </li>
-  <li>Select <em>Google Keep </em>as the provider to import from.</li>
+  <li>Select <em>Google Keep</em> as the provider to import from.</li>
   <li>Upload the ZIP obtained in the previous step.</li>
 </ol>
 <h2>Supported features</h2>
@@ -59,16 +51,14 @@
     <p>Basic formatting (bold, italic, underline)</p>
   </li>
   <li>
-    <p><a href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/BFs8mudNFgCS/_help_p9kXRFAkwN4o">Note color</a>
+    <p><a href="#root/_help_p9kXRFAkwN4o">Note color</a>
     </p>
   </li>
   <li>
     <p>Note titles are maintained, if present.</p>
     <ul>
-      <li>
-        <p>In Google Keep it's common for notes not to have a title, case in which
-          the date and time of the note are used as a title.</p>
-      </li>
+      <li>In Google Keep it's common for notes not to have a title, case in which
+        the date and time of the note are used as a title.</li>
     </ul>
   </li>
   <li>
@@ -81,23 +71,17 @@
 <h2>Limitations</h2>
 <p>Currently the following information is not imported:</p>
 <ul>
-  <li>
-    <p>Labels are disregarded.</p>
-  </li>
-  <li>
-    <p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
-      <a
-      class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/BFs8mudNFgCS/_help_0vhv7lsOLy82">Attachments</a>&nbsp;are not imported.</p>
-  </li>
-  <li>
-    <p>Pinned, archived or trashed state is not preserved, all notes are treated
-      the same.</p>
-  </li>
+  <li>Labels are disregarded.</li>
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
+    <a
+    class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;are not imported.</li>
+  <li>Pinned, archived or trashed state is not preserved, all notes are treated
+    the same.</li>
 </ul>
 <h2>Reporting issues</h2>
 <p>When importing your notes from Google Keep, you might encounter some issues
   with how the notes are imported, or there might be some missing information.
-  In this case, consider <a href="#root/pOsGYCXsbNQG/BgmBlOIl72jZ/_help_wy8So3yZZlH9">reporting it</a>.</p>
+  In this case, consider <a href="#root/_help_wy8So3yZZlH9">reporting it</a>.</p>
 <p>When reporting such an issue make sure to provide the following information:</p>
 <ul>
   <li>A sample of the note is required to better understand what happened.

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
@@ -12,13 +12,12 @@
     select <em>Import from a service…</em>
   </li>
   <li>Select <em>Microsoft OneNote</em> as the provider to import from.</li>
-  <li
- >Press the <em>Connect</em> button, you will be redirected to Microsoft's
+  <li>Press the <em>Connect</em> button, you will be redirected to Microsoft's
     authentication screen where you can log into your account.</li>
-    <li>After the connection is successful, you should be able to see a list of
-      sections that can be imported. Simply check the ones to import and press
-      the <em>Import selected</em> button.</li>
-    <li>Wait for the import to finish.</li>
+  <li>After the connection is successful, you should be able to see a list of
+    sections that can be imported. Simply check the ones to import and press
+    the <em>Import selected</em> button.</li>
+  <li>Wait for the import to finish.</li>
 </ol>
 <h2>Supported features</h2>
 <p>The following features are preserved by Trilium during the import process:</p>
@@ -35,18 +34,17 @@
   <li><a class="reference-link" href="#root/_help_NdowYOC1GFKS">Tables</a>
   </li>
   <li>Images and&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
-  <li
- >To-do lists</li>
-    <li>Hand-drawing is preserved and displayed as an SVG image (however there
-      are some</li>
-    <li>Links between other imported pages are converted to&nbsp;<a class="reference-link"
-      href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;if the text
-      of the link matches the name of the page, or plain links otherwise. If
-      the pages are not part of the import, the original <code spellcheck="false">onenote:</code> link
-      is kept.</li>
-    <li>Tags (apart from to-do lists) are mildly preserved by converting them
-      to emojis. This loses their searchability. Since Trilium has no concept
-      of inline attributes or badges, this is considered a middle-ground.</li>
+  <li>To-do lists</li>
+  <li>Hand-drawing is preserved and displayed as an SVG image (however there
+    are some</li>
+  <li>Links between other imported pages are converted to&nbsp;<a class="reference-link"
+    href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;if the text
+    of the link matches the name of the page, or plain links otherwise. If
+    the pages are not part of the import, the original <code spellcheck="false">onenote:</code> link
+    is kept.</li>
+  <li>Tags (apart from to-do lists) are mildly preserved by converting them
+    to emojis. This loses their searchability. Since Trilium has no concept
+    of inline attributes or badges, this is considered a middle-ground.</li>
 </ul>
 <p>Regarding the note structure:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Notion.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Notion.html
@@ -10,41 +10,38 @@
     <ul>
       <li>Select the page to export.</li>
       <li>Press the […] button at the top-right of the window and select <em>Export</em>.</li>
-      <li
-     >Ensure the following options are set:
+      <li>Ensure the following options are set:
         <ul>
           <li>Export format: HTML</li>
           <li>Page content: Everything</li>
           <li>Include subpages: On</li>
           <li>Create folders for subpages: On</li>
         </ul>
-  </li>
-  <li>Press the Export button.</li>
-  <li>Wait for the download to finish.</li>
-  </ul>
+      </li>
+      <li>Press the Export button.</li>
+      <li>Wait for the download to finish.</li>
+    </ul>
   </li>
   <li>To export an entire workspace, press your user name badge at top-left
     and select <em>Settings</em>.
     <ul>
       <li>In the left section, look for the <em>Workspace</em> category and select <em>General</em>.</li>
-      <li
-     >In the <em>General</em> settings page, look for the <em>Export</em> section
+      <li>In the <em>General</em> settings page, look for the <em>Export</em> section
         and press the <em>Export</em> button corresponding to <em>Workspace content</em>.</li>
-  <li
- >Ensure the following options are set:
-    <ul>
-      <li>Export format: HTML</li>
-      <li>Page content: Everything</li>
-      <li>Include subpages: On</li>
-      <li>Create folders for subpages: On</li>
+      <li>Ensure the following options are set:
+        <ul>
+          <li>Export format: HTML</li>
+          <li>Page content: Everything</li>
+          <li>Include subpages: On</li>
+          <li>Create folders for subpages: On</li>
+        </ul>
+      </li>
+      <li>Press the Export button.</li>
+      <li>Wait for the download to finish. Depending on the size of your workspace
+        it might take a while. You will get a downloadable copy via email if takes
+        too long.</li>
     </ul>
-    </li>
-    <li>Press the Export button.</li>
-    <li>Wait for the download to finish. Depending on the size of your workspace
-      it might take a while. You will get a downloadable copy via email if takes
-      too long.</li>
-    </ul>
-    </li>
+  </li>
 </ul>
 <p>In Trilium Notes:</p>
 <ol>
@@ -53,7 +50,7 @@
   <li>From&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>,
     select <em>Import from a service…</em>
   </li>
-  <li>Select <em>Notion </em>as the provider to import from.</li>
+  <li>Select <em>Notion</em> as the provider to import from.</li>
   <li>Upload the ZIP obtained in the previous step.</li>
 </ol>
 <h2>Supported features</h2>
@@ -61,26 +58,26 @@
 <ul>
   <li>Basic formatting (bold, italic, underline, strikethrough, headings, colors,
     highlights).</li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_S6Xx8QIWTV66">Lists</a>
+  <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>
   </li>
   <li>To-do lists</li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
     <a
-    class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/BFs8mudNFgCS/_help_0vhv7lsOLy82">Attachments</a>.</li>
+    class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
   <li>Toggle sections</li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_YfYAtQBcfo5V">Math Equations</a>&nbsp;(inline
+  <li><a class="reference-link" href="#root/_help_YfYAtQBcfo5V">Math Equations</a>&nbsp;(inline
     or block)</li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_UmgZAfcltxkS">Link Previews</a>
+  <li><a class="reference-link" href="#root/_help_UmgZAfcltxkS">Link Previews</a>
   </li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/UYuUB1ZekNQU/_help_QxEyIjRBizuC">Code blocks</a>,
-    with a best-effort attempt to restore the language.</li>
-  <li><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_s1aBHPd79XYj">Mermaid Diagrams</a>
+  <li><a class="reference-link" href="#root/_help_QxEyIjRBizuC">Code blocks</a>, with
+    a best-effort attempt to restore the language.</li>
+  <li><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>
   </li>
   <li>Links between other imported pages are converted to&nbsp;<a class="reference-link"
     href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;if they are
     part of the same import.</li>
-  <li><a href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_NwBbFdNZ9h7O">Admonitions</a> are
-    preserved, including its emoji (added as part of the content).</li>
+  <li><a href="#root/_help_NwBbFdNZ9h7O">Admonitions</a> are preserved, including its
+    emoji (added as part of the content).</li>
 </ul>
 <h2>Limitations</h2>
 <h3>Missing data from the import</h3>
@@ -94,7 +91,7 @@
 <h3>Collections</h3>
 <p>Currently the import does not fully handle collections. Items that belong
   in a collection are properly positioned but the fields/metadata is not
-  preserved and not turned into&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/_help_GTwFsgaA0lCt">Collections</a>.</p>
+  preserved and not turned into&nbsp;<a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>.</p>
 <h3>Page attributes</h3>
 <p>Currently page attributes are not preserved.</p>
 <h3>Cover images and page icon</h3>
@@ -102,7 +99,7 @@
   default icon. The cover image is not imported at all.</p>
 <h2>Reporting issues</h2>
 <p>When importing your Notion workspace, you might find issues in how a note
-  is imported; in that case consider <a href="#root/pOsGYCXsbNQG/BgmBlOIl72jZ/_help_wy8So3yZZlH9">reporting</a> it.</p>
+  is imported; in that case consider <a href="#root/_help_wy8So3yZZlH9">reporting</a> it.</p>
 <p>When reporting such an issue make sure to provide the following information:</p>
 <ul>
   <li>A .zip export of the original Notion note (and children if applicable).

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
@@ -24,19 +24,23 @@
   <li>Microsoft Excel (.xlsx)
     <ul>
       <li>Preserves basic formatting (fonts, sizes, borders, backgrounds).</li>
-      <li>Formulas are preserved, but note that not all Excel functions are supported
+      <li
+     >Formulas are preserved, but note that not all Excel functions are supported
         and vice-versa with Univer.</li>
-      <li>Supports multi-sheets natively.</li>
+  <li>Images (cell-bound or floating), without preserving rotation.</li>
+  <li
+ >Supports multi-sheets natively.</li>
     </ul>
-  </li>
-  <li>Comma-Separated Values (.csv)
-    <ul>
-      <li>Since it's a text-based format, any formatting is lost.</li>
-      <li>Formulas are evaluated and turned into their final value instead.</li>
-      <li>Multi-sheets spreadsheets are exported as a single ZIP containing a CSV
-        file per sheet.</li>
+    </li>
+    <li>Comma-Separated Values (.csv)
+      <ul>
+        <li>Since it's a text-based format, any formatting is lost.</li>
+        <li>Formulas are evaluated and turned into their final value instead.</li>
+        <li
+       >Multi-sheets spreadsheets are exported as a single ZIP containing a CSV
+          file per sheet.</li>
     </ul>
-  </li>
+    </li>
 </ul>
 <p>Both <a href="#root/_help_mHbBMPDPkVV5">import and export</a> are supported, as
   follows:</p>
@@ -48,10 +52,11 @@
       <li>To avoid this behavior (e.g. to import a .xlsx file as an actual&nbsp;
         <a
         class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>), uncheck the corresponding option in the <a href="#root/_help_mHbBMPDPkVV5">Import dialog</a>.</li>
-      <li>Multiple files can be imported at the same time, including a mixture of
+      <li
+     >Multiple files can be imported at the same time, including a mixture of
         .csv and .xlsx files. Folder structure can be preserved by using a .zip
         file.</li>
-    </ul>
+  </ul>
   </li>
   <li>Unlike importing, exporting is on a per-note basis:
     <ul>
@@ -78,6 +83,15 @@
 <h2>Supported features</h2>
 <p>The spreadsheet has support for the following features:</p>
 <ul>
+  <li>Since v0.104.0, images that can be either inside a cell or floating above.
+    <ul>
+      <li>The images are saved as&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/BFs8mudNFgCS/_help_0vhv7lsOLy82">Attachments</a>&nbsp;for
+        performance reasons.</li>
+      <li>The image upload respects the same compression settings as text&nbsp;
+        <a
+        class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_mT0HEkOsz6i1">Images</a>.</li>
+    </ul>
+  </li>
   <li>Filtering</li>
   <li>Sorting</li>
   <li>Data validation</li>
@@ -93,8 +107,12 @@
   a best-effort HTML rendering of the spreadsheet is done:</p>
 <ul>
   <li>Preserves basic formatting.</li>
-  <li>Since v0.104.0, properly formats numbers and dates.</li>
-  <li>Cells with formulas display the i</li>
+  <li>Cells with formulas display the precalculated value instead of the formula.</li>
+</ul>
+<p>Since v0.104.0:</p>
+<ul>
+  <li>Numbers and dates are properly formatted.</li>
+  <li>Images are shown inside a cell or floating above, including rotation.</li>
 </ul>
 <p>For more advanced use cases, this will most likely not work as intended.
   Feel free to <a href="#root/_help_wy8So3yZZlH9">report issues</a>, but keep in
@@ -113,11 +131,13 @@
   yet:</p>
 <ul>
   <li>Trilium-specific formulas (e.g. to obtain the title of a note).</li>
-  <li>User-defined formulas</li>
-  <li>Cross-workbook calculation</li>
+  <li
+ >User-defined formulas</li>
+    <li>Cross-workbook calculation</li>
 </ul>
 <p>If you would like us to work on these features, consider <a href="https://triliumnotes.org/en/support-us">supporting us</a>.</p>
 <h3>Mobile support</h3>
-<p>There is no dedicated mobile support.</p>
-<p>Mobile support is currently experimental in Univer and when it becomes
-  stable, we could potentially integrate it into Trilium as well.</p>
+<p>Versions prior to v0.104.0 have no dedicated mobile support, which means
+  that the interaction is difficult without a mouse and keyboard. Starting
+  with v0.104.0 we integrate Univer's mobile plugin, which introduces feature
+  such as drag to pan which makes the interface more usable on mobile.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Images.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Images.html
@@ -23,80 +23,82 @@
 </p>
 <h3>Alignment</h3>
 <p>The first set of options configure the alignment are, in order:</p>
-<table>
-  <thead>
-    <tr>
-      <th>Icon</th>
-      <th>Option</th>
-      <th>Preview</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <img src="5_Images_image.png">
-      </td>
-      <td>Inline</td>
-      <td>
-        <img src="1_Images_image.png">
-      </td>
-      <td>As the name suggests, the name can be put inside a paragraph and moved
-        around similarly as if it was a block of text. Use drag &amp; drop or cut-paste
-        to move it around.</td>
-    </tr>
-    <tr>
-      <td>
-        <img src="10_Images_image.png">
-      </td>
-      <td>Centered image</td>
-      <td>
-        <img src="2_Images_image.png">
-      </td>
-      <td>The image will be displayed as a block and centered, not allowing text
-        in either the left or right of it.</td>
-    </tr>
-    <tr>
-      <td>
-        <img src="4_Images_image.png">
-      </td>
-      <td>Wrap text</td>
-      <td>
-        <img src="7_Images_image.png">
-      </td>
-      <td>The image will be displayed to the left or the right of the text.</td>
-    </tr>
-    <tr>
-      <td>
-        <img src="Images_image.png">
-      </td>
-      <td>Block align</td>
-      <td>
-        <img src="3_Images_image.png">
-      </td>
-      <td>Similarly to <em>Centered image</em>, the image will be displayed as a
-        block and aligned either to the left or to the right, but not allowing
-        text to flow on either of its sides.</td>
-    </tr>
-  </tbody>
-</table>
-
-<h2>Compression</h2>
-<p>Since Trilium isn't really meant to be primary storage for image data,
-  it attempts to compress and resize (with pretty aggressive settings) uploaded
-  images before storing them to the database. You may then notice some quality
-  degradation. Basic quality settings is available in&nbsp;<a class="reference-link"
-  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Other.</p>
-<p>If you want to save images in their original resolution, it is recommended
-  to save them as attachment to note (look for the contextual menu in&nbsp;
-  <a
-  class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Import files</em>).</p>
-<h2>Aligning images side-by-side</h2>
-<p>There are generally two ways to display images side by side:</p>
-<ul>
-  <li>If they are roughly the same size, simply make the two images in-line,
-    according to the alignment section above. The images can be dragged &amp;
-    dropped onto the same line.</li>
-  <li>If they are on different size, create a <a href="#root/_help_NdowYOC1GFKS">table</a> with
-    invisible borders.</li>
-</ul>
+<figure
+class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Icon</th>
+        <th>Option</th>
+        <th>Preview</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <img src="5_Images_image.png">
+        </td>
+        <td>Inline</td>
+        <td>
+          <img src="1_Images_image.png">
+        </td>
+        <td>As the name suggests, the name can be put inside a paragraph and moved
+          around similarly as if it was a block of text. Use drag &amp; drop or cut-paste
+          to move it around.</td>
+      </tr>
+      <tr>
+        <td>
+          <img src="10_Images_image.png">
+        </td>
+        <td>Centered image</td>
+        <td>
+          <img src="2_Images_image.png">
+        </td>
+        <td>The image will be displayed as a block and centered, not allowing text
+          in either the left or right of it.</td>
+      </tr>
+      <tr>
+        <td>
+          <img src="4_Images_image.png">
+        </td>
+        <td>Wrap text</td>
+        <td>
+          <img src="7_Images_image.png">
+        </td>
+        <td>The image will be displayed to the left or the right of the text.</td>
+      </tr>
+      <tr>
+        <td>
+          <img src="Images_image.png">
+        </td>
+        <td>Block align</td>
+        <td>
+          <img src="3_Images_image.png">
+        </td>
+        <td>Similarly to <em>Centered image</em>, the image will be displayed as a
+          block and aligned either to the left or to the right, but not allowing
+          text to flow on either of its sides.</td>
+      </tr>
+    </tbody>
+  </table>
+  </figure>
+  <h2>Compression</h2>
+  <p>Since Trilium isn't really meant to be primary storage for image data,
+    it attempts to compress and resize (with pretty aggressive settings) uploaded
+    images before storing them to the database. You may then notice some quality
+    degradation. Basic quality settings is available in&nbsp;<a class="reference-link"
+    href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Other.</p>
+  <p>If you want to save images in their original resolution, it is recommended
+    to save them as attachment to note (look for the contextual menu in&nbsp;
+    <a
+    class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Import files</em>).</p>
+  <h2>Aligning images side-by-side</h2>
+  <p>There are generally two ways to display images side by side:</p>
+  <ul>
+    <li>If they are roughly the same size, simply make the two images in-line,
+      according to the alignment section above. The images can be dragged &amp;
+      dropped onto the same line.</li>
+    <li>If they are on different size, create a <a href="#root/_help_NdowYOC1GFKS">table</a> with
+      invisible borders.</li>
+  </ul>

--- a/apps/server/src/services/notes.spec.ts
+++ b/apps/server/src/services/notes.spec.ts
@@ -41,6 +41,12 @@ describe("collectCanvasImageFileIds", () => {
         expect(collectCanvasImageFileIds("not json")).toEqual(new Set());
         expect(collectCanvasImageFileIds(JSON.stringify({}))).toEqual(new Set());
     });
+
+    it("returns an empty set when the JSON shape is unexpected (null / non-array elements)", () => {
+        expect(collectCanvasImageFileIds(JSON.stringify(null))).toEqual(new Set());
+        expect(collectCanvasImageFileIds(JSON.stringify({ elements: 5 }))).toEqual(new Set());
+        expect(collectCanvasImageFileIds(JSON.stringify({ elements: "oops" }))).toEqual(new Set());
+    });
 });
 
 describe("findBookmarks", () => {

--- a/apps/server/src/services/notes.spec.ts
+++ b/apps/server/src/services/notes.spec.ts
@@ -1,6 +1,6 @@
-import { BAttribute, becca_easy_mocking, checkImageAttachments, findBookmarks, findLlmChatLinks, saveLinks } from "@triliumnext/core";
+import { BAttribute, becca, becca_easy_mocking, checkImageAttachments, collectCanvasImageFileIds, findBookmarks, findLlmChatLinks, saveLinks } from "@triliumnext/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { becca } from "@triliumnext/core";
+
 import { randomString } from "./utils.js";
 
 const { buildNote } = becca_easy_mocking;
@@ -24,6 +24,24 @@ vi.mock("./ws.js", () => ({
 vi.mock("./entity_changes.js", () => ({
     default: { putEntityChange: () => {} }
 }));
+
+describe("collectCanvasImageFileIds", () => {
+    it("collects fileIds from image elements in the scene JSON", () => {
+        const content = JSON.stringify({
+            elements: [
+                { type: "image", fileId: "file-1" },
+                { type: "rectangle" },
+                { type: "image", fileId: "file-2" }
+            ]
+        });
+        expect(collectCanvasImageFileIds(content)).toEqual(new Set([ "file-1", "file-2" ]));
+    });
+
+    it("returns an empty set for malformed content (e.g. note type just changed)", () => {
+        expect(collectCanvasImageFileIds("not json")).toEqual(new Set());
+        expect(collectCanvasImageFileIds(JSON.stringify({}))).toEqual(new Set());
+    });
+});
 
 describe("findBookmarks", () => {
     it("extracts bookmark IDs from empty anchor tags", () => {
@@ -261,6 +279,73 @@ describe("checkImageAttachments", () => {
 
             expect(att.save).toHaveBeenCalled();
             expect(att.utcDateScheduledForErasureSince).toBeNull();
+        });
+    });
+
+    describe("Canvas content", () => {
+        /** Wraps image fileIds into the JSON shape a canvas note persists (one element per fileId). */
+        function canvasContent(...fileIds: string[]) {
+            return JSON.stringify({
+                type: "excalidraw",
+                version: 2,
+                elements: fileIds.map((fileId) => ({ type: "image", fileId })),
+                files: {},
+                appState: {}
+            });
+        }
+
+        it("keeps an image referenced by the scene (attachment titled with its fileId) alive", () => {
+            const note = buildNote({ title: "Canvas", type: "canvas", mime: "application/json", attachments: [{ title: "fileId-1", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+
+            checkImageAttachments(note, canvasContent("fileId-1"));
+
+            expect(att.save).not.toHaveBeenCalled();
+        });
+
+        it("schedules an inserted-then-removed image for erasure", () => {
+            const note = buildNote({ title: "Canvas", type: "canvas", mime: "application/json", attachments: [{ title: "fileId-1", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+
+            // Scene no longer references fileId-1 (the image was deleted from the canvas).
+            checkImageAttachments(note, canvasContent("fileId-2"));
+
+            expect(att.save).toHaveBeenCalled();
+            expect(att.utcDateScheduledForErasureSince).toBeTruthy();
+        });
+
+        it("never schedules the SVG export preview for erasure even though it is unreferenced", () => {
+            const note = buildNote({ title: "Canvas", type: "canvas", mime: "application/json", attachments: [{ title: "canvas-export.svg", role: "image", mime: "image/svg+xml" }] });
+            mockAttachmentSaves(note);
+            const [exportPreview] = note.getAttachments();
+
+            checkImageAttachments(note, canvasContent());
+
+            expect(exportPreview.save).not.toHaveBeenCalled();
+            expect(exportPreview.utcDateScheduledForErasureSince).toBeFalsy();
+        });
+
+        it("cancels erasure when the image is re-referenced (e.g. undo)", () => {
+            const note = buildNote({ title: "Canvas", type: "canvas", mime: "application/json", attachments: [{ title: "fileId-1", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+            att.utcDateScheduledForErasureSince = "2025-01-01 00:00:00.000Z";
+
+            checkImageAttachments(note, canvasContent("fileId-1"));
+
+            expect(att.save).toHaveBeenCalled();
+            expect(att.utcDateScheduledForErasureSince).toBeNull();
+        });
+
+        it("does not perform foreign-attachment copying (no forceFrontendReload)", () => {
+            const note = buildNote({ title: "Canvas", type: "canvas", mime: "application/json", attachments: [{ title: "fileId-1", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+
+            const result = checkImageAttachments(note, canvasContent("fileId-1"));
+
+            expect(result.forceFrontendReload).toBe(false);
         });
     });
 

--- a/apps/server/src/services/notes.spec.ts
+++ b/apps/server/src/services/notes.spec.ts
@@ -204,6 +204,66 @@ describe("checkImageAttachments", () => {
         });
     });
 
+    describe("Spreadsheet content", () => {
+        /** Wraps a drawing source URL into the JSON shape a spreadsheet note persists. */
+        function spreadsheetContent(source: string) {
+            return JSON.stringify({
+                version: 1,
+                workbook: {
+                    resources: [{
+                        name: "SHEET_DRAWING_PLUGIN",
+                        data: JSON.stringify({ "sheet-1": { data: { img1: { imageSourceType: "URL", source } }, order: ["img1"] } })
+                    }]
+                }
+            });
+        }
+
+        it("keeps an attachment referenced by the workbook drawing source alive", () => {
+            const note = buildNote({ title: "Sheet", type: "spreadsheet", mime: "application/json", attachments: [{ title: "image.png", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+
+            checkImageAttachments(note, spreadsheetContent(`api/attachments/${att.attachmentId}/image/image.png`));
+
+            expect(att.save).not.toHaveBeenCalled();
+        });
+
+        it("schedules an inserted-then-removed image for erasure", () => {
+            const note = buildNote({ title: "Sheet", type: "spreadsheet", mime: "application/json", attachments: [{ title: "image.png", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+
+            checkImageAttachments(note, spreadsheetContent("api/attachments/someOtherId/image/image.png"));
+
+            expect(att.save).toHaveBeenCalled();
+            expect(att.utcDateScheduledForErasureSince).toBeTruthy();
+        });
+
+        it("never schedules the preview thumbnail for erasure even though it is unreferenced", () => {
+            const note = buildNote({ title: "Sheet", type: "spreadsheet", mime: "application/json", attachments: [{ title: "spreadsheet-export.png", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [thumbnail] = note.getAttachments();
+
+            // Content with no drawing images at all — the thumbnail is the only "image" attachment.
+            checkImageAttachments(note, JSON.stringify({ version: 1, workbook: { resources: [] } }));
+
+            expect(thumbnail.save).not.toHaveBeenCalled();
+            expect(thumbnail.utcDateScheduledForErasureSince).toBeFalsy();
+        });
+
+        it("cancels erasure when the image is re-referenced", () => {
+            const note = buildNote({ title: "Sheet", type: "spreadsheet", mime: "application/json", attachments: [{ title: "image.png", role: "image", mime: "image/png" }] });
+            mockAttachmentSaves(note);
+            const [att] = note.getAttachments();
+            att.utcDateScheduledForErasureSince = "2025-01-01 00:00:00.000Z";
+
+            checkImageAttachments(note, spreadsheetContent(`api/attachments/${att.attachmentId}/image/image.png`));
+
+            expect(att.save).toHaveBeenCalled();
+            expect(att.utcDateScheduledForErasureSince).toBeNull();
+        });
+    });
+
     describe("foreign attachment copying", () => {
         it("replaces foreign attachment IDs in HTML content", () => {
             const note = buildNote({ title: "Test" });

--- a/docs/Developer Guide/Developer Guide/Documentation.md
+++ b/docs/Developer Guide/Developer Guide/Documentation.md
@@ -1,5 +1,5 @@
 # Documentation
-There are multiple types of documentation for Trilium:<img class="image-style-align-right" src="api/images/H00X7zJNSog1/Documentation_image.png" width="205" height="162">
+There are multiple types of documentation for Trilium:<img class="image-style-align-right" src="api/images/rPK7XJzCDrn2/Documentation_image.png" width="205" height="162">
 
 *   The _User Guide_ represents the user-facing documentation. This documentation can be browsed by users directly from within Trilium, by pressing <kbd>F1</kbd>.
 *   The _Developer's Guide_ represents a set of Markdown documents that present the internals of Trilium, for developers.

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -6786,6 +6786,13 @@
                                     "position": 30
                                 },
                                 {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "ckZ2uNWQmVeX",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
                                     "type": "label",
                                     "name": "iconClass",
                                     "value": "bx bx-import",
@@ -6798,13 +6805,6 @@
                                     "value": "import-export",
                                     "isInheritable": false,
                                     "position": 20
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "ckZ2uNWQmVeX",
-                                    "isInheritable": false,
-                                    "position": 40
                                 }
                             ],
                             "format": "markdown",
@@ -7078,102 +7078,102 @@
                                             "mime": "text/html",
                                             "attributes": [
                                                 {
-                                                    "type": "label",
-                                                    "name": "shareAlias",
-                                                    "value": "notion",
-                                                    "isInheritable": false,
-                                                    "position": 30
-                                                },
-                                                {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "oPVyFC7WL2Lp",
                                                     "isInheritable": false,
-                                                    "position": 40
+                                                    "position": 10
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "8YBEPzcpUgxw",
                                                     "isInheritable": false,
-                                                    "position": 50
+                                                    "position": 20
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "S6Xx8QIWTV66",
                                                     "isInheritable": false,
-                                                    "position": 60
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "hrZ1D00cLbal",
-                                                    "isInheritable": false,
-                                                    "position": 70
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "NwBbFdNZ9h7O",
-                                                    "isInheritable": false,
-                                                    "position": 80
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "GTwFsgaA0lCt",
-                                                    "isInheritable": false,
-                                                    "position": 90
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "YfYAtQBcfo5V",
-                                                    "isInheritable": false,
-                                                    "position": 100
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "UmgZAfcltxkS",
-                                                    "isInheritable": false,
-                                                    "position": 110
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
-                                                    "value": "QxEyIjRBizuC",
-                                                    "isInheritable": false,
-                                                    "position": 120
+                                                    "position": 30
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "mT0HEkOsz6i1",
                                                     "isInheritable": false,
-                                                    "position": 130
+                                                    "position": 40
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "0vhv7lsOLy82",
                                                     "isInheritable": false,
-                                                    "position": 140
+                                                    "position": 50
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "YfYAtQBcfo5V",
+                                                    "isInheritable": false,
+                                                    "position": 60
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "UmgZAfcltxkS",
+                                                    "isInheritable": false,
+                                                    "position": 70
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "QxEyIjRBizuC",
+                                                    "isInheritable": false,
+                                                    "position": 80
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "s1aBHPd79XYj",
                                                     "isInheritable": false,
-                                                    "position": 150
+                                                    "position": 90
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "hrZ1D00cLbal",
+                                                    "isInheritable": false,
+                                                    "position": 100
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "NwBbFdNZ9h7O",
+                                                    "isInheritable": false,
+                                                    "position": 110
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "GTwFsgaA0lCt",
+                                                    "isInheritable": false,
+                                                    "position": 120
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "wy8So3yZZlH9",
                                                     "isInheritable": false,
-                                                    "position": 160
+                                                    "position": 130
+                                                },
+                                                {
+                                                    "type": "label",
+                                                    "name": "shareAlias",
+                                                    "value": "notion",
+                                                    "isInheritable": false,
+                                                    "position": 30
                                                 }
                                             ],
                                             "format": "markdown",
@@ -7198,53 +7198,53 @@
                                             "mime": "text/html",
                                             "attributes": [
                                                 {
-                                                    "type": "label",
-                                                    "name": "shareAlias",
-                                                    "value": "keep",
-                                                    "isInheritable": false,
-                                                    "position": 30
-                                                },
-                                                {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "oPVyFC7WL2Lp",
                                                     "isInheritable": false,
-                                                    "position": 40
+                                                    "position": 10
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "8YBEPzcpUgxw",
                                                     "isInheritable": false,
-                                                    "position": 50
+                                                    "position": 20
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "p9kXRFAkwN4o",
                                                     "isInheritable": false,
-                                                    "position": 60
+                                                    "position": 30
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "mT0HEkOsz6i1",
                                                     "isInheritable": false,
-                                                    "position": 70
+                                                    "position": 40
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "0vhv7lsOLy82",
                                                     "isInheritable": false,
-                                                    "position": 80
+                                                    "position": 50
                                                 },
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
                                                     "value": "wy8So3yZZlH9",
                                                     "isInheritable": false,
-                                                    "position": 90
+                                                    "position": 60
+                                                },
+                                                {
+                                                    "type": "label",
+                                                    "name": "shareAlias",
+                                                    "value": "keep",
+                                                    "isInheritable": false,
+                                                    "position": 30
                                                 }
                                             ],
                                             "format": "markdown",
@@ -11997,6 +11997,20 @@
                                     "value": "bx bx-table",
                                     "isInheritable": false,
                                     "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "0vhv7lsOLy82",
+                                    "isInheritable": false,
+                                    "position": 100
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "mT0HEkOsz6i1",
+                                    "isInheritable": false,
+                                    "position": 110
                                 }
                             ],
                             "format": "markdown",

--- a/docs/User Guide/User Guide/Note Types/Spreadsheets.md
+++ b/docs/User Guide/User Guide/Note Types/Spreadsheets.md
@@ -19,6 +19,7 @@ Starting with v0.104.0, Trilium provides a level of data intercompatibility betw
 *   Microsoft Excel (.xlsx)
     *   Preserves basic formatting (fonts, sizes, borders, backgrounds).
     *   Formulas are preserved, but note that not all Excel functions are supported and vice-versa with Univer.
+    *   Images (cell-bound or floating), without preserving rotation.
     *   Supports multi-sheets natively.
 *   Comma-Separated Values (.csv)
     *   Since it's a text-based format, any formatting is lost.
@@ -42,6 +43,9 @@ Both [import and export](../Basic%20Concepts%20and%20Features/Import%20%26%20Exp
 
 The spreadsheet has support for the following features:
 
+*   Since v0.104.0, images that can be either inside a cell or floating above.
+    *   The images are saved as <a class="reference-link" href="../Basic%20Concepts%20and%20Features/Notes/Attachments.md">Attachments</a> for performance reasons.
+    *   The image upload respects the same compression settings as text <a class="reference-link" href="Text/Images.md">Images</a>.
 *   Filtering
 *   Sorting
 *   Data validation
@@ -56,8 +60,12 @@ We might consider adding [other features](https://docs.univer.ai/guides/sheets/f
 Spreadsheets can be [shared](../Advanced%20Usage/Sharing.md), case in which a best-effort HTML rendering of the spreadsheet is done:
 
 *   Preserves basic formatting.
-*   Since v0.104.0, properly formats numbers and dates.
-*   Cells with formulas display the i
+*   Cells with formulas display the precalculated value instead of the formula.
+
+Since v0.104.0:
+
+*   Numbers and dates are properly formatted.
+*   Images are shown inside a cell or floating above, including rotation.
 
 For more advanced use cases, this will most likely not work as intended. Feel free to [report issues](../Troubleshooting/Reporting%20issues.md), but keep in mind that we might not be able to have a complete feature parity with all the features of Univer.
 
@@ -81,6 +89,4 @@ If you would like us to work on these features, consider [supporting us](https:/
 
 ### Mobile support
 
-There is no dedicated mobile support.
-
-Mobile support is currently experimental in Univer and when it becomes stable, we could potentially integrate it into Trilium as well.
+Versions prior to v0.104.0 have no dedicated mobile support, which means that the interaction is difficult without a mouse and keyboard. Starting with v0.104.0 we integrate Univer's mobile plugin, which introduces feature such as drag to pan which makes the interface more usable on mobile.

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
@@ -535,6 +535,17 @@ describe("parseXlsxToWorkbook images", () => {
         });
         expect(workbook.resources).toBeUndefined();
     });
+
+    it("records the default header sizes so the baked-in image offset cancels in the share view", async () => {
+        // buildDrawing adds the header gutters into transform.left/top; the share renderer subtracts
+        // them back by reading these fields, so they must be present (and match) on imported sheets.
+        const workbook = await parseBuilt((wb) => {
+            wb.addWorksheet("S").getCell("A1").value = "x";
+        });
+        const sheet = workbook.sheets[workbook.sheetOrder[0]];
+        expect(sheet.rowHeader).toEqual({ width: 46, hidden: 0 });
+        expect(sheet.columnHeader).toEqual({ height: 20, hidden: 0 });
+    });
 });
 
 describe("toArrayBuffer", () => {

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
@@ -467,6 +467,76 @@ describe("parseXlsxToWorkbook", () => {
     });
 });
 
+describe("parseXlsxToWorkbook images", () => {
+    // 1x1 transparent PNG.
+    const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+    async function parseBuilt(build: (wb: ExcelJS.Workbook) => void): Promise<Awaited<ReturnType<typeof parseXlsxToWorkbook>>["workbook"]> {
+        const wb = new ExcelJS.Workbook();
+        build(wb);
+        const buffer = await wb.xlsx.writeBuffer();
+        return (await parseXlsxToWorkbook(buffer as ArrayBuffer)).workbook;
+    }
+
+    // Reads the SHEET_DRAWING_PLUGIN resource for a sheet back into a typed shape.
+    function drawingsOf(workbook: { sheetOrder: string[]; resources?: { name: string; data: string }[] }, sheetIndex = 0) {
+        const resource = workbook.resources?.find((r) => r.name === "SHEET_DRAWING_PLUGIN");
+        if (!resource) return null;
+        const parsed = JSON.parse(resource.data) as Record<string, { data: Record<string, any>; order: string[] }>;
+        return parsed[workbook.sheetOrder[sheetIndex]] ?? null;
+    }
+
+    it("imports a two-cell floating image as a base64 drawing with from/to anchors", async () => {
+        const workbook = await parseBuilt((wb) => {
+            const ws = wb.addWorksheet("S");
+            ws.getCell("A1").value = "x";
+            const id = wb.addImage({ base64: PNG, extension: "png" });
+            ws.addImage(id, { tl: { col: 1, row: 2 }, br: { col: 3, row: 5 }, editAs: "twoCell" } as unknown as ExcelJS.ImageRange);
+        });
+
+        const drawings = drawingsOf(workbook);
+        expect(drawings?.order.length).toBe(1);
+        const drawing = drawings?.data[drawings.order[0]];
+        expect(drawing.imageSourceType).toBe("BASE64");
+        expect(drawing.source).toMatch(/^data:image\/png;base64,/);
+        expect(drawing.sheetTransform.from).toMatchObject({ column: 1, row: 2, columnOffset: 0, rowOffset: 0 });
+        expect(drawing.sheetTransform.to).toMatchObject({ column: 3, row: 5 });
+        expect(drawing.transform.width).toBeGreaterThan(0);
+        expect(drawing.transform.height).toBeGreaterThan(0);
+    });
+
+    it("imports a one-cell (ext) image using the extent for the drawing size", async () => {
+        const workbook = await parseBuilt((wb) => {
+            const ws = wb.addWorksheet("S");
+            const id = wb.addImage({ base64: PNG, extension: "png" });
+            ws.addImage(id, { tl: { col: 0, row: 0 }, ext: { width: 120, height: 90 } });
+        });
+
+        const drawing = drawingsOf(workbook)?.data[drawingsOf(workbook)!.order[0]];
+        expect(drawing.transform.width).toBe(120);
+        expect(drawing.transform.height).toBe(90);
+        expect(drawing.sheetTransform.from).toMatchObject({ column: 0, row: 0 });
+    });
+
+    it("preserves multiple images in order", async () => {
+        const workbook = await parseBuilt((wb) => {
+            const ws = wb.addWorksheet("S");
+            const a = wb.addImage({ base64: PNG, extension: "png" });
+            const b = wb.addImage({ base64: PNG, extension: "png" });
+            ws.addImage(a, { tl: { col: 0, row: 0 }, ext: { width: 10, height: 10 } });
+            ws.addImage(b, { tl: { col: 2, row: 2 }, ext: { width: 10, height: 10 } });
+        });
+        expect(drawingsOf(workbook)?.order.length).toBe(2);
+    });
+
+    it("emits no drawing resource for a sheet without images", async () => {
+        const workbook = await parseBuilt((wb) => {
+            wb.addWorksheet("S").getCell("A1").value = "x";
+        });
+        expect(workbook.resources).toBeUndefined();
+    });
+});
+
 describe("toArrayBuffer", () => {
     it("copies a Node Buffer view into a tightly-sized ArrayBuffer, not the whole backing", () => {
         // Buffer.prototype.slice returns a VIEW over the same backing (unlike

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
@@ -29,8 +29,10 @@ import {
     type IRange,
     type IRowData,
     type IStyleData,
+    type IWorkbookData,
     type IWorksheetData,
     type PersistedData,
+    SHEET_DRAWING_RESOURCE,
     VerticalAlign,
     WrapStrategy
 } from "./workbook_model.js";
@@ -58,23 +60,29 @@ export async function parseXlsxToWorkbook(input: ArrayBuffer | Uint8Array): Prom
 
     const sheetOrder: string[] = [];
     const sheets: Record<string, IWorksheetData> = {};
+    const drawingsBySheet: Record<string, SheetDrawings> = {};
 
     wb.eachSheet((ws, sheetIndex) => {
         // Deterministic ids keyed off position; the workbook id/locale are reassigned on load
         // (see persistence.tsx) and sheet view state keys off this id, so stability is all we need.
         const id = `sheet-${sheetIndex}`;
         sheetOrder.push(id);
-        sheets[id] = readSheet(ws, id);
+        const sheet = readSheet(ws, id);
+        sheets[id] = sheet;
+
+        const drawings = readImages(wb, ws, sheet, id);
+        if (drawings) drawingsBySheet[id] = drawings;
     });
 
-    return {
-        version: 1,
-        workbook: {
-            sheetOrder,
-            styles: {},
-            sheets
-        }
-    };
+    const workbook: IWorkbookData = { sheetOrder, styles: {}, sheets };
+
+    // Floating images go in the SHEET_DRAWING_PLUGIN resource (a JSON string keyed by sheet id),
+    // the same shape the editor persists; Univer reconciles the drawing unitId on load.
+    if (Object.keys(drawingsBySheet).length > 0) {
+        workbook.resources = [{ name: SHEET_DRAWING_RESOURCE, data: JSON.stringify(drawingsBySheet) }];
+    }
+
+    return { version: 1, workbook };
 }
 
 function readSheet(ws: ExcelJS.Worksheet, id: string): IWorksheetData {
@@ -108,6 +116,194 @@ function readSheet(ws: ExcelJS.Worksheet, id: string): IWorksheetData {
 
     return sheet;
 }
+
+// #region Images
+
+/** Univer's default header gutter sizes (px); drawing transforms are measured including them. */
+const HEADER_WIDTH = 46;
+const HEADER_HEIGHT = 20;
+
+interface SheetDrawings {
+    data: Record<string, object>;
+    order: string[];
+}
+
+interface CellAnchor {
+    row: number;
+    rowOffset: number;
+    column: number;
+    columnOffset: number;
+}
+
+/**
+ * Reads a worksheet's floating images into Univer drawings. Each image's bytes (from exceljs media)
+ * become an inline base64 `data:` URL, and its exceljs cell anchor inverts into Univer's
+ * `sheetTransform` from/to plus an absolute `transform`. Returns null when the sheet has no
+ * embeddable images. Unsupported formats (anything but png/jpeg/gif) are skipped.
+ */
+function readImages(wb: ExcelJS.Workbook, ws: ExcelJS.Worksheet, sheet: IWorksheetData, sheetId: string): SheetDrawings | null {
+    const images = ws.getImages();
+    if (images.length === 0) return null;
+
+    const data: Record<string, object> = {};
+    const order: string[] = [];
+    images.forEach((image, index) => {
+        const drawing = buildDrawing(wb, sheet, sheetId, image, index);
+        if (!drawing) return;
+        data[drawing.drawingId] = drawing;
+        order.push(drawing.drawingId);
+    });
+
+    return order.length > 0 ? { data, order } : null;
+}
+
+function buildDrawing(wb: ExcelJS.Workbook, sheet: IWorksheetData, sheetId: string, image: ReturnType<ExcelJS.Worksheet["getImages"]>[number], index: number): { drawingId: string } & Record<string, unknown> | null {
+    const source = mediaToDataUrl(wb.getImage(Number(image.imageId)));
+    if (!source) return null;
+
+    const box = anchorToBox(sheet, image.range);
+    if (!box) return null;
+
+    // Univer keeps the orientation fields on every transform; imports are always upright.
+    const orientation = { angle: 0, flipX: false, flipY: false, skewX: 0, skewY: 0 };
+    const cellAnchor = { from: box.from, to: box.to, ...orientation };
+
+    return {
+        // The unitId is reconciled against the loaded workbook, so a placeholder is fine.
+        unitId: "imported",
+        subUnitId: sheetId,
+        drawingId: `image-${sheetId}-${index}`,
+        drawingType: 0,
+        imageSourceType: "BASE64",
+        source,
+        // The transform is in viewport space (includes the header gutters), matching the editor.
+        transform: { left: box.left + HEADER_WIDTH, top: box.top + HEADER_HEIGHT, width: box.width, height: box.height, ...orientation },
+        sheetTransform: cellAnchor,
+        axisAlignSheetTransform: cellAnchor
+    };
+}
+
+/** Converts an exceljs media entry to a base64 `data:` URL, or null for an unsupported format. */
+function mediaToDataUrl(media: { extension?: string; buffer?: Uint8Array | ArrayBuffer } | undefined): string | null {
+    const mime = imageMime(media?.extension);
+    if (!mime || !media?.buffer) return null;
+    const bytes = media.buffer instanceof Uint8Array ? media.buffer : new Uint8Array(media.buffer);
+    return `data:${mime};base64,${bytesToBase64(bytes)}`;
+}
+
+function imageMime(extension: string | undefined): string | null {
+    switch ((extension ?? "").toLowerCase()) {
+        case "png": return "image/png";
+        case "jpeg":
+        case "jpg": return "image/jpeg";
+        case "gif": return "image/gif";
+        default: return null;
+    }
+}
+
+/**
+ * Inverts an exceljs image range into Univer's content-space box: the `from`/`to` cell anchors plus
+ * the absolute `left`/`top`/`width`/`height`. The top-left comes from `tl`; the bottom-right from
+ * `br` (two-cell anchor) or `tl + ext` (one-cell anchor).
+ */
+function anchorToBox(sheet: IWorksheetData, range: ExcelJS.ImageRange): { from: CellAnchor; to: CellAnchor; left: number; top: number; width: number; height: number } | null {
+    const tl = range?.tl as { col: number; row: number } | undefined;
+    if (!tl) return null;
+
+    const left = colPointPx(sheet, tl.col);
+    const top = rowPointPx(sheet, tl.row);
+
+    const br = range.br as { col: number; row: number } | undefined;
+    const ext = (range as { ext?: { width: number; height: number } }).ext;
+
+    let to: CellAnchor;
+    let right: number;
+    let bottom: number;
+    if (br) {
+        to = pointToAnchor(sheet, br.col, br.row);
+        right = colPointPx(sheet, br.col);
+        bottom = rowPointPx(sheet, br.row);
+    } else if (ext) {
+        right = left + ext.width;
+        bottom = top + ext.height;
+        to = pxToAnchor(sheet, right, bottom);
+    } else {
+        return null;
+    }
+
+    return { from: pointToAnchor(sheet, tl.col, tl.row), to, left, top, width: Math.max(0, right - left), height: Math.max(0, bottom - top) };
+}
+
+/** A fractional `{col, row}` point → Univer cell anchor (index + px offset into that cell). */
+function pointToAnchor(sheet: IWorksheetData, col: number, row: number): CellAnchor {
+    const column = Math.floor(col);
+    const rowIndex = Math.floor(row);
+    return {
+        row: rowIndex,
+        rowOffset: (row - rowIndex) * rowHeightPx(sheet, rowIndex),
+        column,
+        columnOffset: (col - column) * columnWidthPx(sheet, column)
+    };
+}
+
+/** An absolute px point → Univer cell anchor, walking the per-track sizes to find the cell. */
+function pxToAnchor(sheet: IWorksheetData, x: number, y: number): CellAnchor {
+    const [column, columnOffset] = trackAtPx(x, (c) => columnWidthPx(sheet, c));
+    const [row, rowOffset] = trackAtPx(y, (r) => rowHeightPx(sheet, r));
+    return { row, rowOffset, column, columnOffset };
+}
+
+function trackAtPx(target: number, sizeOf: (index: number) => number): [number, number] {
+    if (target <= 0) return [0, 0];
+    let cumulative = 0;
+    for (let index = 0; index < 100_000; index++) {
+        const size = sizeOf(index);
+        if (size <= 0) continue;
+        if (cumulative + size > target) return [index, target - cumulative];
+        cumulative += size;
+    }
+    return [0, 0];
+}
+
+/** Absolute x of a fractional column point (content space, no header gutter). */
+function colPointPx(sheet: IWorksheetData, col: number): number {
+    const column = Math.floor(col);
+    let sum = 0;
+    for (let c = 0; c < column; c++) sum += columnWidthPx(sheet, c);
+    return sum + (col - column) * columnWidthPx(sheet, column);
+}
+
+function rowPointPx(sheet: IWorksheetData, row: number): number {
+    const rowIndex = Math.floor(row);
+    let sum = 0;
+    for (let r = 0; r < rowIndex; r++) sum += rowHeightPx(sheet, r);
+    return sum + (row - rowIndex) * rowHeightPx(sheet, rowIndex);
+}
+
+function columnWidthPx(sheet: IWorksheetData, col: number): number {
+    const w = sheet.columnData?.[col]?.w;
+    return isFiniteNumber(w) ? w : (sheet.defaultColumnWidth ?? 88);
+}
+
+function rowHeightPx(sheet: IWorksheetData, row: number): number {
+    const h = sheet.rowData?.[row]?.h;
+    return isFiniteNumber(h) ? h : (sheet.defaultRowHeight ?? 24);
+}
+
+/** Base64-encodes raw bytes in both Node (server import) and the browser. */
+function bytesToBase64(bytes: Uint8Array): string {
+    if (typeof Buffer !== "undefined") {
+        return Buffer.from(bytes).toString("base64");
+    }
+    let binary = "";
+    const CHUNK = 0x8000;
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+    }
+    return btoa(binary);
+}
+
+// #endregion
 
 function readCells(ws: ExcelJS.Worksheet): Record<number, Record<number, ICellData>> {
     const cellData: Record<number, Record<number, ICellData>> = {};

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
@@ -103,7 +103,11 @@ function readSheet(ws: ExcelJS.Worksheet, id: string): IWorksheetData {
         columnCount: Math.max(DEFAULT_COLUMN_COUNT, maxCol + 1),
         // exceljs reports a hidden sheet as state "hidden"/"veryHidden".
         hidden: ws.state && ws.state !== "visible" ? 1 : 0,
-        showGridlines: ws.views?.[0]?.showGridLines === false ? 0 : 1
+        showGridlines: ws.views?.[0]?.showGridLines === false ? 0 : 1,
+        // Record Univer's default header gutters so the share renderer's image-offset subtraction
+        // matches the offset baked into each drawing's transform (see HEADER_WIDTH/HEIGHT below).
+        rowHeader: { width: HEADER_WIDTH, hidden: 0 },
+        columnHeader: { height: HEADER_HEIGHT, hidden: 0 }
     };
 
     if (isFiniteNumber(ws.properties?.defaultColWidth)) {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1403,6 +1403,40 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("top:100px");
     });
 
+    it("extends the grid down to cover a floating image below the data rows", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 50, height: 240 })
+            ])
+        );
+        // Default 24px rows: the image bottom at 240px reaches row 9, so 10 rows are emitted.
+        const rowCount = (html.match(/<tr/g) ?? []).length;
+        expect(rowCount).toBe(10);
+    });
+
+    it("extends the grid right to cover a floating image beyond the data columns", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 200, height: 10 })
+            ])
+        );
+        // Default 88px columns: the image right edge at 200px reaches column 2, so 3 columns emit.
+        const colCount = (html.match(/<col /g) ?? []).length;
+        expect(colCount).toBe(3);
+    });
+
+    it("does not shrink the grid when a floating image fits within the data bounds", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings(
+                [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 50, height: 10 })],
+                { cellData: { "5": { "0": { v: "x" } } } }
+            )
+        );
+        // Data extends to row 5 (6 rows); the small image must not reduce that.
+        const rowCount = (html.match(/<tr/g) ?? []).length;
+        expect(rowCount).toBe(6);
+    });
+
     it("preserves floating image z-order", () => {
         const html = renderSpreadsheetToHtml(
             workbookWithFloatingDrawings([

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -625,6 +625,47 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("<td>x</td>");
     });
 
+    it("wraps a cell whose style enables the wrap strategy", () => {
+        // Univer WrapStrategy.WRAP === 3. Cells default to nowrap (overflow) via the stylesheet;
+        // a wrapping cell must opt back into normal wrapping inline.
+        const html = renderSpreadsheetToHtml(
+            singleCellWorkbook({ v: "This is a cell with line-wrapping", t: 1, s: { tb: 3 } })
+        );
+        expect(html).toContain("white-space:normal");
+        expect(html).toContain("overflow-wrap:break-word");
+    });
+
+    it("wraps a cell via a referenced style that enables wrapping", () => {
+        const input = JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: { wrapStyle: { tb: 3 } },
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        rowCount: 10,
+                        columnCount: 5,
+                        mergeData: [],
+                        cellData: { "0": { "0": { v: "wrapped", s: "wrapStyle" } } },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        });
+        const html = renderSpreadsheetToHtml(input);
+        expect(html).toContain("white-space:normal");
+    });
+
+    it("does not emit wrap styling for a non-wrapping (overflow) cell", () => {
+        // WrapStrategy.OVERFLOW === 1 -> the cell keeps the default nowrap/overflow behaviour.
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "plain", s: { tb: 1 } }));
+        expect(html).not.toContain("white-space:normal");
+    });
+
     it("renders all vertical alignment values", () => {
         const top = renderSpreadsheetToHtml(singleCellWorkbook({ v: "t", s: { vt: 1 } }));
         const middle = renderSpreadsheetToHtml(singleCellWorkbook({ v: "m", s: { vt: 2 } }));
@@ -1095,7 +1136,34 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(
             singleCellWorkbook({ v: "x" }, { showGridlines: 1 })
         );
-        expect(html).toContain('<table class="spreadsheet-table show-gridlines">');
+        expect(html).toContain('<table class="spreadsheet-table show-gridlines" style="width:88px">');
+    });
+
+    it("emits an explicit fixed table width summing the visible column widths", () => {
+        const input = JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        rowCount: 10,
+                        columnCount: 5,
+                        defaultColumnWidth: 88,
+                        mergeData: [],
+                        cellData: { "0": { "0": { v: "a" }, "1": { v: "b" } } },
+                        rowData: {},
+                        columnData: { "0": { w: 120 } }
+                    }
+                }
+            }
+        });
+        const html = renderSpreadsheetToHtml(input);
+        // Column 0 is 120, column 1 falls back to the default 88 -> 208.
+        expect(html).toContain('style="width:208px"');
     });
 
     it("marks a filled cell with has-fill so gridlines can be suppressed under the fill", () => {
@@ -1147,7 +1215,7 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(
             singleCellWorkbook({ v: "x" }, { showGridlines: 0 })
         );
-        expect(html).toContain('<table class="spreadsheet-table">');
+        expect(html).toContain('<table class="spreadsheet-table" style="width:88px">');
         expect(html).not.toContain("show-gridlines");
     });
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1472,6 +1472,43 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("top:208.8px");
     });
 
+    it("rotates a floating image by its transform angle", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                { drawingId: "img1", imageSourceType: "URL", source: "api/attachments/cgN4jEBCA1Kn/image/image.png", transform: { left: 0, top: 0, width: 50, height: 50, angle: 45 } }
+            ])
+        );
+        expect(html).toContain("transform:rotate(45deg)");
+    });
+
+    it("flips a floating image horizontally and vertically", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                { drawingId: "img1", source: "api/attachments/cgN4jEBCA1Kn/image/image.png", transform: { left: 0, top: 0, width: 50, height: 50, flipX: true, flipY: true } }
+            ])
+        );
+        expect(html).toContain("scaleX(-1)");
+        expect(html).toContain("scaleY(-1)");
+    });
+
+    it("combines rotation and flip (flip first, then rotate)", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                { drawingId: "img1", source: "api/attachments/cgN4jEBCA1Kn/image/image.png", transform: { left: 0, top: 0, width: 50, height: 50, angle: 90, flipX: true } }
+            ])
+        );
+        expect(html).toContain("transform:rotate(90deg) scaleX(-1)");
+    });
+
+    it("does not emit a transform for an unrotated, unflipped image", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 50, height: 50 })
+            ])
+        );
+        expect(html).not.toContain("transform:");
+    });
+
     it("renders a base64 floating image", () => {
         const html = renderSpreadsheetToHtml(
             workbookWithFloatingDrawings([

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1390,17 +1390,17 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("height:80px");
     });
 
-    it("offsets a floating image by the trimmed table origin", () => {
-        // Data only at row 2, col 1 -> the table is trimmed; origin is the px distance
-        // from A1 to that corner: 2 default rows (48px) down, 1 default col (88px) right.
+    it("positions a floating image at its absolute sheet coordinates regardless of where data starts", () => {
+        // Data only at row 2, col 1. Because the grid is rendered from the sheet origin (A1),
+        // the floating image keeps the absolute transform coordinates Univer stored (no offset).
         const html = renderSpreadsheetToHtml(
             workbookWithFloatingDrawings(
                 [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 200, top: 100, width: 50, height: 40 })],
                 { cellData: { "2": { "1": { v: "x" } } } }
             )
         );
-        expect(html).toContain("left:112px"); // 200 - 88
-        expect(html).toContain("top:52px"); // 100 - 48
+        expect(html).toContain("left:200px");
+        expect(html).toContain("top:100px");
     });
 
     it("preserves floating image z-order", () => {
@@ -1461,6 +1461,47 @@ describe("renderSpreadsheetToHtml", () => {
     });
 
     // #endregion
+
+    // Wraps a single value placed at an arbitrary (row, col) into a complete workbook payload.
+    function cellAtWorkbook(row: number, col: number): string {
+        return JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        rowCount: 1000,
+                        columnCount: 20,
+                        defaultColumnWidth: 88,
+                        defaultRowHeight: 24,
+                        mergeData: [],
+                        cellData: { [row]: { [col]: { v: "x" } } },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        });
+    }
+
+    it("renders leading empty rows so the grid starts at the sheet origin", () => {
+        // Data only at row 2 -> rows 0 and 1 must still be emitted (empty) so the grid keeps the
+        // editor's geometry and absolutely-positioned floating images line up.
+        const html = renderSpreadsheetToHtml(cellAtWorkbook(2, 0));
+        const rowCount = (html.match(/<tr/g) ?? []).length;
+        expect(rowCount).toBe(3);
+    });
+
+    it("renders leading empty columns so the grid starts at the sheet origin", () => {
+        // Data only at column 2 -> columns 0 and 1 must still be emitted.
+        const html = renderSpreadsheetToHtml(cellAtWorkbook(0, 2));
+        const colCount = (html.match(/<col /g) ?? []).length;
+        expect(colCount).toBe(3);
+    });
 
     it("extends bounds to cover a merge range that exceeds the cell data", () => {
         const input = JSON.stringify({

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1173,6 +1173,227 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("--spreadsheet-gridline-color:transparent");
     });
 
+    // Builds a workbook whose single sheet carries floating drawings in the
+    // SHEET_DRAWING_PLUGIN resource (Univer's z-ordered floating images).
+    function workbookWithFloatingDrawings(
+        drawings: Array<Record<string, unknown> & { drawingId: string }>,
+        opts: { cellData?: unknown; rowData?: unknown; columnData?: unknown } = {}
+    ): string {
+        const sheetId = "s1";
+        const data: Record<string, unknown> = {};
+        for (const d of drawings) data[d.drawingId] = d;
+        const order = drawings.map((d) => d.drawingId);
+        return JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: [sheetId],
+                styles: {},
+                sheets: {
+                    [sheetId]: {
+                        id: sheetId,
+                        name: "Sheet1",
+                        hidden: 0,
+                        rowCount: 1000,
+                        columnCount: 20,
+                        defaultColumnWidth: 88,
+                        defaultRowHeight: 24,
+                        mergeData: [],
+                        cellData: opts.cellData ?? { "0": { "0": { v: "anchor" } } },
+                        rowData: opts.rowData ?? {},
+                        columnData: opts.columnData ?? {}
+                    }
+                },
+                resources: [
+                    { name: "SHEET_DRAWING_PLUGIN", data: JSON.stringify({ [sheetId]: { data, order } }) },
+                    { name: "SHEET_DATA_VALIDATION_PLUGIN", data: JSON.stringify({ [sheetId]: [] }) }
+                ]
+            }
+        });
+    }
+
+    const urlDrawing = (id: string, source: string, transform: Record<string, number>) => ({
+        drawingId: id,
+        unitId: "u",
+        subUnitId: "s1",
+        drawingType: 0,
+        imageSourceType: "URL",
+        source,
+        transform
+    });
+
+    // #region Cell images (cellData[r][c].p.drawings)
+
+    it("renders a cell image embedded in a cell's rich-text document", () => {
+        const html = renderSpreadsheetToHtml(
+            singleCellWorkbook({
+                p: {
+                    drawings: {
+                        d1: {
+                            drawingId: "d1",
+                            imageSourceType: "URL",
+                            source: "api/attachments/NyhtJbXR6Qxh/image/image.png",
+                            transform: { width: 113, height: 96.72268495835375 }
+                        }
+                    },
+                    drawingsOrder: ["d1"]
+                }
+            })
+        );
+        expect(html).toContain('<img class="spreadsheet-cell-image"');
+        expect(html).toContain('src="api/attachments/NyhtJbXR6Qxh/image/image.png"');
+        // The image lives inside a table cell, not a floating wrapper.
+        expect(html).toContain("<td");
+        expect(html).not.toContain("spreadsheet-sheet");
+        // Dimensions come from the drawing transform, rounded to 2 decimals.
+        expect(html).toContain("width:113px");
+        expect(html).toContain("height:96.72px");
+    });
+
+    it("renders a base64 cell image", () => {
+        const html = renderSpreadsheetToHtml(
+            singleCellWorkbook({
+                p: {
+                    drawings: {
+                        d1: {
+                            drawingId: "d1",
+                            imageSourceType: "BASE64",
+                            source: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==",
+                            transform: { width: 10, height: 10 }
+                        }
+                    },
+                    drawingsOrder: ["d1"]
+                }
+            })
+        );
+        expect(html).toContain('src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="');
+    });
+
+    it("renders multiple cell images in drawingsOrder", () => {
+        const html = renderSpreadsheetToHtml(
+            singleCellWorkbook({
+                p: {
+                    drawings: {
+                        first: { drawingId: "first", source: "api/attachments/AAAAAAAAAAAA/image/a.png", transform: { width: 5, height: 5 } },
+                        second: { drawingId: "second", source: "api/attachments/BBBBBBBBBBBB/image/b.png", transform: { width: 5, height: 5 } }
+                    },
+                    drawingsOrder: ["first", "second"]
+                }
+            })
+        );
+        expect(html.indexOf("AAAAAAAAAAAA")).toBeLessThan(html.indexOf("BBBBBBBBBBBB"));
+    });
+
+    it("skips a cell image with an unsafe source", () => {
+        const html = renderSpreadsheetToHtml(
+            singleCellWorkbook({
+                p: {
+                    drawings: {
+                        d1: { drawingId: "d1", source: "javascript:alert(1)", transform: { width: 10, height: 10 } },
+                        d2: { drawingId: "d2", source: "http://evil.example/x.png", transform: { width: 10, height: 10 } }
+                    },
+                    drawingsOrder: ["d1", "d2"]
+                }
+            })
+        );
+        expect(html).not.toContain("<img");
+        expect(html).not.toContain("javascript:");
+        expect(html).not.toContain("evil.example");
+    });
+
+    // #endregion
+
+    // #region Floating images (SHEET_DRAWING_PLUGIN resource)
+
+    it("renders a floating image absolutely positioned in a per-sheet wrapper", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 50, top: 60, width: 100, height: 80 })
+            ])
+        );
+        expect(html).toContain('<div class="spreadsheet-sheet"');
+        expect(html).toContain("position:relative");
+        expect(html).toContain('<img class="spreadsheet-floating-image"');
+        expect(html).toContain('src="api/attachments/cgN4jEBCA1Kn/image/image.png"');
+        expect(html).toContain("position:absolute");
+        // Anchor cell is at (0,0), so the origin offset is zero.
+        expect(html).toContain("left:50px");
+        expect(html).toContain("top:60px");
+        expect(html).toContain("width:100px");
+        expect(html).toContain("height:80px");
+    });
+
+    it("offsets a floating image by the trimmed table origin", () => {
+        // Data only at row 2, col 1 -> the table is trimmed; origin is the px distance
+        // from A1 to that corner: 2 default rows (48px) down, 1 default col (88px) right.
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings(
+                [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 200, top: 100, width: 50, height: 40 })],
+                { cellData: { "2": { "1": { v: "x" } } } }
+            )
+        );
+        expect(html).toContain("left:112px"); // 200 - 88
+        expect(html).toContain("top:52px"); // 100 - 48
+    });
+
+    it("preserves floating image z-order", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/AAAAAAAAAAAA/image/a.png", { left: 0, top: 0, width: 10, height: 10 }),
+                urlDrawing("img2", "api/attachments/BBBBBBBBBBBB/image/b.png", { left: 0, top: 0, width: 10, height: 10 })
+            ])
+        );
+        expect(html.indexOf("AAAAAAAAAAAA")).toBeLessThan(html.indexOf("BBBBBBBBBBBB"));
+    });
+
+    it("renders a base64 floating image", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                { drawingId: "img1", imageSourceType: "BASE64", source: "data:image/jpeg;base64,/9j/4AAQSk==", transform: { left: 0, top: 0, width: 10, height: 10 } }
+            ])
+        );
+        expect(html).toContain('src="data:image/jpeg;base64,/9j/4AAQSk=="');
+    });
+
+    it("rounds fractional floating-image coordinates to two decimals", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 262.3, top: 458.1, width: 549.4, height: 148.555 })
+            ])
+        );
+        expect(html).toContain("width:549.4px");
+        expect(html).toContain("height:148.56px");
+    });
+
+    it("does not wrap the sheet when all floating drawings have unsafe sources", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                { drawingId: "img1", imageSourceType: "URL", source: "http://evil.example/x.png", transform: { left: 0, top: 0, width: 10, height: 10 } }
+            ])
+        );
+        expect(html).not.toContain("spreadsheet-sheet");
+        expect(html).not.toContain("<img");
+        expect(html).not.toContain("evil.example");
+    });
+
+    it("does not add a floating wrapper to a sheet without drawings", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x" }));
+        expect(html).not.toContain("spreadsheet-sheet");
+        expect(html).not.toContain("<img");
+    });
+
+    it("escapes a quote in an attachment-image source", () => {
+        // A crafted source that passes the prefix check but carries an attribute-breaking quote.
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings([
+                urlDrawing("img1", 'api/attachments/AAAAAAAAAAAA/image/"onerror=alert(1).png', { left: 0, top: 0, width: 10, height: 10 })
+            ])
+        );
+        expect(html).not.toContain('"onerror=alert(1)');
+        expect(html).toContain("&quot;onerror");
+    });
+
+    // #endregion
+
     it("extends bounds to cover a merge range that exceeds the cell data", () => {
         const input = JSON.stringify({
             version: 1,

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1245,7 +1245,7 @@ describe("renderSpreadsheetToHtml", () => {
     // SHEET_DRAWING_PLUGIN resource (Univer's z-ordered floating images).
     function workbookWithFloatingDrawings(
         drawings: Array<Record<string, unknown> & { drawingId: string }>,
-        opts: { cellData?: unknown; rowData?: unknown; columnData?: unknown } = {}
+        opts: { cellData?: unknown; rowData?: unknown; columnData?: unknown; sheetExtra?: Record<string, unknown> } = {}
     ): string {
         const sheetId = "s1";
         const data: Record<string, unknown> = {};
@@ -1268,7 +1268,8 @@ describe("renderSpreadsheetToHtml", () => {
                         mergeData: [],
                         cellData: opts.cellData ?? { "0": { "0": { v: "anchor" } } },
                         rowData: opts.rowData ?? {},
-                        columnData: opts.columnData ?? {}
+                        columnData: opts.columnData ?? {},
+                        ...(opts.sheetExtra ?? {})
                     }
                 },
                 resources: [
@@ -1445,6 +1446,30 @@ describe("renderSpreadsheetToHtml", () => {
             ])
         );
         expect(html.indexOf("AAAAAAAAAAAA")).toBeLessThan(html.indexOf("BBBBBBBBBBBB"));
+    });
+
+    it("shifts floating images by the row/column header sizes (Univer transforms include headers)", () => {
+        // Univer measures transform.left/top from the viewport corner, including the row header
+        // (width 46) and column header (height 20). The HTML grid has no headers, so subtract them.
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings(
+                [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 77, top: 208.8, width: 100, height: 80 })],
+                { sheetExtra: { rowHeader: { width: 46, hidden: 0 }, columnHeader: { height: 20, hidden: 0 } } }
+            )
+        );
+        expect(html).toContain("left:31px"); // 77 - 46
+        expect(html).toContain("top:188.8px"); // 208.8 - 20
+    });
+
+    it("does not subtract header sizes when the headers are hidden", () => {
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings(
+                [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 77, top: 208.8, width: 100, height: 80 })],
+                { sheetExtra: { rowHeader: { width: 46, hidden: 1 }, columnHeader: { height: 20, hidden: 1 } } }
+            )
+        );
+        expect(html).toContain("left:77px");
+        expect(html).toContain("top:208.8px");
     });
 
     it("renders a base64 floating image", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -57,9 +57,9 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
         if (visibleSheets.length > 1) {
             parts.push(`<h3>${escapeHtml(sheet.name)}</h3>`);
         }
-        const drawings = getFloatingDrawings(workbook, sheet.id);
-        const table = renderSheet(sheet, workbook.styles ?? {}, drawings);
-        parts.push(wrapWithFloatingImages(table, drawings));
+        const images = placeFloatingImages(sheet, getFloatingDrawings(workbook, sheet.id));
+        const table = renderSheet(sheet, workbook.styles ?? {}, images);
+        parts.push(wrapWithFloatingImages(table, images));
     }
 
     return parts.join("\n");
@@ -67,37 +67,61 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
 
 // #region Images
 
-/**
- * Wraps a rendered sheet table in a positioned container carrying the sheet's floating images, each
- * placed absolutely. Univer stores a floating image's `transform.left`/`top` in px from the sheet
- * origin (A1); the table is also rendered from A1 (leading empty rows/columns included), so those
- * coordinates apply directly. The container's `min-height` is stretched to contain images that
- * float below the table so they don't overlap following content. Returns the table unchanged when
- * the sheet has no renderable floating images.
- */
-function wrapWithFloatingImages(tableHtml: string, drawings: ISheetDrawing[]): string {
-    if (drawings.length === 0) return tableHtml;
+/** A floating image resolved to its content-space box (header offsets removed), ready to emit. */
+interface PlacedImage {
+    src: string;
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}
 
-    const images: string[] = [];
-    let maxBottom = 0;
+/**
+ * Resolves a sheet's floating drawings to renderable boxes in the grid's content coordinate space.
+ * Univer measures `transform.left`/`top` from the viewport corner, *including* the row and column
+ * headers; the HTML grid has no headers, so the header sizes are subtracted to land on A1. Drawings
+ * with an unsafe source or no transform are dropped.
+ */
+function placeFloatingImages(sheet: IWorksheetData, drawings: ISheetDrawing[]): PlacedImage[] {
+    const headerWidth = sheet.rowHeader?.hidden ? 0 : (isFiniteNumber(sheet.rowHeader?.width) ? sheet.rowHeader.width : 0);
+    const headerHeight = sheet.columnHeader?.hidden ? 0 : (isFiniteNumber(sheet.columnHeader?.height) ? sheet.columnHeader.height : 0);
+
+    const placed: PlacedImage[] = [];
     for (const drawing of drawings) {
         const src = sanitizeImageSource(drawing.source);
         if (!src || !drawing.transform) continue;
 
-        const left = toFinite(drawing.transform.left);
-        const top = toFinite(drawing.transform.top);
-        const width = toFinite(drawing.transform.width);
-        const height = toFinite(drawing.transform.height);
-        maxBottom = Math.max(maxBottom, top + height);
+        placed.push({
+            src,
+            left: toFinite(drawing.transform.left) - headerWidth,
+            top: toFinite(drawing.transform.top) - headerHeight,
+            width: toFinite(drawing.transform.width),
+            height: toFinite(drawing.transform.height)
+        });
+    }
+    return placed;
+}
 
-        images.push(
-            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(left)}px;top:${px(top)}px;width:${px(width)}px;height:${px(height)}px" src="${escapeHtml(src)}" alt="">`
+/**
+ * Wraps a rendered sheet table in a positioned container carrying the sheet's floating images, each
+ * placed absolutely at its content-space coordinates (the table is rendered from A1 with no header
+ * gutter, so those coordinates apply directly). The container's `min-height` is stretched to contain
+ * images that float below the table so they don't overlap following content. Returns the table
+ * unchanged when the sheet has no renderable floating images.
+ */
+function wrapWithFloatingImages(tableHtml: string, images: PlacedImage[]): string {
+    if (images.length === 0) return tableHtml;
+
+    let maxBottom = 0;
+    const tags: string[] = [];
+    for (const image of images) {
+        maxBottom = Math.max(maxBottom, image.top + image.height);
+        tags.push(
+            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(image.left)}px;top:${px(image.top)}px;width:${px(image.width)}px;height:${px(image.height)}px" src="${escapeHtml(image.src)}" alt="">`
         );
     }
 
-    if (images.length === 0) return tableHtml;
-
-    return `<div class="spreadsheet-sheet" style="position:relative;min-height:${px(maxBottom)}px">\n${tableHtml}\n${images.join("\n")}\n</div>`;
+    return `<div class="spreadsheet-sheet" style="position:relative;min-height:${px(maxBottom)}px">\n${tableHtml}\n${tags.join("\n")}\n</div>`;
 }
 
 /** Renders the images embedded in a cell's rich-text document (`cell.p.drawings`), in order. */
@@ -148,18 +172,17 @@ function toFinite(value: number | undefined): number {
 }
 
 /**
- * Grows a sheet's max row/column to enclose its renderable floating images. Univer anchors images
- * in absolute px from A1, so an image can reach below or to the right of the last populated cell;
- * extending the bounds makes the grid render enough empty rows/columns to contain it, matching the
- * editor. Unsafe or transform-less drawings are ignored. Returns the bounds unchanged otherwise.
+ * Grows a sheet's max row/column to enclose its floating images. An image placed in content space
+ * can reach below or to the right of the last populated cell; extending the bounds makes the grid
+ * render enough empty rows/columns to contain it, matching the editor. Returns the bounds unchanged
+ * when no image reaches past them.
  */
-function extendBoundsForDrawings(sheet: IWorksheetData, maxRow: number, maxCol: number, drawings: ISheetDrawing[]): { maxRow: number; maxCol: number } {
+function extendBoundsForImages(sheet: IWorksheetData, maxRow: number, maxCol: number, images: PlacedImage[]): { maxRow: number; maxCol: number } {
     let bottomPx = 0;
     let rightPx = 0;
-    for (const drawing of drawings) {
-        if (!drawing.transform || !sanitizeImageSource(drawing.source)) continue;
-        bottomPx = Math.max(bottomPx, toFinite(drawing.transform.top) + toFinite(drawing.transform.height));
-        rightPx = Math.max(rightPx, toFinite(drawing.transform.left) + toFinite(drawing.transform.width));
+    for (const image of images) {
+        bottomPx = Math.max(bottomPx, image.top + image.height);
+        rightPx = Math.max(rightPx, image.left + image.width);
     }
     if (bottomPx <= 0 && rightPx <= 0) return { maxRow, maxCol };
 
@@ -190,13 +213,13 @@ function trackIndexAtPx(targetPx: number, defaultSize: number, count: number | u
 
 // #endregion
 
-function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>, drawings: ISheetDrawing[]): string {
+function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>, images: PlacedImage[]): string {
     const { cellData, mergeData = [], columnData = {}, rowData = {} } = sheet;
 
     // Determine the actual bounds (only cells with data), then extend them to cover any floating
     // images that reach past the data so the grid encloses them like the editor does.
     const bounds = computeBounds(cellData, mergeData);
-    const { maxRow, maxCol } = extendBoundsForDrawings(sheet, bounds?.maxRow ?? -1, bounds?.maxCol ?? -1, drawings);
+    const { maxRow, maxCol } = extendBoundsForImages(sheet, bounds?.maxRow ?? -1, bounds?.maxCol ?? -1, images);
     if (maxRow < 0 || maxCol < 0) {
         return "<p>Empty sheet.</p>";
     }

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -67,20 +67,16 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
 // #region Images
 
 /**
- * Wraps a rendered sheet table in a positioned container carrying the sheet's floating images,
- * each placed absolutely. Univer stores a floating image's `transform.left`/`top` in px from the
- * sheet origin (A1), but the table is trimmed to populated cells, so positions are shifted by the
- * px distance from A1 to the trimmed top-left corner. The container's `min-height` is stretched to
- * contain images that float below the table so they don't overlap following content. Returns the
- * table unchanged when the sheet has no renderable floating images.
+ * Wraps a rendered sheet table in a positioned container carrying the sheet's floating images, each
+ * placed absolutely. Univer stores a floating image's `transform.left`/`top` in px from the sheet
+ * origin (A1); the table is also rendered from A1 (leading empty rows/columns included), so those
+ * coordinates apply directly. The container's `min-height` is stretched to contain images that
+ * float below the table so they don't overlap following content. Returns the table unchanged when
+ * the sheet has no renderable floating images.
  */
 function wrapWithFloatingImages(workbook: IWorkbookData, sheet: IWorksheetData, tableHtml: string): string {
     const drawings = getFloatingDrawings(workbook, sheet.id);
     if (drawings.length === 0) return tableHtml;
-
-    const bounds = computeBounds(sheet.cellData, sheet.mergeData ?? []);
-    const originX = bounds ? sumColumnWidths(sheet, 0, bounds.minCol) : 0;
-    const originY = bounds ? sumRowHeights(sheet, 0, bounds.minRow) : 0;
 
     const images: string[] = [];
     let maxBottom = 0;
@@ -88,8 +84,8 @@ function wrapWithFloatingImages(workbook: IWorkbookData, sheet: IWorksheetData, 
         const src = sanitizeImageSource(drawing.source);
         if (!src || !drawing.transform) continue;
 
-        const left = toFinite(drawing.transform.left) - originX;
-        const top = toFinite(drawing.transform.top) - originY;
+        const left = toFinite(drawing.transform.left);
+        const top = toFinite(drawing.transform.top);
         const width = toFinite(drawing.transform.width);
         const height = toFinite(drawing.transform.height);
         maxBottom = Math.max(maxBottom, top + height);
@@ -127,30 +123,6 @@ function renderCellImages(cell: ICellData): string {
     return images.join("");
 }
 
-function sumRowHeights(sheet: IWorksheetData, fromRow: number, toRowExclusive: number): number {
-    const rowData = sheet.rowData ?? {};
-    const defaultHeight = sheet.defaultRowHeight ?? 24;
-    let sum = 0;
-    for (let row = fromRow; row < toRowExclusive; row++) {
-        const meta = rowData[row];
-        if (meta?.hd) continue;
-        sum += isFiniteNumber(meta?.h) ? meta.h : defaultHeight;
-    }
-    return sum;
-}
-
-function sumColumnWidths(sheet: IWorksheetData, fromCol: number, toColExclusive: number): number {
-    const columnData = sheet.columnData ?? {};
-    const defaultWidth = sheet.defaultColumnWidth ?? 88;
-    let sum = 0;
-    for (let col = fromCol; col < toColExclusive; col++) {
-        const meta = columnData[col];
-        if (meta?.hd) continue;
-        sum += isFiniteNumber(meta?.w) ? meta.w : defaultWidth;
-    }
-    return sum;
-}
-
 /**
  * Validates an image source for inclusion in shared/exported HTML. Accepts only the relative
  * attachment-image URL Trilium emits (`api/attachments/<id>/image/...`, served by both the app
@@ -186,7 +158,12 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
         return "<p>Empty sheet.</p>";
     }
 
-    const { minRow, maxRow, minCol, maxCol } = bounds;
+    // Render from the sheet origin (A1), not the first populated cell: Univer positions floating
+    // images in absolute px from A1, and emitting the leading empty rows/columns keeps the grid in
+    // step with the editor so those images line up. Only trailing empty rows/columns are trimmed.
+    const { maxRow, maxCol } = bounds;
+    const minRow = 0;
+    const minCol = 0;
 
     // Build a set of cells that are hidden by merges (non-origin cells).
     const mergeMap = buildMergeMap(mergeData, minRow, maxRow, minCol, maxCol);

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -22,8 +22,8 @@ import {
     type ICellData,
     isFiniteNumber,
     type IRange,
+    type ISheetDrawing,
     type IStyleData,
-    type IWorkbookData,
     type IWorksheetData,
     parseWorkbookData,
     resolveCellStyle,
@@ -57,8 +57,9 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
         if (visibleSheets.length > 1) {
             parts.push(`<h3>${escapeHtml(sheet.name)}</h3>`);
         }
-        const table = renderSheet(sheet, workbook.styles ?? {});
-        parts.push(wrapWithFloatingImages(workbook, sheet, table));
+        const drawings = getFloatingDrawings(workbook, sheet.id);
+        const table = renderSheet(sheet, workbook.styles ?? {}, drawings);
+        parts.push(wrapWithFloatingImages(table, drawings));
     }
 
     return parts.join("\n");
@@ -74,8 +75,7 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
  * float below the table so they don't overlap following content. Returns the table unchanged when
  * the sheet has no renderable floating images.
  */
-function wrapWithFloatingImages(workbook: IWorkbookData, sheet: IWorksheetData, tableHtml: string): string {
-    const drawings = getFloatingDrawings(workbook, sheet.id);
+function wrapWithFloatingImages(tableHtml: string, drawings: ISheetDrawing[]): string {
     if (drawings.length === 0) return tableHtml;
 
     const images: string[] = [];
@@ -147,21 +147,63 @@ function toFinite(value: number | undefined): number {
     return isFiniteNumber(value) ? value : 0;
 }
 
+/**
+ * Grows a sheet's max row/column to enclose its renderable floating images. Univer anchors images
+ * in absolute px from A1, so an image can reach below or to the right of the last populated cell;
+ * extending the bounds makes the grid render enough empty rows/columns to contain it, matching the
+ * editor. Unsafe or transform-less drawings are ignored. Returns the bounds unchanged otherwise.
+ */
+function extendBoundsForDrawings(sheet: IWorksheetData, maxRow: number, maxCol: number, drawings: ISheetDrawing[]): { maxRow: number; maxCol: number } {
+    let bottomPx = 0;
+    let rightPx = 0;
+    for (const drawing of drawings) {
+        if (!drawing.transform || !sanitizeImageSource(drawing.source)) continue;
+        bottomPx = Math.max(bottomPx, toFinite(drawing.transform.top) + toFinite(drawing.transform.height));
+        rightPx = Math.max(rightPx, toFinite(drawing.transform.left) + toFinite(drawing.transform.width));
+    }
+    if (bottomPx <= 0 && rightPx <= 0) return { maxRow, maxCol };
+
+    return {
+        maxRow: Math.max(maxRow, trackIndexAtPx(bottomPx, sheet.defaultRowHeight ?? 24, sheet.rowCount, (i) => sheet.rowData?.[i])),
+        maxCol: Math.max(maxCol, trackIndexAtPx(rightPx, sheet.defaultColumnWidth ?? 88, sheet.columnCount, (i) => sheet.columnData?.[i]))
+    };
+}
+
+/**
+ * Returns the 0-based index of the last row/column needed to reach `targetPx` from the sheet
+ * origin, walking the per-track sizes (`h`/`w`, hidden tracks contributing 0) and falling back to
+ * `defaultSize`. Bounded by `count` (or a large cap) so a zero/degenerate size can't loop forever.
+ */
+function trackIndexAtPx(targetPx: number, defaultSize: number, count: number | undefined, meta: (index: number) => { hd?: number; h?: number; w?: number } | undefined): number {
+    if (targetPx <= 0 || defaultSize <= 0) return 0;
+    const cap = isFiniteNumber(count) && count > 0 ? count : 100000;
+    let cumulative = 0;
+    let index = 0;
+    while (cumulative < targetPx && index < cap) {
+        const track = meta(index);
+        const size = track?.h ?? track?.w;
+        cumulative += track?.hd ? 0 : (isFiniteNumber(size) ? size : defaultSize);
+        index++;
+    }
+    return index - 1;
+}
+
 // #endregion
 
-function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>): string {
+function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>, drawings: ISheetDrawing[]): string {
     const { cellData, mergeData = [], columnData = {}, rowData = {} } = sheet;
 
-    // Determine the actual bounds (only cells with data).
+    // Determine the actual bounds (only cells with data), then extend them to cover any floating
+    // images that reach past the data so the grid encloses them like the editor does.
     const bounds = computeBounds(cellData, mergeData);
-    if (!bounds) {
+    const { maxRow, maxCol } = extendBoundsForDrawings(sheet, bounds?.maxRow ?? -1, bounds?.maxCol ?? -1, drawings);
+    if (maxRow < 0 || maxCol < 0) {
         return "<p>Empty sheet.</p>";
     }
 
     // Render from the sheet origin (A1), not the first populated cell: Univer positions floating
     // images in absolute px from A1, and emitting the leading empty rows/columns keeps the grid in
     // step with the editor so those images line up. Only trailing empty rows/columns are trimmed.
-    const { maxRow, maxCol } = bounds;
     const minRow = 0;
     const minCol = 0;
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -15,6 +15,7 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 import {
     BorderStyle,
     computeBounds,
+    getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
     type IBorderStyleData,
@@ -22,6 +23,7 @@ import {
     isFiniteNumber,
     type IRange,
     type IStyleData,
+    type IWorkbookData,
     type IWorksheetData,
     parseWorkbookData,
     resolveCellStyle,
@@ -54,11 +56,125 @@ export function renderSpreadsheetToHtml(jsonContent: string): string {
         if (visibleSheets.length > 1) {
             parts.push(`<h3>${escapeHtml(sheet.name)}</h3>`);
         }
-        parts.push(renderSheet(sheet, workbook.styles ?? {}));
+        const table = renderSheet(sheet, workbook.styles ?? {});
+        parts.push(wrapWithFloatingImages(workbook, sheet, table));
     }
 
     return parts.join("\n");
 }
+
+// #region Images
+
+/**
+ * Wraps a rendered sheet table in a positioned container carrying the sheet's floating images,
+ * each placed absolutely. Univer stores a floating image's `transform.left`/`top` in px from the
+ * sheet origin (A1), but the table is trimmed to populated cells, so positions are shifted by the
+ * px distance from A1 to the trimmed top-left corner. The container's `min-height` is stretched to
+ * contain images that float below the table so they don't overlap following content. Returns the
+ * table unchanged when the sheet has no renderable floating images.
+ */
+function wrapWithFloatingImages(workbook: IWorkbookData, sheet: IWorksheetData, tableHtml: string): string {
+    const drawings = getFloatingDrawings(workbook, sheet.id);
+    if (drawings.length === 0) return tableHtml;
+
+    const bounds = computeBounds(sheet.cellData, sheet.mergeData ?? []);
+    const originX = bounds ? sumColumnWidths(sheet, 0, bounds.minCol) : 0;
+    const originY = bounds ? sumRowHeights(sheet, 0, bounds.minRow) : 0;
+
+    const images: string[] = [];
+    let maxBottom = 0;
+    for (const drawing of drawings) {
+        const src = sanitizeImageSource(drawing.source);
+        if (!src || !drawing.transform) continue;
+
+        const left = toFinite(drawing.transform.left) - originX;
+        const top = toFinite(drawing.transform.top) - originY;
+        const width = toFinite(drawing.transform.width);
+        const height = toFinite(drawing.transform.height);
+        maxBottom = Math.max(maxBottom, top + height);
+
+        images.push(
+            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(left)}px;top:${px(top)}px;width:${px(width)}px;height:${px(height)}px" src="${escapeHtml(src)}" alt="">`
+        );
+    }
+
+    if (images.length === 0) return tableHtml;
+
+    return `<div class="spreadsheet-sheet" style="position:relative;min-height:${px(maxBottom)}px">\n${tableHtml}\n${images.join("\n")}\n</div>`;
+}
+
+/** Renders the images embedded in a cell's rich-text document (`cell.p.drawings`), in order. */
+function renderCellImages(cell: ICellData): string {
+    const doc = cell.p;
+    const drawings = doc?.drawings;
+    if (!drawings) return "";
+
+    const order = Array.isArray(doc?.drawingsOrder) ? doc.drawingsOrder : Object.keys(drawings);
+    const images: string[] = [];
+    for (const id of order) {
+        const drawing = drawings[id];
+        const src = drawing ? sanitizeImageSource(drawing.source) : null;
+        if (!drawing || !src) continue;
+
+        const dims: string[] = [];
+        if (isFiniteNumber(drawing.transform?.width)) dims.push(`width:${px(drawing.transform.width)}px`);
+        if (isFiniteNumber(drawing.transform?.height)) dims.push(`height:${px(drawing.transform.height)}px`);
+        const style = dims.length ? ` style="${dims.join(";")}"` : "";
+
+        images.push(`<img class="spreadsheet-cell-image"${style} src="${escapeHtml(src)}" alt="">`);
+    }
+    return images.join("");
+}
+
+function sumRowHeights(sheet: IWorksheetData, fromRow: number, toRowExclusive: number): number {
+    const rowData = sheet.rowData ?? {};
+    const defaultHeight = sheet.defaultRowHeight ?? 24;
+    let sum = 0;
+    for (let row = fromRow; row < toRowExclusive; row++) {
+        const meta = rowData[row];
+        if (meta?.hd) continue;
+        sum += isFiniteNumber(meta?.h) ? meta.h : defaultHeight;
+    }
+    return sum;
+}
+
+function sumColumnWidths(sheet: IWorksheetData, fromCol: number, toColExclusive: number): number {
+    const columnData = sheet.columnData ?? {};
+    const defaultWidth = sheet.defaultColumnWidth ?? 88;
+    let sum = 0;
+    for (let col = fromCol; col < toColExclusive; col++) {
+        const meta = columnData[col];
+        if (meta?.hd) continue;
+        sum += isFiniteNumber(meta?.w) ? meta.w : defaultWidth;
+    }
+    return sum;
+}
+
+/**
+ * Validates an image source for inclusion in shared/exported HTML. Accepts only the relative
+ * attachment-image URL Trilium emits (`api/attachments/<id>/image/...`, served by both the app
+ * and the share view) and inline `data:image/...` URLs. Anything else (`javascript:`, remote
+ * `http(s)`, etc.) returns `null` so the image is dropped. The returned value is still escaped
+ * before being placed in an attribute.
+ */
+function sanitizeImageSource(source: string | null | undefined): string | null {
+    if (typeof source !== "string") return null;
+    const trimmed = source.trim();
+    if (/^api\/attachments\/[a-zA-Z0-9_]+\/image\//.test(trimmed)) return trimmed;
+    if (/^data:image\/(?:png|jpe?g|gif|webp|bmp|svg\+xml)[;,]/i.test(trimmed)) return trimmed;
+    return null;
+}
+
+/** Rounds a px measurement to 2 decimals and renders it without a trailing `.00`. */
+function px(value: number): string {
+    return String(Math.round(value * 100) / 100);
+}
+
+function toFinite(value: number | undefined): number {
+    return isFiniteNumber(value) ? value : 0;
+}
+
+// #endregion
 
 function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>): string {
     const { cellData, mergeData = [], columnData = {}, rowData = {} } = sheet;
@@ -106,7 +222,7 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
             const cell = cellData[row]?.[col];
             const cellStyle = resolveCellStyle(cell?.s, styles);
             const cssText = buildCssText(cellStyle, cell);
-            const value = formatCellValue(cell, cellStyle);
+            const value = formatCellValue(cell, cellStyle) + (cell ? renderCellImages(cell) : "");
 
             const attrs: string[] = [];
             // Cells with a background fill carry `has-fill` so the stylesheet can suppress

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -27,7 +27,8 @@ import {
     type IWorksheetData,
     parseWorkbookData,
     resolveCellStyle,
-    VerticalAlign
+    VerticalAlign,
+    WrapStrategy
 } from "./workbook_model.js";
 
 /**
@@ -190,17 +191,22 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
     // Build a set of cells that are hidden by merges (non-origin cells).
     const mergeMap = buildMergeMap(mergeData, minRow, maxRow, minCol, maxCol);
 
-    const lines: string[] = [];
-    lines.push(buildTableTag(sheet));
-
-    // Colgroup for column widths.
+    // Visible column widths, reused for the colgroup and the table's fixed total width.
     const defaultWidth = sheet.defaultColumnWidth ?? 88;
-    lines.push("<colgroup>");
+    const colWidths: number[] = [];
     for (let col = minCol; col <= maxCol; col++) {
         const colMeta = columnData[col];
         if (colMeta?.hd) continue;
-        const width = isFiniteNumber(colMeta?.w) ? colMeta.w : defaultWidth;
-        lines.push(`<col style="width:${width}px">`);
+        colWidths.push(isFiniteNumber(colMeta?.w) ? colMeta.w : defaultWidth);
+    }
+    const totalWidth = colWidths.reduce((sum, w) => sum + w, 0);
+
+    const lines: string[] = [];
+    lines.push(buildTableTag(sheet, totalWidth));
+
+    lines.push("<colgroup>");
+    for (const width of colWidths) {
+        lines.push(`<col style="width:${px(width)}px">`);
     }
     lines.push("</colgroup>");
 
@@ -251,18 +257,21 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
  * stylesheet can draw a light border on every cell; explicit per-cell borders from the
  * data are emitted inline and override those on the sides they define.
  */
-function buildTableTag(sheet: IWorksheetData): string {
+function buildTableTag(sheet: IWorksheetData, totalWidth: number): string {
     // Default to shown (matching the editor) unless explicitly disabled.
     const showGridlines = sheet.showGridlines !== 0;
-    if (!showGridlines) {
-        return '<table class="spreadsheet-table">';
-    }
+    const className = showGridlines ? "spreadsheet-table show-gridlines" : "spreadsheet-table";
 
-    let style = "";
-    if (sheet.gridlinesColor) {
-        style = ` style="--spreadsheet-gridline-color:${sanitizeCssColor(sheet.gridlinesColor)}"`;
+    const styles: string[] = [];
+    if (showGridlines && sheet.gridlinesColor) {
+        styles.push(`--spreadsheet-gridline-color:${sanitizeCssColor(sheet.gridlinesColor)}`);
     }
-    return `<table class="spreadsheet-table show-gridlines"${style}>`;
+    // An explicit width is required for `table-layout: fixed` (the stylesheet) to honour the
+    // column widths, so cell text overflows into empty neighbours like a spreadsheet instead of
+    // wrapping and growing rows — which would shift the absolutely-positioned floating images.
+    styles.push(`width:${px(totalWidth)}px`);
+
+    return `<table class="${className}" style="${styles.join(";")}">`;
 }
 
 // #region Merge handling
@@ -341,6 +350,13 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
     if (style.vt != null) {
         const valign = verticalAlignToCss(style.vt);
         if (valign) parts.push(`vertical-align:${valign}`);
+    }
+
+    // Cells default to nowrap (overflow into empty neighbours, like the editor); a cell with the
+    // WRAP strategy opts back into normal wrapping so its text breaks within the column width.
+    if (style.tb === WrapStrategy.WRAP) {
+        parts.push("white-space:normal");
+        parts.push("overflow-wrap:break-word");
     }
 
     if (style.bd) {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -74,6 +74,8 @@ interface PlacedImage {
     top: number;
     width: number;
     height: number;
+    /** CSS `transform` value for rotation/flip, or "" when the image is upright and unflipped. */
+    transform: string;
 }
 
 /**
@@ -96,10 +98,26 @@ function placeFloatingImages(sheet: IWorksheetData, drawings: ISheetDrawing[]): 
             left: toFinite(drawing.transform.left) - headerWidth,
             top: toFinite(drawing.transform.top) - headerHeight,
             width: toFinite(drawing.transform.width),
-            height: toFinite(drawing.transform.height)
+            height: toFinite(drawing.transform.height),
+            transform: cssTransform(drawing.transform)
         });
     }
     return placed;
+}
+
+/**
+ * Builds the CSS `transform` for a drawing's rotation/flip, around the default centre origin (which
+ * matches Univer). Flips are applied before the rotation (so they read in the image's own axes), and
+ * an upright, unflipped image yields "" so no transform is emitted.
+ */
+function cssTransform(transform: NonNullable<ISheetDrawing["transform"]>): string {
+    const parts: string[] = [];
+    if (isFiniteNumber(transform.angle) && transform.angle % 360 !== 0) {
+        parts.push(`rotate(${px(transform.angle)}deg)`);
+    }
+    if (transform.flipX) parts.push("scaleX(-1)");
+    if (transform.flipY) parts.push("scaleY(-1)");
+    return parts.join(" ");
 }
 
 /**
@@ -116,8 +134,9 @@ function wrapWithFloatingImages(tableHtml: string, images: PlacedImage[]): strin
     const tags: string[] = [];
     for (const image of images) {
         maxBottom = Math.max(maxBottom, image.top + image.height);
+        const transform = image.transform ? `;transform:${image.transform}` : "";
         tags.push(
-            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(image.left)}px;top:${px(image.top)}px;width:${px(image.width)}px;height:${px(image.height)}px" src="${escapeHtml(image.src)}" alt="">`
+            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(image.left)}px;top:${px(image.top)}px;width:${px(image.width)}px;height:${px(image.height)}px${transform}" src="${escapeHtml(image.src)}" alt="">`
         );
     }
 

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -386,6 +386,129 @@ describe("renderSpreadsheetToXlsx", () => {
             expect(bytes[1]).toBe(0x4b); // 'K'
         });
     });
+
+    describe("images", () => {
+        // 1x1 transparent PNG.
+        const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+        const resolveAsPng: NonNullable<Parameters<typeof renderSpreadsheetToXlsx>[1]>["resolveImage"] =
+            async (source) => (source ? { base64: PNG, extension: "png" } : null);
+
+        function floatingImageWorkbook(drawing: Record<string, unknown> & { drawingId: string }): string {
+            const sheetId = "s1";
+            return JSON.stringify({
+                version: 1,
+                workbook: {
+                    sheetOrder: [sheetId],
+                    styles: {},
+                    sheets: {
+                        [sheetId]: {
+                            id: sheetId,
+                            name: "Sheet1",
+                            hidden: 0,
+                            defaultColumnWidth: 88,
+                            defaultRowHeight: 24,
+                            mergeData: [],
+                            cellData: { "0": { "0": { v: "x" } } },
+                            rowData: {},
+                            columnData: {}
+                        }
+                    },
+                    resources: [
+                        { name: "SHEET_DRAWING_PLUGIN", data: JSON.stringify({ [sheetId]: { data: { [drawing.drawingId]: drawing }, order: [drawing.drawingId] } }) }
+                    ]
+                }
+            });
+        }
+
+        async function load(buffer: ExcelJS.Buffer): Promise<ExcelJS.Workbook> {
+            const wb = new ExcelJS.Workbook();
+            await wb.xlsx.load(buffer as ArrayBuffer);
+            return wb;
+        }
+
+        it("embeds a floating image with a two-cell anchor from its from/to cells", async () => {
+            const buffer = await renderSpreadsheetToXlsx(
+                floatingImageWorkbook({
+                    drawingId: "img1",
+                    imageSourceType: "URL",
+                    source: "api/attachments/cgN4jEBCA1Kn/image/image.png",
+                    sheetTransform: {
+                        from: { row: 4, rowOffset: 12, column: 1, columnOffset: 44 },
+                        to: { row: 8, rowOffset: 0, column: 3, columnOffset: 0 }
+                    }
+                }),
+                { resolveImage: resolveAsPng }
+            );
+            const wb = await load(buffer);
+            const images = wb.getWorksheet("Sheet1")?.getImages() ?? [];
+            expect(images.length).toBe(1);
+            const range = images[0].range;
+            // column 1 + 44/88 = 1.5; row 4 + 12/24 = 4.5; to-corner has no offsets.
+            expect(range.tl.col).toBeCloseTo(1.5);
+            expect(range.tl.row).toBeCloseTo(4.5);
+            expect(range.br?.col).toBeCloseTo(3);
+            expect(range.br?.row).toBeCloseTo(8);
+            expect(wb.model.media[0]?.extension).toBe("png");
+        });
+
+        it("embeds a cell image anchored to its cell at the drawing size", async () => {
+            const buffer = await renderSpreadsheetToXlsx(
+                singleCellWorkbook({
+                    p: {
+                        drawings: {
+                            d1: { drawingId: "d1", source: "api/attachments/BBBBBBBBBBBB/image/y.png", transform: { width: 120, height: 90 } }
+                        },
+                        drawingsOrder: ["d1"]
+                    }
+                }),
+                { resolveImage: resolveAsPng }
+            );
+            const wb = await load(buffer);
+            const images = wb.worksheets[0].getImages();
+            expect(images.length).toBe(1);
+            const range = images[0].range;
+            expect(range.tl.col).toBeCloseTo(0);
+            expect(range.tl.row).toBeCloseTo(0);
+            const ext = (range as unknown as { ext?: { width: number; height: number } }).ext;
+            expect(ext?.width).toBe(120);
+            expect(ext?.height).toBe(90);
+        });
+
+        it("embeds no images when no resolver is provided", async () => {
+            const wb = await load(await renderSpreadsheetToXlsx(
+                floatingImageWorkbook({
+                    drawingId: "img1",
+                    source: "api/attachments/cgN4jEBCA1Kn/image/image.png",
+                    sheetTransform: { from: { row: 0, column: 0 }, to: { row: 2, column: 2 } }
+                })
+            ));
+            expect(wb.getWorksheet("Sheet1")?.getImages().length).toBe(0);
+        });
+
+        it("skips an image the resolver returns null for", async () => {
+            const wb = await load(await renderSpreadsheetToXlsx(
+                floatingImageWorkbook({
+                    drawingId: "img1",
+                    source: "api/attachments/cgN4jEBCA1Kn/image/image.png",
+                    sheetTransform: { from: { row: 0, column: 0 }, to: { row: 2, column: 2 } }
+                }),
+                { resolveImage: async () => null }
+            ));
+            expect(wb.getWorksheet("Sheet1")?.getImages().length).toBe(0);
+        });
+
+        it("skips a floating drawing that has no from/to anchor", async () => {
+            const wb = await load(await renderSpreadsheetToXlsx(
+                floatingImageWorkbook({
+                    drawingId: "img1",
+                    source: "api/attachments/cgN4jEBCA1Kn/image/image.png",
+                    transform: { left: 10, top: 10, width: 50, height: 50 }
+                }),
+                { resolveImage: resolveAsPng }
+            ));
+            expect(wb.getWorksheet("Sheet1")?.getImages().length).toBe(0);
+        });
+    });
 });
 
 describe("uniqueSheetName", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -14,12 +14,15 @@ import ExcelJS from "exceljs";
 
 import {
     BorderStyle,
+    getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
     type IBorderData,
     type ICellData,
+    type IDrawingCellAnchor,
     isFiniteNumber,
     type IStyleData,
+    type IWorkbookData,
     type IWorksheetData,
     parseWorkbookData,
     resolveCellStyle,
@@ -27,12 +30,30 @@ import {
     WrapStrategy
 } from "./workbook_model.js";
 
+/** An image resolved to embeddable bytes. Returned by the caller's {@link XlsxRenderOptions.resolveImage}. */
+export interface ResolvedImage {
+    /** Raw base64 (no `data:` prefix). */
+    base64: string;
+    /** A format exceljs can embed. */
+    extension: "jpeg" | "png" | "gif";
+}
+
+export interface XlsxRenderOptions {
+    /**
+     * Resolves a drawing's `source` (an `api/attachments/...` URL or a `data:` URL) to embeddable
+     * bytes, or `null` to skip it. Image bytes can't be fetched from the platform-agnostic commons
+     * layer, so the caller (which has attachment access) supplies them. When omitted, images are
+     * dropped.
+     */
+    resolveImage?: (source: string) => Promise<ResolvedImage | null>;
+}
+
 /**
  * Parses the raw JSON content of a spreadsheet note and produces an `.xlsx` workbook as a
  * binary buffer. Hidden sheets are skipped; hidden rows/columns are preserved but flagged
  * hidden (Excel keeps the data). Throws if the content is not a parseable workbook.
  */
-export async function renderSpreadsheetToXlsx(jsonContent: string): Promise<ExcelJS.Buffer> {
+export async function renderSpreadsheetToXlsx(jsonContent: string, opts: XlsxRenderOptions = {}): Promise<ExcelJS.Buffer> {
     const { ok, data } = parseWorkbookData(jsonContent);
     if (!ok) {
         throw new Error("Unable to parse spreadsheet data.");
@@ -58,7 +79,10 @@ export async function renderSpreadsheetToXlsx(jsonContent: string): Promise<Exce
     // export) on names that are illegal or collide, so resolve each to an Excel-legal unique name.
     const usedNames = new Set<string>();
     for (const sheet of visibleSheets) {
-        writeSheet(out, sheet, uniqueSheetName(sheet.name, usedNames), styles);
+        const ws = writeSheet(out, sheet, uniqueSheetName(sheet.name, usedNames), styles);
+        if (opts.resolveImage) {
+            await embedImages(out, ws, sheet, workbook, opts.resolveImage);
+        }
     }
 
     return out.xlsx.writeBuffer();
@@ -96,7 +120,7 @@ function sanitizeSheetName(name: string | undefined): string {
     return cleaned;
 }
 
-function writeSheet(out: ExcelJS.Workbook, sheet: IWorksheetData, name: string, styles: Record<string, IStyleData | null>): void {
+function writeSheet(out: ExcelJS.Workbook, sheet: IWorksheetData, name: string, styles: Record<string, IStyleData | null>): ExcelJS.Worksheet {
     const ws = out.addWorksheet(name, {
         views: [{ showGridLines: sheet.showGridlines !== 0 }],
         // Carry Univer's sheet-wide defaults so rows/columns without an explicit size keep it on
@@ -128,7 +152,105 @@ function writeSheet(out: ExcelJS.Workbook, sheet: IWorksheetData, name: string, 
             // Overlapping/invalid merge — skip rather than abort the whole export.
         }
     }
+
+    return ws;
 }
+
+// #region Images
+
+/**
+ * Embeds a sheet's images into the worksheet: floating drawings (from the `SHEET_DRAWING_PLUGIN`
+ * resource) as two-cell anchors spanning their from/to cells, and cell images (`cell.p.drawings`)
+ * anchored to their cell at the drawing's pixel size. Bytes come from `resolveImage`; a drawing is
+ * skipped when it has no usable anchor or its source can't be resolved.
+ */
+async function embedImages(out: ExcelJS.Workbook, ws: ExcelJS.Worksheet, sheet: IWorksheetData, workbook: IWorkbookData, resolveImage: NonNullable<XlsxRenderOptions["resolveImage"]>): Promise<void> {
+    for (const drawing of getFloatingDrawings(workbook, sheet.id)) {
+        const anchor = drawing.sheetTransform;
+        if (!anchor?.from || !anchor?.to) continue;
+
+        const imageId = await addImage(out, drawing.source, resolveImage);
+        if (imageId == null) continue;
+
+        // exceljs's types demand native-EMU anchors, but the runtime accepts fractional {col,row}.
+        ws.addImage(imageId, {
+            tl: anchorPoint(sheet, anchor.from),
+            br: anchorPoint(sheet, anchor.to),
+            editAs: "twoCell"
+        } as unknown as ExcelJS.ImageRange);
+    }
+
+    const { cellData } = sheet;
+    for (const rowStr of Object.keys(cellData)) {
+        const row = Number(rowStr);
+        const cols = cellData[row];
+        for (const colStr of Object.keys(cols)) {
+            await embedCellImages(out, ws, row, Number(colStr), cols[Number(colStr)], resolveImage);
+        }
+    }
+}
+
+async function embedCellImages(out: ExcelJS.Workbook, ws: ExcelJS.Worksheet, row: number, col: number, cell: ICellData | undefined, resolveImage: NonNullable<XlsxRenderOptions["resolveImage"]>): Promise<void> {
+    const doc = cell?.p;
+    const drawings = doc?.drawings;
+    if (!drawings) return;
+
+    const order = Array.isArray(doc?.drawingsOrder) ? doc.drawingsOrder : Object.keys(drawings);
+    for (const id of order) {
+        const drawing = drawings[id];
+        if (!drawing) continue;
+
+        const width = toFinite(drawing.transform?.width);
+        const height = toFinite(drawing.transform?.height);
+        if (width <= 0 || height <= 0) continue;
+
+        const imageId = await addImage(out, drawing.source, resolveImage);
+        if (imageId == null) continue;
+
+        // exceljs anchors are 0-based, matching Univer's row/column indices.
+        ws.addImage(imageId, { tl: { col, row }, ext: { width, height }, editAs: "oneCell" } as unknown as ExcelJS.ImageRange);
+    }
+}
+
+/** Resolves a drawing source to bytes and registers it on the workbook, returning its image id. */
+async function addImage(out: ExcelJS.Workbook, source: string | undefined, resolveImage: NonNullable<XlsxRenderOptions["resolveImage"]>): Promise<number | null> {
+    if (!source) return null;
+    const resolved = await resolveImage(source);
+    if (!resolved?.base64) return null;
+    return out.addImage({ base64: resolved.base64, extension: resolved.extension });
+}
+
+/**
+ * Converts a Univer cell anchor to an exceljs fractional `{ col, row }` point: the cell index plus
+ * the px offset expressed as a fraction of that cell's width/height. exceljs re-expands the fraction
+ * using the same column/row sizes, reproducing the editor's placement.
+ */
+function anchorPoint(sheet: IWorksheetData, anchor: IDrawingCellAnchor): { col: number; row: number } {
+    const column = toFinite(anchor.column);
+    const row = toFinite(anchor.row);
+    const colWidth = columnWidthPx(sheet, column);
+    const rowHeight = rowHeightPx(sheet, row);
+    return {
+        col: column + (colWidth > 0 ? toFinite(anchor.columnOffset) / colWidth : 0),
+        row: row + (rowHeight > 0 ? toFinite(anchor.rowOffset) / rowHeight : 0)
+    };
+}
+
+function columnWidthPx(sheet: IWorksheetData, col: number): number {
+    const w = sheet.columnData?.[col]?.w;
+    return isFiniteNumber(w) ? w : (sheet.defaultColumnWidth ?? 88);
+}
+
+function rowHeightPx(sheet: IWorksheetData, row: number): number {
+    const h = sheet.rowData?.[row]?.h;
+    return isFiniteNumber(h) ? h : (sheet.defaultRowHeight ?? 24);
+}
+
+function toFinite(value: number | undefined): number {
+    return isFiniteNumber(value) ? value : 0;
+}
+
+// #endregion
 
 function applyColumns(ws: ExcelJS.Worksheet, sheet: IWorksheetData): void {
     const columnData = sheet.columnData ?? {};

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -79,6 +79,21 @@ export interface ISheetDrawing {
     imageSourceType?: string;
     source?: string;
     transform?: IDrawingTransform | null;
+    /** Cell-anchored extent (top-left/bottom-right), used by the XLSX emitter's two-cell anchor. */
+    sheetTransform?: ISheetDrawingAnchor | null;
+}
+
+export interface ISheetDrawingAnchor {
+    from?: IDrawingCellAnchor;
+    to?: IDrawingCellAnchor;
+}
+
+/** A drawing corner anchored to a cell plus a px offset into it (`row`/`column` are 0-based). */
+export interface IDrawingCellAnchor {
+    row?: number;
+    rowOffset?: number;
+    column?: number;
+    columnOffset?: number;
 }
 
 /** A drawing's absolute box. `left`/`top` are px from the sheet origin (A1); cell images omit them. */

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -47,6 +47,15 @@ export interface IWorksheetData {
     columnData?: Record<number, IColumnData>;
     showGridlines?: number;
     gridlinesColor?: string | null;
+    rowHeader?: ISheetHeader;
+    columnHeader?: ISheetHeader;
+}
+
+/** The row-number / column-letter gutters. Univer's drawing transforms are offset by their size. */
+export interface ISheetHeader {
+    width?: number;
+    height?: number;
+    hidden?: number;
 }
 
 export type CellMatrix = Record<number, Record<number, ICellData>>;

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -102,6 +102,10 @@ export interface IDrawingTransform {
     top?: number;
     width?: number;
     height?: number;
+    /** Clockwise rotation in degrees, applied around the box centre. */
+    angle?: number;
+    flipX?: boolean;
+    flipY?: boolean;
 }
 
 export interface IStyleData {

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -24,6 +24,13 @@ export interface IWorkbookData {
     name?: string;
     styles?: Record<string, IStyleData | null>;
     sheets: Record<string, IWorksheetData>;
+    /** Plugin payloads (e.g. floating drawings); each `data` is itself a JSON string. */
+    resources?: IResource[];
+}
+
+export interface IResource {
+    name: string;
+    data: string;
 }
 
 export interface IWorksheetData {
@@ -49,6 +56,28 @@ export interface ICellData {
     t?: number | null;
     s?: IStyleData | string | null;
     f?: string | null;
+    /** Rich-text document payload; carries images anchored inside the cell. */
+    p?: ICellDocumentData | null;
+}
+
+export interface ICellDocumentData {
+    drawings?: Record<string, ISheetDrawing>;
+    drawingsOrder?: string[];
+}
+
+export interface ISheetDrawing {
+    drawingId?: string;
+    imageSourceType?: string;
+    source?: string;
+    transform?: IDrawingTransform | null;
+}
+
+/** A drawing's absolute box. `left`/`top` are px from the sheet origin (A1); cell images omit them. */
+export interface IDrawingTransform {
+    left?: number;
+    top?: number;
+    width?: number;
+    height?: number;
 }
 
 export interface IStyleData {
@@ -249,4 +278,32 @@ export function computeBounds(cellData: CellMatrix, mergeData: IRange[] = []): B
 /** Checks that a value is a finite number (guards against stringified payloads from JSON). */
 export function isFiniteNumber(v: unknown): v is number {
     return typeof v === "number" && Number.isFinite(v);
+}
+
+/** Univer stores floating sheet images (drawings) under this workbook resource. */
+export const SHEET_DRAWING_RESOURCE = "SHEET_DRAWING_PLUGIN";
+
+/**
+ * Extracts the floating drawings for one sheet from the `SHEET_DRAWING_PLUGIN` resource, in
+ * their stored z-order. The resource `data` is itself a JSON string keyed by sheet id:
+ * `{ [sheetId]: { data: { [drawingId]: drawing }, order: string[] } }`. Returns an empty array
+ * when the resource is absent, unparseable, or carries no drawings for the sheet.
+ */
+export function getFloatingDrawings(workbook: IWorkbookData, sheetId: string): ISheetDrawing[] {
+    const resource = workbook.resources?.find((r) => r.name === SHEET_DRAWING_RESOURCE);
+    if (!resource?.data) return [];
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(resource.data);
+    } catch {
+        return [];
+    }
+
+    const sheetEntry = (parsed as Record<string, { data?: Record<string, ISheetDrawing>; order?: string[] }> | null)?.[sheetId];
+    const data = sheetEntry?.data;
+    if (!data) return [];
+
+    const order = Array.isArray(sheetEntry?.order) ? sheetEntry.order : Object.keys(data);
+    return order.map((id) => data[id]).filter((d): d is ISheetDrawing => Boolean(d));
 }

--- a/packages/share-theme/src/styles/content.css
+++ b/packages/share-theme/src/styles/content.css
@@ -140,13 +140,21 @@ body.type-webView {
     border: 1px solid var(--spreadsheet-gridline-color, var(--background-highlight));
 }
 
-/* A sheet that has floating images is wrapped in a positioned container; the images are
-   emitted as absolutely-positioned <img> with inline left/top/width/height (computed from the
-   Univer drawing transform, relative to the trimmed table origin). */
+/* A sheet that has floating images is wrapped in a positioned container; the images are emitted as
+   absolutely-positioned <img> with inline left/top/width/height in the grid's content coordinates
+   (the Univer transform, with the row/column header sizes removed). */
 .spreadsheet-sheet {
     position: relative;
     font-size: 11pt;
     line-height: 1.2;
+    /* Carry the table's top spacing on the wrapper so the table's top edge sits exactly at the
+       wrapper origin — the images are positioned absolutely from there, so any table margin would
+       shift them vertically out of alignment with the grid. */
+    margin-top: 1em;
+}
+
+.spreadsheet-sheet .spreadsheet-table {
+    margin-top: 0;
 }
 
 /* Images embedded inside a cell flow with the cell content. */

--- a/packages/share-theme/src/styles/content.css
+++ b/packages/share-theme/src/styles/content.css
@@ -130,3 +130,21 @@ body.type-webView {
 .spreadsheet-table.show-gridlines td:not(.has-fill) {
     border: 1px solid var(--spreadsheet-gridline-color, var(--background-highlight));
 }
+
+/* A sheet that has floating images is wrapped in a positioned container; the images are
+   emitted as absolutely-positioned <img> with inline left/top/width/height (computed from the
+   Univer drawing transform, relative to the trimmed table origin). */
+.spreadsheet-sheet {
+    position: relative;
+}
+
+.spreadsheet-floating-image {
+    object-fit: contain;
+}
+
+/* Images embedded inside a cell flow with the cell content. */
+.spreadsheet-cell-image {
+    display: block;
+    max-width: 100%;
+    object-fit: contain;
+}

--- a/packages/share-theme/src/styles/content.css
+++ b/packages/share-theme/src/styles/content.css
@@ -108,10 +108,19 @@ body.type-webView {
     border-collapse: collapse;
     width: auto;
     margin-top: 1em;
+    /* Honour the per-column widths emitted in the colgroup (and the explicit table width) so the
+       grid keeps the editor's geometry. Without this, a cell wider than its column would stretch
+       the column and break the alignment of the absolutely-positioned floating images. */
+    table-layout: fixed;
 }
 
 .spreadsheet-table td {
     padding: 2px 4px;
+    /* Match the spreadsheet: long text overflows into empty neighbouring cells rather than
+       wrapping, which keeps every row at its declared height. Wrapping would grow rows and push
+       the floating images (positioned in absolute px) out of alignment with the grid. */
+    white-space: nowrap;
+    overflow: visible;
 }
 
 /* When the source sheet has gridlines enabled, draw a light 1px line on every cell edge.

--- a/packages/share-theme/src/styles/content.css
+++ b/packages/share-theme/src/styles/content.css
@@ -149,10 +149,6 @@ body.type-webView {
     line-height: 1.2;
 }
 
-.spreadsheet-floating-image {
-    object-fit: contain;
-}
-
 /* Images embedded inside a cell flow with the cell content. */
 .spreadsheet-cell-image {
     display: block;

--- a/packages/share-theme/src/styles/content.css
+++ b/packages/share-theme/src/styles/content.css
@@ -145,6 +145,8 @@ body.type-webView {
    Univer drawing transform, relative to the trimmed table origin). */
 .spreadsheet-sheet {
     position: relative;
+    font-size: 11pt;
+    line-height: 1.2;
 }
 
 .spreadsheet-floating-image {

--- a/packages/trilium-core/src/index.ts
+++ b/packages/trilium-core/src/index.ts
@@ -92,7 +92,7 @@ export { default as SearchContext } from "./services/search/search_context";
 export { default as search, } from "./services/search/services/search";
 export { type default as SearchResult } from "./services/search/search_result";
 export { type SearchParams } from "./services/search/services/types";
-export { checkImageAttachments, default as note_service, findBookmarks, findLlmChatLinks, saveLinks } from "./services/notes";
+export { checkImageAttachments, collectCanvasImageFileIds, default as note_service, findBookmarks, findLlmChatLinks, saveLinks } from "./services/notes";
 export type { NoteParams } from "./services/notes";
 export * as sanitize from "./services/sanitizer";
 export * as routes from "./routes";

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -416,11 +416,20 @@ function protectNote(note: BNote, protect: boolean) {
     }
 }
 
+/**
+ * Title of the spreadsheet preview image. Unlike the inline drawing images, this attachment is not
+ * referenced from the note content — it is the note's rendered thumbnail, looked up by title by the
+ * image endpoint — so it must be exempt from the orphan-erasure scheduling below.
+ */
+const SPREADSHEET_PREVIEW_ATTACHMENT_TITLE = "spreadsheet-export.png";
+
 export function checkImageAttachments(note: BNote, content: string) {
     const foundAttachmentIds = new Set<string>();
     let match;
 
-    const patterns = note.isMarkdown()
+    // Spreadsheet content is JSON storing inline images as bare `api/attachments/{id}/image/...`
+    // URLs (no `src="..."` wrapper), so it scans with the same loose pattern as Markdown.
+    const patterns = (note.isMarkdown() || note.type === "spreadsheet")
         ? [
             // ![...](api/attachments/{id}/image/...) or similar markdown image syntax
             /api\/attachments\/([a-zA-Z0-9_]+)\/image/g,
@@ -447,6 +456,12 @@ export function checkImageAttachments(note: BNote, content: string) {
         // auto-scheduled for erasure when no longer referenced. Other roles (e.g. "viewConfig",
         // "importSource") are managed explicitly by their owners and must not be cleaned up here.
         if (attachment.role !== "image" && attachment.role !== "file") {
+            continue;
+        }
+
+        // The spreadsheet preview thumbnail is never referenced from the content, so leave it alone
+        // (otherwise it would be scheduled for erasure on every save).
+        if (note.type === "spreadsheet" && attachment.title === SPREADSHEET_PREVIEW_ATTACHMENT_TITLE) {
             continue;
         }
 
@@ -892,7 +907,7 @@ function saveAttachments(note: BNote, content: string) {
 
 
 export function saveLinks(note: BNote, content: string | Uint8Array) {
-    if ((note.type !== "text" && note.type !== "relationMap" && note.type !== "llmChat" && !note.isMarkdown()) || (note.isProtected && !protectedSessionService.isProtectedSessionAvailable())) {
+    if ((note.type !== "text" && note.type !== "relationMap" && note.type !== "llmChat" && note.type !== "spreadsheet" && !note.isMarkdown()) || (note.isProtected && !protectedSessionService.isProtectedSessionAvailable())) {
         return {
             forceFrontendReload: false,
             content
@@ -915,6 +930,11 @@ export function saveLinks(note: BNote, content: string | Uint8Array) {
     } else if (note.isMarkdown() && typeof content === "string") {
         findMarkdownImageLinks(content, foundLinks);
         findMarkdownInternalLinks(content, foundLinks);
+        ({ forceFrontendReload, content } = checkImageAttachments(note, content));
+    } else if (note.type === "spreadsheet" && typeof content === "string") {
+        // Spreadsheet images are stored as attachments referenced from the workbook JSON; scan for
+        // orphans (inserted-then-removed images) so they get scheduled for erasure. There are no
+        // Trilium internal links to extract from spreadsheet content.
         ({ forceFrontendReload, content } = checkImageAttachments(note, content));
     } else if (note.type === "relationMap" && typeof content === "string") {
         findRelationMapLinks(content, foundLinks);

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -558,8 +558,9 @@ export function collectCanvasImageFileIds(content: string): Set<string> {
 
     try {
         const parsed = JSON.parse(content) as { elements?: { fileId?: string }[] };
-        for (const element of parsed.elements ?? []) {
-            if (element.fileId) {
+        const elements = Array.isArray(parsed?.elements) ? parsed.elements : [];
+        for (const element of elements) {
+            if (element?.fileId) {
                 fileIds.add(element.fileId);
             }
         }

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -423,29 +423,44 @@ function protectNote(note: BNote, protect: boolean) {
  */
 const SPREADSHEET_PREVIEW_ATTACHMENT_TITLE = "spreadsheet-export.png";
 
+/**
+ * Title of the canvas SVG export image. Like the spreadsheet thumbnail, it is the note's rendered
+ * preview (looked up by title, not referenced from the scene JSON), so it must be exempt from the
+ * orphan-erasure scheduling below.
+ */
+const CANVAS_EXPORT_ATTACHMENT_TITLE = "canvas-export.svg";
+
 export function checkImageAttachments(note: BNote, content: string) {
+    // Canvas references images by the Excalidraw fileId stored as the attachment *title* in its
+    // scene JSON, so orphans are detected by title; every other type references them by attachmentId
+    // embedded in the content (an image URL or attachment link).
+    const isCanvas = note.type === "canvas";
     const foundAttachmentIds = new Set<string>();
-    let match;
+    const foundCanvasFileIds = isCanvas ? collectCanvasImageFileIds(content) : new Set<string>();
 
-    // Spreadsheet content is JSON storing inline images as bare `api/attachments/{id}/image/...`
-    // URLs (no `src="..."` wrapper), so it scans with the same loose pattern as Markdown.
-    const patterns = (note.isMarkdown() || note.type === "spreadsheet")
-        ? [
-            // ![...](api/attachments/{id}/image/...) or similar markdown image syntax
-            /api\/attachments\/([a-zA-Z0-9_]+)\/image/g,
-            // [...](#root/{noteId}?viewMode=attachments&attachmentId={id})
-            /attachmentId=([a-zA-Z0-9_]+)/g
-        ]
-        : [
-            // <img src="api/attachments/{id}/image/...">
-            /src="[^"]*api\/attachments\/([a-zA-Z0-9_]+)\/image/g,
-            // <a href="...attachmentId={id}">
-            /href="[^"]+attachmentId=([a-zA-Z0-9_]+)/g
-        ];
+    if (!isCanvas) {
+        let match;
 
-    for (const pattern of patterns) {
-        while ((match = pattern.exec(content))) {
-        foundAttachmentIds.add(match[1]);
+        // Spreadsheet content is JSON storing inline images as bare `api/attachments/{id}/image/...`
+        // URLs (no `src="..."` wrapper), so it scans with the same loose pattern as Markdown.
+        const patterns = (note.isMarkdown() || note.type === "spreadsheet")
+            ? [
+                // ![...](api/attachments/{id}/image/...) or similar markdown image syntax
+                /api\/attachments\/([a-zA-Z0-9_]+)\/image/g,
+                // [...](#root/{noteId}?viewMode=attachments&attachmentId={id})
+                /attachmentId=([a-zA-Z0-9_]+)/g
+            ]
+            : [
+                // <img src="api/attachments/{id}/image/...">
+                /src="[^"]*api\/attachments\/([a-zA-Z0-9_]+)\/image/g,
+                // <a href="...attachmentId={id}">
+                /href="[^"]+attachmentId=([a-zA-Z0-9_]+)/g
+            ];
+
+        for (const pattern of patterns) {
+            while ((match = pattern.exec(content))) {
+            foundAttachmentIds.add(match[1]);
+            }
         }
     }
 
@@ -465,7 +480,14 @@ export function checkImageAttachments(note: BNote, content: string) {
             continue;
         }
 
-        const attachmentInContent = attachment.attachmentId && foundAttachmentIds.has(attachment.attachmentId);
+        // Likewise for the canvas SVG export preview.
+        if (isCanvas && attachment.title === CANVAS_EXPORT_ATTACHMENT_TITLE) {
+            continue;
+        }
+
+        const attachmentInContent = isCanvas
+            ? foundCanvasFileIds.has(attachment.title)
+            : !!attachment.attachmentId && foundAttachmentIds.has(attachment.attachmentId);
 
         if (attachment.utcDateScheduledForErasureSince && attachmentInContent) {
             attachment.utcDateScheduledForErasureSince = null;
@@ -474,6 +496,12 @@ export function checkImageAttachments(note: BNote, content: string) {
             attachment.utcDateScheduledForErasureSince = date_utils.utcNowDateTime();
             attachment.save();
         }
+    }
+
+    // Canvas references images by title, not by attachmentId, so the foreign-attachment copy step
+    // (which keys off attachmentIds found in the content) does not apply.
+    if (isCanvas) {
+        return { forceFrontendReload: false, content };
     }
 
     const existingAttachmentIds = new Set<string | undefined>(attachments.map((att) => att.attachmentId));
@@ -517,6 +545,29 @@ export function checkImageAttachments(note: BNote, content: string) {
         forceFrontendReload: unknownAttachments.length > 0,
         content
     };
+}
+
+/**
+ * Collects the Excalidraw `fileId`s referenced by a canvas note's scene JSON. Canvas images are
+ * stored as attachments titled with these fileIds, so the set identifies which image attachments are
+ * still in use (the persisted scene contains only non-deleted elements). Returns an empty set for
+ * malformed content rather than throwing, so a save is never blocked.
+ */
+export function collectCanvasImageFileIds(content: string): Set<string> {
+    const fileIds = new Set<string>();
+
+    try {
+        const parsed = JSON.parse(content) as { elements?: { fileId?: string }[] };
+        for (const element of parsed.elements ?? []) {
+            if (element.fileId) {
+                fileIds.add(element.fileId);
+            }
+        }
+    } catch {
+        // Malformed content (e.g. note type just changed) — treat as referencing nothing.
+    }
+
+    return fileIds;
 }
 
 function findImageLinks(content: string, foundLinks: FoundLink[]) {
@@ -907,7 +958,7 @@ function saveAttachments(note: BNote, content: string) {
 
 
 export function saveLinks(note: BNote, content: string | Uint8Array) {
-    if ((note.type !== "text" && note.type !== "relationMap" && note.type !== "llmChat" && note.type !== "spreadsheet" && !note.isMarkdown()) || (note.isProtected && !protectedSessionService.isProtectedSessionAvailable())) {
+    if ((note.type !== "text" && note.type !== "relationMap" && note.type !== "llmChat" && note.type !== "spreadsheet" && note.type !== "canvas" && !note.isMarkdown()) || (note.isProtected && !protectedSessionService.isProtectedSessionAvailable())) {
         return {
             forceFrontendReload: false,
             content
@@ -935,6 +986,11 @@ export function saveLinks(note: BNote, content: string | Uint8Array) {
         // Spreadsheet images are stored as attachments referenced from the workbook JSON; scan for
         // orphans (inserted-then-removed images) so they get scheduled for erasure. There are no
         // Trilium internal links to extract from spreadsheet content.
+        ({ forceFrontendReload, content } = checkImageAttachments(note, content));
+    } else if (note.type === "canvas" && typeof content === "string") {
+        // Canvas images are stored as attachments titled with the Excalidraw fileId referenced from
+        // the scene JSON; scan for orphans (inserted-then-removed images) so they get scheduled for
+        // erasure. There are no Trilium internal links to extract from canvas content.
         ({ forceFrontendReload, content } = checkImageAttachments(note, content));
     } else if (note.type === "relationMap" && typeof content === "string") {
         findRelationMapLinks(content, foundLinks);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       '@univerjs/preset-sheets-data-validation':
         specifier: 0.24.0
         version: 0.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-drawing':
+        specifier: 0.24.0
+        version: 0.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
       '@univerjs/preset-sheets-filter':
         specifier: 0.24.0
         version: 0.24.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)


### PR DESCRIPTION
## Summary

Adds end-to-end image support for spreadsheet (Univer) notes — in the editor, the published **share** view, and **XLSX** import/export — plus the parallel image-attachment handling for canvas.

### Editor & storage
- Image support in the spreadsheet note type via the Univer drawing preset.
- Inserted images (both **cell-embedded** and **floating**) are stored as note **attachments** rather than inline, with server-side orphan detection for inserted-then-removed images.

### Share view (`render_to_html`)
- Renders both **cell images** (inside their `<td>`) and **floating images** (absolutely positioned).
- Pixel-accurate alignment with the editor: `table-layout: fixed` + cell overflow (no wrapping), per-cell **line-wrapping** when the cell opts in, grid rendered from the sheet **origin** (leading empty rows/cols preserved), grid **extended** to enclose images that reach past the data, and **header-offset** removal (Univer transforms include the row/column gutters).
- Honours image **rotation / flip** via CSS `transform`.
- Matches original cell **font** and image **sizing**.
- Sources are restricted to relative `api/attachments/.../image/...` and `data:` URLs (escaped); everything else is dropped.

### XLSX export (`render_to_xlsx`)
- Embeds floating images as **two-cell anchors** and cell images anchored to their cell, via exceljs. Image bytes are resolved through a caller-supplied `resolveImage` callback so the commons emitter stays pure (the client fetches attachment URLs / decodes data URLs). png/jpeg/gif.

### XLSX import (`parse_from_xlsx`)
- Reads embedded images back, inlining them as **base64** floating drawings (inverting the export anchor math). They render across editor/share and re-export. png/jpeg/gif.

## Tests
Extensive unit coverage in `@triliumnext/commons` for the HTML/XLSX emitters and the XLSX parser (rendering, alignment, rotation, anchor math, import/export round-tripping).

## Notes / follow-ups
- Converting imported images into **attachments** at import time (instead of inline base64) is implemented locally but **deliberately excluded** from this PR while the approach is being evaluated.
- exceljs can't embed/rotate SVG/WebP, so those are skipped on XLSX export; rotation is share-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)