### PR TITLE
feat(attr): add #openAtBottom label to open notes scrolled to the bottom

### DIFF
--- a/apps/client/src/widgets/type_widgets/code/Code.tsx
+++ b/apps/client/src/widgets/type_widgets/code/Code.tsx
@@ -112,6 +112,15 @@ export function EditableCode({ note, ntxId, noteContext, debounceUpdate, parentC
             codeEditor.setText(content ?? "");
             codeEditor.setMimeType(note.mime);
             codeEditor.clearHistory();
+            if (note?.hasLabel("openAtBottom")) {
+                requestAnimationFrame(() => {
+                    editorRef.current?.scrollToEnd();
+                    const scrollContainer = containerRef.current?.closest(".scrolling-container");
+                    if (scrollContainer instanceof HTMLElement) {
+                        scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: "instant" });
+                    }
+                });
+            }
         },
         dataSaved,
         updateInterval

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -70,6 +70,10 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
                     viewScope.bookmark = undefined;
                 });
             }
+
+            if (note?.hasLabel("openAtBottom")) {
+                scrollEditorToBottom(watchdogRef.current?.editor as CKTextEditor | undefined, containerRef.current);
+            }
         },
         dataSaved(savedData) {
             // Store back the saved data in order to retrieve it in case the CKEditor crashes.
@@ -289,10 +293,30 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
                     editor.setData(contentRef.current);
                     parentComponent?.triggerEvent("textEditorRefreshed", { ntxId, editor });
 
+                    if (note?.hasLabel("openAtBottom")) {
+                        scrollEditorToBottom(editor, containerRef.current);
+                    }
                 }}
             />}
         </>
     );
+}
+
+function scrollEditorToBottom(editor: CKTextEditor | null | undefined, container: HTMLElement | null) {
+    requestAnimationFrame(() => {
+        if (editor) {
+            editor.model.change((writer) => {
+                const rootItem = editor.model.document.getRoot();
+                if (rootItem) {
+                    writer.setSelection(writer.createPositionAt(rootItem, "end"));
+                }
+            });
+        }
+        const scrollContainer = container?.closest(".scrolling-container");
+        if (scrollContainer instanceof HTMLElement) {
+            scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior: "instant" });
+        }
+    });
 }
 
 /**

--- a/docs/User Guide/User Guide/Advanced Usage/Attributes/Labels.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Attributes/Labels.md
@@ -52,6 +52,7 @@ This is a list of labels that Trilium natively supports.
 | `hidePromotedAttributes` | Hide <a class="reference-link" href="Promoted%20Attributes.md">Promoted Attributes</a> on this note. Generally useful when defining inherited attributes, but the parent note doesn't need them. |
 | `readOnly` | Marks a note to always be [read-only](../../Basic%20Concepts%20and%20Features/Notes/Read-Only%20Notes.md), if it's a supported note (text, code, mermaid). |
 | `autoReadOnlyDisabled` | Disables automatic [read-only mode](../../Basic%20Concepts%20and%20Features/Notes/Read-Only%20Notes.md) for the given note. |
+| `openAtBottom` | When opening a text or code note, scrolls the viewport to the bottom of the content. Useful for append-only notes such as logs or journals. |
 | `appCss` | Marks CSS notes which are loaded into the Trilium application and can thus be used to modify Trilium's looks. See <a class="reference-link" href="../../Theme%20development/Custom%20app-wide%20CSS.md">Custom app-wide CSS</a> for more info. |
 | `appTheme` | Marks CSS notes which are full Trilium themes and are thus available in Trilium options. See <a class="reference-link" href="../../Theme%20development">Theme development</a> for more information. |
 | `appThemeBase` | Set to `next`, `next-light`, or `next-dark` to use the corresponding TriliumNext theme (auto, light or dark) as the base for a custom theme, instead of the legacy one. See <a class="reference-link" href="../../Theme%20development/Customize%20the%20Next%20theme.md">Customize the Next theme</a> for more information. |

--- a/packages/codemirror/src/index.ts
+++ b/packages/codemirror/src/index.ts
@@ -272,6 +272,7 @@ export default class CodeMirror extends EditorView {
         const endPos = this.state.doc.length;
         this.dispatch({
             selection: EditorSelection.cursor(endPos),
+            scrollIntoView: true,
         });
     }
 

--- a/packages/commons/src/lib/attribute_names.ts
+++ b/packages/commons/src/lib/attribute_names.ts
@@ -72,6 +72,7 @@ type Labels = {
     webViewSrc: string;
     "disabled:webViewSrc": string;
     readOnly: boolean;
+    openAtBottom: boolean;
     fullContentWidth: boolean;
     displayMode: string;
     tabWidth: number;

--- a/packages/commons/src/lib/builtin_attributes.ts
+++ b/packages/commons/src/lib/builtin_attributes.ts
@@ -11,6 +11,7 @@ export default [
     { type: "label", name: "appThemeBase" },
     { type: "label", name: "hidePromotedAttributes" },
     { type: "label", name: "readOnly" },
+    { type: "label", name: "openAtBottom" },
     { type: "label", name: "autoReadOnlyDisabled" },
     { type: "label", name: "cssClass" },
     { type: "label", name: "iconClass" },


### PR DESCRIPTION
## Summary

Adds a new built-in label `#openAtBottom` that scrolls the viewport to the bottom of a note's content when the note is opened. Useful for append-only notes such as logs or journals.

## Behavior

- On opening a note with `#openAtBottom`, the viewport scrolls to the end and the cursor is placed there
- Works even when the editor has no focus (e.g. navigating via the note tree)
- Works for both text notes (CKEditor5) and code notes (CodeMirror)

## Implementation

The scroll is triggered from two places to cover all open paths:

- **`onContentChange`** — fires on every note switch; scrolls the `.scrolling-container` and moves the CKEditor model selection to `"end"` (or calls `scrollToEnd()` for CodeMirror)
- **`onEditorInitialized`** — covers the initial mount case where content may arrive before the editor is ready

### Files changed

- `packages/commons/src/lib/attribute_names.ts` — type-safe `openAtBottom: boolean` label definition
- `packages/commons/src/lib/builtin_attributes.ts` — registers the label for attribute autocomplete
- `apps/client/src/widgets/type_widgets/text/EditableText.tsx` — `scrollEditorToBottom()` helper sets the CKEditor model selection to `"end"` and scrolls `.scrolling-container`; called from both `onContentChange` and `onEditorInitialized`
- `apps/client/src/widgets/type_widgets/code/Code.tsx` — in `onContentChange`, calls `scrollToEnd()` and scrolls `.scrolling-container` (same pattern as `insertBlankLineAtTop`)
- `packages/codemirror/src/index.ts` — fixes `scrollToEnd()` to include `scrollIntoView: true`; previously it only moved the cursor without scrolling CodeMirror's own view unless `focus()` was called afterward
- `docs/User Guide/.../Attributes/Labels.md` — documents the new label in the predefined labels table

## Test plan

- [ ] Add `#openAtBottom` to a text note with enough content to scroll; navigate away and back — viewport and cursor should be at the bottom
- [ ] Same for a code note
- [ ] Verify that clicking back into an already-open note does not re-scroll to the bottom
- [ ] Verify a note without the label still opens at the top
- [ ] Verify `#openAtBottom` appears in attribute autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)