### PR TITLE
Fix/note type change

### DIFF
--- a/apps/client/src/widgets/NoteDetail.tsx
+++ b/apps/client/src/widgets/NoteDetail.tsx
@@ -101,7 +101,12 @@ export default function NoteDetail() {
         // globally, so it gets also to e.g. ribbon components. But this means that the event can be generated multiple
         // times if the same note is open in several tabs.
 
-        if (note.noteId && loadResults.isNoteContentReloaded(note.noteId, parentComponent.componentId)) {
+        if (note.noteId
+            && loadResults.isNoteReloaded(note.noteId, parentComponent.componentId)
+            && (type !== (await getExtendedWidgetType(note, noteContext)) || mime !== note?.mime)) {
+            // this needs to have a triggerEvent so that e.g., note type (not in the component subtree) is updated
+            parentComponent.triggerEvent("noteTypeMimeChanged", { noteId: note.noteId });
+        } else if (note.noteId && loadResults.isNoteContentReloaded(note.noteId, parentComponent.componentId)) {
             // probably incorrect event
             // calling this.refresh() is not enough since the event needs to be propagated to children as well
             // FIXME: create a separate event to force hierarchical refresh
@@ -109,11 +114,6 @@ export default function NoteDetail() {
             // this uses handleEvent to make sure that the ordinary content updates are propagated only in the subtree
             // to avoid the problem in #3365
             parentComponent.handleEvent("noteTypeMimeChanged", { noteId: note.noteId });
-        } else if (note.noteId
-            && loadResults.isNoteReloaded(note.noteId, parentComponent.componentId)
-            && (type !== (await getExtendedWidgetType(note, noteContext)) || mime !== note?.mime)) {
-            // this needs to have a triggerEvent so that e.g., note type (not in the component subtree) is updated
-            parentComponent.triggerEvent("noteTypeMimeChanged", { noteId: note.noteId });
         } else {
             const attrs = loadResults.getAttributeRows();
 

--- a/apps/client/src/widgets/note_context_aware_widget.ts
+++ b/apps/client/src/widgets/note_context_aware_widget.ts
@@ -118,7 +118,7 @@ class NoteContextAwareWidget extends BasicWidget {
     }
 
     async noteTypeMimeChangedEvent({ noteId }: EventData<"noteTypeMimeChanged">) {
-        if (this.isNote(noteId)) {
+        if (this.isNote(noteId)) {console.log(1011111111)
             await this.refresh();
         }
     }

--- a/apps/client/src/widgets/note_context_aware_widget.ts
+++ b/apps/client/src/widgets/note_context_aware_widget.ts
@@ -118,7 +118,7 @@ class NoteContextAwareWidget extends BasicWidget {
     }
 
     async noteTypeMimeChangedEvent({ noteId }: EventData<"noteTypeMimeChanged">) {
-        if (this.isNote(noteId)) {console.log(1011111111)
+        if (this.isNote(noteId)) {
             await this.refresh();
         }
     }

--- a/apps/client/src/widgets/ribbon/FormattingToolbar.tsx
+++ b/apps/client/src/widgets/ribbon/FormattingToolbar.tsx
@@ -124,7 +124,7 @@ function useRenderState(activeNoteContext: NoteContext | undefined, activeNote: 
     const [ textNoteEditorType ] = useTriliumOption("textNoteEditorType");
     const [ state, setState ] = useState("hidden");
 
-    useTriliumEvents([ "newNoteContextCreated", "noteContextRemoved", "readOnlyTemporarilyDisabled" ], () => {
+    useTriliumEvents([ "newNoteContextCreated", "noteContextRemoved", "readOnlyTemporarilyDisabled", "noteTypeMimeChanged" ], () => {
         getFormattingToolbarState(activeNoteContext, activeNote, textNoteEditorType).then(setState);
     });
 


### PR DESCRIPTION
1. fix: noteTypeMimeChanged not triggered when a newly created note is switched to a template note type
2. fix: update pinned FormattingToolbar when note type changes, closes https://github.com/TriliumNext/Trilium/issues/10253