### PR TITLE
Fix calendar events spanning day boundaries without an end date

### DIFF
--- a/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
@@ -113,6 +113,19 @@ describe("Building events", () => {
         expect(events[1]).toMatchObject({ title: "Note 2", start: "2025-05-07" });
     });
 
+    it("supports events without an end time", async () => {
+        const noteIds = buildNotes([
+            { title: "Note 1", "#startDate": "2025-05-05", "#endDate": "2025-05-05", "#startTime": "13:30" },
+        ]);
+        const events = await buildEvents(noteIds);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            title: "Note 1",
+            start: "2025-05-05T13:30:00",
+            end: "2025-05-05"
+        });
+    });
 });
 
 describe("Promoted attributes", () => {

--- a/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
@@ -199,6 +199,28 @@ describe("Recurrence", () => {
         expect(events[0].end).toBeUndefined();
     });
 
+    it("supports recurrence spanning day boundary", async () => {
+        const noteIds = buildNotes([
+            {
+                title: "Recurring Event Spanning Day Boundary",
+                "#startDate": "2025-05-05",
+                "#startTime": "23:00",
+                "#endTime": "1:00",
+                "#recurrence": "FREQ=DAILY;COUNT=3"
+            }
+        ]);
+        const events = await buildEvents(noteIds);
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            title: "Recurring Event Spanning Day Boundary",
+            start: "2025-05-05T23:00:00",
+            duration: "02:00"
+        });
+        expect(events[0].rrule).toContain("DTSTART:20250505T230000");
+        expect(events[0].end).toBeUndefined();
+    });
+
     it("supports recurrence with start and end time (duration calculated)", async () => {
         const noteIds = buildNotes([
             {

--- a/apps/client/src/widgets/collections/calendar/event_builder.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.ts
@@ -121,6 +121,11 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
         }
 
         endDate = (endTime ? `${endDate}T${endTime}:00` : endDate);
+        // If the end date is now before the start date, bump it a day forward to account for times spanning the day boundary
+        if (endDate && dayjs(endDate).isBefore(dayjs(startDate))) {
+            endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DDTHH:mm:ss");
+        }
+
         const eventData: EventInput = {
             id: note.noteId,
             title,

--- a/apps/client/src/widgets/collections/calendar/event_builder.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.ts
@@ -122,7 +122,7 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
 
         endDate = (endTime ? `${endDate}T${endTime}:00` : endDate);
         // If the end date is now before the start date, bump it a day forward to account for times spanning the day boundary
-        if (endDate && dayjs(endDate).isBefore(dayjs(startDate))) {
+        if (endDate && endTime && dayjs(endDate).isBefore(dayjs(startDate))) {
             endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DDTHH:mm:ss");
         }
 


### PR DESCRIPTION
If events have an end time before their start time, buildNotes currently generates a negative duration on recurring events or an end before start on non-recurring events. Neither of these render properly, so it makes sense to assume the event crosses the day boundary into the following day. This also makes recurring events crossing day boundaries more intuitive, since one previously needed to assign an end date the day after its start date, which doesn't hold much meaning.

Before:
<img width="2014" height="1253" alt="image" src="https://github.com/user-attachments/assets/6af47bec-5765-4610-9d06-7c2dab1d5a08" />

After:
<img width="2014" height="1253" alt="image" src="https://github.com/user-attachments/assets/7ee8910b-234c-4cd9-98ed-5697fb78754b" />

Thanks for the amazing work on Trilium :)