### PR TITLE
fix: various bug fixes (share, math, attachments, forms, runtime)

### DIFF
--- a/apps/client/src/services/content_renderer_text.spec.ts
+++ b/apps/client/src/services/content_renderer_text.spec.ts
@@ -2,7 +2,7 @@
 // DOMPurify relies on browser-faithful DOM traversal (NodeIterator); happy-dom
 // mishandles it and strips valid markup (surfaced by dompurify 3.4.8). Run the
 // sanitization-dependent specs under jsdom, which matches real-browser behavior.
-import { trimIndentation } from "@triliumnext/commons";
+import { KATEX_MACROS, trimIndentation } from "@triliumnext/commons";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FAttachment from "../entities/fattachment";
@@ -202,9 +202,10 @@ describe("Text content renderer", () => {
         // The math span is preserved through the rendering pass.
         expect(contentEl.querySelector("span.math-tex")).not.toBeNull();
         // The conditional KaTeX auto-render branch ran: it was invoked exactly once
-        // with the rendered content element ($renderedContent[0]) and the trust flag.
+        // with the rendered content element ($renderedContent[0]), the trust flag, and the
+        // shared MathLive→KaTeX macros (spread into a fresh object KaTeX may mutate).
         expect(renderMathInElementSpy).toHaveBeenCalledTimes(1);
-        expect(renderMathInElementSpy).toHaveBeenCalledWith(contentEl, { trust: true, throwOnError: false });
+        expect(renderMathInElementSpy).toHaveBeenCalledWith(contentEl, { trust: true, throwOnError: false, macros: { ...KATEX_MACROS } });
     });
 
     it("does not invoke KaTeX inline rendering when no math-tex spans are present", async () => {

--- a/apps/client/src/services/content_renderer_text.ts
+++ b/apps/client/src/services/content_renderer_text.ts
@@ -1,3 +1,5 @@
+import { KATEX_MACROS } from "@triliumnext/commons";
+
 import FAttachment from "../entities/fattachment.js";
 import FNote from "../entities/fnote.js";
 import { default as content_renderer, type RenderOptions } from "./content_renderer.js";
@@ -45,7 +47,8 @@ export async function postProcessRichContent(note: FNote | FAttachment, $rendere
         // throwOnError: false makes KaTeX render invalid formulas as an inline red error
         // (with the parse message as a tooltip) instead of throwing and leaving raw `$…$`
         // text plus a console error — matching the editor's behavior.
-        renderMathInElement($renderedContent[0], { trust: true, throwOnError: false });
+        // Spread KATEX_MACROS into a fresh object: KaTeX may mutate it (e.g. via `\gdef`).
+        renderMathInElement($renderedContent[0], { trust: true, throwOnError: false, macros: { ...KATEX_MACROS } });
     }
 
     const getNoteIdFromLink = (el: HTMLElement) => tree.getNoteIdFromUrl($(el).attr("href") || "");

--- a/apps/client/src/services/katex_macros.spec.ts
+++ b/apps/client/src/services/katex_macros.spec.ts
@@ -1,0 +1,27 @@
+import { KATEX_MACROS } from "@triliumnext/commons";
+import katex from "katex";
+import { describe, expect, it } from "vitest";
+
+// Guards against the MathLive→KaTeX mismatch from issue #9523: the visual math editor
+// emits commands KaTeX doesn't define, so they must be mapped to valid KaTeX. These tests
+// render against the real KaTeX engine so a typo in a macro value would surface as a throw.
+describe("KaTeX MathLive compatibility macros", () => {
+    it("renders every mapped MathLive command without erroring", () => {
+        for (const [command, replacement] of Object.entries(KATEX_MACROS)) {
+            // throwOnError makes KaTeX throw on an unknown command rather than emitting red
+            // error text, so a successful render proves both the macro key is needed (the
+            // bare command is unknown) and its replacement is valid KaTeX.
+            expect(() => katex.renderToString(command, { throwOnError: true }), `${command} should be unknown to KaTeX`).toThrow();
+            expect(() => katex.renderToString(command, { throwOnError: true, macros: { ...KATEX_MACROS } }), `${command} → ${replacement}`).not.toThrow();
+        }
+    });
+
+    it("renders a differential integral expression that previously failed (issue #9523)", () => {
+        const html = katex.renderToString("\\int f(x) \\differentialD x", {
+            throwOnError: true,
+            macros: { ...KATEX_MACROS }
+        });
+        // \mathrm{d} produces an upright "d", wrapped by KaTeX in a `mathrm` span.
+        expect(html).toContain("mathrm");
+    });
+});

--- a/apps/client/src/stylesheets/theme-next/dialogs.css
+++ b/apps/client/src/stylesheets/theme-next/dialogs.css
@@ -106,6 +106,16 @@
     border-top: unset;
 }
 
+/*
+ * Footer buttons indicate focus on plain :focus (not only :focus-visible) so the
+ * dialog's auto-focused default action (e.g. the OK button of a confirm dialog) shows a
+ * ring even when the dialog was opened by mouse — programmatic focus after a pointer
+ * interaction does not match :focus-visible.
+ */
+.modal .modal-footer button.btn:focus {
+    outline: 2px solid var(--input-focus-outline-color);
+}
+
 /* Tool dialogs - small dialogs without a backdrop */
 div.tn-tool-dialog {
     border-radius: 10px;

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1233,7 +1233,7 @@
     "pause": "Pause (Space)",
     "seek": "Seek (Left/Right arrow keys)",
     "back-10s": "Back 10s (Left arrow key)",
-    "forward-30s": "Forward 30s",
+    "forward-10s": "Forward 10s (Right arrow key)",
     "previous-video": "Previous video: {{- title}}",
     "next-video": "Next video: {{- title}}",
     "previous-audio": "Previous audio: {{- title}}",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -718,7 +718,7 @@
     "download": "Download",
     "rename_attachment": "Rename attachment",
     "upload_new_revision": "Upload new revision",
-    "copy_link_to_clipboard": "Copy link to clipboard",
+    "copy_link_to_clipboard": "Copy reference to clipboard",
     "convert_attachment_into_note": "Convert attachment into note",
     "delete_attachment": "Delete attachment",
     "upload_success": "New attachment revision has been uploaded.",
@@ -1887,7 +1887,7 @@
     "will_be_deleted_soon": "This attachment will be automatically deleted soon",
     "deletion_reason": ", because the attachment is not linked in the note's content. To prevent deletion, add the attachment link back into the content or convert the attachment into note.",
     "role_and_size": "Role: {{role}}, size: {{size}}, MIME: {{- mimeType}}",
-    "link_copied": "Attachment link copied to clipboard.",
+    "link_copied": "Attachment reference copied to clipboard.",
     "unrecognized_role": "Unrecognized attachment role '{{role}}'."
   },
   "bookmark_switch": {

--- a/apps/client/src/utils/formatters.spec.ts
+++ b/apps/client/src/utils/formatters.spec.ts
@@ -49,6 +49,22 @@ describe("formatters", () => {
         expect(formatDateTime(new Date(), "none", "full")).toBeTruthy();
     });
 
+    it("renders a date-only string as the same calendar day in any timezone", () => {
+        // Regression for #8497: a "YYYY-MM-DD" string was parsed as UTC midnight by the
+        // Date constructor, which rolls back to the previous day for negative UTC
+        // offsets (e.g. the Recent Changes date headers showed yesterday for a UTC-8
+        // user). It must be treated as a local calendar date instead.
+        options.set("formattingLocale", "en-US");
+
+        // The date header itself must match the local calendar day, not a UTC shift.
+        expect(formatDateTime("2026-01-25", "full", "none")).toBe(new Date(2026, 0, 25).toLocaleDateString("en-US", { dateStyle: "full" }));
+
+        // Timezone-independent guard: a correctly parsed date-only string is *local*
+        // midnight in any timezone, so its time renders as 00:00. The buggy UTC parse
+        // produced a non-midnight local time in every zone east/west of UTC.
+        expect(formatDateTime("2026-01-25", "none", "short")).toBe("12:00 AM");
+    });
+
     it("falls back to the locale option then navigator.language", () => {
         // Empty formattingLocale forces the `|| options.get("locale")` branch.
         options.set("formattingLocale", "");

--- a/apps/client/src/utils/formatters.ts
+++ b/apps/client/src/utils/formatters.ts
@@ -12,10 +12,20 @@ export function formatDateTime(date: string | Date | number | null | undefined, 
 
     const locale = normalizeLocale(options.get("formattingLocale") || options.get("locale") || navigator.language);
 
-    let parsedDate;
+    let parsedDate: Date;
     if (typeof date === "string" || typeof date === "number") {
-        // Parse the given string as a date
-        parsedDate = new Date(date);
+        const dateOnlyMatch = typeof date === "string" && /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+        if (dateOnlyMatch) {
+            // A date-only string ("YYYY-MM-DD") is parsed as UTC midnight by the Date
+            // constructor, so it rolls back to the previous day when displayed in a
+            // negative UTC offset (e.g. the Recent Changes date headers). Treat it as a
+            // local calendar date so the same day is shown regardless of timezone.
+            const [ , year, month, day ] = dateOnlyMatch;
+            parsedDate = new Date(Number(year), Number(month) - 1, Number(day));
+        } else {
+            // Parse the given string as a date
+            parsedDate = new Date(date);
+        }
     } else if (date instanceof Date) {
         // The given date is already a Date instance or a number
         parsedDate = date;

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -320,6 +320,7 @@ function RelationInput({ inputId, ...props }: CellProps & { inputId: string }) {
         <NoteAutocomplete
             id={inputId}
             noteId={props.cell.valueAttr.value}
+            opts={{ allowCreatingNotes: true }}
             noteIdChanged={async (value) => {
                 const { note, cell, componentId, setCells } = props;
                 await updateAttribute(note, cell, componentId, value, setCells);

--- a/apps/client/src/widgets/dialogs/confirm.tsx
+++ b/apps/client/src/widgets/dialogs/confirm.tsx
@@ -1,7 +1,7 @@
 import Modal from "../react/Modal";
 import Button from "../react/Button";
 import { t } from "../../services/i18n";
-import { useState } from "preact/hooks";
+import { useRef, useState } from "preact/hooks";
 import FormCheckbox from "../react/FormCheckbox";
 import { useTriliumEvent } from "../react/hooks";
 import { isValidElement, type VNode } from "preact";
@@ -18,6 +18,7 @@ export default function ConfirmDialog() {
     const [ opts, setOpts ] = useState<ConfirmDialogProps>();
     const [ isDeleteNoteChecked, setIsDeleteNoteChecked ] = useState(false);
     const [ shown, setShown ] = useState(false);
+    const okButtonRef = useRef<HTMLButtonElement>(null);
 
     function showDialog(title: string | null, message: MessageType, callback: ConfirmDialogCallback, isConfirmDeleteNoteBox: boolean) {
         setOpts({
@@ -39,6 +40,7 @@ export default function ConfirmDialog() {
             size="md"
             zIndex={2000}
             scrollable={true}
+            onShown={() => okButtonRef.current?.focus()}
             onHidden={() => {
                 opts?.callback?.({
                     confirmed: false,
@@ -48,7 +50,7 @@ export default function ConfirmDialog() {
             }}
             footer={<>
                 <Button text={t("confirm.cancel")} onClick={() => setShown(false)} />
-                <Button text={t("confirm.ok")} onClick={() => {
+                <Button buttonRef={okButtonRef} text={t("confirm.ok")} onClick={() => {
                     opts?.callback?.({
                         confirmed: true,
                         isDeleteNoteChecked

--- a/apps/client/src/widgets/react/FormList.spec.tsx
+++ b/apps/client/src/widgets/react/FormList.spec.tsx
@@ -1,0 +1,89 @@
+import { type ComponentChildren, render } from "preact";
+import { describe, expect, it, vi } from "vitest";
+
+// FormList instantiates a real Bootstrap dropdown in an effect; stub it so the
+// component mounts without pulling in Bootstrap's layout-dependent machinery.
+vi.mock("bootstrap", () => ({
+    Dropdown: { getOrCreateInstance: () => ({ dispose() {} }) },
+    Tooltip: class { static getInstance() { return null; } }
+}));
+
+import FormList, { FormListItem } from "./FormList";
+
+describe("FormList keyboard activation", () => {
+    it.each([ "Enter", " " ])("activates the focused item on %j like a click", (key) => {
+        const { container, onSelect } = renderList();
+        const item = getItem(container, "text");
+
+        const event = press(item, key);
+
+        expect(onSelect).toHaveBeenCalledExactlyOnceWith("text");
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("ignores keys other than Enter/Space", () => {
+        const { container, onSelect } = renderList();
+
+        const event = press(getItem(container, "text"), "a");
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("does not activate a disabled item", () => {
+        const { container, onSelect } = renderList();
+
+        press(getItem(container, "code"), "Enter");
+
+        expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("leaves typing inside an embedded input alone", () => {
+        const onSelect = vi.fn();
+        const container = mount(
+            <FormList onSelect={onSelect}>
+                <input className="embedded-search" />
+                <FormListItem value="text">Text</FormListItem>
+            </FormList>
+        );
+        const input = container.querySelector<HTMLInputElement>(".embedded-search");
+        expect(input).not.toBeNull();
+
+        const event = press(input as HTMLInputElement, "Enter");
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+});
+
+function renderList() {
+    const onSelect = vi.fn();
+    const container = mount(
+        <FormList onSelect={onSelect}>
+            <FormListItem value="text">Text</FormListItem>
+            <FormListItem value="code" disabled>Code</FormListItem>
+        </FormList>
+    );
+    return { container, onSelect };
+}
+
+function mount(node: ComponentChildren) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    render(node, container);
+    return container;
+}
+
+function getItem(container: HTMLElement, value: string) {
+    const item = container.querySelector<HTMLElement>(`.dropdown-item[data-value="${value}"]`);
+    if (!item) {
+        throw new Error(`No dropdown item with value "${value}"`);
+    }
+    return item;
+}
+
+function press(el: Element, key: string) {
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    el.dispatchEvent(event);
+    return event;
+}

--- a/apps/client/src/widgets/react/FormList.tsx
+++ b/apps/client/src/widgets/react/FormList.tsx
@@ -65,12 +65,38 @@ export default function FormList({ children, onSelect, style, fullHeight, wrappe
                     if (value && onSelect) {
                         onSelect(value);
                     }
-                }}>
+                }} onKeyDown={onDropdownMenuKeyDown}>
                     {children}
                 </div>
             </div>
         </div>
     );
+}
+
+/**
+ * Activates the currently focused list item on Enter/Space, so the list is keyboard-operable
+ * and not mouse-only. The focused item is "clicked" to reuse the existing item- and list-level
+ * click handlers (e.g. {@link FormList}'s `onSelect`, toggle items).
+ */
+function onDropdownMenuKeyDown(e: KeyboardEvent) {
+    if (e.key !== "Enter" && e.key !== " ") {
+        return;
+    }
+
+    const target = e.target as HTMLElement;
+
+    // Let inputs/textareas rendered inside the list handle their own typing.
+    if (target.closest("input, textarea, select")) {
+        return;
+    }
+
+    const dropdownItem = target.closest(".dropdown-item") as HTMLElement | null;
+    if (!dropdownItem || dropdownItem.classList.contains("disabled")) {
+        return;
+    }
+
+    e.preventDefault();
+    dropdownItem.click();
 }
 
 export interface FormListBadge {

--- a/apps/client/src/widgets/react/FormList.tsx
+++ b/apps/client/src/widgets/react/FormList.tsx
@@ -85,13 +85,15 @@ function onDropdownMenuKeyDown(e: KeyboardEvent) {
 
     const target = e.target as HTMLElement;
 
-    // Let inputs/textareas rendered inside the list handle their own typing.
-    if (target.closest("input, textarea, select")) {
+    const dropdownItem = target.closest(".dropdown-item") as HTMLElement | null;
+    if (!dropdownItem || dropdownItem.classList.contains("disabled")) {
         return;
     }
 
-    const dropdownItem = target.closest(".dropdown-item") as HTMLElement | null;
-    if (!dropdownItem || dropdownItem.classList.contains("disabled")) {
+    // Let interactive elements nested inside the item (inputs, buttons, links, anything
+    // focusable) handle their own Enter/Space instead of hijacking it for the parent item.
+    const interactive = target.closest("input, textarea, select, button, a, [tabindex]");
+    if (interactive && interactive !== dropdownItem) {
         return;
     }
 

--- a/apps/client/src/widgets/type_widgets/Attachment.tsx
+++ b/apps/client/src/widgets/type_widgets/Attachment.tsx
@@ -190,7 +190,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
         }
     }, [ isZoomableImage ]);
 
-    async function copyAttachmentLinkToClipboard() {
+    async function copyAttachmentReferenceToClipboard() {
         if (attachment.role === "image") {
             const $img = refToJQuerySelector(isZoomableImage ? imageViewerWrapper : contentWrapper).find("img");
             if ($img.length) image.copyImageReferenceToClipboard($img.parent());
@@ -217,7 +217,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
                 <div className="attachment-title-line">
                     <AttachmentActions
                         attachment={attachment}
-                        copyAttachmentLinkToClipboard={copyAttachmentLinkToClipboard}
+                        copyAttachmentReferenceToClipboard={copyAttachmentReferenceToClipboard}
                         onShowOcr={supportsOcr ? () => appContext.triggerCommand("showOcrTextDialog", {
                             textUrl: `ocr/attachments/${attachment.attachmentId}/text`,
                             processUrl: `ocr/process-attachment/${attachment.attachmentId}`
@@ -286,7 +286,7 @@ function DeletionAlert({ utcDateScheduledForErasureSince }: { utcDateScheduledFo
     );
 }
 
-function AttachmentActions({ attachment, copyAttachmentLinkToClipboard, onShowOcr }: { attachment: FAttachment, copyAttachmentLinkToClipboard: () => void, onShowOcr?: () => void }) {
+function AttachmentActions({ attachment, copyAttachmentReferenceToClipboard, onShowOcr }: { attachment: FAttachment, copyAttachmentReferenceToClipboard: () => void, onShowOcr?: () => void }) {
     const isElectron = utils.isElectron();
     const fileUploadRef = useRef<HTMLInputElement>(null);
 
@@ -317,8 +317,8 @@ function AttachmentActions({ attachment, copyAttachmentLinkToClipboard, onShowOc
                     onClick={() => open.downloadAttachment(attachment.attachmentId)}
                 >{t("attachments_actions.download")}</FormListItem>
                 <FormListItem
-                    icon="bx bx-link"
-                    onClick={copyAttachmentLinkToClipboard}
+                    icon="bx bx-directions"
+                    onClick={copyAttachmentReferenceToClipboard}
                 >{t("attachments_actions.copy_link_to_clipboard")}</FormListItem>
                 {onShowOcr && (
                     <FormListItem

--- a/apps/client/src/widgets/type_widgets/Attachment.tsx
+++ b/apps/client/src/widgets/type_widgets/Attachment.tsx
@@ -317,7 +317,7 @@ function AttachmentActions({ attachment, copyAttachmentReferenceToClipboard, onS
                     onClick={() => open.downloadAttachment(attachment.attachmentId)}
                 >{t("attachments_actions.download")}</FormListItem>
                 <FormListItem
-                    icon="bx bx-directions"
+                    icon="bx bx-copy"
                     onClick={copyAttachmentReferenceToClipboard}
                 >{t("attachments_actions.copy_link_to_clipboard")}</FormListItem>
                 {onShowOcr && (

--- a/apps/client/src/widgets/type_widgets/file/Audio.tsx
+++ b/apps/client/src/widgets/type_widgets/file/Audio.tsx
@@ -75,7 +75,7 @@ export default function AudioPreview({ note, noteContext, isVisible = true }: { 
                         <MediaSiblingButton navigation={siblingNavigation} direction="previous" tooltipI18nKey="media.previous-audio" />
                         <SkipButton mediaRef={audioRef} seconds={-10} icon="bx bx-rewind" text={t("media.back-10s")} />
                         <PlayPauseButton playing={playing} togglePlayback={togglePlayback} />
-                        <SkipButton mediaRef={audioRef} seconds={30} icon="bx bx-fast-forward" text={t("media.forward-30s")} />
+                        <SkipButton mediaRef={audioRef} seconds={10} icon="bx bx-fast-forward" text={t("media.forward-10s")} />
                         <MediaSiblingButton navigation={siblingNavigation} direction="next" tooltipI18nKey="media.next-audio" />
                     </div>
 

--- a/apps/client/src/widgets/type_widgets/file/Video.tsx
+++ b/apps/client/src/widgets/type_widgets/file/Video.tsx
@@ -81,7 +81,7 @@ export default function VideoPreview({ note, noteContext, isVisible = true }: { 
                         <MediaSiblingButton navigation={siblingNavigation} direction="previous" tooltipI18nKey="media.previous-video" />
                         <SkipButton mediaRef={videoRef} seconds={-10} icon="bx bx-rewind" text={t("media.back-10s")} />
                         <PlayPauseButton playing={playing} togglePlayback={togglePlayback} />
-                        <SkipButton mediaRef={videoRef} seconds={30} icon="bx bx-fast-forward" text={t("media.forward-30s")} />
+                        <SkipButton mediaRef={videoRef} seconds={10} icon="bx bx-fast-forward" text={t("media.forward-10s")} />
                         <MediaSiblingButton navigation={siblingNavigation} direction="next" tooltipI18nKey="media.next-video" />
                     </div>
                     <div className="right">

--- a/apps/client/src/widgets/type_widgets/text/config.spec.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.spec.ts
@@ -146,6 +146,15 @@ describe("CK config", () => {
         expect(languages).not.toContain("application-javascript-env-frontend");
         expect(languages).not.toContain("application-javascript-env-backend");
     });
+
+    it("wires the MathLive→KaTeX compatibility macros into the math engine", async () => {
+        const config = await buildConfig(baseOpts());
+
+        const macros = (config.math as { katexRenderOptions?: { macros?: Record<string, string> } } | undefined)
+            ?.katexRenderOptions?.macros;
+        // Without this mapping, MathLive's \differentialD renders as raw error text (issue #9523).
+        expect(macros?.["\\differentialD"]).toBe("\\mathrm{d}");
+    });
 });
 
 describe("CK config - licensing", () => {

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -1,6 +1,6 @@
 import { buildExtraCommands, type EditorConfig, getCkLocale, loadPremiumPlugins, TemplateDefinition } from "@triliumnext/ckeditor5";
 import emojiDefinitionsUrl from "@triliumnext/ckeditor5/src/emoji_definitions/en.json?url";
-import { ALLOWED_PROTOCOLS, DISPLAYABLE_LOCALE_IDS, MIME_TYPE_AUTO, normalizeMimeTypeForCKEditor } from "@triliumnext/commons";
+import { ALLOWED_PROTOCOLS, DISPLAYABLE_LOCALE_IDS, KATEX_MACROS, MIME_TYPE_AUTO, normalizeMimeTypeForCKEditor } from "@triliumnext/commons";
 
 import { copyTextWithToast } from "../../../services/clipboard_ext.js";
 import { t } from "../../../services/i18n.js";
@@ -41,7 +41,10 @@ export async function buildConfig(opts: BuildEditorOptions): Promise<EditorConfi
                 (window as any).katex = (await import("../../../services/math.js")).default;
             },
             forceOutputType: false, // forces output to use outputType
-            enablePreview: true // Enable preview view
+            enablePreview: true, // Enable preview view
+            // Map MathLive-only commands (e.g. \differentialD) onto KaTeX equivalents so
+            // formulas produced by the visual editor render instead of erroring out (#9523).
+            katexRenderOptions: { macros: KATEX_MACROS }
         },
         mermaid: {
             lazyLoad: async () => (await import("mermaid")).default, // FIXME

--- a/apps/server/src/assets/translations/en/server.json
+++ b/apps/server/src/assets/translations/en/server.json
@@ -362,7 +362,8 @@
     "expand": "Expand",
     "toggle-navigation": "Toggle Navigation",
     "toggle-toc": "Toggle Table of Contents",
-    "logo-alt": "Logo"
+    "logo-alt": "Logo",
+    "login": "Login"
   },
   "hidden_subtree_templates": {
     "text-snippet": "Text Snippet",

--- a/apps/server/src/services/auth.spec.ts
+++ b/apps/server/src/services/auth.spec.ts
@@ -155,15 +155,17 @@ describe("Auth", () => {
             expect(res.redirectedTo).toBe("login");
         });
 
-        it("checkAuth honours redirectBareDomain: 404 when no shareRoot, else redirects to share", () => {
+        it("checkAuth honours redirectBareDomain: redirects to share when a shareRoot exists, else to login", () => {
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(false);
             vi.spyOn(openID, "isOpenIDEnabled").mockReturnValue(false);
             cls.init(() => options.setOption("redirectBareDomain", "true"));
 
+            // No shareRoot configured: fall back to login instead of a 404 dead-end (#7869).
             const labelSpy = vi.spyOn(attributes, "getNotesWithLabel").mockReturnValue([]);
-            const res404 = makeRes();
-            auth.checkAuth(makeReq({ session: { loggedIn: false } }), res404 as never, vi.fn());
-            expect(res404.statusCode).toBe(404);
+            const resLogin = makeRes();
+            auth.checkAuth(makeReq({ session: { loggedIn: false } }), resLogin as never, vi.fn());
+            expect(resLogin.redirectedTo).toBe("login");
+            expect(resLogin.statusCode).not.toBe(404);
 
             labelSpy.mockReturnValue([{ noteId: "x" } as never]);
             const resShare = makeRes();

--- a/apps/server/src/services/auth.ts
+++ b/apps/server/src/services/auth.ts
@@ -36,14 +36,16 @@ function checkAuth(req: Request, res: Response, next: NextFunction) {
         const hasRedirectBareDomain = options.getOptionOrNull("redirectBareDomain") === "true";
 
         if (hasRedirectBareDomain) {
-            // Check if any note has the #shareRoot label
+            // Only redirect to the share page when a share root is actually configured.
+            // Otherwise (e.g. the owner's session expired before they set one up) fall back
+            // to the login page rather than stranding the user on a 404. See #7869.
             const shareRootNotes = attributes.getNotesWithLabel("shareRoot");
-            if (shareRootNotes.length === 0) {
-                res.status(404).json({ message: "Share root not found. Please set up a note with #shareRoot label first." });
+            if (shareRootNotes.length > 0) {
+                res.redirect("share");
                 return;
             }
         }
-        res.redirect(hasRedirectBareDomain ? "share" : "login");
+        res.redirect("login");
     } else if (currentTotpStatus !== lastAuthState.totpEnabled || currentSsoStatus !== lastAuthState.ssoEnabled) {
         req.session.destroy((err) => {
             if (err) console.error('Error destroying session:', err);

--- a/apps/server/src/services/image_provider.spec.ts
+++ b/apps/server/src/services/image_provider.spec.ts
@@ -189,4 +189,64 @@ describe('serverImageProvider.processImage', () => {
         expect(tooHigh).toBe(at75);
         expect(valid).not.toBe(at75);
     });
+
+    it('bakes EXIF orientation into the pixels when shrinking a rotated photo (#4254)', async () => {
+        setOptions({ compressImages: 'true', imageMaxWidthHeight: '100' });
+
+        // A 600x400 landscape JPEG tagged "rotate 90 CW" (orientation 6) is how a portrait photo
+        // shot on a rotated camera is stored. Shrinking re-encodes to JPEG and drops the EXIF tag,
+        // so the rotation must be baked into the pixels — otherwise the saved image is displayed
+        // sideways (the original bug). Re-decoding the shrunk output must therefore be portrait.
+        const oriented = await makeOrientedJpeg(600, 400, 6);
+        const result = await serverImageProvider.processImage(oriented, 'portrait.jpg', true);
+
+        expect(result.format).toEqual({ ext: 'jpg', mime: 'image/jpeg' });
+        // Smaller than the original proves the resize/re-encode path actually ran (where the bug lived).
+        expect(result.buffer.byteLength).toBeLessThan(oriented.byteLength);
+
+        const decoded = await Jimp.read(Buffer.from(result.buffer));
+        expect(decoded.bitmap.height).toBeGreaterThan(decoded.bitmap.width);
+    });
+
+    it('leaves a genuinely landscape photo landscape after shrinking (#4254 control)', async () => {
+        setOptions({ compressImages: 'true', imageMaxWidthHeight: '100' });
+
+        // Identical pixels with a normal orientation tag (1) must stay landscape — proving the
+        // portrait result above comes from honouring EXIF, not an unconditional rotation.
+        const landscape = await makeOrientedJpeg(600, 400, 1);
+        const result = await serverImageProvider.processImage(landscape, 'landscape.jpg', true);
+
+        const decoded = await Jimp.read(Buffer.from(result.buffer));
+        expect(decoded.bitmap.width).toBeGreaterThan(decoded.bitmap.height);
+    });
 });
+
+/**
+ * Builds a noisy `width`x`height` JPEG (stored at those dimensions) carrying an EXIF Orientation
+ * tag. Orientation 6 ("rotate 90 CW") means a 600x400 stored image should be displayed as 400x600
+ * portrait; orientation 1 means no rotation. Used to reproduce the rotated-on-import bug (#4254).
+ */
+async function makeOrientedJpeg(width: number, height: number, orientation: number): Promise<Uint8Array> {
+    const image = new Jimp({ width, height, color: 0x3366ccff });
+    for (let x = 0; x < width; x++) {
+        for (let y = 0; y < height; y++) {
+            const r = (x * 31 + y * 17) % 256;
+            const g = (x * 13 + y * 7) % 256;
+            const b = (x * 5 + y * 23) % 256;
+            image.setPixelColor((((r << 24) | (g << 16) | (b << 8) | 0xff) >>> 0), x, y);
+        }
+    }
+    const jpeg = Buffer.from(await image.getBuffer('image/jpeg', { quality: 90 }));
+    const tiff = Buffer.from([
+        0x4d, 0x4d, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, // "MM" (big-endian), magic 42, IFD0 offset 8
+        0x00, 0x01,                                     // one directory entry
+        0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, // Orientation tag (0x0112), type SHORT, count 1
+        0x00, orientation, 0x00, 0x00,                  // value: big-endian SHORT, right-padded
+        0x00, 0x00, 0x00, 0x00                          // next-IFD offset (none)
+    ]);
+    const payload = Buffer.concat([Buffer.from('Exif\0\0', 'latin1'), tiff]);
+    const length = payload.length + 2;
+    const app1 = Buffer.concat([Buffer.from([0xff, 0xe1, (length >> 8) & 0xff, length & 0xff]), payload]);
+    // The APP1/EXIF segment must sit immediately after the SOI marker (0xFFD8).
+    return new Uint8Array(Buffer.concat([jpeg.subarray(0, 2), app1, jpeg.subarray(2)]));
+}

--- a/apps/server/src/services/ws_messaging_provider.spec.ts
+++ b/apps/server/src/services/ws_messaging_provider.spec.ts
@@ -167,6 +167,18 @@ describe("WebSocketMessagingProvider", () => {
             const { server } = init();
             expect(() => server.emit("error", new Error("ws boom"))).not.toThrow();
         });
+
+        it("handles a per-connection error without throwing and untracks the client", () => {
+            // A protocol error on a single socket (e.g. WS_ERR_INVALID_CLOSE_CODE) must not
+            // bubble up as an uncaught exception that crashes the process. See issue #9598.
+            const { server } = init();
+            const ws = makeSocket();
+            server.emit("connection", ws, {});
+            expect(provider.sendMessageToClient("client-id", { type: "ping" } as any)).toBe(true);
+
+            expect(() => ws.emit("error", new Error("WS_ERR_INVALID_CLOSE_CODE"))).not.toThrow();
+            expect(provider.sendMessageToClient("client-id", { type: "ping" } as any)).toBe(false);
+        });
     });
 
     describe("sendMessageToAllClients", () => {

--- a/apps/server/src/services/ws_messaging_provider.ts
+++ b/apps/server/src/services/ws_messaging_provider.ts
@@ -47,6 +47,16 @@ export default class WebSocketMessagingProvider implements MessagingProvider {
 
             console.log(`websocket client connected`);
 
+            ws.on("error", (error) => {
+                // A protocol error on a single connection (e.g. WS_ERR_INVALID_CLOSE_CODE from a
+                // malformed close frame sent by a browser going to sleep) emits an "error" event on
+                // this socket. Without a listener, Node's EventEmitter rethrows it as an uncaught
+                // exception and crashes the whole process. Log and drop the connection instead.
+                // https://github.com/TriliumNext/Trilium/issues/9598
+                console.error("WebSocket connection error:", error);
+                this.clientMap.delete(id);
+            });
+
             ws.on("message", (messageJson) => {
                 void (async () => {
                     try {

--- a/apps/server/src/share/content_renderer.ts
+++ b/apps/server/src/share/content_renderer.ts
@@ -184,7 +184,7 @@ function renderNoteContentInternal(note: SNote | BNote, renderArgs: RenderArgs) 
     }
 
     const { header, content, isEmpty } = getContent(note);
-    const showLoginInShareTheme = options.getOption("showLoginInShareTheme");
+    const showLoginInShareTheme = options.getOptionBool("showLoginInShareTheme");
     const opts = {
         note,
         header,

--- a/apps/server/src/share/routes.spec.ts
+++ b/apps/server/src/share/routes.spec.ts
@@ -1,3 +1,4 @@
+import { cls, options } from "@triliumnext/core";
 import type { Application, NextFunction,Request, Response } from "express";
 import supertest from "supertest";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -37,6 +38,24 @@ describe("Share API test", () => {
             .get("/share/YjlPRj2E9fOV")
             .expect(401)
             .expect("WWW-Authenticate", 'Basic realm="User Visible Realm", charset="UTF-8"');
+        expect(cannotSetHeadersCount).toBe(0);
+    });
+
+    it("shows the login link in the share theme only when showLoginInShareTheme is enabled", async () => {
+        // Regression test for #8323: the login link was lost when the share theme was
+        // rewritten. It must render on the share root landing page (the redirectBareDomain
+        // target) when the option is enabled, and stay hidden otherwise.
+        const disabled = await supertest(app).get("/share/").expect(200);
+        expect(disabled.text).not.toContain("login-link");
+
+        cls.init(() => options.setOption("showLoginInShareTheme", "true"));
+        try {
+            const enabled = await supertest(app).get("/share/").expect(200);
+            expect(enabled.text).toContain(`class="login-link"`);
+            expect(enabled.text).toContain(`href="../login"`);
+        } finally {
+            cls.init(() => options.setOption("showLoginInShareTheme", "false"));
+        }
         expect(cannotSetHeadersCount).toBe(0);
     });
 

--- a/packages/ckeditor5-math/src/utils.ts
+++ b/packages/ckeditor5-math/src/utils.ts
@@ -133,7 +133,8 @@ export async function renderEquation(
 					katex.render( equation, el, {
 						throwOnError: false,
 						displayMode: display,
-						...katexRenderOptions
+						...katexRenderOptions,
+						...normalizeKatexMacros( katexRenderOptions )
 					} );
 				}
 				if ( preview ) {
@@ -213,6 +214,18 @@ export function getBalloonPositionData( editor: Editor ): {
 			]
 		};
 	}
+}
+
+// CKEditor stores plain-object config values with a null prototype (`Object.create( null )`),
+// but KaTeX calls `macros.hasOwnProperty()` directly while expanding macros, which throws on a
+// prototype-less object. Rebuild `macros` as an ordinary object so the lookup works (this also
+// hands KaTeX a disposable copy it can safely mutate, e.g. via `\gdef`).
+function normalizeKatexMacros( options: KatexOptions ): { macros?: object } {
+	const { macros } = options;
+	if ( macros && typeof macros === 'object' ) {
+		return { macros: { ...macros } };
+	}
+	return {};
 }
 
 function selectRenderMode(

--- a/packages/ckeditor5-math/tests/utils.ts
+++ b/packages/ckeditor5-math/tests/utils.ts
@@ -1,0 +1,43 @@
+import katex from 'katex';
+import { renderEquation } from '../src/utils.js';
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+
+describe( 'renderEquation (KaTeX)', () => {
+	let element: HTMLDivElement;
+	const globalWithKatex = window as unknown as { katex: typeof katex | undefined };
+	const originalKatex = globalWithKatex.katex;
+
+	beforeEach( () => {
+		// The lazy loader installs KaTeX on the global; renderEquation reads it from there.
+		globalWithKatex.katex = katex;
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+	} );
+
+	afterEach( () => {
+		element.remove();
+		globalWithKatex.katex = originalKatex;
+	} );
+
+	// Regression for #9523: CKEditor stores config objects with a null prototype
+	// (`Object.create( null )`), and KaTeX calls `macros.hasOwnProperty()` directly while
+	// expanding macros, which throws "hasOwnProperty is not a function" on such an object.
+	it( 'renders with a prototype-less macros object (as produced by CKEditor config)', async () => {
+		const macros = Object.assign( Object.create( null ), { '\\differentialD': '\\mathrm{d}' } );
+
+		// Confirms the root cause: passing the raw null-prototype object straight to KaTeX throws.
+		expect( () => katex.renderToString( '\\differentialD', { macros, throwOnError: true } ) ).to.throw();
+
+		await renderEquation( '\\int f(x) \\differentialD x', element, 'katex', undefined, false, false, '', [], { macros } );
+
+		// renderEquation normalizes the object, so the formula renders instead of erroring.
+		expect( element.querySelector( '.katex' ) ).to.not.be.null;
+		expect( element.textContent ?? '' ).to.not.contain( 'hasOwnProperty' );
+	} );
+
+	it( 'renders without any custom macros', async () => {
+		await renderEquation( 'x^2', element, 'katex', undefined, false, false, '', [], {} );
+
+		expect( element.querySelector( '.katex' ) ).to.not.be.null;
+	} );
+} );

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/i18n.js";
+export * from "./lib/katex_macros.js";
 export * from "./lib/options_interface.js";
 export * from "./lib/keyboard_actions_interface.js";
 export * from "./lib/hidden_subtree.js";

--- a/packages/commons/src/lib/katex_macros.ts
+++ b/packages/commons/src/lib/katex_macros.ts
@@ -1,0 +1,33 @@
+/**
+ * KaTeX macros that map commands emitted by the MathLive visual math editor
+ * (used in the rich-text editor's math dialog) onto equivalents that KaTeX — the
+ * engine Trilium uses to *render* math — actually understands.
+ *
+ * MathLive produces commands that are not part of KaTeX's command set, so without
+ * these macros the formula renders as raw red error text. Defining them here means
+ * both newly typed and already-stored formulas render correctly, regardless of how
+ * the LaTeX was produced (visual editor, LaTeX textarea, paste, import or sync).
+ *
+ * This covers every command a user can trigger just by typing — MathLive's inline
+ * shortcuts auto-insert `\differentialD` (`dx`/`dy`/`dt`), `\questeq` (`?=`) and
+ * `\Colon` (`::`) — plus the rest of the ISO 80000-2 upright-operator family that
+ * shares the same definition (`\exponentialE`, `\imaginaryI`, …). Upright operators
+ * map to `\mathrm{…}` to match MathLive's own rendering. Obscure macros that only
+ * appear when a user deliberately types them are intentionally not mirrored here.
+ *
+ * This list must be applied to every KaTeX render path: the rich-text editor
+ * (`katexRenderOptions`), read-only note rendering, and the share theme.
+ *
+ * @see https://github.com/TriliumNext/Trilium/issues/9523
+ */
+export const KATEX_MACROS: Record<string, string> = {
+    // ISO 80000-2 upright operators (mathlive MACROS table)
+    "\\differentialD": "\\mathrm{d}",
+    "\\capitalDifferentialD": "\\mathrm{D}",
+    "\\exponentialE": "\\mathrm{e}",
+    "\\imaginaryI": "\\mathrm{i}",
+    "\\imaginaryJ": "\\mathrm{j}",
+    // Relational shortcuts (mathlive inline shortcuts: `?=` and `::`)
+    "\\questeq": "\\stackrel{?}{=}", // U+225F questioned-equal: "?" over "="
+    "\\Colon": "\\dblcolon" // U+2237 proportion / double colon
+};

--- a/packages/commons/src/lib/markdown_renderer.spec.ts
+++ b/packages/commons/src/lib/markdown_renderer.spec.ts
@@ -321,6 +321,19 @@ describe("renderToHtml", () => {
         });
     });
 
+    describe("tables (CustomMarkdownRenderer.table)", () => {
+        it("wraps a table in <figure class=\"table\"> to match CKEditor's structure (#10270)", () => {
+            const html = render("| a | b |\n|---|---|\n| c | d |");
+            expect(html).toContain('<figure class="table">');
+            expect(html).toContain("</figure>");
+            // The wrapper hugs the table with no stray whitespace between them.
+            expect(html).toContain('<figure class="table"><table>');
+            expect(html).toContain("</table></figure>");
+            expect(html).toContain("<th>a</th>");
+            expect(html).toContain("<td>c</td>");
+        });
+    });
+
     describe("blockquotes / admonitions (CustomMarkdownRenderer.blockquote)", () => {
         it("renders a [!NOTE] admonition", () => {
             expect(render("> [!NOTE]\n> body")).toBe('<aside class="admonition note"><p>body</p></aside>');

--- a/packages/commons/src/lib/markdown_renderer.spec.ts
+++ b/packages/commons/src/lib/markdown_renderer.spec.ts
@@ -91,6 +91,26 @@ describe("extractCodeBlocks", () => {
         const hasFencedBlock = values.some((v) => v.includes("print('hello')"));
         expect(hasFencedBlock).toBe(true);
     });
+
+    it("should extract a fenced code block nested in a blockquote, prefixes and all (#10268)", () => {
+        const input = [ "> ```", "> echo ${VAR} ${VAR2}", "> ```" ].join("\n");
+        const { processedText, placeholderMap } = extractCodeBlocks(input);
+
+        expect(placeholderMap.size).toBe(1);
+        expect(processedText).not.toContain("```");
+        // The whole block, including the `> ` prefixes, is captured verbatim so the
+        // blockquote still renders after restoration.
+        expect([...placeholderMap.values()][0]).toBe(input);
+    });
+
+    it("should extract a fenced code block in a doubly-nested blockquote", () => {
+        const input = [ "> > ```", "> > $ $", "> > ```" ].join("\n");
+        const { processedText, placeholderMap } = extractCodeBlocks(input);
+
+        expect(placeholderMap.size).toBe(1);
+        expect(processedText).not.toContain("```");
+        expect([...placeholderMap.values()][0]).toBe(input);
+    });
 });
 
 describe("renderToHtml", () => {
@@ -400,6 +420,16 @@ describe("renderToHtml", () => {
             expect(render("$e=mc^2$$")).toBe("<p>$e=mc^2$$</p>");
             expect(render("$$$x$$")).toBe("<p>$$$x$$</p>");
             expect(render("$$e=mc^2$")).not.toContain("math-tex");
+        });
+
+        it("does not treat dollars in a blockquoted code block as formulas (#10268)", () => {
+            // The fence lines carry a `> ` prefix, so the code block must still be shielded
+            // from formula extraction — otherwise `${VAR} ${VAR2}` is mangled into a math span.
+            const html = render([ "> ```", "> echo ${VAR} ${VAR2}", "> ```" ].join("\n"));
+            expect(html).toContain("echo ${VAR} ${VAR2}");
+            expect(html).not.toContain("math-tex");
+            expect(html).not.toContain("FORMULA");
+            expect(html).toContain("<blockquote>");
         });
     });
 

--- a/packages/commons/src/lib/markdown_renderer.ts
+++ b/packages/commons/src/lib/markdown_renderer.ts
@@ -249,8 +249,13 @@ export function extractCodeBlocks(text: string): { processedText: string; placeh
     let id = 0;
     const timestamp = Date.now();
 
+    // `(?:>[ \t]*)*` allows blockquote prefixes on the fence lines so that fenced
+    // code blocks nested in a blockquote (`> ``` `) are still shielded. Otherwise their
+    // contents leak into formula extraction, which mangles `$…$` runs like `${VAR}` (#10268).
+    // The whole match is restored verbatim before marked parses, so the prefixes are
+    // preserved and the blockquote still renders correctly.
     text = text
-        .replace(/^[ \t]*```[^\n]*\n[\s\S]*?^[ \t]*```[ \t]*$/gm, (m) => {
+        .replace(/^[ \t]*(?:>[ \t]*)*```[^\n]*\n[\s\S]*?^[ \t]*(?:>[ \t]*)*```[ \t]*$/gm, (m) => {
             const key = `<!--CODE_BLOCK_${timestamp}_${id++}-->`;
             codeMap.set(key, m);
             return key;

--- a/packages/commons/src/lib/markdown_renderer.ts
+++ b/packages/commons/src/lib/markdown_renderer.ts
@@ -387,6 +387,15 @@ export class CustomMarkdownRenderer extends Renderer {
         return super.image(token).replace(` alt=""`, "");
     }
 
+    override table(token: Tokens.Table): string {
+        // CKEditor wraps every table in `<figure class="table">`, and its content CSS
+        // (`.ck-content .table`) styles that wrapper rather than a bare `<table>`. Without
+        // it, imported tables render unstyled in read-only mode until the note is opened in
+        // the editor — which re-wraps them on save (#10270). Emit the wrapper here so
+        // imported markdown matches CKEditor's structure up front.
+        return `<figure class="table">${super.table(token).trimEnd()}</figure>`;
+    }
+
     override blockquote({ tokens }: Tokens.Blockquote): string {
         const body = this.parser.parse(tokens);
 

--- a/packages/share-theme/package.json
+++ b/packages/share-theme/package.json
@@ -24,6 +24,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
+    "@triliumnext/commons": "workspace:*",
     "fuse.js": "7.4.2",
     "katex": "0.17.0",
     "mermaid": "11.15.0"

--- a/packages/share-theme/src/scripts/modules/math.ts
+++ b/packages/share-theme/src/scripts/modules/math.ts
@@ -1,3 +1,4 @@
+import { KATEX_MACROS } from "@triliumnext/commons/src/lib/katex_macros.js";
 import "katex/dist/katex.min.css";
 
 export default async function setupMath() {
@@ -13,6 +14,8 @@ export default async function setupMath() {
     if (!contentEl) return;
     // throwOnError: false renders invalid formulas as an inline red error instead of
     // throwing and leaving raw `$…$` text plus a console error (matches the editor).
-    renderMathInElement(contentEl, { throwOnError: false });
+    // macros map MathLive-only commands (e.g. \differentialD) onto KaTeX equivalents.
+    // Spread into a fresh object: KaTeX may mutate it (e.g. via `\gdef`).
+    renderMathInElement(contentEl, { throwOnError: false, macros: { ...KATEX_MACROS } });
     document.body.classList.add("math-loaded");
 }

--- a/packages/share-theme/src/styles/content-footer.css
+++ b/packages/share-theme/src/styles/content-footer.css
@@ -66,5 +66,12 @@
 
 #content-footer .updated time {
     font-weight: bold;
-    
+
+}
+
+#content-footer .login {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+    font-size: smaller;
 }

--- a/packages/share-theme/src/templates/page.ejs
+++ b/packages/share-theme/src/templates/page.ejs
@@ -103,8 +103,12 @@ const mobileLogoHeight = logoHeight && logoWidth ? 32 / (logoWidth / logoHeight)
 const shareRootLink = subRoot.note.hasLabel("shareRootLink") ? sanitizeUrl(subRoot.note.getLabelValue("shareRootLink") ?? "") : `./${subRoot.note.noteId}`;
 const headingRe = /(<h[1-6]>)(.+?)(<\/h[1-6]>)/g;
 const headingMatches = [...content.matchAll(headingRe)];
+// Unique slug per heading (in document order) so duplicate titles get distinct
+// anchor IDs and the ToC links point to the right occurrence.
+const headingSlugs = utils.slugifyHeadings(headingMatches.map((m) => m[2]));
+let headingIndex = 0;
 content = content.replaceAll(headingRe, (...match) => {
-    const slug = utils.slugify(utils.stripTags(match[2]));
+    const slug = headingSlugs[headingIndex++];
     match[0] = match[0].replace(match[3], `<a id="${slug}" class="toc-anchor" name="${slug}" href="#${slug}">#</a>${match[3]}`);
     return match[0];
 });
@@ -216,25 +220,19 @@ content = content.replaceAll(headingRe, (...match) => {
         if (headingMatches.length > 1) {
             const level = (m) => parseInt(m[1].replace(/[<h>]+/g, ""));
 
-            const toc = [
-                {
-                    level: level(headingMatches[0]),
-                    name: headingMatches[0][2],
-                    children: []
-                }
-            ];
+            const makeEntry = (i) => ({level: level(headingMatches[i]), name: headingMatches[i][2], slug: headingSlugs[i], children: []});
+            const toc = [ makeEntry(0) ];
             const last = (arr = toc) => arr[arr.length - 1];
-            const makeEntry = (m) => ({level: level(m), name: m[2], children: []});
             const getLevelArr = (lvl, arr = toc) => {
                 if (arr[0].level === lvl) return arr;
                 const top = last(arr);
                 return top.children.length ? getLevelArr(lvl, top.children) : top.children;
             };
-            
-            
+
+
             for (let m = 1; m < headingMatches.length; m++) {
                 const target = getLevelArr(level(headingMatches[m]));
-                target.push(makeEntry(headingMatches[m]));
+                target.push(makeEntry(m));
             }
         %>
             <div id="toc-pane">

--- a/packages/share-theme/src/templates/page.ejs
+++ b/packages/share-theme/src/templates/page.ejs
@@ -204,6 +204,12 @@ content = content.replaceAll(headingRe, (...match) => {
                 <% if (hasTree) { %>
                     <%- include("prev_next", { note: note, subRoot: subRoot }) %>
                 <% } %>
+
+                <% if (showLoginInShareTheme && !isStatic) { %>
+                    <div class="login">
+                        <a href="../login" class="login-link"><%= t("share_theme.login") %></a>
+                    </div>
+                <% } %>
             </footer>
         </div>
         <%

--- a/packages/share-theme/src/templates/toc_item.ejs
+++ b/packages/share-theme/src/templates/toc_item.ejs
@@ -1,6 +1,6 @@
 <%
 const strippedName = utils.stripTags(entry.name);
-const slug = utils.slugify(strippedName);
+const slug = entry.slug ?? utils.slugify(strippedName);
 %>
 
 <li>

--- a/packages/trilium-core/src/becca/entities/battachment.spec.ts
+++ b/packages/trilium-core/src/becca/entities/battachment.spec.ts
@@ -382,6 +382,90 @@ describe("BAttachment (real DB)", () => {
 
             expect(() => getContext().init(() => att.convertToNote())).toThrow(/non-string content/);
         });
+
+        it("rewrites a reference link to a converted 'file' attachment so it points at the new note", () => {
+            const note = createNote({ content: "<p>placeholder</p>" });
+            const att = getContext().init(() =>
+                note.saveAttachment({ role: "file", mime: "text/plain", title: "doc-" + counter, content: "file body" })
+            );
+            const attachmentId = att.attachmentId;
+            expect(attachmentId).toBeDefined();
+
+            // CKEditor stores attachment reference links with the `&` HTML-encoded as `&amp;`.
+            const refContent = `<p>see <a class="reference-link" href="#root/${note.noteId}?viewMode=attachments&amp;attachmentId=${attachmentId}">doc</a></p>`;
+            getContext().init(() => note.setContent(refContent));
+
+            const { note: created } = getContext().init(() => att.convertToNote());
+
+            // The dangling attachment link is collapsed into a plain note link to the new note.
+            const expected = `<p>see <a class="reference-link" href="#root/${created.noteId}">doc</a></p>`;
+            expect(unwrapStringOrBuffer(note.getContent())).toBe(expected);
+
+            // ...and the parent gains an internal-link relation to the new note (no longer a [missing attachment]).
+            const internalLinks = note
+                .getRelations()
+                .filter((rel) => rel.name === "internalLink")
+                .map((rel) => rel.value);
+            expect(internalLinks).toContain(created.noteId);
+        });
+
+        it("rewrites a reference link that uses an unencoded '&' separator", () => {
+            const note = createNote({ content: "<p>x</p>" });
+            const att = getContext().init(() =>
+                note.saveAttachment({ role: "file", mime: "text/plain", title: "raw-" + counter, content: "y" })
+            );
+            const attachmentId = att.attachmentId;
+
+            const refContent = `<a href="#root/${note.noteId}?viewMode=attachments&attachmentId=${attachmentId}">raw</a>`;
+            getContext().init(() => note.setContent(refContent));
+
+            const { note: created } = getContext().init(() => att.convertToNote());
+
+            expect(unwrapStringOrBuffer(note.getContent())).toBe(`<a href="#root/${created.noteId}">raw</a>`);
+        });
+
+        it("rewrites both the embedded image and a reference link when converting an 'image' attachment", () => {
+            const note = createNote({ content: "<p>x</p>" });
+            const att = getContext().init(() =>
+                note.saveAttachment({ role: "image", mime: "image/png", title: "pic-" + counter, content: "binarydata" })
+            );
+            const attachmentId = att.attachmentId;
+            expect(attachmentId).toBeDefined();
+
+            const refContent =
+                `<img src="api/attachments/${attachmentId}/image/pic.png">` +
+                `<a class="reference-link" href="#root/${note.noteId}?viewMode=attachments&amp;attachmentId=${attachmentId}">pic</a>`;
+            getContext().init(() => note.setContent(refContent));
+
+            const { note: created } = getContext().init(() => att.convertToNote());
+
+            const expected =
+                `<img src="api/images/${created.noteId}/pic.png">` +
+                `<a class="reference-link" href="#root/${created.noteId}">pic</a>`;
+            expect(unwrapStringOrBuffer(note.getContent())).toBe(expected);
+        });
+
+        it("leaves reference links to other attachments untouched when converting one of them", () => {
+            const note = createNote({ content: "<p>x</p>" });
+            const target = getContext().init(() =>
+                note.saveAttachment({ role: "file", mime: "text/plain", title: "target-" + counter, content: "a" })
+            );
+            const other = getContext().init(() =>
+                note.saveAttachment({ role: "file", mime: "text/plain", title: "other-" + counter, content: "b" })
+            );
+
+            const otherHref = `#root/${note.noteId}?viewMode=attachments&amp;attachmentId=${other.attachmentId}`;
+            const refContent =
+                `<a href="#root/${note.noteId}?viewMode=attachments&amp;attachmentId=${target.attachmentId}">target</a>` +
+                `<a href="${otherHref}">other</a>`;
+            getContext().init(() => note.setContent(refContent));
+
+            const { note: created } = getContext().init(() => target.convertToNote());
+
+            // Only the converted attachment's link is rewritten; the other attachment's link is left intact.
+            const expected = `<a href="#root/${created.noteId}">target</a>` + `<a href="${otherHref}">other</a>`;
+            expect(unwrapStringOrBuffer(note.getContent())).toBe(expected);
+        });
     });
 
     describe("getPojo / getPojoToSave", () => {

--- a/packages/trilium-core/src/becca/entities/battachment.ts
+++ b/packages/trilium-core/src/becca/entities/battachment.ts
@@ -172,27 +172,48 @@ class BAttachment extends AbstractBeccaEntity<BAttachment> {
             isProtected: this.isProtected
         });
 
+        const attachmentId = this.attachmentId;
+
         this.markAsDeleted();
 
         const parentNote = this.getNote();
 
-        if (this.role === "image" && parentNote.type === "text") {
+        if (parentNote.type === "text") {
             const origContent = parentNote.getContent();
 
             if (typeof origContent !== "string") {
-                throw new Error(`Note with ID '${note.noteId} has a text type but non-string content.`);
+                throw new Error(`Note with ID '${note.noteId}' has a text type but non-string content.`);
             }
 
-            const oldAttachmentUrl = `api/attachments/${this.attachmentId}/image/`;
-            const newNoteUrl = `api/images/${note.noteId}/`;
+            let fixedContent = origContent;
 
-            const fixedContent = replaceAll(origContent, oldAttachmentUrl, newNoteUrl);
+            if (this.role === "image") {
+                // Rewrite embedded images (`<img src="api/attachments/{attachmentId}/image/...">`)
+                // to point at the new image note.
+                const oldAttachmentUrl = `api/attachments/${attachmentId}/image/`;
+                const newNoteUrl = `api/images/${note.noteId}/`;
+
+                fixedContent = replaceAll(fixedContent, oldAttachmentUrl, newNoteUrl);
+            }
+
+            // Rewrite reference links to the attachment so they point at the new note instead of
+            // resolving to "[missing attachment]" once the attachment is gone. These links are stored
+            // as `<a href="#root/{ownerId}?viewMode=attachments&attachmentId={attachmentId}">` (the `&`
+            // may be HTML-encoded as `&amp;`), which we collapse to a plain note link `#root/{noteId}`.
+            if (attachmentId) {
+                fixedContent = fixedContent.replace(
+                    new RegExp(`href="[^"]*attachmentId=${attachmentId}"`, "g"),
+                    `href="#root/${note.noteId}"`
+                );
+            }
 
             if (fixedContent !== origContent) {
                 parentNote.setContent(fixedContent);
             }
 
-            noteService.asyncPostProcessContent(note, fixedContent);
+            // Re-scan the parent (not the new image/file note, which has no scannable links) so its
+            // link relations are updated to reflect the rewritten URLs and reference links.
+            noteService.asyncPostProcessContent(parentNote, fixedContent);
         }
 
         return { note, branch };

--- a/packages/trilium-core/src/becca/entities/battachment.ts
+++ b/packages/trilium-core/src/becca/entities/battachment.ts
@@ -10,7 +10,7 @@ import AbstractBeccaEntity from "./abstract_becca_entity.js";
 import type BBranch from "./bbranch.js";
 import type BNote from "./bnote.js";
 import { getSql } from "../../services/sql/index.js";
-import { formatDownloadTitle, isStringNote, replaceAll } from "../../services/utils";
+import { escapeRegExp, formatDownloadTitle, isStringNote, replaceAll } from "../../services/utils";
 
 const attachmentRoleToNoteTypeMapping = {
     image: "image",
@@ -202,7 +202,7 @@ class BAttachment extends AbstractBeccaEntity<BAttachment> {
             // may be HTML-encoded as `&amp;`), which we collapse to a plain note link `#root/{noteId}`.
             if (attachmentId) {
                 fixedContent = fixedContent.replace(
-                    new RegExp(`href="[^"]*attachmentId=${attachmentId}"`, "g"),
+                    new RegExp(`href="[^"]*attachmentId=${escapeRegExp(attachmentId)}[^"]*"`, "g"),
                     `href="#root/${note.noteId}"`
                 );
             }

--- a/packages/trilium-core/src/services/utils/index.spec.ts
+++ b/packages/trilium-core/src/services/utils/index.spec.ts
@@ -794,6 +794,29 @@ describe("#slugify", () => {
     });
 });
 
+describe("#slugifyHeadings", () => {
+    it("slugifies each heading in order", () => {
+        expect(utils.slugifyHeadings(["First Section", "Second Section"])).toStrictEqual(["first-section", "second-section"]);
+    });
+
+    it("disambiguates duplicate titles with a numeric suffix", () => {
+        expect(utils.slugifyHeadings(["Notes", "Notes", "Notes"])).toStrictEqual(["notes", "notes-1", "notes-2"]);
+    });
+
+    it("avoids colliding a suffix with an existing slug", () => {
+        // "Notes 1" naturally slugifies to "notes-1", so the second "Notes" must skip to "notes-2"
+        expect(utils.slugifyHeadings(["Notes", "Notes 1", "Notes"])).toStrictEqual(["notes", "notes-1", "notes-2"]);
+    });
+
+    it("strips HTML tags before slugifying", () => {
+        expect(utils.slugifyHeadings(["<b>Bold</b> Heading"])).toStrictEqual(["bold-heading"]);
+    });
+
+    it("returns an empty array for no headings", () => {
+        expect(utils.slugifyHeadings([])).toStrictEqual([]);
+    });
+});
+
 describe("#sanitizeSvg", () => {
     it("should remove script elements", () => {
         const maliciousSvg = '<svg><script>alert("XSS")</script><rect width="100" height="100"/></svg>';

--- a/packages/trilium-core/src/services/utils/index.ts
+++ b/packages/trilium-core/src/services/utils/index.ts
@@ -410,6 +410,29 @@ export function stripTags(text: string) {
     return text.replace(/<(?:.|\n)*?>/gm, "");
 }
 
+/**
+ * Generates a list of unique slugs for the given heading titles, preserving
+ * document order. Titles are stripped of HTML tags and slugified; when the same
+ * slug would be produced more than once (e.g. multiple headings sharing a
+ * title), subsequent occurrences get a numeric suffix (`foo`, `foo-1`, `foo-2`, …).
+ *
+ * This keeps anchor IDs and their table-of-contents links unique on shared
+ * pages, so clicking a duplicate heading in the ToC jumps to the right one.
+ */
+export function slugifyHeadings(titles: string[]): string[] {
+    const used = new Set<string>();
+    return titles.map((title) => {
+        const base = slugify(stripTags(title));
+        let slug = base;
+        let counter = 1;
+        while (used.has(slug)) {
+            slug = `${base}-${counter++}`;
+        }
+        used.add(slug);
+        return slug;
+    });
+}
+
 export function toObject<T, K extends string | number | symbol, V>(array: T[], fn: (item: T) => [K, V]): Record<K, V> {
     const obj: Record<K, V> = {} as Record<K, V>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1568,6 +1568,9 @@ importers:
 
   packages/share-theme:
     dependencies:
+      '@triliumnext/commons':
+        specifier: workspace:*
+        version: link:../commons
       fuse.js:
         specifier: 7.4.2
         version: 7.4.2


### PR DESCRIPTION
A collection of independent bug fixes across share, markdown/math, attachments, forms, and the desktop/server runtime. Each commit is self-contained and references the issue it closes.

## Share & theme
- **#8318** — Give duplicate headings unique TOC anchors so clicking a duplicate heading in the ToC jumps to the right one
- **#7869** — Redirect to login instead of 404 when the bare-domain share root is missing
- **#8323** — Restore the login link in the share theme

## Markdown & math
- **#9523** — Render MathLive commands unsupported by KaTeX (via shared `katex_macros`)
- **#10268** — Shield blockquoted code fences from formula extraction
- **#10270** — Wrap imported tables in `figure.table` for read-only rendering

## Attachments
- **#5818** — Rewrite links when converting an attachment to a note
- **#5118** — Clarify "Copy link to clipboard" as "Copy reference to clipboard"

## Forms & dialogs
- **#8330** — Activate the focused list item with Enter/Space
- **#9751** — Auto-focus the OK button in confirm dialogs so Enter/Space confirms
- **#8187** — Show "Create note" in promoted relation autocomplete
- Show the focus ring on auto-focused dialog footer buttons (theme-next)

## Media
- **#9752** — Align the forward seek button with the 10s shortcut

## Server / runtime
- **#9598** — Handle per-connection socket errors to prevent a crash
- **#8497** — Show the correct date header in recent changes for negative UTC offsets
- Guard EXIF orientation when shrinking images (test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
