### PR TITLE
feat(client): add inverse DAG view to NotePathsTab (POC)

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1094,7 +1094,9 @@
     "intro_not_placed": "This note is not yet placed into the note tree.",
     "outside_hoisted": "This path is outside of hoisted note and you would have to unhoist.",
     "archived": "Archived",
-    "search": "Search"
+    "search": "Search",
+    "show_flat_list": "Show Flat List",
+    "show_inverse_tree": "Show Inverse Tree"
   },
   "note_properties": {
     "this_note_was_originally_taken_from": "This note was originally taken from:",

--- a/apps/client/src/widgets/ribbon/NotePathsTab.css
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.css
@@ -48,7 +48,6 @@ body.experimental-feature-new-layout .note-paths-widget {
 
     .note-path-inverse-tree {
         list-style: none;
-        padding: 0;
         margin: 0;
         background: var(--card-background-color);
         border-radius: 6px;

--- a/apps/client/src/widgets/ribbon/NotePathsTab.css
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.css
@@ -3,64 +3,109 @@ body.experimental-feature-new-layout .note-paths-widget {
         color: var(--muted-text-color);
     }
 
-    .note-path-list {
+    .note-path-list,
+    .note-path-inverse-tree-container {
         margin: 12px 0;
         padding: 0;
         list-style: none;
+    }
 
-        /* Note path card */
-        li {
-            --border-radius: 6px;
+    .note-path-list li {
+        --border-radius: 6px;
+        position: relative;
+        background: var(--card-background-color);
+        padding: 8px 20px 8px 25px;
 
-            position: relative;
-            background: var(--card-background-color);
-            padding: 8px 20px 8px 25px;
-
-            &:first-child {
-                border-top-left-radius: var(--border-radius);
-                border-top-right-radius: var(--border-radius);
-            }
-
-            &:last-child {
-                border-bottom-left-radius: var(--border-radius);
-                border-bottom-right-radius: var(--border-radius);
-            }
-
-            & + li {
-                margin-top: 2px;
-            }
-
-            /* Current path arrow */
-            &.path-current::before {
-                position: absolute;
-                display: flex;
-                justify-content: flex-end;
-                align-items: center;
-                content: "\ee8f";
-                top: 0;
-                left: 0;
-                width: 20px;
-                bottom: 0;
-                font-family: "boxicons";
-                font-size: .75em;
-                color: var(--menu-item-icon-color);
-            }
+        &:first-child {
+            border-top-left-radius: var(--border-radius);
+            border-top-right-radius: var(--border-radius);
         }
 
-        /* Note path segment */
-        a {
-            margin-inline: 2px;
-            padding-inline: 2px;
-            color: currentColor;
-            font-weight: normal;
-            text-decoration: none;
-
-            /* The last segment of the note path */
-            &.basename {
-                color: var(--muted-text-color);
-            }
+        &:last-child {
+            border-bottom-left-radius: var(--border-radius);
+            border-bottom-right-radius: var(--border-radius);
         }
 
+        & + li {
+            margin-top: 2px;
+        }
+
+        &.path-current::before {
+            position: absolute;
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            content: "\ee8f";
+            top: 0;
+            left: 0;
+            width: 20px;
+            bottom: 0;
+            font-family: "boxicons";
+            font-size: .75em;
+            color: var(--menu-item-icon-color);
+        }
+    }
+
+    .note-path-inverse-tree {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        background: var(--card-background-color);
+        border-radius: 6px;
+        padding: 8px 12px;
+    }
+
+    .note-path-node {
+        position: relative;
+        list-style: none;
+    }
+
+    .note-path-row {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 8px;
+        border-radius: 4px;
+        transition: background-color 0.15s ease;
+
+        &:hover {
+            background-color: var(--hover-background-color, rgba(0, 0, 0, 0.04));
+        }
+    }
+
+    .note-path-node.path-on-active-branch > .note-path-row::before {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        content: "\ee8f";
+        left: -12px;
+        top: 0;
+        bottom: 0;
+        font-family: "boxicons";
+        font-size: .75em;
+        color: var(--menu-item-icon-color);
+    }
+
+    .note-path-tree-branches {
+        list-style: none;
+        margin: 0;
+        padding-left: 20px;
+        position: relative;
+
+        border-left: 1px dashed var(--border-color, rgba(0, 0, 0, 0.12));
+    }
+
+    a {
+        margin-inline: 2px;
+        padding-inline: 2px;
+        color: currentColor;
+        font-weight: normal;
+        text-decoration: none;
+
+        &.basename {
+            color: var(--muted-text-color);
+        }
     }
 }
 
@@ -74,14 +119,24 @@ body.experimental-feature-new-layout .note-paths-widget {
     margin-top: 10px;
 }
 
-.note-path-list .path-current a {
+.note-path-list .path-current a,
+.note-path-node.path-current > .note-path-row a {
     font-weight: bold;
 }
 
-.note-path-list .path-archived a {
+.note-path-list .path-archived a,
+.note-path-node.path-archived > .note-path-row a {
     color: var(--muted-text-color) !important;
 }
 
-.note-path-list .path-search a {
+.note-path-list .path-search a,
+.note-path-node.path-search > .note-path-row a {
     font-style: italic;
+}
+
+.note-path-row .separator {
+    color: var(--muted-text-color);
+    opacity: 0.5;
+    font-size: 0.9em;
+    padding-left: 2px;
 }

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -220,14 +220,6 @@ function InverseTreeNodeComponent({
     const [isExpanded, setIsExpanded] = useState(true);
     const hasChildren = node.children.size > 0;
 
-    const isPartofCurrentPath = useMemo(() => {
-        if (!currentNotePath) return false;
-        return (
-            currentNotePath === node.fullPathString ||
-            currentNotePath.startsWith(node.fullPathString + "/")
-        );
-    }, [node.fullPathString, currentNotePath]);
-
     const [classes, icons] = useMemo(() => {
         const classList: string[] = ["note-path-node"];
         const iconList: { icon: string; title: string }[] = [];
@@ -259,7 +251,7 @@ function InverseTreeNodeComponent({
         }
 
         return [classList.join(" "), iconList];
-    }, [node, isPartofCurrentPath]);
+    }, [node]);
 
     const childNodes = Array.from(node.children.values());
 

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -14,7 +14,8 @@ import { TabContext } from "./ribbon-interface";
 
 interface InverseTreeNode {
     noteId: string;
-    fullPathString: string;
+    fullPathString: string;       // Direct path to this specific ancestor note
+    fullNotePathString: string;   // Full destination path to the active note via this branch
     isCurrent: boolean;
     isOnActiveTrail: boolean;
     record?: NotePathRecord;
@@ -45,6 +46,9 @@ export function NotePathsWidget({
     const parentComponent = useContext(ParentComponent);
     const [isTreeView, setIsTreeView] = useState(true);
 
+    // Track total parent paths available to check if clones exist
+    const hasMultiplePaths = useMemo(() => (sortedNotePaths?.length ?? 0) >= 2, [sortedNotePaths]);
+
     const treeRoots = useMemo(() => {
         if (!sortedNotePaths || !isTreeView) return [];
 
@@ -69,14 +73,13 @@ export function NotePathsWidget({
                     node = {
                         noteId,
                         fullPathString: realPath,
+                        fullNotePathString: originalPath.join("/"), // Capture full line down to target note
                         isCurrent: realPath === currentNotePath,
                         isOnActiveTrail: false,
                         children: new Map()
                     };
                     currentLevel.set(branchId, node);
                 } else {
-                    // If the node was previously created by another clone path,
-                    // override it if this iteration represents the actual current path context.
                     if (
                         realPath === currentNotePath ||
                         currentNotePath?.startsWith(`${realPath}/`)
@@ -191,6 +194,7 @@ export function NotePathsWidget({
                                 node={rootNode}
                                 currentNotePath={currentNotePath}
                                 isRoot={true}
+                                hasMultiplePaths={hasMultiplePaths}
                             />
                         ))}
                     </ul>
@@ -222,11 +226,13 @@ export function NotePathsWidget({
 function InverseTreeNodeComponent({
     node,
     currentNotePath,
-    isRoot = false
+    isRoot = false,
+    hasMultiplePaths = false
 }: {
     node: InverseTreeNode;
     currentNotePath?: string | null | undefined;
     isRoot?: boolean;
+    hasMultiplePaths?: boolean;
 }) {
     const [isExpanded, setIsExpanded] = useState(true);
     const hasChildren = node.children.size > 0;
@@ -277,7 +283,7 @@ function InverseTreeNodeComponent({
         >
             <div
                 className="note-path-row"
-                style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}
+                style={{ display: "flex", alignItems: "center", gap: "0.25rem", flexWrap: "wrap" }}
             >
                 {hasChildren && (
                     <span
@@ -303,6 +309,7 @@ function InverseTreeNodeComponent({
                     </span>
                 )}
 
+                {/* Main link: Jumps directly up to this ancestor note */}
                 <NoteLink
                     notePath={node.fullPathString}
                     className={clsx({
@@ -312,21 +319,49 @@ function InverseTreeNodeComponent({
                     noPreview
                 />
 
+                {/* Separator: Only shows if note has children to walk down to */}
                 {hasChildren && (
-                    <span className="separator">
+                    <span className="separator" style={{ margin: "0 4px", opacity: 0.5 }}>
                         {NOTE_PATH_TITLE_SEPARATOR}
                     </span>
                 )}
 
+                {/* Contextual Action Capsule Block instead of bare auto-titled text */}
+                {hasMultiplePaths && !node.isOnActiveTrail && (
+                    <span
+                        className="btn btn-xs btn-outline-secondary py-0 px-2"
+                        style={{
+                            fontSize: "0.65rem",
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: "4px",
+                            marginLeft: "12px",
+                            height: "20px",
+                            borderRadius: "3px",
+                            pointerEvents: "none" // Prevents the whole capsule wrapper from triggering navigation clicks
+                        }}
+                    >
+                        <i className="bx bx-git-branch" style={{ fontSize: "0.75rem", opacity: 0.7 }} />
+
+                        <span style={{ pointerEvents: "auto", fontWeight: "bold" }}>
+                            <NoteLink
+                                notePath={node.fullNotePathString}
+                                style={{ textDecoration: "underline" }}
+                                noPreview
+                            />
+                        </span>
+                    </span>
+                )}
+
                 {icons.map(({ icon, title }) => (
-                    <i key={title} className={icon} title={title} />
+                    <i key={title} className={icon} title={title} style={{ marginLeft: "4px" }} />
                 ))}
             </div>
 
             {hasChildren && isExpanded && (
                 <ul
                     className="note-path-tree-branches"
-                    style={{ listStyleType: "none", margin: "0.1rem 0 0 0" }}
+                    style={{ listStyleType: "none", margin: "0.1rem 0 0 1.2rem", padding: 0 }}
                 >
                     {childNodes.map((childNode) => (
                         <InverseTreeNodeComponent
@@ -334,6 +369,7 @@ function InverseTreeNodeComponent({
                             node={childNode}
                             currentNotePath={currentNotePath}
                             isRoot={false}
+                            hasMultiplePaths={hasMultiplePaths}
                         />
                     ))}
                 </ul>

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -44,7 +44,7 @@ export function NotePathsWidget({
     currentNotePath?: string | null | undefined;
 }) {
     const parentComponent = useContext(ParentComponent);
-    const [isTreeView, setIsTreeView] = useState(true);
+    const [isTreeView, setIsTreeView] = useState(false);
 
     // Track total parent paths available to check if clones exist
     const hasMultiplePaths = useMemo(() => (sortedNotePaths?.length ?? 0) >= 2, [sortedNotePaths]);

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -156,7 +156,7 @@ export function NotePathsWidget({
                                 isTreeView ? "bx bx-list-ul" : "bx bx-git-merge"
                             }
                         />
-                        {isTreeView ? "Show Flat List" : "Show Inverse Tree"}
+                        {isTreeView ? t("note_paths.show_flat_list") : t("note_paths.show_inverse_tree")}
                     </button>
                 )}
             </div>
@@ -319,7 +319,7 @@ function InverseTreeNodeComponent({
                 >
                     {childNodes.map((childNode) => (
                         <InverseTreeNodeComponent
-                            key={childNode.branchId}
+                            key={childNode.noteId}
                             node={childNode}
                             currentNotePath={currentNotePath}
                             isRoot={false}

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -13,7 +13,6 @@ import { joinElements, ParentComponent } from "../react/react_utils";
 import { TabContext } from "./ribbon-interface";
 
 interface InverseTreeNode {
-    branchId: string;
     noteId: string;
     fullPathString: string;
     isCurrent: boolean;
@@ -177,7 +176,7 @@ export function NotePathsWidget({
                     >
                         {treeRoots.map((rootNode) => (
                             <InverseTreeNodeComponent
-                                key={rootNode.branchId}
+                                key={rootNode.noteId}
                                 node={rootNode}
                                 currentNotePath={currentNotePath}
                                 isRoot={true}

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -77,9 +77,14 @@ export function NotePathsWidget({
                 } else {
                     // If the node was previously created by another clone path,
                     // override it if this iteration represents the actual current path context.
-                    if (realPath === currentNotePath) {
-                        node.isCurrent = true;
+                    if (
+                        realPath === currentNotePath ||
+                        currentNotePath?.startsWith(`${realPath}/`)
+                    ) {
                         node.fullPathString = realPath;
+                        if (realPath === currentNotePath) {
+                            node.isCurrent = true;
+                        }
                     }
                 }
 

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -67,7 +67,6 @@ export function NotePathsWidget({
 
                 if (!node) {
                     node = {
-                        branchId,
                         noteId,
                         fullPathString: realPath,
                         isCurrent: realPath === currentNotePath,
@@ -75,6 +74,13 @@ export function NotePathsWidget({
                         children: new Map()
                     };
                     currentLevel.set(branchId, node);
+                } else {
+                    // If the node was previously created by another clone path,
+                    // override it if this iteration represents the actual current path context.
+                    if (realPath === currentNotePath) {
+                        node.isCurrent = true;
+                        node.fullPathString = realPath;
+                    }
                 }
 
                 if (i === originalPath.length - 1) {

--- a/apps/client/src/widgets/ribbon/NotePathsTab.tsx
+++ b/apps/client/src/widgets/ribbon/NotePathsTab.tsx
@@ -12,72 +12,350 @@ import NoteLink from "../react/NoteLink";
 import { joinElements, ParentComponent } from "../react/react_utils";
 import { TabContext } from "./ribbon-interface";
 
-export default function NotePathsTab({ note, hoistedNoteId, notePath }: TabContext) {
-    const sortedNotePaths = useSortedNotePaths(note, hoistedNoteId);
-    return <NotePathsWidget sortedNotePaths={sortedNotePaths} currentNotePath={notePath} />;
+interface InverseTreeNode {
+    branchId: string;
+    noteId: string;
+    fullPathString: string;
+    isCurrent: boolean;
+    isOnActiveTrail: boolean;
+    record?: NotePathRecord;
+    children: Map<string, InverseTreeNode>;
 }
 
-export function NotePathsWidget({ sortedNotePaths, currentNotePath }: {
+export default function NotePathsTab({
+    note,
+    hoistedNoteId,
+    notePath
+}: TabContext) {
+    const sortedNotePaths = useSortedNotePaths(note, hoistedNoteId);
+    return (
+        <NotePathsWidget
+            sortedNotePaths={sortedNotePaths}
+            currentNotePath={notePath}
+        />
+    );
+}
+
+export function NotePathsWidget({
+    sortedNotePaths,
+    currentNotePath
+}: {
     sortedNotePaths: NotePathRecord[] | undefined;
     currentNotePath?: string | null | undefined;
 }) {
     const parentComponent = useContext(ParentComponent);
+    const [isTreeView, setIsTreeView] = useState(true);
+
+    const treeRoots = useMemo(() => {
+        if (!sortedNotePaths || !isTreeView) return [];
+
+        const roots = new Map<string, InverseTreeNode>();
+
+        for (const record of sortedNotePaths) {
+            const originalPath = record.notePath ?? [];
+            const branchIds = (record as any).branchIds ?? [];
+
+            if (!originalPath.length) continue;
+
+            let currentLevel = roots;
+
+            for (let i = originalPath.length - 1; i >= 0; i--) {
+                const noteId = originalPath[i];
+                const branchId = branchIds[i] || noteId;
+                const realPath = originalPath.slice(0, i + 1).join("/");
+
+                let node = currentLevel.get(branchId);
+
+                if (!node) {
+                    node = {
+                        branchId,
+                        noteId,
+                        fullPathString: realPath,
+                        isCurrent: realPath === currentNotePath,
+                        isOnActiveTrail: false,
+                        children: new Map()
+                    };
+                    currentLevel.set(branchId, node);
+                }
+
+                if (i === originalPath.length - 1) {
+                    node.record = record;
+                }
+
+                currentLevel = node.children;
+            }
+        }
+
+        const rootNodes = Array.from(roots.values());
+
+        function markTrail(
+            nodes: Map<string, InverseTreeNode>,
+            depth: number
+        ): boolean {
+            if (!currentNotePath) return false;
+
+            const ids = currentNotePath.split("/");
+            const targetIndex = ids.length - 1 - depth;
+
+            if (targetIndex < 0) return false;
+
+            for (const node of nodes.values()) {
+                if (node.noteId !== ids[targetIndex]) continue;
+
+                if (targetIndex === 0) {
+                    node.isOnActiveTrail = true;
+                    return true;
+                }
+
+                if (markTrail(node.children, depth + 1)) {
+                    node.isOnActiveTrail = true;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        markTrail(roots, 0);
+        return rootNodes;
+    }, [sortedNotePaths, currentNotePath, isTreeView]);
+
     return (
-        <div class="note-paths-widget">
-            <>
-                <div className="note-path-intro">
-                    {sortedNotePaths?.length ? t("note_paths.intro_placed") : t("note_paths.intro_not_placed")}
+        <div className="note-paths-widget">
+            <div
+                className="note-path-header"
+                style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginBottom: "0.75rem"
+                }}
+            >
+                <div className="note-path-intro" style={{ margin: 0 }}>
+                    {sortedNotePaths?.length
+                        ? t("note_paths.intro_placed")
+                        : t("note_paths.intro_not_placed")}
                 </div>
 
+                {sortedNotePaths && sortedNotePaths.length > 0 && (
+                    <button
+                        className="btn btn-sm"
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "0.25rem",
+                            padding: "2px 8px"
+                        }}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setIsTreeView(!isTreeView);
+                        }}
+                    >
+                        <i
+                            className={
+                                isTreeView ? "bx bx-list-ul" : "bx bx-git-merge"
+                            }
+                        />
+                        {isTreeView ? "Show Flat List" : "Show Inverse Tree"}
+                    </button>
+                )}
+            </div>
+
+            {isTreeView ? (
+                <div
+                    className="note-path-inverse-tree-container"
+                    style={{ overflowX: "auto", padding: "0.5rem 0" }}
+                >
+                    <ul
+                        className="note-path-inverse-tree"
+                        style={{
+                            listStyleType: "none",
+                            padding: 0,
+                            margin: 0
+                        }}
+                    >
+                        {treeRoots.map((rootNode) => (
+                            <InverseTreeNodeComponent
+                                key={rootNode.branchId}
+                                node={rootNode}
+                                currentNotePath={currentNotePath}
+                                isRoot={true}
+                            />
+                        ))}
+                    </ul>
+                </div>
+            ) : (
                 <ul className="note-path-list">
-                    {sortedNotePaths?.length ? sortedNotePaths.map(sortedNotePath => (
-                        <NotePath
-                            key={sortedNotePath.notePath}
+                    {sortedNotePaths?.map((sortedNotePath) => (
+                        <NotePathClassic
+                            key={sortedNotePath.notePath?.join("/")}
                             currentNotePath={currentNotePath}
                             notePathRecord={sortedNotePath}
                         />
-                    )) : undefined}
+                    ))}
                 </ul>
+            )}
 
+            <div style={{ marginTop: "1rem" }}>
                 <LinkButton
                     text={t("note_paths.clone_button")}
-                    onClick={() => parentComponent?.triggerCommand("cloneNoteIdsTo")}
+                    onClick={() =>
+                        parentComponent?.triggerCommand("cloneNoteIdsTo")
+                    }
                 />
-            </>
+            </div>
         </div>
     );
 }
 
-export function useSortedNotePaths(note: FNote | null | undefined, hoistedNoteId?: string) {
-    const [ sortedNotePaths, setSortedNotePaths ] = useState<NotePathRecord[]>();
+function InverseTreeNodeComponent({
+    node,
+    currentNotePath,
+    isRoot = false
+}: {
+    node: InverseTreeNode;
+    currentNotePath?: string | null | undefined;
+    isRoot?: boolean;
+}) {
+    const [isExpanded, setIsExpanded] = useState(true);
+    const hasChildren = node.children.size > 0;
 
-    function refresh() {
-        if (!note) return;
-        setSortedNotePaths(note
-            .getSortedNotePathRecords(hoistedNoteId)
-            .filter((notePath) => !notePath.isHidden));
-    }
+    const isPartofCurrentPath = useMemo(() => {
+        if (!currentNotePath) return false;
+        return (
+            currentNotePath === node.fullPathString ||
+            currentNotePath.startsWith(node.fullPathString + "/")
+        );
+    }, [node.fullPathString, currentNotePath]);
 
-    useEffect(refresh, [ note, hoistedNoteId ]);
-    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
-        const noteId = note?.noteId;
-        if (!noteId) return;
-        if (loadResults.getBranchRows().find((branch) => branch.noteId === noteId)
-            || loadResults.isNoteReloaded(noteId)) {
-            refresh();
+    const [classes, icons] = useMemo(() => {
+        const classList: string[] = ["note-path-node"];
+        const iconList: { icon: string; title: string }[] = [];
+
+        if (node.isCurrent) classList.push("path-current");
+        if (node.isOnActiveTrail) classList.push("path-on-active-branch");
+
+        if (node.record) {
+            if (!node.record.isInHoistedSubTree) {
+                iconList.push({
+                    icon: "bx bx-trending-up",
+                    title: t("note_paths.outside_hoisted")
+                });
+            }
+            if (node.record.isArchived) {
+                classList.push("path-archived");
+                iconList.push({
+                    icon: "bx bx-archive",
+                    title: t("note_paths.archived")
+                });
+            }
+            if (node.record.isSearch) {
+                classList.push("path-search");
+                iconList.push({
+                    icon: "bx bx-search",
+                    title: t("note_paths.search")
+                });
+            }
         }
-    });
 
-    return sortedNotePaths;
+        return [classList.join(" "), iconList];
+    }, [node, isPartofCurrentPath]);
+
+    const childNodes = Array.from(node.children.values());
+
+    return (
+        <li
+            className={classes}
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                margin: "0.2rem 0"
+            }}
+        >
+            <div
+                className="note-path-row"
+                style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}
+            >
+                {hasChildren && (
+                    <span
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setIsExpanded(!isExpanded);
+                        }}
+                        style={{
+                            cursor: "pointer",
+                            display: "inline-flex",
+                            padding: "2px",
+                            userSelect: "none"
+                        }}
+                    >
+                        <i
+                            className={
+                                isExpanded
+                                    ? "bx bx-chevron-down"
+                                    : "bx bx-chevron-right"
+                            }
+                        />
+                    </span>
+                )}
+
+                <NoteLink
+                    notePath={node.fullPathString}
+                    className={clsx({
+                        basename: isRoot,
+                        "active-trail": node.isOnActiveTrail
+                    })}
+                    noPreview
+                />
+
+                {hasChildren && (
+                    <span className="separator">
+                        {NOTE_PATH_TITLE_SEPARATOR}
+                    </span>
+                )}
+
+                {icons.map(({ icon, title }) => (
+                    <i key={title} className={icon} title={title} />
+                ))}
+            </div>
+
+            {hasChildren && isExpanded && (
+                <ul
+                    className="note-path-tree-branches"
+                    style={{ listStyleType: "none", margin: "0.1rem 0 0 0" }}
+                >
+                    {childNodes.map((childNode) => (
+                        <InverseTreeNodeComponent
+                            key={childNode.branchId}
+                            node={childNode}
+                            currentNotePath={currentNotePath}
+                            isRoot={false}
+                        />
+                    ))}
+                </ul>
+            )}
+        </li>
+    );
 }
 
-function NotePath({ currentNotePath, notePathRecord }: { currentNotePath?: string | null, notePathRecord?: NotePathRecord }) {
+function NotePathClassic({
+    currentNotePath,
+    notePathRecord
+}: {
+    currentNotePath?: string | null;
+    notePathRecord?: NotePathRecord;
+}) {
     const notePath = notePathRecord?.notePath;
-    const notePathString = useMemo(() => (notePath ?? []).join("/"), [ notePath ]);
+    const notePathString = useMemo(
+        () => (notePath ?? []).join("/"),
+        [notePath]
+    );
 
-    const [ classes, icons ] = useMemo(() => {
+    const [classes, icons] = useMemo(() => {
         const classes: string[] = [];
-        const icons: { icon: string, title: string }[] = [];
+        const icons: { icon: string; title: string }[] = [];
 
         if (notePathString === currentNotePath) {
             classes.push("path-current");
@@ -86,23 +364,31 @@ function NotePath({ currentNotePath, notePathRecord }: { currentNotePath?: strin
         if (!notePathRecord || notePathRecord.isInHoistedSubTree) {
             classes.push("path-in-hoisted-subtree");
         } else {
-            icons.push({ icon: "bx bx-trending-up", title: t("note_paths.outside_hoisted") });
+            icons.push({
+                icon: "bx bx-trending-up",
+                title: t("note_paths.outside_hoisted")
+            });
         }
 
         if (notePathRecord?.isArchived) {
             classes.push("path-archived");
-            icons.push({ icon: "bx bx-archive", title: t("note_paths.archived") });
+            icons.push({
+                icon: "bx bx-archive",
+                title: t("note_paths.archived")
+            });
         }
 
         if (notePathRecord?.isSearch) {
             classes.push("path-search");
-            icons.push({ icon: "bx bx-search", title: t("note_paths.search") });
+            icons.push({
+                icon: "bx bx-search",
+                title: t("note_paths.search")
+            });
         }
 
-        return [ classes.join(" "), icons ];
-    }, [ notePathString, currentNotePath, notePathRecord ]);
+        return [classes.join(" "), icons];
+    }, [notePathString, currentNotePath, notePathRecord]);
 
-    // Determine the full note path (for the links) of every component of the current note path.
     const pathSegments: string[] = [];
     const fullNotePaths: string[] = [];
     for (const noteId of notePath ?? []) {
@@ -111,17 +397,57 @@ function NotePath({ currentNotePath, notePathRecord }: { currentNotePath?: strin
     }
 
     return (
-        <li class={classes}>
-            {joinElements(fullNotePaths.map((notePath, index, arr) => (
-                <NoteLink key={notePath}
-                    className={clsx({"basename": (index === arr.length - 1)})}
-                    notePath={notePath}
-                    noPreview />
-            )), NOTE_PATH_TITLE_SEPARATOR)}
+        <li className={classes}>
+            {joinElements(
+                fullNotePaths.map((notePath, index, arr) => (
+                    <NoteLink
+                        key={notePath}
+                        className={clsx({
+                            basename: index === arr.length - 1
+                        })}
+                        notePath={notePath}
+                        noPreview
+                    />
+                )),
+                NOTE_PATH_TITLE_SEPARATOR
+            )}
 
             {icons.map(({ icon, title }) => (
-                <i key={title} class={icon} title={title} />
+                <i key={title} className={icon} title={title} />
             ))}
         </li>
     );
+}
+
+export function useSortedNotePaths(
+    note: FNote | null | undefined,
+    hoistedNoteId?: string
+) {
+    const [sortedNotePaths, setSortedNotePaths] = useState<NotePathRecord[]>();
+
+    function refresh() {
+        if (!note) return;
+        setSortedNotePaths(
+            note
+                .getSortedNotePathRecords(hoistedNoteId)
+                .filter((notePath) => !notePath.isHidden)
+        );
+    }
+
+    useEffect(refresh, [note, hoistedNoteId]);
+
+    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
+        const noteId = note?.noteId;
+        if (!noteId) return;
+        if (
+            loadResults
+                .getBranchRows()
+                .find((branch) => branch.noteId === noteId) ||
+            loadResults.isNoteReloaded(noteId)
+        ) {
+            refresh();
+        }
+    });
+
+    return sortedNotePaths;
 }


### PR DESCRIPTION
This is a draft proposed solution for #7024.

I might not be able to get this through the finish line. The Code as is works. It is more of a solution idea, that I came up with, but because of time constraints, its AI-generated, but validated by hand. What is missing would be: 1. documentation, 2. checking if the code like this is okay.

<img width="1533" height="1043" alt="image" src="https://github.com/user-attachments/assets/e3072351-27d9-4722-aeb9-c6e4c6af4c75" />

If you see Trilium as a DAG because of note clones, you can invert the tree. This cleanly visualizes where you are from the current note.

This visualization scales up better. It avoids the problem of paths exploding if a grandparent note gets cloned.

Of course, the flat list is preserved. It is no longer the default view, but the secondary one.

<img width="694" height="274" alt="image" src="https://github.com/user-attachments/assets/efc614d3-b0e5-471e-bb17-bd93027ce697" />
