### PR TITLE
fix(board): ignore IME composition Enter when editing card and column titles

### DIFF
--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -5,6 +5,7 @@ import { Dispatch, StateUpdater, useCallback, useEffect, useMemo, useRef, useSta
 
 import FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
+import { isIMEComposing } from "../../../services/shortcuts";
 import toast from "../../../services/toast";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import FormTextArea from "../../react/FormTextArea";
@@ -269,6 +270,12 @@ export function TitleEditor({ currentValue, placeholder, save, dismiss, mode, is
     });
 
     const onKeyDown = (e: TargetedKeyboardEvent<HTMLInputElement | HTMLTextAreaElement> | KeyboardEvent) => {
+        // Skip processing during IME composition so the Enter that commits a
+        // CJK conversion does not also save the title with unconfirmed text.
+        if (isIMEComposing(e)) {
+            return;
+        }
+
         if (e.key === "Enter" || e.key === "Escape") {
             e.preventDefault();
             e.stopPropagation();


### PR DESCRIPTION
### What

The board view's inline title editor saves its value when Enter is pressed. During IME composition (Japanese, Chinese, Korean and other CJK input), the Enter that confirms a candidate conversion arrives as a normal `keydown`. Today that Enter runs the commit path and calls `preventDefault()`, so the conversion is swallowed and the card or column title is saved with the unconfirmed, half-composed text.

### Why it's a small change

The rest of the client already handles this. `isIMEComposing()` in `apps/client/src/services/shortcuts.ts` is used by `note_title.tsx`, `ribbon/components/AttributeEditor.tsx`, `find.ts` and `quick_search.ts` to ignore keydowns while the IME is composing. The board's `TitleEditor` (in `widgets/collections/board/index.tsx`) was the one text input that missed it, so this applies the same guard:

```ts
if (isIMEComposing(e)) {
    return;
}
```

`TitleEditor` is the single editor used for renaming a card, renaming a column, adding a new column and adding a new item, so this one guard covers all four.

### Scope and safety

- No-op for non-IME input: on a real Enter, `isComposing` is `false` (and `keyCode` is 13), so the existing save/dismiss path runs exactly as before.
- The keydown handlers on the focusable card / column / "add" `div`s in `card.tsx` and `column.tsx` are left unchanged. They open or begin editing on Enter and are not text inputs, so IME composition does not apply there.

I confirmed the patched file transpiles and mirrors the existing `isIMEComposing(e)` idiom used elsewhere in the client. I couldn't drive a real IME conversion in an automated test (same limitation as the existing composition handling), so I checked the logic by hand against the conversion-commit flow. Happy to add a regression test if you'd like one.
