### PR TITLE
feat(users): phase 2 per-user note isolation and permissions

### DIFF
--- a/apps/server/src/routes/api/permissions.spec.ts
+++ b/apps/server/src/routes/api/permissions.spec.ts
@@ -1,0 +1,116 @@
+import { cls, getSql, permission_service, user_service } from "@triliumnext/core";
+import type { Request } from "express";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import sqlInit from "../../services/sql_init.js";
+import permissionsRoute from "./permissions.js";
+
+function req(body: Record<string, unknown> = {}, params: Record<string, string> = {}, session: Record<string, unknown> = {}) {
+    return { body, params, session } as unknown as Request<Record<string, string>>;
+}
+
+function adminSession(): Record<string, unknown> {
+    const adminUserId = getSql().getValue<string>("SELECT value FROM options WHERE name = 'adminUserId'");
+    return { userId: adminUserId };
+}
+
+function insertNote(noteId: string, ownerId: string | null) {
+    const n = new Date().toISOString();
+    getSql().execute(
+        `INSERT OR IGNORE INTO notes (noteId, title, type, mime, isProtected, isDeleted, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId)
+         VALUES (?, 'perm-test', 'text', 'text/html', 0, 0, ?, ?, ?, ?, ?)`,
+        [noteId, n, n, n, n, ownerId]
+    );
+}
+
+describe("Permissions API", () => {
+    let guestId: string;
+
+    beforeAll(async () => {
+        sqlInit.initializeDb();
+        await sqlInit.dbReady;
+    });
+
+    beforeEach(() => {
+        guestId = cls.init(() => user_service.createUser(`perm-guest-${Date.now()}`, null, false));
+        cls.init(() => permission_service.clearPermissionCache());
+    });
+
+    afterEach(() => {
+        cls.init(() => {
+            try { user_service.deleteUser(guestId); } catch { /* may throw if guestId is somehow the primary admin */ }
+            permission_service.clearPermissionCache();
+        });
+    });
+
+    describe("listPermissions", () => {
+        it("returns 403 without admin session", () => {
+            const result = cls.init(() => permissionsRoute.listPermissions(req({}, { noteId: "root" })));
+            expect(Array.isArray(result) && result[0]).toBe(403);
+        });
+
+        it("returns permissions for a note as admin", () => {
+            const noteId = "root";
+            const result = cls.init(() => permissionsRoute.listPermissions(req({}, { noteId }, adminSession())));
+            expect(Array.isArray(result)).toBe(true);
+        });
+    });
+
+    describe("createPermission", () => {
+        it("returns 403 without admin session", () => {
+            const result = cls.init(() => permissionsRoute.createPermission(req({ noteId: "root", userId: guestId })));
+            expect(Array.isArray(result) && result[0]).toBe(403);
+        });
+
+        it("returns 400 when noteId is missing", () => {
+            const result = cls.init(() => permissionsRoute.createPermission(req({ userId: guestId }, {}, adminSession())));
+            expect(Array.isArray(result) && result[0]).toBe(400);
+        });
+
+        it("returns 400 when neither userId nor groupId provided", () => {
+            const result = cls.init(() => permissionsRoute.createPermission(req({ noteId: "root" }, {}, adminSession())));
+            expect(Array.isArray(result) && result[0]).toBe(400);
+        });
+
+        it("grants permission and returns permissionId", () => {
+            const noteId = "note-perm-create-test";
+            const adminUserId = getSql().getValue<string>("SELECT value FROM options WHERE name = 'adminUserId'");
+            insertNote(noteId, adminUserId);
+
+            const result = cls.init(() =>
+                permissionsRoute.createPermission(
+                    req({ noteId, userId: guestId, canWrite: false }, {}, adminSession())
+                )
+            );
+            expect(typeof (result as Record<string, string>).permissionId).toBe("string");
+
+            const perms = cls.init(() => permission_service.getPermissionsForNote(noteId));
+            expect(perms.length).toBe(1);
+            expect(perms[0].userId).toBe(guestId);
+        });
+    });
+
+    describe("deletePermission", () => {
+        it("returns 403 without admin session", () => {
+            const result = cls.init(() => permissionsRoute.deletePermission(req({}, { permissionId: "fake" })));
+            expect(Array.isArray(result) && result[0]).toBe(403);
+        });
+
+        it("revokes an existing permission", () => {
+            const noteId = "note-perm-delete-test";
+            const adminUserId = getSql().getValue<string>("SELECT value FROM options WHERE name = 'adminUserId'");
+            insertNote(noteId, adminUserId);
+
+            const permissionId = cls.init(() =>
+                permission_service.grantPermission(noteId, guestId, null, false)
+            );
+
+            cls.init(() =>
+                permissionsRoute.deletePermission(req({}, { permissionId }, adminSession()))
+            );
+
+            const perms = cls.init(() => permission_service.getPermissionsForNote(noteId));
+            expect(perms.length).toBe(0);
+        });
+    });
+});

--- a/apps/server/src/routes/api/permissions.ts
+++ b/apps/server/src/routes/api/permissions.ts
@@ -1,0 +1,57 @@
+import { permission_service, user_service } from "@triliumnext/core";
+import type { Request } from "express";
+
+function callerIsAdmin(req: Request): boolean {
+    const userId = req.session?.userId;
+    if (!userId) return false;
+    const caller = user_service.getUserById(userId);
+    return !!caller?.isAdmin;
+}
+
+function listPermissions(req: Request<{ noteId: string }>) {
+    if (!callerIsAdmin(req)) return [403, { message: "Admin access required." }];
+    const { noteId } = req.params;
+    return permission_service.getPermissionsForNote(noteId);
+}
+
+function createPermission(req: Request) {
+    if (!callerIsAdmin(req)) return [403, { message: "Admin access required." }];
+
+    const { noteId, userId, groupId, canWrite } = req.body as {
+        noteId?: unknown;
+        userId?: unknown;
+        groupId?: unknown;
+        canWrite?: unknown;
+    };
+
+    if (typeof noteId !== "string" || noteId.trim() === "") {
+        return [400, { message: "noteId is required." }];
+    }
+    if (!userId && !groupId) {
+        return [400, { message: "userId or groupId is required." }];
+    }
+    if (userId !== undefined && (typeof userId !== "string" || userId.trim() === "")) {
+        return [400, { message: "userId must be a non-empty string." }];
+    }
+    if (groupId !== undefined && (typeof groupId !== "string" || groupId.trim() === "")) {
+        return [400, { message: "groupId must be a non-empty string." }];
+    }
+
+    const permissionId = permission_service.grantPermission(
+        noteId.trim(),
+        typeof userId === "string" ? userId.trim() : null,
+        typeof groupId === "string" ? groupId.trim() : null,
+        canWrite === true || canWrite === "true"
+    );
+
+    return { permissionId };
+}
+
+function deletePermission(req: Request<{ permissionId: string }>) {
+    if (!callerIsAdmin(req)) return [403, { message: "Admin access required." }];
+
+    const { permissionId } = req.params;
+    permission_service.revokePermission(permissionId);
+}
+
+export default { listPermissions, createPermission, deletePermission };

--- a/apps/server/src/routes/api/permissions.ts
+++ b/apps/server/src/routes/api/permissions.ts
@@ -30,10 +30,10 @@ function createPermission(req: Request) {
     if (!userId && !groupId) {
         return [400, { message: "userId or groupId is required." }];
     }
-    if (userId !== undefined && (typeof userId !== "string" || userId.trim() === "")) {
+    if (userId !== undefined && userId !== null && (typeof userId !== "string" || userId.trim() === "")) {
         return [400, { message: "userId must be a non-empty string." }];
     }
-    if (groupId !== undefined && (typeof groupId !== "string" || groupId.trim() === "")) {
+    if (groupId !== undefined && groupId !== null && (typeof groupId !== "string" || groupId.trim() === "")) {
         return [400, { message: "groupId must be a non-empty string." }];
     }
 

--- a/apps/server/src/routes/route_api.ts
+++ b/apps/server/src/routes/route_api.ts
@@ -1,6 +1,4 @@
-import { entity_changes as entityChangesService, NotFoundError, routes, utils as coreUtils, ValidationError } from "@triliumnext/core";
-import { cls } from "@triliumnext/core";
-import { getLog } from "@triliumnext/core";
+import { cls, entity_changes as entityChangesService, getLog, NotFoundError, routes, utils as coreUtils, ValidationError, warmBeccaForUser } from "@triliumnext/core";
 import express, { type RequestHandler } from "express";
 import type { ParamsDictionary } from "express-serve-static-core";
 import { mkdirSync } from "fs";
@@ -96,7 +94,16 @@ function internalRoute<P extends ParamsDictionary>(method: HttpMethod, path: str
                 cls.set("hoistedNoteId", req.headers["trilium-hoisted-note-id"] || "root");
                 cls.set("userId", req.session?.userId);
 
+                const userId = req.session?.userId;
                 const cb = () => routeHandler(req, res, next);
+
+                if (userId) {
+                    // warmBeccaForUser populates the per-user Becca cache so getBecca()
+                    // returns the right filtered view when the route handler runs.
+                    return warmBeccaForUser(userId).then(() =>
+                        transactional ? sql.transactional(cb) : cb()
+                    );
+                }
 
                 return transactional ? sql.transactional(cb) : cb();
             });

--- a/apps/server/src/routes/routes.ts
+++ b/apps/server/src/routes/routes.ts
@@ -21,7 +21,6 @@ import shareRoutes from "../share/routes.js";
 import clipperRoute from "./api/clipper.js";
 import databaseRoute from "./api/database.js";
 import etapiTokensApiRoutes from "./api/etapi_tokens.js";
-import usersApiRoute from "./api/users.js";
 import filesRoute from "./api/files.js";
 import fontsRoute from "./api/fonts.js";
 // API routes
@@ -32,10 +31,12 @@ import loginApiRoute from "./api/login.js";
 import metricsRoute from "./api/metrics.js";
 import ocrRoute from "./api/ocr.js";
 import onenoteImportRoute from "./api/onenote_import.js";
+import permissionsApiRoute from "./api/permissions.js";
 import recoveryCodes from './api/recovery_codes.js';
 import senderRoute from "./api/sender.js";
 import systemInfoRoute from "./api/system_info.js";
 import totp from './api/totp.js';
+import usersApiRoute from "./api/users.js";
 import { doubleCsrfProtection as csrfMiddleware } from "./csrf_protection.js";
 import * as indexRoute from "./index.js";
 import loginRoute from "./login.js";
@@ -145,6 +146,10 @@ function register(app: express.Application) {
     apiRoute(GET, "/api/users",             usersApiRoute.getUsers);
     apiRoute(PST, "/api/users",             usersApiRoute.createUser);
     apiRoute(DEL, "/api/users/:userId",     usersApiRoute.deleteUser);
+
+    apiRoute(GET,  "/api/notes/:noteId/permissions",        permissionsApiRoute.listPermissions);
+    apiRoute(PST,  "/api/permissions",                      permissionsApiRoute.createPermission);
+    apiRoute(DEL,  "/api/permissions/:permissionId",        permissionsApiRoute.deletePermission);
 
     // in case of local electron, local calls are allowed unauthenticated, for server they need auth
     const clipperMiddleware = isElectron ? [] : [auth.checkEtapiToken];

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -62,7 +62,7 @@ function getUserEmail() {
 function clearSavedUser() {
     sql.transactional(() => {
         sql.execute("DELETE FROM oauth_enrollment");
-        sql.execute("UPDATE users SET username = 'admin', email = NULL WHERE isAdmin = 1 AND isDeleted = 0");
+        sql.execute("UPDATE users SET username = 'admin', email = NULL WHERE userId = (SELECT value FROM options WHERE name = 'adminUserId')");
     });
     return {
         success: true,

--- a/apps/server/src/services/ws_messaging_provider.ts
+++ b/apps/server/src/services/ws_messaging_provider.ts
@@ -19,9 +19,14 @@ type SessionParser = (req: IncomingMessage, params: {}, cb: () => void) => void;
  * desktop runs IpcMessagingProvider instead so the renderer↔server messaging
  * channel never crosses a TCP socket. See `apps/server/src/main.ts`.
  */
+interface ClientEntry {
+    ws: WebSocket;
+    userId?: string;
+}
+
 export default class WebSocketMessagingProvider implements MessagingProvider {
     private webSocketServer!: WebSocketServer;
-    private clientMap = new Map<string, WebSocket>();
+    private clientMap = new Map<string, ClientEntry>();
     private clientMessageHandler?: ClientMessageHandler;
 
     init(httpServer: HttpServer, sessionParser: express.RequestHandler) {
@@ -43,9 +48,10 @@ export default class WebSocketMessagingProvider implements MessagingProvider {
         this.webSocketServer.on("connection", (ws, req) => {
             const id = randomString(10);
             (ws as any).id = id;
-            this.clientMap.set(id, ws);
+            const userId: string | undefined = (req as any).session?.userId;
+            this.clientMap.set(id, { ws, userId });
 
-            console.log(`websocket client connected`);
+            console.log(`websocket client connected (clientId=${id})`);
 
             ws.on("error", (error) => {
                 // A protocol error on a single connection (e.g. WS_ERR_INVALID_CLOSE_CODE from a
@@ -107,13 +113,22 @@ export default class WebSocketMessagingProvider implements MessagingProvider {
         }
     }
 
+    sendMessageToUserClients(userId: string, message: WebSocketMessage): void {
+        const jsonStr = JSON.stringify(message);
+        for (const entry of this.clientMap.values()) {
+            if (entry.userId === userId && entry.ws.readyState === WebSocket.OPEN) {
+                entry.ws.send(jsonStr);
+            }
+        }
+    }
+
     sendMessageToClient(clientId: string, message: WebSocketMessage): boolean {
-        const client = this.clientMap.get(clientId);
-        if (!client || client.readyState !== WebSocket.OPEN) {
+        const entry = this.clientMap.get(clientId);
+        if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
             return false;
         }
 
-        client.send(JSON.stringify(message));
+        entry.ws.send(JSON.stringify(message));
         return true;
     }
 

--- a/packages/commons/src/lib/rows.ts
+++ b/packages/commons/src/lib/rows.ts
@@ -147,5 +147,6 @@ export interface NoteRow {
     utcDateCreated?: string;
     utcDateModified?: string;
     content?: string | Uint8Array;
+    ownerId?: string | null;
 }
 

--- a/packages/trilium-core/src/assets/schema.sql
+++ b/packages/trilium-core/src/assets/schema.sql
@@ -168,6 +168,25 @@ CREATE TABLE IF NOT EXISTS "user_group_members"
     FOREIGN KEY (groupId) REFERENCES user_groups(groupId)
 );
 
+CREATE TABLE IF NOT EXISTS "note_permissions"
+(
+    permissionId    TEXT PRIMARY KEY NOT NULL,
+    noteId          TEXT NOT NULL,
+    userId          TEXT,
+    groupId         TEXT,
+    canRead         INT NOT NULL DEFAULT 1,
+    canWrite        INT NOT NULL DEFAULT 0,
+    dateCreated     TEXT NOT NULL,
+    utcDateModified TEXT NOT NULL,
+    FOREIGN KEY (noteId)   REFERENCES notes(noteId),
+    FOREIGN KEY (userId)   REFERENCES users(userId),
+    FOREIGN KEY (groupId)  REFERENCES user_groups(groupId),
+    CHECK (userId IS NOT NULL OR groupId IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS IDX_note_permissions_noteId  ON note_permissions(noteId);
+CREATE INDEX IF NOT EXISTS IDX_note_permissions_userId  ON note_permissions(userId);
+CREATE INDEX IF NOT EXISTS IDX_note_permissions_groupId ON note_permissions(groupId);
+
 -- Single-row table that holds the cryptographic OAuth enrollment for the instance owner.
 -- Separate from `users` because this data (scrypt hash, encrypted data key) is server-only
 -- and must never be synced.

--- a/packages/trilium-core/src/becca/becca-interface.spec.ts
+++ b/packages/trilium-core/src/becca/becca-interface.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import { getContext } from "../services/context.js";
 import noteService from "../services/notes.js";
 
@@ -29,49 +29,49 @@ describe("Becca interface (real DB)", () => {
             // There is a #label attribute somewhere in the fixture; even if not,
             // the goal is to exercise the '#'/'~' stripping branch. We assert the
             // result is an array and the lookup is equivalent to the unprefixed key.
-            const withHash = becca.findAttributes("label", "#archived");
-            const withoutHash = becca.findAttributes("label", "archived");
+            const withHash = getBecca().findAttributes("label", "#archived");
+            const withoutHash = getBecca().findAttributes("label", "archived");
             expect(Array.isArray(withHash)).toBe(true);
             expect(withHash).toEqual(withoutHash);
         });
 
         it("strips a leading '~' from the name before lookup", () => {
-            const withTilde = becca.findAttributes("relation", "~template");
-            const withoutTilde = becca.findAttributes("relation", "template");
+            const withTilde = getBecca().findAttributes("relation", "~template");
+            const withoutTilde = getBecca().findAttributes("relation", "template");
             expect(Array.isArray(withTilde)).toBe(true);
             expect(withTilde).toEqual(withoutTilde);
         });
 
         it("returns an empty array when nothing matches", () => {
-            expect(becca.findAttributes("label", "definitely-missing-xyz")).toEqual([]);
+            expect(getBecca().findAttributes("label", "definitely-missing-xyz")).toEqual([]);
         });
     });
 
     describe("getNotes", () => {
         it("skips missing ids when ignoreMissing is true", () => {
             const { note } = createNote("root");
-            const result = becca.getNotes([note.noteId, "missing-note-id"], true);
+            const result = getBecca().getNotes([note.noteId, "missing-note-id"], true);
             expect(result.map((n) => n.noteId)).toEqual([note.noteId]);
         });
 
         it("throws on a missing id when ignoreMissing is false", () => {
-            expect(() => becca.getNotes(["missing-note-id"], false)).toThrow();
+            expect(() => getBecca().getNotes(["missing-note-id"], false)).toThrow();
         });
 
         it("defaults ignoreMissing to false (throws)", () => {
-            expect(() => becca.getNotes(["another-missing-id"])).toThrow();
+            expect(() => getBecca().getNotes(["another-missing-id"])).toThrow();
         });
     });
 
     describe("getAttributeOrThrow", () => {
         it("throws when the attribute does not exist", () => {
-            expect(() => becca.getAttributeOrThrow("missing-attribute-id")).toThrow();
+            expect(() => getBecca().getAttributeOrThrow("missing-attribute-id")).toThrow();
         });
 
         it("returns the attribute when present", () => {
             const { note } = createNote("root");
             const attr = getContext().init(() => note.addLabel("becca-interface-label"));
-            const fetched = becca.getAttributeOrThrow(attr.attributeId);
+            const fetched = getBecca().getAttributeOrThrow(attr.attributeId);
             expect(fetched.attributeId).toBe(attr.attributeId);
         });
     });
@@ -88,16 +88,16 @@ describe("Becca interface (real DB)", () => {
                 })
             );
 
-            const fetched = becca.getAttachments([attachment.attachmentId]);
+            const fetched = getBecca().getAttachments([attachment.attachmentId]);
             expect(fetched.map((a) => a.attachmentId)).toContain(attachment.attachmentId);
         });
 
         it("getBlob returns null when no blobId is provided", () => {
-            expect(becca.getBlob({})).toBeNull();
+            expect(getBecca().getBlob({})).toBeNull();
         });
 
         it("getBlob returns null when the blobId has no matching row", () => {
-            expect(becca.getBlob({ blobId: "missing-blob-id" })).toBeNull();
+            expect(getBecca().getBlob({ blobId: "missing-blob-id" })).toBeNull();
         });
 
         it("getBlob returns a blob for a saved attachment's blobId", () => {
@@ -112,7 +112,7 @@ describe("Becca interface (real DB)", () => {
             );
 
             expect(attachment.blobId).toBeDefined();
-            const blob = becca.getBlob({ blobId: attachment.blobId });
+            const blob = getBecca().getBlob({ blobId: attachment.blobId });
             expect(blob).not.toBeNull();
             expect(blob?.blobId).toBe(attachment.blobId);
         });
@@ -120,27 +120,27 @@ describe("Becca interface (real DB)", () => {
 
     describe("getEntity", () => {
         it("returns null when entityName is empty", () => {
-            expect(becca.getEntity("", "someId")).toBeNull();
+            expect(getBecca().getEntity("", "someId")).toBeNull();
         });
 
         it("returns null when entityId is empty", () => {
-            expect(becca.getEntity("notes", "")).toBeNull();
+            expect(getBecca().getEntity("notes", "")).toBeNull();
         });
 
         it("resolves a note through the camelCase collection lookup", () => {
             const { note } = createNote("root");
-            const entity = becca.getEntity("notes", note.noteId);
+            const entity = getBecca().getEntity("notes", note.noteId);
             expect(entity).not.toBeNull();
             expect((entity as { noteId?: string })?.noteId).toBe(note.noteId);
         });
 
         it("returns null for a known collection when the id is absent", () => {
-            expect(becca.getEntity("notes", "missing-note-id")).toBeNull();
+            expect(getBecca().getEntity("notes", "missing-note-id")).toBeNull();
         });
 
         it("routes 'revisions' to getRevision", () => {
             // No such revision exists, but the branch is exercised and returns null.
-            expect(becca.getEntity("revisions", "missing-revision-id")).toBeNull();
+            expect(getBecca().getEntity("revisions", "missing-revision-id")).toBeNull();
         });
 
         it("routes 'attachments' to getAttachment", () => {
@@ -154,7 +154,7 @@ describe("Becca interface (real DB)", () => {
                 })
             );
 
-            const entity = becca.getEntity("attachments", attachment.attachmentId);
+            const entity = getBecca().getEntity("attachments", attachment.attachmentId);
             expect(entity).not.toBeNull();
             expect((entity as { attachmentId?: string })?.attachmentId).toBe(attachment.attachmentId);
         });
@@ -162,11 +162,11 @@ describe("Becca interface (real DB)", () => {
         it("converts snake_case entity names to camelCase collections (etapi_tokens)", () => {
             // The etapiTokens collection exists on becca; a missing id yields null,
             // proving the snake_case -> camelCase conversion resolved a real collection.
-            expect(becca.getEntity("etapi_tokens", "missing-token-id")).toBeNull();
+            expect(getBecca().getEntity("etapi_tokens", "missing-token-id")).toBeNull();
         });
 
         it("throws for an entity name that maps to no collection", () => {
-            expect(() => becca.getEntity("totally_unknown_entity", "id")).toThrow();
+            expect(() => getBecca().getEntity("totally_unknown_entity", "id")).toThrow();
         });
     });
 
@@ -174,18 +174,18 @@ describe("Becca interface (real DB)", () => {
         it("schedules an incremental update when the index already exists", () => {
             const { note } = createNote("root");
             // Build the index first so flatTextIndex is non-null.
-            becca.getFlatTextIndex();
+            getBecca().getFlatTextIndex();
 
-            becca.dirtyNoteFlatText(note.noteId);
-            expect(becca.dirtyFlatTextNoteIds.has(note.noteId)).toBe(true);
+            getBecca().dirtyNoteFlatText(note.noteId);
+            expect(getBecca().dirtyFlatTextNoteIds.has(note.noteId)).toBe(true);
         });
 
         it("builds the full index on first access and includes created notes", () => {
             const { note } = createNote("root");
             // Force a full rebuild by invalidating the note set.
-            becca.dirtyNoteSetCache();
+            getBecca().dirtyNoteSetCache();
 
-            const index = becca.getFlatTextIndex();
+            const index = getBecca().getFlatTextIndex();
             expect(index.notes.length).toBeGreaterThan(0);
             expect(index.flatTexts.length).toBe(index.notes.length);
             expect(index.noteIdToIdx.has(note.noteId)).toBe(true);
@@ -194,17 +194,17 @@ describe("Becca interface (real DB)", () => {
         it("recomputes only dirtied notes on the incremental path", () => {
             const { note } = createNote("root");
             // Ensure the index exists.
-            becca.getFlatTextIndex();
+            getBecca().getFlatTextIndex();
 
             // Dirty an existing note id (in the index) so the incremental branch runs.
-            becca.dirtyNoteFlatText(note.noteId);
+            getBecca().dirtyNoteFlatText(note.noteId);
             // Also dirty an id that is not present in the index map (idx === undefined branch).
-            becca.dirtyFlatTextNoteIds.add("not-in-index-id");
+            getBecca().dirtyFlatTextNoteIds.add("not-in-index-id");
 
-            const idx = becca.getFlatTextIndex().noteIdToIdx.get(note.noteId);
+            const idx = getBecca().getFlatTextIndex().noteIdToIdx.get(note.noteId);
             expect(idx).toBeDefined();
             // After recompute the dirty set is cleared.
-            expect(becca.dirtyFlatTextNoteIds.size).toBe(0);
+            expect(getBecca().dirtyFlatTextNoteIds.size).toBe(0);
         });
 
         it("builds the index without heap logging when process.memoryUsage is unavailable", () => {
@@ -218,8 +218,8 @@ describe("Becca interface (real DB)", () => {
             proc.memoryUsage = undefined;
 
             try {
-                becca.dirtyNoteSetCache(); // force a full rebuild
-                const index = becca.getFlatTextIndex();
+                getBecca().dirtyNoteSetCache(); // force a full rebuild
+                const index = getBecca().getFlatTextIndex();
                 expect(index.notes.length).toBeGreaterThan(0);
             } finally {
                 proc.memoryUsage = original;

--- a/packages/trilium-core/src/becca/becca-interface.ts
+++ b/packages/trilium-core/src/becca/becca-interface.ts
@@ -368,4 +368,5 @@ export interface NotePojo {
     dateModified?: string;
     utcDateCreated: string;
     utcDateModified?: string;
+    ownerId?: string | null;
 }

--- a/packages/trilium-core/src/becca/becca.ts
+++ b/packages/trilium-core/src/becca/becca.ts
@@ -3,7 +3,6 @@
 import Becca from "./becca-interface.js";
 import { getCachedBecca, setCachedBecca } from "./becca_cache.js";
 import { getUserId, get } from "../services/context.js";
-import { getLog } from "../services/log.js";
 import { getSql } from "../services/sql/index.js";
 
 const adminBecca = new Becca();
@@ -42,8 +41,7 @@ export function getBecca(): Becca {
         return userBecca;
     }
 
-    getLog().warn(`getBecca: cache miss for user ${userId}, falling back to adminBecca; ensure warmBeccaForUser() runs before request handlers`);
-    return adminBecca;
+    throw new Error(`getBecca: no cached Becca for user ${userId}; warmBeccaForUser() must run before request handlers`);
 }
 
 export async function warmBeccaForUser(userId: string): Promise<Becca> {

--- a/packages/trilium-core/src/becca/becca.ts
+++ b/packages/trilium-core/src/becca/becca.ts
@@ -2,7 +2,7 @@
 
 import Becca from "./becca-interface.js";
 import { getCachedBecca, setCachedBecca } from "./becca_cache.js";
-import { getUserId, get } from "../services/context.js";
+import { getUserId, get, set as ctxSet } from "../services/context.js";
 import { getSql } from "../services/sql/index.js";
 
 const adminBecca = new Becca();
@@ -20,6 +20,8 @@ function isUserAdmin(userId: string): boolean {
 
 // "loadingBecca" in CLS is set by loadBeccaForUser so entity constructors
 // register into the target Becca being built, not adminBecca.
+// "resolvedBecca" is set once by warmBeccaForUser to avoid re-running the admin
+// SQL check on every getBecca() call within the same request.
 // Outside a request, or for admins, falls back to adminBecca.
 export function getBecca(): Becca {
     const loadingBecca = get<Becca>("loadingBecca");
@@ -30,6 +32,11 @@ export function getBecca(): Becca {
     const userId = getUserId();
     if (!userId) {
         return adminBecca;
+    }
+
+    const resolved = get<Becca>("resolvedBecca");
+    if (resolved) {
+        return resolved;
     }
 
     if (isUserAdmin(userId)) {
@@ -45,18 +52,25 @@ export function getBecca(): Becca {
 }
 
 export async function warmBeccaForUser(userId: string): Promise<Becca> {
+    let becca: Becca;
+
     if (isUserAdmin(userId)) {
-        return adminBecca;
+        becca = adminBecca;
+    } else {
+        const existing = getCachedBecca(userId);
+        if (existing) {
+            becca = existing;
+        } else {
+            const { loadBeccaForUser } = await import("./becca_loader.js");
+            const userBecca = new Becca();
+            await loadBeccaForUser(userBecca, userId, false);
+            setCachedBecca(userId, userBecca);
+            becca = userBecca;
+        }
     }
 
-    const existing = getCachedBecca(userId);
-    if (existing) return existing;
-
-    const { loadBeccaForUser } = await import("./becca_loader.js");
-    const userBecca = new Becca();
-    await loadBeccaForUser(userBecca, userId, false);
-    setCachedBecca(userId, userBecca);
-    return userBecca;
+    ctxSet("resolvedBecca", becca);
+    return becca;
 }
 
 export { adminBecca };

--- a/packages/trilium-core/src/becca/becca.ts
+++ b/packages/trilium-core/src/becca/becca.ts
@@ -1,7 +1,65 @@
 "use strict";
 
 import Becca from "./becca-interface.js";
+import { getCachedBecca, setCachedBecca } from "./becca_cache.js";
+import { getUserId, get } from "../services/context.js";
+import { getLog } from "../services/log.js";
+import { getSql } from "../services/sql/index.js";
 
-const becca = new Becca();
+const adminBecca = new Becca();
 
-export default becca;
+// Direct SQL instead of going through user_service -> options -> becca (circular).
+function isUserAdmin(userId: string): boolean {
+    try {
+        return !!getSql().getValue<number>(
+            "SELECT isAdmin FROM users WHERE userId = ? AND isDeleted = 0", [userId]
+        );
+    } catch {
+        return false;
+    }
+}
+
+// "loadingBecca" in CLS is set by loadBeccaForUser so entity constructors
+// register into the target Becca being built, not adminBecca.
+// Outside a request, or for admins, falls back to adminBecca.
+export function getBecca(): Becca {
+    const loadingBecca = get<Becca>("loadingBecca");
+    if (loadingBecca) {
+        return loadingBecca;
+    }
+
+    const userId = getUserId();
+    if (!userId) {
+        return adminBecca;
+    }
+
+    if (isUserAdmin(userId)) {
+        return adminBecca;
+    }
+
+    const userBecca = getCachedBecca(userId);
+    if (userBecca) {
+        return userBecca;
+    }
+
+    getLog().warn(`getBecca: cache miss for user ${userId}, falling back to adminBecca; ensure warmBeccaForUser() runs before request handlers`);
+    return adminBecca;
+}
+
+export async function warmBeccaForUser(userId: string): Promise<Becca> {
+    if (isUserAdmin(userId)) {
+        return adminBecca;
+    }
+
+    const existing = getCachedBecca(userId);
+    if (existing) return existing;
+
+    const { loadBeccaForUser } = await import("./becca_loader.js");
+    const userBecca = new Becca();
+    await loadBeccaForUser(userBecca, userId, false);
+    setCachedBecca(userId, userBecca);
+    return userBecca;
+}
+
+export { adminBecca };
+export default adminBecca;

--- a/packages/trilium-core/src/becca/becca_cache.ts
+++ b/packages/trilium-core/src/becca/becca_cache.ts
@@ -1,0 +1,41 @@
+import Becca from "./becca-interface.js";
+import { getLog } from "../services/log.js";
+
+interface CacheEntry {
+    becca: Becca;
+    lastAccess: number;
+}
+
+const IDLE_TTL_MS = 30 * 60 * 1000;
+
+const cache = new Map<string, CacheEntry>();
+
+export function getCachedBecca(userId: string): Becca | null {
+    const entry = cache.get(userId);
+    if (!entry) return null;
+    entry.lastAccess = Date.now();
+    return entry.becca;
+}
+
+export function setCachedBecca(userId: string, userBecca: Becca): void {
+    cache.set(userId, { becca: userBecca, lastAccess: Date.now() });
+}
+
+export function evictUser(userId: string): void {
+    cache.delete(userId);
+    getLog().info(`becca_cache: evicted user ${userId}`);
+}
+
+export function evictIdle(): void {
+    const threshold = Date.now() - IDLE_TTL_MS;
+    for (const [userId, entry] of cache) {
+        if (entry.lastAccess < threshold) {
+            getLog().info(`becca_cache: evicting idle Becca for user ${userId}`);
+            cache.delete(userId);
+        }
+    }
+}
+
+export function clearAll(): void {
+    cache.clear();
+}

--- a/packages/trilium-core/src/becca/becca_loader.spec.ts
+++ b/packages/trilium-core/src/becca/becca_loader.spec.ts
@@ -5,7 +5,7 @@ import eventService from "../services/events.js";
 import noteService from "../services/notes.js";
 import { getSql } from "../services/sql/index.js";
 import ws from "../services/ws.js";
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import beccaLoader, { load, reload } from "./becca_loader.js";
 import BNote from "./entities/bnote.js";
 
@@ -25,17 +25,17 @@ function createNote(parentNoteId: string): BNote {
 
 describe("becca_loader", () => {
     afterEach(() => {
-        // The shared fixture DB is loaded (becca.loaded === true) after setup;
+        // The shared fixture DB is loaded (getBecca().loaded === true) after setup;
         // some tests flip this, so always restore it.
-        becca.loaded = true;
+        getBecca().loaded = true;
         vi.restoreAllMocks();
     });
 
     describe("ENTITY_CHANGE_SYNCED listener", () => {
         it("returns early without touching becca when becca is not loaded", () => {
-            becca.loaded = false;
+            getBecca().loaded = false;
 
-            const before = Object.keys(becca.notes).length;
+            const before = Object.keys(getBecca().notes).length;
             eventService.emit(eventService.ENTITY_CHANGE_SYNCED, {
                 entityName: "notes",
                 entityRow: {
@@ -49,8 +49,8 @@ describe("becca_loader", () => {
             });
 
             // Nothing was created since the listener bailed out.
-            expect(becca.getNote("loaderNotLoaded")).toBeNull();
-            expect(Object.keys(becca.notes).length).toBe(before);
+            expect(getBecca().getNote("loaderNotLoaded")).toBeNull();
+            expect(Object.keys(getBecca().notes).length).toBe(before);
         });
 
         it("updates an existing becca entity from the synced row", () => {
@@ -68,14 +68,14 @@ describe("becca_loader", () => {
                 }
             });
 
-            const updated = becca.getNoteOrThrow(note.noteId);
+            const updated = getBecca().getNoteOrThrow(note.noteId);
             expect(updated.title).toBe("synced-updated-title");
             expect(updated.type).toBe("code");
         });
 
         it("creates a brand-new becca entity from a synced row when not yet present", () => {
             const newNoteId = "loaderBrandNew1";
-            expect(becca.getNote(newNoteId)).toBeNull();
+            expect(getBecca().getNote(newNoteId)).toBeNull();
 
             eventService.emit(eventService.ENTITY_CHANGE_SYNCED, {
                 entityName: "notes",
@@ -89,7 +89,7 @@ describe("becca_loader", () => {
                 }
             });
 
-            const created = becca.getNoteOrThrow(newNoteId);
+            const created = getBecca().getNoteOrThrow(newNoteId);
             expect(created).toBeInstanceOf(BNote);
             expect(created.title).toBe("brand-new");
             // init() ran, so the derived collections are initialised.
@@ -110,7 +110,7 @@ describe("becca_loader", () => {
 
     describe("ENTITY_DELETED listener", () => {
         it("branchDeleted returns early for an unknown branch id", () => {
-            const branchesBefore = Object.keys(becca.branches).length;
+            const branchesBefore = Object.keys(getBecca().branches).length;
 
             expect(() =>
                 eventService.emit(eventService.ENTITY_DELETED, {
@@ -120,11 +120,11 @@ describe("becca_loader", () => {
             ).not.toThrow();
 
             // No branches were removed.
-            expect(Object.keys(becca.branches).length).toBe(branchesBefore);
+            expect(Object.keys(getBecca().branches).length).toBe(branchesBefore);
         });
 
         it("attributeDeleted returns early for an unknown attribute id", () => {
-            const attributesBefore = Object.keys(becca.attributes).length;
+            const attributesBefore = Object.keys(getBecca().attributes).length;
 
             expect(() =>
                 eventService.emit(eventService.ENTITY_DELETED, {
@@ -133,13 +133,13 @@ describe("becca_loader", () => {
                 })
             ).not.toThrow();
 
-            expect(Object.keys(becca.attributes).length).toBe(attributesBefore);
+            expect(Object.keys(getBecca().attributes).length).toBe(attributesBefore);
         });
     });
 
     describe("ENTER_PROTECTED_SESSION listener", () => {
         it("swallows errors thrown while decrypting protected notes", () => {
-            const spy = vi.spyOn(becca, "decryptProtectedNotes").mockImplementation(() => {
+            const spy = vi.spyOn(getBecca(), "decryptProtectedNotes").mockImplementation(() => {
                 throw new Error("boom");
             });
 
@@ -165,10 +165,10 @@ describe("becca_loader", () => {
                 load();
             });
 
-            const token = becca.getEtapiToken(etapiTokenId);
+            const token = getBecca().getEtapiToken(etapiTokenId);
             expect(token).not.toBeNull();
             expect(token?.name).toBe("loader-test-token");
-            expect(becca.loaded).toBe(true);
+            expect(getBecca().loaded).toBe(true);
         });
     });
 
@@ -178,7 +178,7 @@ describe("becca_loader", () => {
 
             getContext().init(() => reload("custom reason"));
 
-            expect(becca.loaded).toBe(true);
+            expect(getBecca().loaded).toBe(true);
             expect(spy).toHaveBeenCalledWith("custom reason");
         });
 

--- a/packages/trilium-core/src/becca/becca_loader.ts
+++ b/packages/trilium-core/src/becca/becca_loader.ts
@@ -106,79 +106,81 @@ export async function loadBeccaForUser(target: import("./becca-interface.js").de
     ctxSet("loadingBecca", target);
 
     const sql = getSql();
-    sql.disableSlowQueryLogging(() => {
-        const noteQuery = isAdmin
-            ? /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
-                        FROM notes WHERE isDeleted = 0`
-            : /*sql*/`WITH RECURSIVE visible_roots(noteId) AS (
-                          SELECT noteId FROM notes
-                           WHERE isDeleted = 0 AND ownerId = ?
-                          UNION
-                          SELECT noteId FROM note_permissions
-                           WHERE userId = ?
-                              OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?)
-                      ),
-                      visible_notes(noteId) AS (
-                          SELECT noteId FROM visible_roots
-                          UNION
-                          SELECT b.noteId
-                            FROM branches b
-                            JOIN visible_notes vn ON b.parentNoteId = vn.noteId
-                           WHERE b.isDeleted = 0
-                      )
-                      SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
-                        FROM notes
-                       WHERE isDeleted = 0 AND noteId IN visible_notes`;
+    try {
+        sql.disableSlowQueryLogging(() => {
+            const noteQuery = isAdmin
+                ? /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
+                            FROM notes WHERE isDeleted = 0`
+                : /*sql*/`WITH RECURSIVE visible_roots(noteId) AS (
+                              SELECT noteId FROM notes
+                               WHERE isDeleted = 0 AND (ownerId = ? OR noteId = 'root' OR noteId LIKE '\_%' ESCAPE '\')
+                              UNION
+                              SELECT noteId FROM note_permissions
+                               WHERE userId = ?
+                                  OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?)
+                          ),
+                          visible_notes(noteId) AS (
+                              SELECT noteId FROM visible_roots
+                              UNION
+                              SELECT b.noteId
+                                FROM branches b
+                                JOIN visible_notes vn ON b.parentNoteId = vn.noteId
+                               WHERE b.isDeleted = 0
+                          )
+                          SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
+                            FROM notes
+                           WHERE isDeleted = 0 AND noteId IN visible_notes`;
 
-        const noteParams = isAdmin ? [] : [userId, userId, userId];
+            const noteParams = isAdmin ? [] : [userId, userId, userId];
 
-        const visibleNoteIds = new Set<string>();
+            const visibleNoteIds = new Set<string>();
 
-        for (const row of sql.getRawRows(noteQuery, noteParams)) {
-            const note = new BNote().update(row);
-            visibleNoteIds.add(row[0] as string);
-            note.init();
-        }
-
-        const branchRows = sql.getRawRows(
-            /*sql*/`SELECT branchId, noteId, parentNoteId, prefix, notePosition, isExpanded, utcDateModified
-                      FROM branches WHERE isDeleted = 0`
-        );
-        branchRows.sort((a, b) => ((a[4] as number) || 0) - ((b[4] as number) || 0));
-        for (const row of branchRows) {
-            const noteId = row[1] as string;
-            const parentNoteId = row[2] as string;
-            if (visibleNoteIds.has(noteId) && (parentNoteId === "none" || visibleNoteIds.has(parentNoteId))) {
-                new BBranch().update(row).init();
+            for (const row of sql.getRawRows(noteQuery, noteParams)) {
+                const note = new BNote().update(row);
+                visibleNoteIds.add(row[0] as string);
+                note.init();
             }
-        }
 
-        for (const row of sql.getRawRows(
-            /*sql*/`SELECT attributeId, noteId, type, name, value, isInheritable, position, utcDateModified
-                      FROM attributes WHERE isDeleted = 0`
-        )) {
-            if (visibleNoteIds.has(row[1] as string)) {
-                new BAttribute().update(row).init();
+            const branchRows = sql.getRawRows(
+                /*sql*/`SELECT branchId, noteId, parentNoteId, prefix, notePosition, isExpanded, utcDateModified
+                          FROM branches WHERE isDeleted = 0`
+            );
+            branchRows.sort((a, b) => ((a[4] as number) || 0) - ((b[4] as number) || 0));
+            for (const row of branchRows) {
+                const noteId = row[1] as string;
+                const parentNoteId = row[2] as string;
+                if (visibleNoteIds.has(noteId) && (parentNoteId === "none" || parentNoteId === "root" || parentNoteId.startsWith("_") || visibleNoteIds.has(parentNoteId))) {
+                    new BBranch().update(row).init();
+                }
             }
-        }
 
-        // Options and ETAPI tokens are global; load them for every user.
-        for (const row of sql.getRows<OptionRow>(/*sql*/`SELECT name, value, isSynced, utcDateModified FROM options`)) {
-            new BOption(row);
-        }
+            for (const row of sql.getRawRows(
+                /*sql*/`SELECT attributeId, noteId, type, name, value, isInheritable, position, utcDateModified
+                          FROM attributes WHERE isDeleted = 0`
+            )) {
+                if (visibleNoteIds.has(row[1] as string)) {
+                    new BAttribute().update(row).init();
+                }
+            }
 
-        for (const row of sql.getRows<EtapiTokenRow>(
-            /*sql*/`SELECT etapiTokenId, name, tokenHash, utcDateCreated, utcDateModified FROM etapi_tokens WHERE isDeleted = 0`
-        )) {
-            new BEtapiToken(row);
-        }
-    });
+            // Options and ETAPI tokens are global; load them for every user.
+            for (const row of sql.getRows<OptionRow>(/*sql*/`SELECT name, value, isSynced, utcDateModified FROM options`)) {
+                new BOption(row);
+            }
+
+            for (const row of sql.getRows<EtapiTokenRow>(
+                /*sql*/`SELECT etapiTokenId, name, tokenHash, utcDateCreated, utcDateModified FROM etapi_tokens WHERE isDeleted = 0`
+            )) {
+                new BEtapiToken(row);
+            }
+        });
+    } finally {
+        ctxSet("loadingBecca", undefined);
+    }
 
     for (const noteId in target.notes) {
         target.notes[noteId].sortParents();
     }
-
-    ctxSet("loadingBecca", undefined);
 
     target.loaded = true;
     getLog().info(`Becca user load (userId=${userId}) took ${Date.now() - start}ms`);

--- a/packages/trilium-core/src/becca/becca_loader.ts
+++ b/packages/trilium-core/src/becca/becca_loader.ts
@@ -13,7 +13,7 @@ import BEtapiToken from "./entities/betapi_token.js";
 import BNote from "./entities/bnote.js";
 import BOption from "./entities/boption.js";
 import { getSql } from "../services/sql";
-import { getContext } from "../services/context.js";
+import { getContext, set as ctxSet } from "../services/context.js";
 
 export const beccaLoaded = new Promise<void>(async (res, rej) => {
     // We have to import async since options init requires keyboard actions which require translations.
@@ -28,6 +28,13 @@ export const beccaLoaded = new Promise<void>(async (res, rej) => {
     });
 });
 
+function notesHasOwnerIdColumn(): boolean {
+    const cols = getSql().getColumn<string>(
+        "SELECT name FROM pragma_table_info('notes')"
+    );
+    return cols.includes("ownerId");
+}
+
 function load() {
     const start = Date.now();
     becca.reset();
@@ -38,7 +45,15 @@ function load() {
         // using a raw query and passing arrays to avoid allocating new objects,
         // this is worth it for the becca load since it happens every run and blocks the app until finished
 
-        for (const row of sql.getRawRows(/*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified FROM notes WHERE isDeleted = 0`)) {
+        // ownerId was added in migration 239; during the migration chain from older DBs the column
+        // may not exist yet. Detect at runtime so old JS migration modules (like 0220) can still call
+        // load() without crashing.
+        const hasOwnerId = notesHasOwnerIdColumn();
+        const noteQuery = hasOwnerId
+            ? /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId FROM notes WHERE isDeleted = 0`
+            : /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified FROM notes WHERE isDeleted = 0`;
+
+        for (const row of sql.getRawRows(noteQuery)) {
             new BNote().update(row).init();
         }
 
@@ -77,6 +92,84 @@ function reload(reason: string) {
     load();
 
     ws.reloadFrontend(reason || "becca reloaded");
+}
+
+/**
+ * Loads notes (and branches/attributes) visible to a specific user into the given Becca instance.
+ * Admin users get the unfiltered set. Non-admin users see only notes they own or have been
+ * explicitly granted access to via note_permissions.
+ */
+export async function loadBeccaForUser(target: import("./becca-interface.js").default, userId: string, isAdmin: boolean): Promise<void> {
+    const start = Date.now();
+    target.reset();
+
+    ctxSet("loadingBecca", target);
+
+    const sql = getSql();
+    sql.disableSlowQueryLogging(() => {
+        const noteQuery = isAdmin
+            ? /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
+                        FROM notes WHERE isDeleted = 0`
+            : /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
+                        FROM notes
+                       WHERE isDeleted = 0
+                         AND (ownerId = ?
+                              OR noteId IN (
+                                  SELECT noteId FROM note_permissions
+                                   WHERE userId = ?
+                                      OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?)
+                              ))`;
+
+        const noteParams = isAdmin ? [] : [userId, userId, userId];
+
+        const visibleNoteIds = new Set<string>();
+
+        for (const row of sql.getRawRows(noteQuery, noteParams)) {
+            const note = new BNote().update(row);
+            visibleNoteIds.add(row[0] as string);
+            note.init();
+        }
+
+        const branchRows = sql.getRawRows(
+            /*sql*/`SELECT branchId, noteId, parentNoteId, prefix, notePosition, isExpanded, utcDateModified
+                      FROM branches WHERE isDeleted = 0`
+        );
+        branchRows.sort((a, b) => ((a[4] as number) || 0) - ((b[4] as number) || 0));
+        for (const row of branchRows) {
+            if (visibleNoteIds.has(row[1] as string)) {
+                new BBranch().update(row).init();
+            }
+        }
+
+        for (const row of sql.getRawRows(
+            /*sql*/`SELECT attributeId, noteId, type, name, value, isInheritable, position, utcDateModified
+                      FROM attributes WHERE isDeleted = 0`
+        )) {
+            if (visibleNoteIds.has(row[1] as string)) {
+                new BAttribute().update(row).init();
+            }
+        }
+
+        // Options and ETAPI tokens are global; load them for every user.
+        for (const row of sql.getRows<OptionRow>(/*sql*/`SELECT name, value, isSynced, utcDateModified FROM options`)) {
+            new BOption(row);
+        }
+
+        for (const row of sql.getRows<EtapiTokenRow>(
+            /*sql*/`SELECT etapiTokenId, name, tokenHash, utcDateCreated, utcDateModified FROM etapi_tokens WHERE isDeleted = 0`
+        )) {
+            new BEtapiToken(row);
+        }
+    });
+
+    for (const noteId in target.notes) {
+        target.notes[noteId].sortParents();
+    }
+
+    ctxSet("loadingBecca", undefined);
+
+    target.loaded = true;
+    getLog().info(`Becca user load (userId=${userId}) took ${Date.now() - start}ms`);
 }
 
 eventService.subscribeBeccaLoader([eventService.ENTITY_CHANGE_SYNCED], ({ entityName, entityRow }) => {

--- a/packages/trilium-core/src/becca/becca_loader.ts
+++ b/packages/trilium-core/src/becca/becca_loader.ts
@@ -110,15 +110,25 @@ export async function loadBeccaForUser(target: import("./becca-interface.js").de
         const noteQuery = isAdmin
             ? /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
                         FROM notes WHERE isDeleted = 0`
-            : /*sql*/`SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
+            : /*sql*/`WITH RECURSIVE visible_roots(noteId) AS (
+                          SELECT noteId FROM notes
+                           WHERE isDeleted = 0 AND ownerId = ?
+                          UNION
+                          SELECT noteId FROM note_permissions
+                           WHERE userId = ?
+                              OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?)
+                      ),
+                      visible_notes(noteId) AS (
+                          SELECT noteId FROM visible_roots
+                          UNION
+                          SELECT b.noteId
+                            FROM branches b
+                            JOIN visible_notes vn ON b.parentNoteId = vn.noteId
+                           WHERE b.isDeleted = 0
+                      )
+                      SELECT noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId
                         FROM notes
-                       WHERE isDeleted = 0
-                         AND (ownerId = ?
-                              OR noteId IN (
-                                  SELECT noteId FROM note_permissions
-                                   WHERE userId = ?
-                                      OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?)
-                              ))`;
+                       WHERE isDeleted = 0 AND noteId IN visible_notes`;
 
         const noteParams = isAdmin ? [] : [userId, userId, userId];
 
@@ -136,7 +146,9 @@ export async function loadBeccaForUser(target: import("./becca-interface.js").de
         );
         branchRows.sort((a, b) => ((a[4] as number) || 0) - ((b[4] as number) || 0));
         for (const row of branchRows) {
-            if (visibleNoteIds.has(row[1] as string)) {
+            const noteId = row[1] as string;
+            const parentNoteId = row[2] as string;
+            if (visibleNoteIds.has(noteId) && (parentNoteId === "none" || visibleNoteIds.has(parentNoteId))) {
                 new BBranch().update(row).init();
             }
         }

--- a/packages/trilium-core/src/becca/becca_service.spec.ts
+++ b/packages/trilium-core/src/becca/becca_service.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import beccaService from "./becca_service.js";
 import BAttribute from "./entities/battribute.js";
 import BBranch from "./entities/bbranch.js";
@@ -163,7 +163,7 @@ describe("becca_service", () => {
             const child = buildNote({ id: childId, title: "Child" });
             const grandChild = buildNote({ id: grandChildId, title: "Grandchild" });
 
-            const root = becca.notes["root"];
+            const root = getBecca().notes["root"];
             expect(root).toBeDefined();
             linkBranch(childId, "root");
             linkBranch(grandChildId, childId);

--- a/packages/trilium-core/src/becca/becca_service.ts
+++ b/packages/trilium-core/src/becca/becca_service.ts
@@ -1,19 +1,19 @@
 "use strict";
 
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import { getLog } from "../services/log.js";
 import { getHoistedNoteId } from "../services/context.js";
 
 function isNotePathArchived(notePath: string[]) {
     const noteId = notePath[notePath.length - 1];
-    const note = becca.notes[noteId];
+    const note = getBecca().notes[noteId];
 
     if (note.isArchived) {
         return true;
     }
 
     for (let i = 0; i < notePath.length - 1; i++) {
-        const note = becca.notes[notePath[i]];
+        const note = getBecca().notes[notePath[i]];
 
         // this is going through parents so archived must be inheritable
         if (note.hasInheritableArchivedLabel()) {
@@ -25,8 +25,8 @@ function isNotePathArchived(notePath: string[]) {
 }
 
 function getNoteTitle(childNoteId: string, parentNoteId?: string) {
-    const childNote = becca.notes[childNoteId];
-    const parentNote = parentNoteId ? becca.notes[parentNoteId] : null;
+    const childNote = getBecca().notes[childNoteId];
+    const parentNote = parentNoteId ? getBecca().notes[parentNoteId] : null;
 
     if (!childNote) {
         getLog().info(`Cannot find note '${childNoteId}'`);
@@ -35,7 +35,7 @@ function getNoteTitle(childNoteId: string, parentNoteId?: string) {
 
     const title = childNote.getTitleOrProtected();
 
-    const branch = parentNote ? becca.getBranchFromChildAndParent(childNote.noteId, parentNote.noteId) : null;
+    const branch = parentNote ? getBecca().getBranchFromChildAndParent(childNote.noteId, parentNote.noteId) : null;
 
     return `${branch && branch.prefix ? `${branch.prefix} - ` : ""}${title}`;
 }
@@ -46,8 +46,8 @@ function getNoteTitle(childNoteId: string, parentNoteId?: string) {
  * @returns An object containing the title and icon class of the note.
  */
 function getNoteTitleAndIcon(childNoteId: string, parentNoteId?: string) {
-    const childNote = becca.notes[childNoteId];
-    const parentNote = parentNoteId ? becca.notes[parentNoteId] : null;
+    const childNote = getBecca().notes[childNoteId];
+    const parentNote = parentNoteId ? getBecca().notes[parentNoteId] : null;
 
     if (!childNote) {
         getLog().info(`Cannot find note '${childNoteId}'`);
@@ -59,7 +59,7 @@ function getNoteTitleAndIcon(childNoteId: string, parentNoteId?: string) {
     const title = childNote.getTitleOrProtected();
     const icon = childNote.getIcon();
 
-    const branch = parentNote ? becca.getBranchFromChildAndParent(childNote.noteId, parentNote.noteId) : null;
+    const branch = parentNote ? getBecca().getBranchFromChildAndParent(childNote.noteId, parentNote.noteId) : null;
 
     return {
         icon,

--- a/packages/trilium-core/src/becca/entities/abstract_becca_entity.ts
+++ b/packages/trilium-core/src/becca/entities/abstract_becca_entity.ts
@@ -6,7 +6,7 @@ import dateUtils from "../../services/utils/date";
 import entityChangesService from "../../services/entity_changes.js";
 import { getLog } from "../../services/log.js";
 import protectedSessionService from "../../services/protected_session.js";
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import type { ConstructorData,default as Becca } from "../becca-interface.js";
 import { getSql } from "../../services/sql";
 import { concat2, encodeUtf8, unwrapStringOrBuffer, wrapStringOrBuffer } from "../../services/utils/binary";
@@ -45,7 +45,7 @@ abstract class AbstractBeccaEntity<T extends AbstractBeccaEntity<T>> {
     }
 
     protected get becca(): Becca {
-        return becca;
+        return getBecca();
     }
 
     protected putEntityChange(isDeleted: boolean) {

--- a/packages/trilium-core/src/becca/entities/battachment.spec.ts
+++ b/packages/trilium-core/src/becca/entities/battachment.spec.ts
@@ -6,7 +6,7 @@ import { getContext } from "../../services/context.js";
 import noteService from "../../services/notes.js";
 import protectedSessionService from "../../services/protected_session.js";
 import { encodeUtf8, unwrapStringOrBuffer } from "../../services/utils/binary.js";
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import BAttachment from "./battachment.js";
 import type BNote from "./bnote.js";
 
@@ -173,7 +173,7 @@ describe("BAttachment (real DB)", () => {
             protectedSessionService.resetDataKey();
 
             // Reload from the DB so a protected, encrypted-from-row instance is produced.
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
             expect(reloaded.isProtected).toBe(true);
             expect(reloaded.isContentAvailable()).toBe(false);
             expect(reloaded.getTitleOrProtected()).toBe("[protected]");
@@ -195,7 +195,7 @@ describe("BAttachment (real DB)", () => {
             expect(attachmentId).toBeDefined();
 
             // Reload with the session still available -> decrypt() runs the try branch.
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
             expect(reloaded.isProtected).toBe(true);
             expect(reloaded.title).toBe(plainTitle);
             expect(reloaded.isDecrypted).toBe(true);
@@ -218,7 +218,7 @@ describe("BAttachment (real DB)", () => {
             // decryptString returns null -> the `|| ""` fallback is exercised.
             vi.spyOn(protectedSessionService, "decryptString").mockReturnValue(null);
 
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
             expect(reloaded.title).toBe("");
             expect(reloaded.isDecrypted).toBe(true);
         });
@@ -242,7 +242,7 @@ describe("BAttachment (real DB)", () => {
                 throw new Error("kaput");
             });
 
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
             expect(reloaded.isProtected).toBe(true);
             // The catch branch was taken: isDecrypted was never flipped to true.
             expect(reloaded.isDecrypted).toBeFalsy();
@@ -291,7 +291,7 @@ describe("BAttachment (real DB)", () => {
             expect(attachmentId).toBeDefined();
 
             protectedSessionService.resetDataKey();
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
 
             expect(() => getContext().init(() => reloaded.convertToNote())).toThrow(/protected session/);
         });
@@ -316,7 +316,7 @@ describe("BAttachment (real DB)", () => {
             expect(created.title).toBe("fileconv-" + counter);
             expect(branch.parentNoteId).toBe(note.noteId);
             // The attachment row is now soft-deleted, so it is no longer retrievable.
-            expect(attachmentId ? becca.getAttachment(attachmentId) : null).toBeFalsy();
+            expect(attachmentId ? getBecca().getAttachment(attachmentId) : null).toBeFalsy();
             // Parent content is unchanged (no image-url rewrite for a 'file' role).
             expect(unwrapStringOrBuffer(note.getContent())).toBe(parentContent);
         });
@@ -545,7 +545,7 @@ describe("BAttachment (real DB)", () => {
             expect(attachmentId).toBeDefined();
 
             protectedSessionService.resetDataKey();
-            const reloaded = attachmentId ? becca.getAttachmentOrThrow(attachmentId) : att;
+            const reloaded = attachmentId ? getBecca().getAttachmentOrThrow(attachmentId) : att;
             // Loaded protected attachment outside a session is not decrypted.
             expect(reloaded.isDecrypted).toBeFalsy();
 

--- a/packages/trilium-core/src/becca/entities/battribute.spec.ts
+++ b/packages/trilium-core/src/becca/entities/battribute.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getContext } from "../../services/context.js";
 import noteService from "../../services/notes.js";
 import { randomString } from "../../services/utils/index.js";
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import BAttribute from "./battribute.js";
 import BNote from "./bnote.js";
 
@@ -26,7 +26,7 @@ describe("BAttribute", () => {
     describe("init", () => {
         it("creates a skeleton note when the owner noteId is not yet in becca", () => {
             const skeletonNoteId = `skeleton-${randomString(8)}`;
-            expect(skeletonNoteId in becca.notes).toBe(false);
+            expect(skeletonNoteId in getBecca().notes).toBe(false);
 
             const attr = new BAttribute({
                 attributeId: `attr-${randomString(8)}`,
@@ -38,7 +38,7 @@ describe("BAttribute", () => {
                 isInheritable: false
             });
 
-            const skeleton = becca.getNote(skeletonNoteId);
+            const skeleton = getBecca().getNote(skeletonNoteId);
             expect(skeleton).not.toBeNull();
             expect(skeleton?.ownedAttributes).toContain(attr);
         });
@@ -299,7 +299,7 @@ describe("BAttribute", () => {
                 isInheritable: false
             });
 
-            // Point the attribute at a noteId that does not exist in becca.
+            // Point the attribute at a noteId that does not exist in getBecca().
             attr.noteId = `gone-${randomString(8)}`;
 
             expect(() => attr.getNote()).toThrow();

--- a/packages/trilium-core/src/becca/entities/bbranch.spec.ts
+++ b/packages/trilium-core/src/becca/entities/bbranch.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import { getContext } from "../../services/context.js";
 import noteService from "../../services/notes.js";
 import BBranch from "./bbranch.js";
@@ -28,7 +28,7 @@ function createNote(parentNoteId: string): { note: BNote; branch: BBranch } {
 describe("BBranch (real DB)", () => {
     describe("deleteBranch", () => {
         it("refuses to delete the root branch", () => {
-            const rootBranch = becca.getBranchOrThrow("none_root");
+            const rootBranch = getBecca().getBranchOrThrow("none_root");
 
             expect(() => getContext().init(() => rootBranch.deleteBranch())).toThrow();
         });
@@ -159,8 +159,8 @@ describe("BBranch (real DB)", () => {
             // returns a falsy value. getChildBranches() will then yield an entry
             // that beforeSaving must skip.
             const key = `${existing.note.noteId}-${parent.note.noteId}`;
-            const savedBranch = becca.childParentToBranch[key];
-            delete becca.childParentToBranch[key];
+            const savedBranch = getBecca().childParentToBranch[key];
+            delete getBecca().childParentToBranch[key];
 
             try {
                 const newBranch = getContext().init(() => {
@@ -179,7 +179,7 @@ describe("BBranch (real DB)", () => {
                 expect(newBranch.notePosition).toBe(10);
             } finally {
                 // Restore the becca map so subsequent assertions/teardown are consistent.
-                becca.childParentToBranch[key] = savedBranch;
+                getBecca().childParentToBranch[key] = savedBranch;
             }
         });
     });

--- a/packages/trilium-core/src/becca/entities/betapi_token.spec.ts
+++ b/packages/trilium-core/src/becca/entities/betapi_token.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import BEtapiToken from "./betapi_token.js";
 import { getContext } from "../../services/context.js";
 import { getSql } from "../../services/sql/index.js";
@@ -34,11 +34,11 @@ describe("BEtapiToken constructor", () => {
         expect(token.isDeleted).toBe(false);
         expect(typeof token.utcDateCreated).toBe("string");
         expect(token.utcDateModified).toBe(token.utcDateCreated);
-        expect(becca.etapiTokens["betapi-spec-1"]).toBe(token);
+        expect(getBecca().etapiTokens["betapi-spec-1"]).toBe(token);
     });
 
     it("does not register the token in becca when the id is missing", () => {
-        const before = Object.keys(becca.etapiTokens).length;
+        const before = Object.keys(getBecca().etapiTokens).length;
 
         const token = new BEtapiToken({
             etapiTokenId: undefined,
@@ -49,7 +49,7 @@ describe("BEtapiToken constructor", () => {
         // updateFromRow and init both skip registration since etapiTokenId is falsy.
         expect(token.etapiTokenId).toBeUndefined();
         expect(token.name).toBe("idless token");
-        expect(Object.keys(becca.etapiTokens).length).toBe(before);
+        expect(Object.keys(getBecca().etapiTokens).length).toBe(before);
     });
 
     it("keeps supplied dates and reflects the deleted flag", () => {
@@ -76,10 +76,10 @@ describe("BEtapiToken init", () => {
             tokenHash: "hash-init"
         });
 
-        delete becca.etapiTokens["betapi-spec-init-1"];
+        delete getBecca().etapiTokens["betapi-spec-init-1"];
         token.init();
 
-        expect(becca.etapiTokens["betapi-spec-init-1"]).toBe(token);
+        expect(getBecca().etapiTokens["betapi-spec-init-1"]).toBe(token);
     });
 });
 
@@ -125,7 +125,7 @@ describe("BEtapiToken save (beforeSaving)", () => {
         expect(row).toBeDefined();
         expect(row?.name).toBe("save token");
         expect(row?.tokenHash).toBe("hash-save");
-        expect(becca.etapiTokens[etapiTokenId]).toBe(token);
+        expect(getBecca().etapiTokens[etapiTokenId]).toBe(token);
         // beforeSaving refreshes utcDateModified to "now", differing from the supplied value.
         expect(typeof token.utcDateModified).toBe("string");
     });

--- a/packages/trilium-core/src/becca/entities/bnote.ts
+++ b/packages/trilium-core/src/becca/entities/bnote.ts
@@ -22,11 +22,14 @@ import { getSql } from "../../services/sql/index.js";
 import { formatDownloadTitle, isStringNote, normalize, randomString, replaceAll } from "../../services/utils/index.js";
 
 // ownerId exists only after migration 239. Saves that run during migrations 220-238
-// must skip it or the INSERT fails. PRAGMA table_info is O(1) on SQLite.
+// must skip it or the INSERT fails. Result is cached so the PRAGMA runs once per process.
+let ownerIdColExists: boolean | undefined;
 function ownerIdColumnExists(): boolean {
+    if (ownerIdColExists !== undefined) return ownerIdColExists;
     try {
         const cols = getSql().getColumn<string>("SELECT name FROM pragma_table_info('notes')");
-        return cols.includes("ownerId");
+        ownerIdColExists = cols.includes("ownerId");
+        return ownerIdColExists;
     } catch {
         return false;
     }

--- a/packages/trilium-core/src/becca/entities/bnote.ts
+++ b/packages/trilium-core/src/becca/entities/bnote.ts
@@ -21,6 +21,17 @@ import { getLog } from "../../services/log.js";
 import { getSql } from "../../services/sql/index.js";
 import { formatDownloadTitle, isStringNote, normalize, randomString, replaceAll } from "../../services/utils/index.js";
 
+// ownerId exists only after migration 239. Saves that run during migrations 220-238
+// must skip it or the INSERT fails. PRAGMA table_info is O(1) on SQLite.
+function ownerIdColumnExists(): boolean {
+    try {
+        const cols = getSql().getColumn<string>("SELECT name FROM pragma_table_info('notes')");
+        return cols.includes("ownerId");
+    } catch {
+        return false;
+    }
+}
+
 const LABEL = "label";
 const RELATION = "relation";
 
@@ -66,6 +77,7 @@ class BNote extends AbstractBeccaEntity<BNote> {
     title!: string;
     type!: NoteType;
     mime!: string;
+    ownerId!: string | null;
     /** set during the deletion operation, before it is completed (removed from becca completely). */
     isBeingDeleted!: boolean;
     isDecrypted!: boolean;
@@ -104,10 +116,10 @@ class BNote extends AbstractBeccaEntity<BNote> {
     }
 
     updateFromRow(row: Partial<NoteRow>) {
-        this.update([row.noteId, row.title, row.type, row.mime, row.isProtected, row.blobId, row.dateCreated, row.dateModified, row.utcDateCreated, row.utcDateModified]);
+        this.update([row.noteId, row.title, row.type, row.mime, row.isProtected, row.blobId, row.dateCreated, row.dateModified, row.utcDateCreated, row.utcDateModified, row.ownerId]);
     }
 
-    update([noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified]: any) {
+    update([noteId, title, type, mime, isProtected, blobId, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId]: any) {
         // ------ Database persisted attributes ------
 
         this.noteId = noteId;
@@ -120,6 +132,7 @@ class BNote extends AbstractBeccaEntity<BNote> {
         this.dateModified = dateModified;
         this.utcDateCreated = utcDateCreated || dateUtils.utcNowDateTime();
         this.utcDateModified = utcDateModified;
+        this.ownerId = ownerId ?? null;
         this.isBeingDeleted = false;
 
         // ------ Derived attributes ------
@@ -1709,7 +1722,8 @@ class BNote extends AbstractBeccaEntity<BNote> {
             dateCreated: this.dateCreated,
             dateModified: this.dateModified,
             utcDateCreated: this.utcDateCreated,
-            utcDateModified: this.utcDateModified
+            utcDateModified: this.utcDateModified,
+            ownerId: this.ownerId
         };
     }
 
@@ -1723,6 +1737,10 @@ class BNote extends AbstractBeccaEntity<BNote> {
                 // updating protected note outside of protected session means we will keep original ciphertexts
                 delete pojo.title;
             }
+        }
+
+        if (!ownerIdColumnExists()) {
+            delete pojo.ownerId;
         }
 
         return pojo;

--- a/packages/trilium-core/src/becca/entities/bnote_content.spec.ts
+++ b/packages/trilium-core/src/becca/entities/bnote_content.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { dayjs } from "@triliumnext/commons";
 
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import { getContext } from "../../services/context.js";
 import eraseService from "../../services/erase.js";
 import noteService from "../../services/notes.js";
@@ -261,7 +261,7 @@ describe("BNote content / misc getters", () => {
             const res = getContext().init(() => source.cloneTo(target.noteId));
 
             expect(res.success).toBe(true);
-            expect(becca.getBranchFromChildAndParent(source.noteId, target.noteId)).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.noteId, target.noteId)).not.toBeNull();
         });
 
         it("fails when the target parent cannot be resolved to a branch", () => {

--- a/packages/trilium-core/src/becca/entities/bnote_tree.spec.ts
+++ b/packages/trilium-core/src/becca/entities/bnote_tree.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import attributeService from "../../services/attributes.js";
 import cloningService from "../../services/cloning.js";
 import { getContext } from "../../services/context.js";
@@ -199,7 +199,7 @@ describe("BNote tree / note-path / subtree methods (real DB)", () => {
 
             // _hidden short-circuit (line 860): _hidden is never included in its
             // own templated subtree.
-            const hidden = becca.getNoteOrThrow("_hidden");
+            const hidden = getBecca().getNoteOrThrow("_hidden");
             expect(hidden.getSubtreeNotesIncludingTemplated()).not.toContain(hidden);
         });
 
@@ -273,7 +273,7 @@ describe("BNote tree / note-path / subtree methods (real DB)", () => {
         });
 
         it("skips the _hidden subtree by default but includes it when requested", () => {
-            const root = becca.getNoteOrThrow("root");
+            const root = getBecca().getNoteOrThrow("root");
 
             // Default (includeHidden: false) skips _hidden (line 917-920).
             const withoutHidden = root.getSubtree().notes.map((n) => n.noteId);
@@ -536,7 +536,7 @@ describe("BNote tree / note-path / subtree methods (real DB)", () => {
             // The "_"-prefixed branch of the filter (line 1745): every visible
             // child branch under _hidden must be a non-underscore note, since all
             // of _hidden's system children are filtered out.
-            const hidden = becca.getNoteOrThrow("_hidden");
+            const hidden = getBecca().getNoteOrThrow("_hidden");
             expect(hidden.getVisibleChildBranches().every((b) => !b.noteId.startsWith("_"))).toBe(true);
 
             // A note whose only child is underscore-prefixed has no visible

--- a/packages/trilium-core/src/becca/entities/brevision.spec.ts
+++ b/packages/trilium-core/src/becca/entities/brevision.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import becca from "../becca.js";
+import { getBecca } from "../becca.js";
 import type BNote from "./bnote.js";
 import BRevision from "./brevision.js";
 import { getContext } from "../../services/context.js";
@@ -279,11 +279,11 @@ describe("Revision eraseRevision", () => {
         const revision = getContext().init(() => note.saveRevision());
         const revisionId = revision.revisionId ?? "";
         expect(revisionId).not.toBe("");
-        expect(becca.getRevision(revisionId)).not.toBeNull();
+        expect(getBecca().getRevision(revisionId)).not.toBeNull();
 
         getContext().init(() => revision.eraseRevision());
 
-        expect(becca.getRevision(revisionId)).toBeNull();
+        expect(getBecca().getRevision(revisionId)).toBeNull();
     });
 });
 

--- a/packages/trilium-core/src/becca/entities/brevision.ts
+++ b/packages/trilium-core/src/becca/entities/brevision.ts
@@ -2,7 +2,6 @@
 
 import protectedSessionService from "../../services/protected_session.js";
 import dateUtils from "../../services/utils/date";
-import becca from "../becca.js";
 import AbstractBeccaEntity from "./abstract_becca_entity.js";
 import BAttachment from "./battachment.js";
 import type { AttachmentRow, NoteType, RevisionPojo, RevisionRow, RevisionSource } from "@triliumnext/commons";
@@ -75,7 +74,7 @@ class BRevision extends AbstractBeccaEntity<BRevision> {
     }
 
     getNote() {
-        return becca.notes[this.noteId];
+        return this.becca.notes[this.noteId];
     }
 
     /** @returns true if the note has string content (not binary) */

--- a/packages/trilium-core/src/becca/similarity.spec.ts
+++ b/packages/trilium-core/src/becca/similarity.spec.ts
@@ -1,7 +1,7 @@
 import { trimIndentation } from "@triliumnext/commons";
 import { describe, expect, it } from "vitest";
 
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import { buildNote } from "../test/becca_easy_mocking";
 import BAttribute from "./entities/battribute.js";
 import BBranch from "./entities/bbranch.js";
@@ -72,13 +72,13 @@ describe("buildRewardMap", () => {
 
         // Give the parent's branch (parent -> grandparent) a prefix so the
         // ancestor branch-prefix path is exercised.
-        const parentBranch = becca.getNote(parentId)?.getParentBranches()[0];
+        const parentBranch = getBecca().getNote(parentId)?.getParentBranches()[0];
         expect(parentBranch).toBeDefined();
         if (parentBranch) {
             parentBranch.prefix = "Continent";
         }
 
-        const child = becca.getNoteOrThrow(childId);
+        const child = getBecca().getNoteOrThrow(childId);
         const map = buildRewardMap(child);
 
         // Ancestor title words appear with a (small) reward.
@@ -100,10 +100,10 @@ describe("buildRewardMap", () => {
         });
 
         // Protected (not decrypted) ancestor -> its title is not rewarded.
-        const parent = becca.getNoteOrThrow(parentId);
+        const parent = getBecca().getNoteOrThrow(parentId);
         parent.isDecrypted = false;
 
-        const child = becca.getNoteOrThrow(childId);
+        const child = getBecca().getNoteOrThrow(childId);
         // archived is in IGNORED_ATTR_NAMES: its name is not rewarded.
         new BAttribute({
             attributeId: randomString(12),
@@ -148,7 +148,7 @@ describe("buildRewardMap", () => {
             isInheritable: true
         });
 
-        const child = becca.getNoteOrThrow(childId);
+        const child = getBecca().getNoteOrThrow(childId);
         const inherited = child.getAttributes().find((a) => a.name === "category");
         expect(inherited).toBeDefined();
         expect(inherited?.noteId).toStrictEqual(parentId);

--- a/packages/trilium-core/src/becca/similarity.ts
+++ b/packages/trilium-core/src/becca/similarity.ts
@@ -1,4 +1,4 @@
-import becca from "./becca.js";
+import { getBecca } from "./becca.js";
 import { getLog } from "../services/log.js";
 import beccaService from "./becca_service.js";
 import dateUtils from "../services/utils/date";
@@ -254,7 +254,7 @@ async function findSimilarNotes(noteId: string): Promise<SimilarNote[] | undefin
     const results: SimilarNote[] = [];
     let i = 0;
 
-    const baseNote = becca.notes[noteId];
+    const baseNote = getBecca().notes[noteId];
 
     if (!baseNote || !baseNote.utcDateCreated) {
         return [];
@@ -423,7 +423,7 @@ async function findSimilarNotes(noteId: string): Promise<SimilarNote[] | undefin
         return score;
     }
 
-    for (const candidateNote of Object.values(becca.notes)) {
+    for (const candidateNote of Object.values(getBecca().notes)) {
         if (candidateNote.noteId === baseNote.noteId
             || candidateNote.isHiddenCompletely()
             || hasConnectingRelation(candidateNote, baseNote)
@@ -465,7 +465,7 @@ async function findSimilarNotes(noteId: string): Promise<SimilarNote[] | undefin
 
         if (results.length >= 1) {
             for (const { noteId } of results) {
-                const note = becca.notes[noteId];
+                const note = getBecca().notes[noteId];
 
                 displayRewards = true;
                 ancestorRewardCache = {}; // reset cache

--- a/packages/trilium-core/src/index.ts
+++ b/packages/trilium-core/src/index.ts
@@ -70,8 +70,9 @@ export { default as user_service, type User as UserRecord, PrimaryAdminDeletionE
 export * from "./services/messaging/index";
 export type { MessagingProvider, ServerMessagingProvider, MessageClient, MessageHandler } from "./services/messaging/types";
 
-export { default as becca } from "./becca/becca";
+export { default as becca, getBecca, warmBeccaForUser } from "./becca/becca";
 export { default as becca_loader } from "./becca/becca_loader";
+export { default as permission_service } from "./services/permission_service";
 export { default as becca_service } from "./becca/becca_service";
 export { default as entity_constructor } from "./becca/entity_constructor";
 export { default as similarity } from "./becca/similarity";

--- a/packages/trilium-core/src/migrations/0220__migrate_images_to_attachments.ts
+++ b/packages/trilium-core/src/migrations/0220__migrate_images_to_attachments.ts
@@ -1,4 +1,4 @@
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { getLog } from "../services/log.js";
 import { getSql } from "../services/sql/index.js";
 import { getContext } from "../services/context.js";
@@ -14,7 +14,7 @@ export default () => {
 
         becca_loader.load();
 
-        for (const note of Object.values(becca.notes)) {
+        for (const note of Object.values(getBecca().notes)) {
             try {
                 const attachment = note.convertToParentAttachment({ autoConversion: true });
 

--- a/packages/trilium-core/src/migrations/0233__migrate_geo_map_to_collection.spec.ts
+++ b/packages/trilium-core/src/migrations/0233__migrate_geo_map_to_collection.spec.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it, beforeEach } from "vitest";
 import * as cls from "../services/context.js";
 import { getSql } from "../services/sql/index.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import becca_loader from "../becca/becca_loader.js";
 import migration from "./0233__migrate_geo_map_to_collection.js";
 
@@ -112,9 +112,9 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
                 becca_loader.load();
 
                 // Verify initial state
-                const geoMapNote1 = becca.getNote(testNoteId);
-                const geoMapNote2 = becca.getNote(testNoteId2);
-                const regularNote = becca.getNote(regularNoteId);
+                const geoMapNote1 = getBecca().getNote(testNoteId);
+                const geoMapNote2 = getBecca().getNote(testNoteId2);
+                const regularNote = getBecca().getNote(regularNoteId);
 
                 expect(geoMapNote1).toBeTruthy();
                 expect(geoMapNote1?.type).toBe("geoMap");
@@ -130,9 +130,9 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
                 becca_loader.load();
 
                 // Verify migration results
-                const migratedNote1 = becca.getNote(testNoteId);
-                const migratedNote2 = becca.getNote(testNoteId2);
-                const unchangedNote = becca.getNote(regularNoteId);
+                const migratedNote1 = getBecca().getNote(testNoteId);
+                const migratedNote2 = getBecca().getNote(testNoteId2);
+                const unchangedNote = getBecca().getNote(regularNoteId);
 
                 // Check that geoMap notes were converted to book type
                 expect(migratedNote1).toBeTruthy();
@@ -204,7 +204,7 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
                 // Reload becca
                 becca_loader.load();
 
-                const note = becca.getNote(testNoteId);
+                const note = getBecca().getNote(testNoteId);
                 expect(note).toBeTruthy();
 
                 // Create an existing viewConfig attachment with the same title
@@ -227,7 +227,7 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
 
                 // Reload becca after migration
                 becca_loader.load();
-                const migratedNote = becca.getNote(testNoteId);
+                const migratedNote = getBecca().getNote(testNoteId);
 
                 // Verify that existing attachment was updated, not duplicated
                 if (migratedNote) {
@@ -272,7 +272,7 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
                 becca_loader.load();
 
                 // Verify initial state
-                const protectedNote = becca.getNote(testNoteId);
+                const protectedNote = getBecca().getNote(testNoteId);
                 expect(protectedNote).toBeTruthy();
                 expect(protectedNote?.type).toBe("geoMap");
                 expect(protectedNote?.isProtected).toBe(true);
@@ -286,7 +286,7 @@ describe("Migration 0233: Migrate geoMap to collection", () => {
 
                 // Reload becca after migration attempt
                 becca_loader.load();
-                const noteAfterMigration = becca.getNote(testNoteId);
+                const noteAfterMigration = getBecca().getNote(testNoteId);
 
                 // If migration succeeds, verify the transformation
                 expect(noteAfterMigration).toBeTruthy();

--- a/packages/trilium-core/src/migrations/0233__migrate_geo_map_to_collection.ts
+++ b/packages/trilium-core/src/migrations/0233__migrate_geo_map_to_collection.ts
@@ -1,5 +1,5 @@
-import becca from "../becca/becca";
-import becca_loader from "../becca/becca_loader";
+import { adminBecca } from "../becca/becca.js";
+import becca_loader from "../becca/becca_loader.js";
 import { getContext } from "../services/context";
 import hidden_subtree from "../services/hidden_subtree";
 
@@ -10,7 +10,7 @@ export default () => {
         // Ensure the geomap template is generated.
         hidden_subtree.checkHiddenSubtree(true);
 
-        for (const note of Object.values(becca.notes)) {
+        for (const note of Object.values(adminBecca.notes)) {
             if (note.type as string !== "geoMap") {
                 continue;
             }

--- a/packages/trilium-core/src/migrations/0234__migrate_ai_chat_to_code.ts
+++ b/packages/trilium-core/src/migrations/0234__migrate_ai_chat_to_code.ts
@@ -1,12 +1,12 @@
-import becca from "../becca/becca";
-import becca_loader from "../becca/becca_loader";
+import { adminBecca } from "../becca/becca.js";
+import becca_loader from "../becca/becca_loader.js";
 import { getContext } from "../services/context";
 
 export default () => {
     getContext().init(() => {
         becca_loader.load();
 
-        for (const note of Object.values(becca.notes)) {
+        for (const note of Object.values(adminBecca.notes)) {
             if (note.type as string !== "aiChat") {
                 continue;
             }

--- a/packages/trilium-core/src/migrations/migrations.ts
+++ b/packages/trilium-core/src/migrations/migrations.ts
@@ -9,6 +9,30 @@ export function getMaxMigrationVersion() {
 
 // Migrations should be kept in descending order, so the latest migration is first.
 export const MIGRATIONS: (SqlMigration | JsMigration)[] = [
+    // Add note_permissions table (note sharing ACL, users and groups).
+    {
+        version: 240,
+        ignoreErrors: true,
+        sql: /*sql*/`
+            CREATE TABLE IF NOT EXISTS "note_permissions" (
+                permissionId    TEXT PRIMARY KEY NOT NULL,
+                noteId          TEXT NOT NULL,
+                userId          TEXT,
+                groupId         TEXT,
+                canRead         INT NOT NULL DEFAULT 1,
+                canWrite        INT NOT NULL DEFAULT 0,
+                dateCreated     TEXT NOT NULL,
+                utcDateModified TEXT NOT NULL,
+                FOREIGN KEY (noteId)   REFERENCES notes(noteId),
+                FOREIGN KEY (userId)   REFERENCES users(userId),
+                FOREIGN KEY (groupId)  REFERENCES user_groups(groupId),
+                CHECK (userId IS NOT NULL OR groupId IS NOT NULL)
+            );
+            CREATE INDEX IF NOT EXISTS IDX_note_permissions_noteId  ON note_permissions(noteId);
+            CREATE INDEX IF NOT EXISTS IDX_note_permissions_userId  ON note_permissions(userId);
+            CREATE INDEX IF NOT EXISTS IDX_note_permissions_groupId ON note_permissions(groupId);
+        `
+    },
     // Add multi-user identity tables (users, user_groups, user_group_members)
     // and nullable ownership columns on notes/entity_changes/etapi_tokens.
     // Admin-user seeding and user_data teardown happen in sql_init.ts after

--- a/packages/trilium-core/src/routes/api/attachments.ts
+++ b/packages/trilium-core/src/routes/api/attachments.ts
@@ -5,7 +5,7 @@ import type { File } from "../../services/import/common.js";
 
 type FileRequest<P> = Omit<Request<P>, "file"> & { file?: File };
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import blobService from "../../services/blob.js";
 import imageService from "../../services/image.js";
 import { wrapStringOrBuffer } from "../../services/utils/binary.js";
@@ -17,7 +17,7 @@ function getAttachmentBlob(req: Request<{ attachmentId: string }>) {
 }
 
 function getAttachments(req: Request<{ noteId: string }>) {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     return note.getAttachments();
 }
@@ -25,14 +25,14 @@ function getAttachments(req: Request<{ noteId: string }>) {
 function getAttachment(req: Request<{ attachmentId: string }>) {
     const { attachmentId } = req.params;
 
-    return becca.getAttachmentOrThrow(attachmentId);
+    return getBecca().getAttachmentOrThrow(attachmentId);
 }
 
 function getAllAttachments(req: Request<{ attachmentId: string }>) {
     const { attachmentId } = req.params;
     // one particular attachment is requested, but return all note's attachments
 
-    const attachment = becca.getAttachmentOrThrow(attachmentId);
+    const attachment = getBecca().getAttachmentOrThrow(attachmentId);
     return attachment.getNote()?.getAttachments() || [];
 }
 
@@ -43,7 +43,7 @@ function saveAttachment(req: Request<{ noteId: string }>) {
     const isValidMatchBy = (typeof matchByQuery === "string") && (matchByQuery === "attachmentId" || matchByQuery === "title");
     const matchBy = isValidMatchBy ? matchByQuery : undefined;
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
     note.saveAttachment({ attachmentId, role, mime, title, content }, matchBy);
 }
 
@@ -58,7 +58,7 @@ function uploadAttachment(req: FileRequest<{ noteId: string }>) {
         };
     }
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
     let url;
 
     // Convert buffer to Uint8Array (Buffer extends Uint8Array, string needs encoding)
@@ -88,7 +88,7 @@ function renameAttachment(req: Request<{ attachmentId: string }>) {
     const { title } = req.body;
     const { attachmentId } = req.params;
 
-    const attachment = becca.getAttachmentOrThrow(attachmentId);
+    const attachment = getBecca().getAttachmentOrThrow(attachmentId);
 
     if (!title?.trim()) {
         throw new ValidationError("Title must not be empty");
@@ -101,7 +101,7 @@ function renameAttachment(req: Request<{ attachmentId: string }>) {
 function deleteAttachment(req: Request<{ attachmentId: string }>) {
     const { attachmentId } = req.params;
 
-    const attachment = becca.getAttachment(attachmentId);
+    const attachment = getBecca().getAttachment(attachmentId);
 
     if (attachment) {
         attachment.markAsDeleted();
@@ -111,7 +111,7 @@ function deleteAttachment(req: Request<{ attachmentId: string }>) {
 function convertAttachmentToNote(req: Request<{ attachmentId: string }>) {
     const { attachmentId } = req.params;
 
-    const attachment = becca.getAttachmentOrThrow(attachmentId);
+    const attachment = getBecca().getAttachmentOrThrow(attachmentId);
     return attachment.convertToNote() satisfies ConvertAttachmentToNoteResponse;
 }
 

--- a/packages/trilium-core/src/routes/api/attributes.ts
+++ b/packages/trilium-core/src/routes/api/attributes.ts
@@ -1,7 +1,7 @@
 import { UpdateAttributeResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BAttribute from "../../becca/entities/battribute.js";
 import attributeService from "../../services/attributes.js";
 import { getLog } from "../../services/log.js";
@@ -9,7 +9,7 @@ import { getSql } from "../../services/sql/index.js";
 import { ValidationError } from "../../errors.js";
 
 function getEffectiveNoteAttributes(req: Request<{ noteId: string }>) {
-    const note = becca.getNote(req.params.noteId);
+    const note = getBecca().getNote(req.params.noteId);
 
     return note?.getAttributes();
 }
@@ -20,7 +20,7 @@ function updateNoteAttribute(req: Request<{ noteId: string }>) {
 
     let attribute: BAttribute;
     if (body.attributeId) {
-        attribute = becca.getAttributeOrThrow(body.attributeId);
+        attribute = getBecca().getAttributeOrThrow(body.attributeId);
 
         if (attribute.noteId !== noteId) {
             throw new ValidationError(`Attribute '${body.attributeId}' is not owned by ${noteId}`);
@@ -75,7 +75,7 @@ function setNoteAttribute(req: Request) {
     const attributeId = getSql().getValue<string | null>(/*sql*/`SELECT attributeId FROM attributes WHERE isDeleted = 0 AND noteId = ? AND type = ? AND name = ?`, [noteId, body.type, body.name]);
 
     if (attributeId) {
-        const attr = becca.getAttribute(attributeId);
+        const attr = getBecca().getAttribute(attributeId);
         /* v8 ignore next 3 -- unreachable: the attributeId comes from a SQL query over non-deleted rows, which are always present in becca, so getAttribute cannot return null here */
         if (!attr) {
             throw new ValidationError(`Missing attribute with ID ${attributeId}.`);
@@ -101,7 +101,7 @@ function deleteNoteAttribute(req: Request<{ noteId: string; attributeId: string 
     const noteId = req.params.noteId;
     const attributeId = req.params.attributeId;
 
-    const attribute = becca.getAttribute(attributeId);
+    const attribute = getBecca().getAttribute(attributeId);
 
     if (attribute) {
         if (attribute.noteId !== noteId) {
@@ -116,7 +116,7 @@ function updateNoteAttributes(req: Request<{ noteId: string }>) {
     const noteId = req.params.noteId;
     const incomingAttributes = req.body;
 
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
     if (!note) {
         throw new ValidationError(`Cannot find note with ID ${noteId}.`);
     }
@@ -144,7 +144,7 @@ function updateNoteAttributes(req: Request<{ noteId: string }>) {
         }
 
         if (incAttr.type === "relation") {
-            const targetNote = becca.getNote(incAttr.value);
+            const targetNote = getBecca().getNote(incAttr.value);
 
             if (!targetNote) {
                 getLog().error(`Target note of relation ${JSON.stringify(incAttr)} does not exist or is deleted`);
@@ -204,7 +204,7 @@ function createRelation(req: Request<{ noteId: string; targetNoteId: string; nam
         name,
         targetNoteId
     ]);
-    let attribute = becca.getAttribute(attributeId);
+    let attribute = getBecca().getAttribute(attributeId);
 
     if (!attribute) {
         attribute = new BAttribute({
@@ -230,7 +230,7 @@ function deleteRelation(req: Request) {
     ]);
 
     if (attributeId) {
-        const attribute = becca.getAttribute(attributeId);
+        const attribute = getBecca().getAttribute(attributeId);
         if (attribute) {
             attribute.markAsDeleted();
         }

--- a/packages/trilium-core/src/routes/api/autocomplete.ts
+++ b/packages/trilium-core/src/routes/api/autocomplete.ts
@@ -1,6 +1,6 @@
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import * as cls from "../../services/context.js";
 import { getLog } from "../../services/log.js";
 import searchService from "../../services/search/services/search.js";
@@ -47,7 +47,7 @@ function getRecentNotes(activeNoteId: string) {
         params.push(`%${hoistedNoteId}%`);
     }
 
-    const recentNotes = becca.getRecentNotesFromQuery(
+    const recentNotes = getBecca().getRecentNotesFromQuery(
         `
     SELECT
         recent_notes.*

--- a/packages/trilium-core/src/routes/api/branches.ts
+++ b/packages/trilium-core/src/routes/api/branches.ts
@@ -3,7 +3,7 @@ import eraseService from "../../services/erase.js";
 import eventService from "../../services/events.js";
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import entityChangesService from "../../services/entity_changes.js";
 import { getLog } from "../../services/log.js";
 import TaskContext from "../../services/task_context.js";
@@ -20,8 +20,8 @@ import { ValidationError } from "../../errors.js";
 function moveBranchToParent(req: Request<{ branchId: string, parentBranchId: string }>) {
     const { branchId, parentBranchId } = req.params;
 
-    const branchToMove = becca.getBranch(branchId);
-    const targetParentBranch = becca.getBranch(parentBranchId);
+    const branchToMove = getBecca().getBranch(branchId);
+    const targetParentBranch = getBecca().getBranch(parentBranchId);
 
     if (!branchToMove || !targetParentBranch) {
         throw new ValidationError(`One or both branches '${branchId}', '${parentBranchId}' have not been found`);
@@ -33,8 +33,8 @@ function moveBranchToParent(req: Request<{ branchId: string, parentBranchId: str
 function moveBranchBeforeNote(req: Request<{ branchId: string, beforeBranchId: string }>) {
     const { branchId, beforeBranchId } = req.params;
 
-    const branchToMove = becca.getBranchOrThrow(branchId);
-    const beforeBranch = becca.getBranchOrThrow(beforeBranchId);
+    const branchToMove = getBecca().getBranchOrThrow(branchId);
+    const beforeBranch = getBecca().getBranchOrThrow(beforeBranchId);
 
     const validationResult = treeService.validateParentChild(beforeBranch.parentNoteId, branchToMove.noteId, branchId);
 
@@ -50,7 +50,7 @@ function moveBranchBeforeNote(req: Request<{ branchId: string, beforeBranchId: s
     getSql().execute("UPDATE branches SET notePosition = notePosition + 10 WHERE parentNoteId = ? AND notePosition >= ? AND isDeleted = 0", [beforeBranch.parentNoteId, originalBeforeNotePosition]);
 
     // also need to update becca positions
-    const parentNote = becca.getNoteOrThrow(beforeBranch.parentNoteId);
+    const parentNote = getBecca().getNoteOrThrow(beforeBranch.parentNoteId);
 
     for (const childBranch of parentNote.getChildBranches()) {
         if (childBranch.notePosition >= originalBeforeNotePosition) {
@@ -81,8 +81,8 @@ function moveBranchBeforeNote(req: Request<{ branchId: string, beforeBranchId: s
 function moveBranchAfterNote(req: Request<{ branchId: string, afterBranchId: string }>) {
     const { branchId, afterBranchId } = req.params;
 
-    const branchToMove = becca.getBranchOrThrow(branchId);
-    const afterNote = becca.getBranchOrThrow(afterBranchId);
+    const branchToMove = getBecca().getBranchOrThrow(branchId);
+    const afterNote = getBecca().getBranchOrThrow(afterBranchId);
 
     const validationResult = treeService.validateParentChild(afterNote.parentNoteId, branchToMove.noteId, branchId);
 
@@ -97,7 +97,7 @@ function moveBranchAfterNote(req: Request<{ branchId: string, afterBranchId: str
     getSql().execute("UPDATE branches SET notePosition = notePosition + 10 WHERE parentNoteId = ? AND notePosition > ? AND isDeleted = 0", [afterNote.parentNoteId, originalAfterNotePosition]);
 
     // also need to update becca positions
-    const parentNote = becca.getNoteOrThrow(afterNote.parentNoteId);
+    const parentNote = getBecca().getNoteOrThrow(afterNote.parentNoteId);
 
     for (const childBranch of parentNote.getChildBranches()) {
         if (childBranch.notePosition > originalAfterNotePosition) {
@@ -136,7 +136,7 @@ function setExpanded(req: Request<{ branchId: string, expanded: string }>) {
         // we don't sync expanded label
         // also this does not trigger updates to the frontend, this would trigger too many reloads
 
-        const branch = becca.branches[branchId];
+        const branch = getBecca().branches[branchId];
 
         if (branch) {
             branch.isExpanded = !!expanded;
@@ -176,7 +176,7 @@ function setExpandedForSubtree(req: Request<{ branchId: string, expanded: string
     sql.executeMany(/*sql*/`UPDATE branches SET isExpanded = ${expandedValue} WHERE branchId IN (???)`, branchIds);
 
     for (const branchId of branchIds) {
-        const branch = becca.branches[branchId];
+        const branch = getBecca().branches[branchId];
 
         if (branch) {
             branch.isExpanded = !!expanded;
@@ -236,7 +236,7 @@ function setExpandedForSubtree(req: Request<{ branchId: string, expanded: string
 function deleteBranch(req: Request<{ branchId: string }>) {
     const last = req.query.last === "true";
     const eraseNotes = req.query.eraseNotes === "true";
-    const branch = becca.getBranchOrThrow(req.params.branchId);
+    const branch = getBecca().getBranchOrThrow(req.params.branchId);
 
     const taskContext = TaskContext.getInstance(req.query.taskId as string, "deleteNotes", null);
 
@@ -266,7 +266,7 @@ function setPrefix(req: Request<{ branchId: string }>) {
     //TriliumNextTODO: req.body arrives as string, so req.body.prefix will be undefined – did the code below ever even work?
     const prefix = isEmptyOrWhitespace(req.body.prefix) ? null : req.body.prefix;
 
-    const branch = becca.getBranchOrThrow(branchId);
+    const branch = getBecca().getBranchOrThrow(branchId);
     branch.prefix = prefix;
     branch.save();
 }
@@ -287,7 +287,7 @@ function setPrefixBatch(req: Request) {
     let updatedCount = 0;
 
     for (const branchId of branchIds) {
-        const branch = becca.getBranch(branchId);
+        const branch = getBecca().getBranch(branchId);
         if (branch) {
             branch.prefix = normalizedPrefix;
             branch.save();

--- a/packages/trilium-core/src/routes/api/bulk_action.ts
+++ b/packages/trilium-core/src/routes/api/bulk_action.ts
@@ -1,5 +1,5 @@
 import type { Request } from "express";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import bulkActionService from "../../services/bulk_actions.js";
 
 function execute(req: Request) {
@@ -10,7 +10,7 @@ function execute(req: Request) {
 
     const affectedNoteIds = getAffectedNoteIds(noteIds, includeDescendants);
 
-    const bulkActionNote = becca.getNoteOrThrow("_bulkAction");
+    const bulkActionNote = getBecca().getNoteOrThrow("_bulkAction");
 
     if (actions && actions.length > 0) {
         for (const action of actions) {
@@ -38,7 +38,7 @@ function getAffectedNoteIds(noteIds: string[], includeDescendants: boolean) {
     const affectedNoteIds = new Set<string>();
 
     for (const noteId of noteIds) {
-        const note = becca.getNote(noteId);
+        const note = getBecca().getNote(noteId);
 
         if (!note) {
             continue;

--- a/packages/trilium-core/src/routes/api/export.ts
+++ b/packages/trilium-core/src/routes/api/export.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import opmlExportService from "../../services/export/opml.js";
 import singleExportService from "../../services/export/single.js";
 import zipExportService from "../../services/export/zip.js";
@@ -11,7 +11,7 @@ import { NotFoundError, ValidationError } from "../../errors.js";
 
 async function exportBranch(req: Request<{ branchId: string; type: string; format: string; taskId: string }>, res: Response) {
     const { branchId, type, format, taskId } = req.params;
-    const branch = becca.getBranch(branchId);
+    const branch = getBecca().getBranch(branchId);
 
     if (!branch) {
         const message = `Cannot export branch '${branchId}' since it does not exist.`;

--- a/packages/trilium-core/src/routes/api/files.ts
+++ b/packages/trilium-core/src/routes/api/files.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import { downloadData, downloadNoteInt } from "../helpers";
 
 const downloadFile = (req: Request<{ noteId: string }>, res: Response) => downloadNoteInt(req.params.noteId, res, true);
@@ -9,7 +9,7 @@ const downloadAttachment = (req: Request<{ attachmentId: string }>, res: Respons
 const openAttachment = (req: Request<{ attachmentId: string }>, res: Response) => downloadAttachmentInt(req.params.attachmentId, res, false);
 
 function downloadAttachmentInt(attachmentId: string, res: Response, contentDisposition = true) {
-    const attachment = becca.getAttachment(attachmentId);
+    const attachment = getBecca().getAttachment(attachmentId);
 
     if (!attachment) {
         return res.setHeader("Content-Type", "text/plain").status(404).send(`Attachment '${attachmentId}' doesn't exist.`);

--- a/packages/trilium-core/src/routes/api/image.spec.ts
+++ b/packages/trilium-core/src/routes/api/image.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import * as cls from "../../services/context.js";
 import { getSql } from "../../services/sql/index.js";
 import { unwrapStringOrBuffer } from "../../services/utils/binary.js";
@@ -44,7 +44,7 @@ async function createImageNote({
 
     cls.init(() =>
         getSql().transactional(() => {
-            const note = becca.getNoteOrThrow(noteId);
+            const note = getBecca().getNoteOrThrow(noteId);
             note.type = type as never;
             note.mime = mime;
             note.save();
@@ -200,7 +200,7 @@ describe("Image API (core)", () => {
             const { noteId } = await createTextNote(api);
             return cls.init(() =>
                 getSql().transactional(() => {
-                    const note = becca.getNoteOrThrow(noteId);
+                    const note = getBecca().getNoteOrThrow(noteId);
                     const attachment = note.saveAttachment(
                         { role, mime, title: "att", content: content as never },
                         "title"
@@ -279,7 +279,7 @@ describe("Image API (core)", () => {
             expect(res.body.uploaded).toBe(true);
             // The real service synchronously snapshots a revision and sets the label.
             cls.init(() => {
-                expect(becca.getNoteOrThrow(noteId).getOwnedLabelValue("originalFileName")).toBe("x.png");
+                expect(getBecca().getNoteOrThrow(noteId).getOwnedLabelValue("originalFileName")).toBe("x.png");
             });
         });
     });

--- a/packages/trilium-core/src/routes/api/image.ts
+++ b/packages/trilium-core/src/routes/api/image.ts
@@ -3,7 +3,7 @@ import type { File } from "../../services/import/common.js";
 
 type FileRequest<P> = Omit<Request<P>, "file"> & { file?: File };
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BNote from "../../becca/entities/bnote.js";
 import type BRevision from "../../becca/entities/brevision.js";
 import imageService from "../../services/image.js";
@@ -11,13 +11,13 @@ import { sanitizeSvg, SVG_CONTENT_SECURITY_POLICY } from "../../services/utils/i
 import { unwrapStringOrBuffer } from "../../services/utils/binary.js";
 
 function returnImageFromNote(req: Request<{ noteId: string }>, res: Response) {
-    const image = becca.getNote(req.params.noteId);
+    const image = getBecca().getNote(req.params.noteId);
 
     return returnImageInt(image, res);
 }
 
 function returnImageFromRevision(req: Request<{ revisionId: string }>, res: Response) {
-    const image = becca.getRevision(req.params.revisionId);
+    const image = getBecca().getRevision(req.params.revisionId);
 
     return returnImageInt(image, res);
 }
@@ -84,7 +84,7 @@ export function renderPngAttachment(image: BNote | BRevision, res: Response, att
 }
 
 function returnAttachedImage(req: Request<{ attachmentId: string }>, res: Response) {
-    const attachment = becca.getAttachment(req.params.attachmentId);
+    const attachment = getBecca().getAttachment(req.params.attachmentId);
 
     if (!attachment) {
         res.set("Content-Type", "image/png");
@@ -110,7 +110,7 @@ function updateImage(req: FileRequest<{ noteId: string }>) {
     const { noteId } = req.params;
     const { file } = req;
 
-    const _note = becca.getNoteOrThrow(noteId);
+    const _note = getBecca().getNoteOrThrow(noteId);
 
     if (!file) {
         return {

--- a/packages/trilium-core/src/routes/api/import.spec.ts
+++ b/packages/trilium-core/src/routes/api/import.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import enexImportService from "../../services/import/enex";
 import singleImportService from "../../services/import/single";
 import TaskContext from "../../services/task_context";
@@ -29,7 +29,7 @@ function file(originalname: string, buffer: Buffer | string, mimetype = "text/pl
 }
 
 function noteContent(noteId: string): string {
-    return unwrapStringOrBuffer(becca.getNote(noteId)!.getContent());
+    return unwrapStringOrBuffer(getBecca().getNote(noteId)!.getContent());
 }
 
 describe("Import API (core)", () => {
@@ -61,7 +61,7 @@ describe("Import API (core)", () => {
             expect(res.status).toBe(200);
             expect(res.body.noteId).toBeTruthy();
 
-            const note = becca.getNote(res.body.noteId);
+            const note = getBecca().getNote(res.body.noteId);
             expect(note).toBeTruthy();
             expect(note!.getParentBranches().some((b) => b.parentNoteId === parentNoteId)).toBe(true);
             // plain text is wrapped in HTML paragraphs by the real importer
@@ -88,7 +88,7 @@ describe("Import API (core)", () => {
             );
             expect(Buffer.isBuffer(zip.body)).toBe(true);
 
-            const before = becca.getNote(parentNoteId)!.getChildNotes().length;
+            const before = getBecca().getNote(parentNoteId)!.getChildNotes().length;
             const res = await api.post<{ noteId: string }>(
                 `/api/notes/${parentNoteId}/notes-import`,
                 { body: {}, file: { originalname: "roundtrip.zip", mimetype: "application/zip", buffer: zip.body } }
@@ -96,8 +96,8 @@ describe("Import API (core)", () => {
 
             expect(res.status).toBe(200);
             expect(res.body.noteId).toBeTruthy();
-            expect(becca.getNote(res.body.noteId)).toBeTruthy();
-            expect(becca.getNote(parentNoteId)!.getChildNotes().length).toBeGreaterThan(before);
+            expect(getBecca().getNote(res.body.noteId)).toBeTruthy();
+            expect(getBecca().getNote(parentNoteId)!.getChildNotes().length).toBeGreaterThan(before);
         });
 
         it("returns 500 when the zip importer throws on garbage bytes", async () => {
@@ -154,7 +154,7 @@ describe("Import API (core)", () => {
             expect(res.status).toBe(200);
             // root note title is the filename without the .enex extension
             expect(res.body.title).toBe("book");
-            const root = becca.getNote(res.body.noteId)!;
+            const root = getBecca().getNote(res.body.noteId)!;
             expect(root.getChildNotes().some((c) => c.title === "Enex Note")).toBe(true);
         });
 
@@ -226,7 +226,7 @@ describe("Import API (core)", () => {
                 [parentNoteId]
             );
             expect(after).toBe(before + 1);
-            expect(becca.getNote(parentNoteId)!.getAttachments().some((a) => a.title === "attach.txt")).toBe(true);
+            expect(getBecca().getNote(parentNoteId)!.getAttachments().some((a) => a.title === "attach.txt")).toBe(true);
         });
 
         it("returns 500 when the attachment importer throws", async () => {

--- a/packages/trilium-core/src/routes/api/import.ts
+++ b/packages/trilium-core/src/routes/api/import.ts
@@ -4,7 +4,7 @@ import type { File } from "../../services/import/common.js";
 
 type ImportRequest<P> = Omit<Request<P>, "file"> & { file?: File };
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import becca_loader from "../../becca/becca_loader.js";
 import type BNote from "../../becca/entities/bnote.js";
 import { ValidationError } from "../../errors.js";
@@ -35,7 +35,7 @@ async function importNotesToBranch(req: ImportRequest<{ parentNoteId: string }>)
         throw new ValidationError("No file has been uploaded");
     }
 
-    const parentNote = becca.getNoteOrThrow(parentNoteId);
+    const parentNote = getBecca().getNoteOrThrow(parentNoteId);
 
     // running all the event handlers on imported notes (and attributes) is slow
     // and may produce unintended consequences
@@ -102,7 +102,7 @@ function importAttachmentsToNote(req: ImportRequest<{ parentNoteId: string }>) {
         throw new ValidationError("No file has been uploaded");
     }
 
-    const parentNote = becca.getNoteOrThrow(parentNoteId);
+    const parentNote = getBecca().getNoteOrThrow(parentNoteId);
     const taskContext = TaskContext.getInstance(taskId, "importNotes", options);
 
     // unlike in note import, we let the events run, because a huge number of attachments is not likely

--- a/packages/trilium-core/src/routes/api/keys.ts
+++ b/packages/trilium-core/src/routes/api/keys.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import keyboard_actions from "../../services/keyboard_actions";
 
 function getKeyboardActions() {
@@ -8,10 +8,10 @@ function getKeyboardActions() {
 }
 
 function getShortcutsForNotes() {
-    const labels = becca.findAttributes("label", "keyboardShortcut");
+    const labels = getBecca().findAttributes("label", "keyboardShortcut");
 
     // launchers have different handling
-    return labels.filter((attr) => becca.getNote(attr.noteId)?.type !== "launcher");
+    return labels.filter((attr) => getBecca().getNote(attr.noteId)?.type !== "launcher");
 }
 
 export default {

--- a/packages/trilium-core/src/routes/api/note_map.spec.ts
+++ b/packages/trilium-core/src/routes/api/note_map.spec.ts
@@ -1,7 +1,7 @@
 import { trimIndentation } from "@triliumnext/commons";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import { createTextNote } from "../../test/api_fixtures";
 import { CoreApiTester } from "../../test/api_tester";
 import { buildNote, buildNotes } from "../../test/becca_easy_mocking";
@@ -351,7 +351,7 @@ describe("Note map service (branch coverage)", () => {
     it("updateDescendantCountMapForSearch: search parent aggregates child counts", () => {
         const target = buildNote({ id: "udcTarget", title: "Target", children: [ { id: "udcChild", title: "Child" } ] });
         const searchNote = buildNote({ id: "udcSearch", title: "Search", type: "search" });
-        const spy = vi.spyOn(searchNote, "getSearchResultNotes").mockReturnValue([ becca.notes["udcTarget"]! ]);
+        const spy = vi.spyOn(searchNote, "getSearchResultNotes").mockReturnValue([ getBecca().notes["udcTarget"]! ]);
 
         const res = note_map.getTreeMap(req(searchNote.noteId)) as TreeMapResponse;
         // the search note's descendant count is derived from its resolved results

--- a/packages/trilium-core/src/routes/api/note_map.ts
+++ b/packages/trilium-core/src/routes/api/note_map.ts
@@ -1,6 +1,6 @@
 import BAttribute from "../../becca/entities/battribute";
 import BNote from "../../becca/entities/bnote";
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import type { BacklinkCountResponse, BacklinksResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 import { HTMLElement, parse, TextNode } from "node-html-parser";
@@ -20,7 +20,7 @@ function buildDescendantCountMap(noteIdsToCount: string[]) {
 
     function getCount(noteId: string): number {
         if (!(noteId in noteIdToCountMap)) {
-            const note = becca.getNote(noteId);
+            const note = getBecca().getNote(noteId);
             /* v8 ignore next 3 -- defensive guard: noteIds come from real notes / their resolved children */
             if (!note) {
                 return 0;
@@ -98,7 +98,7 @@ function getNeighbors(note: BNote, depth: number): string[] {
 }
 
 function getLinkMap(req: Request<{ noteId: string }>) {
-    const mapRootNote = becca.getNoteOrThrow(req.params.noteId);
+    const mapRootNote = getBecca().getNoteOrThrow(req.params.noteId);
 
     // if the map root itself has "excludeFromNoteMap" attribute (journal typically) then there wouldn't be anything
     // to display, so we'll just ignore it
@@ -134,19 +134,19 @@ function getLinkMap(req: Request<{ noteId: string }>) {
     const noteIdsArray = Array.from(noteIds);
 
     const notes = noteIdsArray.map((noteId) => {
-        const note = becca.getNoteOrThrow(noteId);
+        const note = getBecca().getNoteOrThrow(noteId);
 
         return [note.noteId, note.getTitleOrProtected(), note.type, note.getLabelValue("color")];
     });
 
-    const links = Object.values(becca.attributes)
+    const links = Object.values(getBecca().attributes)
         .filter((rel) => {
             if (rel.type !== "relation" || rel.name === "relationMapLink" || rel.name === "template" || rel.name === "inherit") {
                 return false;
             } else if (!noteIds.has(rel.noteId) || !noteIds.has(rel.value)) {
                 return false;
             } else if (rel.name === "imageLink") {
-                const parentNote = becca.getNote(rel.noteId);
+                const parentNote = getBecca().getNote(rel.noteId);
                 /* v8 ignore next 3 -- defensive guard: rel.noteId is already constrained to noteIds (existing notes) */
                 if (!parentNote) {
                     return false;
@@ -176,7 +176,7 @@ function getLinkMap(req: Request<{ noteId: string }>) {
 }
 
 function getTreeMap(req: Request<{ noteId: string }>) {
-    const mapRootNote = becca.getNoteOrThrow(req.params.noteId);
+    const mapRootNote = getBecca().getNoteOrThrow(req.params.noteId);
     // if the map root itself has "excludeFromNoteMap" (journal typically) then there wouldn't be anything to display,
     // so we'll just ignore it
     const ignoreExcludeFromNoteMap = mapRootNote.isLabelTruthy("excludeFromNoteMap");
@@ -232,7 +232,7 @@ function getTreeMap(req: Request<{ noteId: string }>) {
 
 function updateDescendantCountMapForSearch(noteIdToDescendantCountMap: Record<string, number>, relationships: { parentNoteId: string; childNoteId: string }[]) {
     for (const { parentNoteId, childNoteId } of relationships) {
-        const parentNote = becca.notes[parentNoteId];
+        const parentNote = getBecca().notes[parentNoteId];
         if (!parentNote || parentNote.type !== "search") {
             continue;
         }
@@ -352,7 +352,7 @@ function getFilteredBacklinks(note: BNote): BAttribute[] {
 
 function getBacklinks(req: Request<{ noteId: string }>): BacklinksResponse {
     const { noteId } = req.params;
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     let backlinksWithExcerptCount = 0;
 
@@ -379,7 +379,7 @@ function getBacklinks(req: Request<{ noteId: string }>): BacklinksResponse {
 function getBacklinkCount(req: Request<{ noteId: string }>): BacklinkCountResponse {
     const { noteId } = req.params;
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     return {
         count: getFilteredBacklinks(note).length

--- a/packages/trilium-core/src/routes/api/notes.spec.ts
+++ b/packages/trilium-core/src/routes/api/notes.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import noteService from "../../services/notes";
 import { getSql } from "../../services/sql/index";
 import { createTextNote } from "../../test/api_fixtures";
@@ -170,12 +170,12 @@ describe("Notes API (core)", () => {
 
         it("400s force-saving a revision of a protected note without a protected session", async () => {
             const { noteId } = await createTextNote(api, { title: "Protected revision" });
-            becca.notes[noteId].isProtected = true;
+            getBecca().notes[noteId].isProtected = true;
 
             const res = await api.post(`/api/notes/${noteId}/revision`, { body: {} });
             expect(res.status).toBe(400);
 
-            becca.notes[noteId].isProtected = false;
+            getBecca().notes[noteId].isProtected = false;
         });
 
         it("returns a null attachment for a note ineligible for conversion", async () => {
@@ -189,12 +189,12 @@ describe("Notes API (core)", () => {
     describe("title and type", () => {
         it("400s changing the title of a protected note without a protected session", async () => {
             const { noteId } = await createTextNote(api, { title: "Locked" });
-            becca.notes[noteId].isProtected = true;
+            getBecca().notes[noteId].isProtected = true;
 
             const res = await api.put(`/api/notes/${noteId}/title`, { body: { title: "Nope" } });
             expect(res.status).toBe(400);
 
-            becca.notes[noteId].isProtected = false;
+            getBecca().notes[noteId].isProtected = false;
         });
 
         it("leaves the note untouched when the title is unchanged", async () => {
@@ -230,7 +230,7 @@ describe("Notes API (core)", () => {
             });
             expect(res.status).toBe(204);
 
-            const children = becca.notes[parent.noteId].getChildNotes();
+            const children = getBecca().notes[parent.noteId].getChildNotes();
             expect(children[0].title).toBe("Alpha");
         });
 
@@ -244,7 +244,7 @@ describe("Notes API (core)", () => {
             try {
                 const res = await api.put(`/api/notes/${noteId}/protect/1`, { query: { subtree: "1" } });
                 expect(res.status).toBe(204);
-                expect(spy).toHaveBeenCalledWith(becca.notes[noteId], true, true, expect.anything());
+                expect(spy).toHaveBeenCalledWith(getBecca().notes[noteId], true, true, expect.anything());
             } finally {
                 spy.mockRestore();
             }

--- a/packages/trilium-core/src/routes/api/notes.ts
+++ b/packages/trilium-core/src/routes/api/notes.ts
@@ -4,7 +4,7 @@ import type { Request } from "express";
 import blobService from "../../services/blob";
 import eraseService from "../../services/erase.js";
 import { ValidationError } from "../../errors.js";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BBranch from "../../becca/entities/bbranch.js";
 import { getLog } from "../../services/log.js";
 import noteService from "../../services/notes.js";
@@ -39,7 +39,7 @@ import { randomString } from "../../services/utils/index";
  *     tags: ["data"]
  */
 function getNote(req: Request<{ noteId: string }>) {
-    return becca.getNoteOrThrow(req.params.noteId);
+    return getBecca().getNoteOrThrow(req.params.noteId);
 }
 
 /**
@@ -93,7 +93,7 @@ function getNoteBlob(req: Request<{ noteId: string }>) {
  *     tags: ["data"]
  */
 function getNoteMetadata(req: Request<{ noteId: string }>) {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     return {
         dateCreated: note.dateCreated,
@@ -179,7 +179,7 @@ function deleteNote(req: Request<{ noteId: string }>) {
     // note how deleteId is separate from taskId - single taskId produces separate deleteId for each "top level" deleted note
     const deleteId = randomString(10);
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     if (typeof taskId !== "string") {
         throw new ValidationError("Missing or incorrect type for task ID.");
@@ -218,7 +218,7 @@ function sortChildNotes(req: Request<{ noteId: string }>) {
 
 function protectNote(req: Request<{ noteId: string; isProtected: string }>) {
     const noteId = req.params.noteId;
-    const note = becca.notes[noteId];
+    const note = getBecca().notes[noteId];
     const protect = !!parseInt(req.params.isProtected);
     const includingSubTree = !!parseInt(req.query?.subtree as string);
 
@@ -234,7 +234,7 @@ function setNoteTypeMime(req: Request<{ noteId: string }>) {
     const { noteId } = req.params;
     const { type, mime } = req.body;
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
     note.type = type;
     note.mime = mime;
     note.save();
@@ -244,7 +244,7 @@ function changeTitle(req: Request<{ noteId: string }>) {
     const noteId = req.params.noteId;
     const title = req.body.title;
 
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     if (!note.isContentAvailable()) {
         throw new ValidationError(`Note '${noteId}' is not available for change`);
@@ -307,7 +307,7 @@ function getDeleteNotesPreview(req: Request) {
     }
 
     for (const branchId of branchIdsToDelete) {
-        const branch = becca.getBranch(branchId);
+        const branch = getBecca().getBranch(branchId);
 
         if (!branch) {
             getLog().error(`Branch ${branchId} was not found and delete preview can't be calculated for this note.`);
@@ -345,7 +345,7 @@ function getDeleteNotesPreview(req: Request) {
 
 function forceSaveRevision(req: Request<{ noteId: string }>) {
     const { noteId } = req.params;
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     if (!note.isContentAvailable()) {
         throw new ValidationError(`Note revision of a protected note cannot be created outside of a protected session.`);
@@ -361,7 +361,7 @@ function forceSaveRevision(req: Request<{ noteId: string }>) {
 
 function convertNoteToAttachment(req: Request<{ noteId: string }>) {
     const { noteId } = req.params;
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     return {
         attachment: note.convertToParentAttachment()

--- a/packages/trilium-core/src/routes/api/others.ts
+++ b/packages/trilium-core/src/routes/api/others.ts
@@ -1,4 +1,4 @@
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 
 import { RenderMarkdownResponse, ToMarkdownResponse } from "@triliumnext/commons";
 import type { Request } from "express";
@@ -29,7 +29,7 @@ function toMarkdown(req: Request) {
 function getIconUsage() {
     const iconClassToCountMap: Record<string, number> = {};
 
-    for (const { value: iconClass, noteId } of becca.findAttributes("label", "iconClass")) {
+    for (const { value: iconClass, noteId } of getBecca().findAttributes("label", "iconClass")) {
         if (noteId.startsWith("_")) {
             continue; // ignore icons of "system" notes since they were not set by the user
         }

--- a/packages/trilium-core/src/routes/api/recent_changes.ts
+++ b/packages/trilium-core/src/routes/api/recent_changes.ts
@@ -1,6 +1,6 @@
 import protectedSessionService from "../../services/protected_session.js";
 import noteService from "../../services/notes.js";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type { Request } from "express";
 import type { RecentChangeRow } from "@triliumnext/commons";
 import { getSql } from "../../services/sql/index.js";
@@ -26,7 +26,7 @@ function getRecentChanges(req: Request<{ ancestorNoteId: string }>) {
             JOIN notes USING(noteId)`);
 
     for (const revisionRow of revisionRows) {
-        const note = becca.getNote(revisionRow.noteId);
+        const note = getBecca().getNote(revisionRow.noteId);
 
         // for deleted notes, the becca note is null, and it's not possible to (easily) determine if it belongs to a subtree
         if (ancestorNoteId === "root" || note?.hasAncestor(ancestorNoteId)) {
@@ -62,7 +62,7 @@ function getRecentChanges(req: Request<{ ancestorNoteId: string }>) {
             WHERE notes.isDeleted = 1`);
 
     for (const noteRow of noteRows) {
-        const note = becca.getNote(noteRow.noteId);
+        const note = getBecca().getNote(noteRow.noteId);
 
         // for deleted notes, the becca note is null, and it's not possible to (easily) determine if it belongs to a subtree
         if (ancestorNoteId === "root" || note?.hasAncestor(ancestorNoteId)) {

--- a/packages/trilium-core/src/routes/api/relation-map.ts
+++ b/packages/trilium-core/src/routes/api/relation-map.ts
@@ -1,5 +1,5 @@
 import type { Request } from "express";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import { RelationMapPostResponse } from "@triliumnext/commons";
 import { getSql } from "../../services/sql/index.js";
 
@@ -22,7 +22,7 @@ function getRelationMap(req: Request) {
 
     const questionMarks = noteIds.map((_noteId) => "?").join(",");
 
-    const relationMapNote = becca.getNoteOrThrow(relationMapNoteId);
+    const relationMapNote = getBecca().getNoteOrThrow(relationMapNoteId);
 
     const displayRelationsVal = relationMapNote.getLabelValue("displayRelations");
     const displayRelations = !displayRelationsVal ? [] : displayRelationsVal.split(",").map((token) => token.trim());
@@ -31,7 +31,7 @@ function getRelationMap(req: Request) {
     const hideRelations = !hideRelationsVal ? [] : hideRelationsVal.split(",").map((token) => token.trim());
 
     const foundNoteIds = getSql().getColumn<string>(/*sql*/`SELECT noteId FROM notes WHERE isDeleted = 0 AND noteId IN (${questionMarks})`, noteIds);
-    const notes = becca.getNotes(foundNoteIds);
+    const notes = getBecca().getNotes(foundNoteIds);
 
     for (const note of notes) {
         resp.noteTitles[note.noteId] = note.title;

--- a/packages/trilium-core/src/routes/api/revisions.spec.ts
+++ b/packages/trilium-core/src/routes/api/revisions.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import * as cls from "../../services/context";
 import { getSql } from "../../services/sql/index";
 import { unwrapStringOrBuffer } from "../../services/utils/binary";
@@ -412,9 +412,9 @@ describe("Revisions API (core)", () => {
             // A real protected revision needs a protected session to set up; instead
             // override the lookup (getRevisionOrThrow builds a fresh BRevision per call)
             // to report its content as unavailable.
-            const revision = becca.getRevisionOrThrow(revisionId);
+            const revision = getBecca().getRevisionOrThrow(revisionId);
             revision.isContentAvailable = () => false;
-            vi.spyOn(becca, "getRevisionOrThrow").mockReturnValue(revision);
+            vi.spyOn(getBecca(), "getRevisionOrThrow").mockReturnValue(revision);
 
             const res = await api.get<string>(`/api/revisions/${revisionId}/download`);
             expect(res.status).toBe(401);
@@ -426,9 +426,9 @@ describe("Revisions API (core)", () => {
 
             // Force the defensive "missing creation date" guard in getRevisionFilename
             // (real revisions always have a creation date).
-            const revision = becca.getRevisionOrThrow(revisionId);
+            const revision = getBecca().getRevisionOrThrow(revisionId);
             revision.dateCreated = undefined as never;
-            vi.spyOn(becca, "getRevisionOrThrow").mockReturnValue(revision);
+            vi.spyOn(getBecca(), "getRevisionOrThrow").mockReturnValue(revision);
 
             const res = await api.get(`/api/revisions/${revisionId}/download`);
             expect(res.status).toBe(500);

--- a/packages/trilium-core/src/routes/api/revisions.ts
+++ b/packages/trilium-core/src/routes/api/revisions.ts
@@ -1,7 +1,7 @@
 import { EditedNotesResponse, RevisionItem, RevisionPojo } from "@triliumnext/commons";
 import type { Request, Response } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BNote from "../../becca/entities/bnote.js";
 import type BRevision from "../../becca/entities/brevision.js";
 import blobService from "../../services/blob.js";
@@ -30,7 +30,7 @@ function getRevisionBlob(req: Request<{ revisionId: string }>) {
 }
 
 function getRevisions(req: Request<{ noteId: string }>) {
-    return becca.getRevisionsFromQuery(
+    return getBecca().getRevisionsFromQuery(
         `
         SELECT revisions.*,
                 LENGTH(blobs.content) AS contentLength
@@ -43,7 +43,7 @@ function getRevisions(req: Request<{ noteId: string }>) {
 }
 
 function getRevision(req: Request<{ revisionId: string }>) {
-    const revision = becca.getRevisionOrThrow(req.params.revisionId);
+    const revision = getBecca().getRevisionOrThrow(req.params.revisionId);
 
     if (revision.type === "file") {
         if (revision.hasStringContent()) {
@@ -85,7 +85,7 @@ function getRevisionFilename(revision: BRevision) {
 }
 
 function downloadRevision(req: Request<{ revisionId: string }>, res: Response) {
-    const revision = becca.getRevisionOrThrow(req.params.revisionId);
+    const revision = getBecca().getRevisionOrThrow(req.params.revisionId);
 
     if (!revision.isContentAvailable()) {
         return res.setHeader("Content-Type", "text/plain").status(401).send("Protected session not available");
@@ -110,7 +110,7 @@ function eraseRevision(req: Request<{ revisionId: string }>) {
 }
 
 function updateRevisionDescription(req: Request<{ revisionId: string }>) {
-    const revision = becca.getRevisionOrThrow(req.params.revisionId);
+    const revision = getBecca().getRevisionOrThrow(req.params.revisionId);
     const { description } = req.body;
 
     if (typeof description !== "string") {
@@ -124,12 +124,12 @@ function updateRevisionDescription(req: Request<{ revisionId: string }>) {
 function eraseAllExcessRevisions() {
     const allNoteIds = getSql().getRows("SELECT noteId FROM notes WHERE SUBSTRING(noteId, 1, 1) != '_'") as { noteId: string }[];
     allNoteIds.forEach((row) => {
-        becca.getNote(row.noteId)?.eraseExcessRevisionSnapshots();
+        getBecca().getNote(row.noteId)?.eraseExcessRevisionSnapshots();
     });
 }
 
 function restoreRevision(req: Request<{ revisionId: string }>) {
-    const revision = becca.getRevision(req.params.revisionId);
+    const revision = getBecca().getRevision(req.params.revisionId);
 
     if (revision) {
         const note = revision.getNote();
@@ -180,7 +180,7 @@ function getEditedNotesOnDate(req: Request) {
     { date: `${req.params.date}%` }
     );
 
-    let notes = becca.getNotes(noteIds, true);
+    let notes = getBecca().getNotes(noteIds, true);
 
     // Narrow down the results if a note is hoisted, similar to "Jump to note".
     const hoistedNoteId = cls.getHoistedNoteId();
@@ -210,7 +210,7 @@ function getNotePathData(note: BNote): NotePath | undefined {
             branchId = "none_root";
         } else {
             const parentNote = note.parents[0];
-            branchId = becca.getBranchFromChildAndParent(note.noteId, parentNote.noteId)?.branchId;
+            branchId = getBecca().getBranchFromChildAndParent(note.noteId, parentNote.noteId)?.branchId;
         }
 
         return {

--- a/packages/trilium-core/src/routes/api/script.ts
+++ b/packages/trilium-core/src/routes/api/script.ts
@@ -2,7 +2,7 @@
 
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import attributeService from "../../services/attributes.js";
 import scriptService, { type Bundle } from "../../services/script.js";
 import syncService from "../../services/sync.js";
@@ -28,7 +28,7 @@ async function exec(req: Request) {
     try {
         const body = req.body as ScriptBody;
 
-        const execute = (body: ScriptBody) => scriptService.executeScript(body.script, body.params, body.startNoteId, body.currentNoteId, body.originEntityName, body.originEntityId, becca);
+        const execute = (body: ScriptBody) => scriptService.executeScript(body.script, body.params, body.startNoteId, body.currentNoteId, body.originEntityName, body.originEntityId, getBecca());
 
         const result = body.transactional ? getSql().transactional(() => execute(body)) : await execute(body);
 
@@ -48,7 +48,7 @@ async function exec(req: Request) {
 
 function run(req: Request<{ noteId: string }>) {
     assertScriptingEnabled();
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     const result = scriptService.executeNote(note, { originEntity: note });
 
@@ -91,7 +91,7 @@ function getWidgetBundles() {
 
 function getRelationBundles(req: Request<{ noteId: string, relationName: string }>) {
     const noteId = req.params.noteId;
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
     const relationName = req.params.relationName;
 
     const attributes = note.getAttributes();
@@ -102,7 +102,7 @@ function getRelationBundles(req: Request<{ noteId: string, relationName: string 
     const bundles: Bundle[] = [];
 
     for (const noteId of uniqueNoteIds) {
-        const note = becca.getNoteOrThrow(noteId);
+        const note = getBecca().getNoteOrThrow(noteId);
 
         if (!note.isJavaScript() || note.getScriptEnv() !== "frontend") {
             continue;
@@ -119,7 +119,7 @@ function getRelationBundles(req: Request<{ noteId: string, relationName: string 
 }
 
 function getBundle(req: Request<{ noteId: string }>) {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
     const { script, params } = req.body ?? {};
 
     return scriptService.getScriptBundleForFrontend(note, script, params);

--- a/packages/trilium-core/src/routes/api/search.ts
+++ b/packages/trilium-core/src/routes/api/search.ts
@@ -1,6 +1,6 @@
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import attributeFormatter from "../../services/attribute_formatter.js";
 import bulkActionService from "../../services/bulk_actions.js";
 import hoistedNoteService from "../../services/hoisted_note.js";
@@ -12,7 +12,7 @@ import becca_service from "../../becca/becca_service.js";
 import { getHoistedNoteId } from "../../services/context.js";
 
 function searchFromNote(req: Request<{ noteId: string }>): SearchNoteResult {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     /* v8 ignore next 4 -- unreachable: getNoteOrThrow already throws on a missing note */
     if (!note) {
@@ -28,7 +28,7 @@ function searchFromNote(req: Request<{ noteId: string }>): SearchNoteResult {
 }
 
 function searchAndExecute(req: Request<{ noteId: string }>) {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     /* v8 ignore next 4 -- unreachable: getNoteOrThrow already throws on a missing note */
     if (!note) {

--- a/packages/trilium-core/src/routes/api/similar_notes.ts
+++ b/packages/trilium-core/src/routes/api/similar_notes.ts
@@ -1,12 +1,12 @@
 import { SimilarNoteResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import similarity from "../../becca/similarity.js";
 
 async function getSimilarNotes(req: Request<{ noteId: string }>) {
     const noteId = req.params.noteId;
-    becca.getNoteOrThrow(noteId);
+    getBecca().getNoteOrThrow(noteId);
 
     return (await similarity.findSimilarNotes(noteId) satisfies SimilarNoteResponse);
 }

--- a/packages/trilium-core/src/routes/api/special_notes.ts
+++ b/packages/trilium-core/src/routes/api/special_notes.ts
@@ -1,6 +1,6 @@
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import * as cls from "../../services/context.js";
 import dateNoteService from "../../services/date_notes.js";
 import specialNotesService, { type LauncherType } from "../../services/special_notes.js";
@@ -12,7 +12,7 @@ function getInboxNote(req: Request<{ date: string }>) {
 
 function getDayNote(req: Request<{ date: string }>) {
     const calendarRootId = req.query.calendarRootId;
-    const calendarRoot = typeof calendarRootId === "string" ? becca.getNoteOrThrow(calendarRootId) : null;
+    const calendarRoot = typeof calendarRootId === "string" ? getBecca().getNoteOrThrow(calendarRootId) : null;
     return dateNoteService.getDayNote(req.params.date, calendarRoot);
 }
 
@@ -56,7 +56,7 @@ function getDayNotesForMonth(req: Request) {
         const rows = sql.getRows<{ date: string; noteId: string }>(query, [month]);
         const result: Record<string, string> = {};
         for (const { date, noteId } of rows) {
-            const note = becca.getNote(noteId);
+            const note = getBecca().getNote(noteId);
             if (note?.hasAncestor(String(calendarRoot))) {
                 result[date] = noteId;
             }
@@ -88,7 +88,7 @@ function createSearchNote(req: Request) {
 }
 
 function getHoistedNote() {
-    return becca.getNote(cls.getHoistedNoteId());
+    return getBecca().getNote(cls.getHoistedNoteId());
 }
 
 function createLauncher(req: Request<{ parentNoteId: string, launcherType: string }>) {

--- a/packages/trilium-core/src/routes/api/sql.spec.ts
+++ b/packages/trilium-core/src/routes/api/sql.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import config from "../../services/config";
 import { getSql } from "../../services/sql/index";
 import { createTextNote } from "../../test/api_fixtures";
@@ -120,9 +120,9 @@ describe("SQL API (core)", () => {
 
         it("rejects a note whose content is not a string", async () => {
             const { noteId } = await createTextNote(api, { title: "Binary content" });
-            const note = becca.getNoteOrThrow(noteId);
+            const note = getBecca().getNoteOrThrow(noteId);
             vi.spyOn(note, "getContent").mockReturnValue(new Uint8Array([ 1, 2, 3 ]));
-            vi.spyOn(becca, "getNoteOrThrow").mockReturnValue(note);
+            vi.spyOn(getBecca(), "getNoteOrThrow").mockReturnValue(note);
 
             const res = await api.post<{ message: string }>(`/api/sql/execute/${noteId}`);
             expect(res.status).toBe(400);

--- a/packages/trilium-core/src/routes/api/sql.ts
+++ b/packages/trilium-core/src/routes/api/sql.ts
@@ -1,6 +1,6 @@
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import { getSql } from "../../services/sql/index.js";
 import { ValidationError } from "../../errors.js";
 import { assertSqlConsoleEnabled } from "../../services/scripting_guard.js";
@@ -29,7 +29,7 @@ function getSchema() {
 function execute(req: Request<{ noteId: string }>) {
     assertSqlConsoleEnabled();
     const sql = getSql();
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
 
     const content = note.getContent();
     if (typeof content !== "string") {

--- a/packages/trilium-core/src/routes/api/stats.ts
+++ b/packages/trilium-core/src/routes/api/stats.ts
@@ -1,4 +1,4 @@
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type { Request } from "express";
 import { NoteSizeResponse, SubtreeSizeResponse } from "@triliumnext/commons";
 import { getSql } from "../../services/sql/index.js";
@@ -27,7 +27,7 @@ function getNoteSize(req: Request) {
 }
 
 function getSubtreeSize(req: Request<{ noteId: string }>) {
-    const note = becca.getNoteOrThrow(req.params.noteId);
+    const note = getBecca().getNoteOrThrow(req.params.noteId);
     const subTreeNoteIds = note.getSubtreeNoteIds();
     const sql = getSql();
     sql.fillParamList(subTreeNoteIds);

--- a/packages/trilium-core/src/routes/api/tree.spec.ts
+++ b/packages/trilium-core/src/routes/api/tree.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca";
+import { getBecca } from "../../becca/becca.js";
 import { createTextNote } from "../../test/api_fixtures";
 import { CoreApiTester } from "../../test/api_tester";
 
@@ -70,11 +70,11 @@ describe("Tree API (core)", () => {
 
         it("skips a collected branch id that is missing from the cache", async () => {
             // Force a dangling branchId into the collection (via the child-branch
-            // lookup in collectEntityIds) so the `becca.branches[branchId]` lookup
+            // lookup in collectEntityIds) so the `getBecca().branches[branchId]` lookup
             // misses and the guard runs. Use `load` so getTree's own collect()
             // recursion (which needs a real childNote) isn't affected.
-            const original = becca.getBranchFromChildAndParent.bind(becca);
-            vi.spyOn(becca, "getBranchFromChildAndParent").mockImplementation((childNoteId, parentNoteId) => {
+            const original = getBecca().getBranchFromChildAndParent.bind(getBecca());
+            vi.spyOn(getBecca(), "getBranchFromChildAndParent").mockImplementation((childNoteId, parentNoteId) => {
                 const branch = original(childNoteId, parentNoteId);
                 if (branch) {
                     Object.defineProperty(branch, "branchId", { value: "ghostBranch123", configurable: true });
@@ -89,8 +89,8 @@ describe("Tree API (core)", () => {
 
         it("skips a collected attribute id that is missing from the cache", async () => {
             const { noteId } = await createTextNote(api, { title: "Note with ghost attribute" });
-            const note = becca.notes[noteId];
-            // Replace the note's owned attributes with one whose id is absent from becca.attributes.
+            const note = getBecca().notes[noteId];
+            // Replace the note's owned attributes with one whose id is absent from getBecca().attributes.
             vi.spyOn(note, "ownedAttributes", "get").mockReturnValue([
                 { attributeId: "ghostAttr123", type: "label", name: "x", targetNote: undefined } as never
             ]);

--- a/packages/trilium-core/src/routes/api/tree.ts
+++ b/packages/trilium-core/src/routes/api/tree.ts
@@ -1,7 +1,7 @@
 import type { AttributeRow, BranchRow, NoteRow } from "@triliumnext/commons";
 import type { Request } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import { NotFoundError } from "../../errors.js";
 import { getLog } from "../../services/log.js";
 import type BNote from "../../becca/entities/bnote.js";
@@ -28,7 +28,7 @@ function getNotesAndBranchesAndAttributes(_noteIds: string[] | Set<string>) {
         }
 
         for (const childNote of note.children) {
-            const childBranch = becca.getBranchFromChildAndParent(childNote.noteId, note.noteId);
+            const childBranch = getBecca().getBranchFromChildAndParent(childNote.noteId, note.noteId);
             if (childBranch && childBranch.branchId) {
                 collectedBranchIds.add(childBranch.branchId);
             }
@@ -44,7 +44,7 @@ function getNotesAndBranchesAndAttributes(_noteIds: string[] | Set<string>) {
     }
 
     for (const noteId of noteIds) {
-        const note = becca.notes[noteId];
+        const note = getBecca().notes[noteId];
 
         if (!note) {
             continue;
@@ -56,7 +56,7 @@ function getNotesAndBranchesAndAttributes(_noteIds: string[] | Set<string>) {
     const notes: NoteRow[] = [];
 
     for (const noteId of collectedNoteIds) {
-        const note = becca.notes[noteId];
+        const note = getBecca().notes[noteId];
 
         notes.push({
             noteId: note.noteId,
@@ -82,7 +82,7 @@ function getNotesAndBranchesAndAttributes(_noteIds: string[] | Set<string>) {
     }
 
     for (const branchId of collectedBranchIds) {
-        const branch = becca.branches[branchId];
+        const branch = getBecca().branches[branchId];
 
         if (!branch) {
             getLog().error(`Could not find branch for branchId=${branchId}`);
@@ -102,7 +102,7 @@ function getNotesAndBranchesAndAttributes(_noteIds: string[] | Set<string>) {
     const attributes: AttributeRow[] = [];
 
     for (const attributeId of collectedAttributeIds) {
-        const attribute = becca.attributes[attributeId];
+        const attribute = getBecca().attributes[attributeId];
 
         if (!attribute) {
             getLog().error(`Could not find attribute for attributeId=${attributeId}`);
@@ -180,7 +180,7 @@ function getTree(req: Request) {
         for (const childNote of parentNote.children) {
             collectedNoteIds.add(childNote.noteId);
 
-            const childBranch = becca.getBranchFromChildAndParent(childNote.noteId, parentNote.noteId);
+            const childBranch = getBecca().getBranchFromChildAndParent(childNote.noteId, parentNote.noteId);
 
             if (childBranch?.isExpanded) {
                 collect(childBranch.childNote);
@@ -188,11 +188,11 @@ function getTree(req: Request) {
         }
     }
 
-    if (!(subTreeNoteId in becca.notes)) {
+    if (!(subTreeNoteId in getBecca().notes)) {
         throw new NotFoundError(`Note '${subTreeNoteId}' not found in the cache`);
     }
 
-    collect(becca.notes[subTreeNoteId]);
+    collect(getBecca().notes[subTreeNoteId]);
 
     return getNotesAndBranchesAndAttributes(collectedNoteIds);
 }

--- a/packages/trilium-core/src/routes/helpers.ts
+++ b/packages/trilium-core/src/routes/helpers.ts
@@ -1,12 +1,12 @@
 import { Response } from "express";
-import becca from "../becca/becca";
+import { getBecca } from "../becca/becca.js";
 import BNote from "../becca/entities/bnote";
 import protected_session from "../services/protected_session";
 import BAttachment from "../becca/entities/battachment";
 import { getContentDisposition } from "../services/utils/index";
 
 export function downloadNoteInt(noteId: string, res: Response, contentDisposition = true) {
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
 
     if (!note) {
         return res.setHeader("Content-Type", "text/plain").status(404).send(`Note '${noteId}' doesn't exist.`);

--- a/packages/trilium-core/src/services/attributes.spec.ts
+++ b/packages/trilium-core/src/services/attributes.spec.ts
@@ -1,7 +1,7 @@
 import type { AttributeRow } from "@triliumnext/commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { init as clsInit } from "./context.js";
 import noteService from "./notes.js";
 import attributeService from "./attributes.js";
@@ -82,9 +82,9 @@ describe("attributes service", () => {
             expect(attr.name).toBe("myUniqueLabelOne");
             expect(attr.value).toBe("alpha");
 
-            const note = becca.getNote(noteId);
+            const note = getBecca().getNote(noteId);
             expect(note?.getOwnedLabelValue("myUniqueLabelOne")).toBe("alpha");
-            expect(becca.attributes[attr.attributeId]).toBe(attr);
+            expect(getBecca().attributes[attr.attributeId]).toBe(attr);
         });
 
         it("defaults the label value to an empty string when omitted", () => {
@@ -93,7 +93,7 @@ describe("attributes service", () => {
             const attr = clsInit(() => createLabel(noteId, "myUniqueLabelTwo"));
 
             expect(attr.value).toBe("");
-            expect(becca.getNote(noteId)?.getOwnedLabelValue("myUniqueLabelTwo")).toBe("");
+            expect(getBecca().getNote(noteId)?.getOwnedLabelValue("myUniqueLabelTwo")).toBe("");
         });
 
         it("persists a relation pointing at the target note via createRelation", () => {
@@ -106,7 +106,7 @@ describe("attributes service", () => {
             expect(attr.name).toBe("myUniqueRel");
             expect(attr.value).toBe(targetId);
 
-            const source = becca.getNote(sourceId);
+            const source = getBecca().getNote(sourceId);
             expect(source?.getRelationValue("myUniqueRel")).toBe(targetId);
             expect(source?.getRelationTarget("myUniqueRel")?.noteId).toBe(targetId);
         });
@@ -123,8 +123,8 @@ describe("attributes service", () => {
             const attr = clsInit(() => createAttribute(row));
 
             expect(attr.attributeId).toBeTruthy();
-            expect(becca.attributes[attr.attributeId]?.name).toBe("myUniqueRawAttr");
-            expect(becca.getNote(noteId)?.getOwnedLabelValue("myUniqueRawAttr")).toBe("raw");
+            expect(getBecca().attributes[attr.attributeId]?.name).toBe("myUniqueRawAttr");
+            expect(getBecca().getNote(noteId)?.getOwnedLabelValue("myUniqueRawAttr")).toBe("raw");
         });
     });
 

--- a/packages/trilium-core/src/services/attributes.ts
+++ b/packages/trilium-core/src/services/attributes.ts
@@ -1,7 +1,7 @@
 import { type AttributeRow, BUILTIN_ATTRIBUTES } from "@triliumnext/commons";
 
 import searchService from "./search/services/search.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getSql } from "./sql/index.js";
@@ -20,7 +20,7 @@ function getNotesWithLabel(name: string, value?: string): BNote[] {
 // TODO: should be in search service
 function getNoteWithLabel(name: string, value?: string): BNote | null {
     // optimized version (~20 times faster) without using normal search, useful for e.g., finding date notes
-    const attrs = becca.findAttributes("label", name);
+    const attrs = getBecca().findAttributes("label", name);
 
     if (value === undefined) {
         return attrs[0]?.getNote();

--- a/packages/trilium-core/src/services/backend_script_api.spec.ts
+++ b/packages/trilium-core/src/services/backend_script_api.spec.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { buildNote } from "../test/becca_easy_mocking.js";
 import BackendScriptApi from "./backend_script_api.js";
 import ws from "./ws.js";
 
 describe("BackendScriptApi.log", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         vi.spyOn(ws, "sendMessageToAllClients").mockImplementation(() => {}).mockClear();
     });
 
@@ -34,7 +34,7 @@ describe("BackendScriptApi.log", () => {
 });
 
 describe("BackendScriptApi markdown conversion", () => {
-    beforeEach(() => becca.reset());
+    beforeEach(() => getBecca().reset());
 
     function makeApi() {
         const startNote = buildNote({ type: "code", mime: "application/javascript;env=backend", content: "" });

--- a/packages/trilium-core/src/services/backend_script_api.ts
+++ b/packages/trilium-core/src/services/backend_script_api.ts
@@ -11,7 +11,7 @@ import { NoteParams } from "./notes.js";
 import SearchContext from "./search/search_context";
 import syncMutex from "./sync_mutex";
 import zipExportService from "./export/zip";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BAttachment from "../becca/entities/battachment.js";
 import type BAttribute from "../becca/entities/battribute.js";
 import type BBranch from "../becca/entities/bbranch.js";
@@ -515,16 +515,16 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
     this.cheerio = cheerio;
     this.htmlParser = htmlParser;
     this.getInstanceName = () => (config.General ? config.General.instanceName : null);
-    this.getNote = (noteId) => becca.getNote(noteId);
-    this.getBranch = (branchId) => becca.getBranch(branchId);
-    this.getAttribute = (attributeId) => becca.getAttribute(attributeId);
-    this.getAttachment = (attachmentId) => becca.getAttachment(attachmentId);
-    this.getRevision = (revisionId) => becca.getRevision(revisionId);
-    this.getEtapiToken = (etapiTokenId) => becca.getEtapiToken(etapiTokenId);
-    this.getEtapiTokens = () => becca.getEtapiTokens();
-    this.getOption = (optionName) => becca.getOption(optionName);
+    this.getNote = (noteId) => getBecca().getNote(noteId);
+    this.getBranch = (branchId) => getBecca().getBranch(branchId);
+    this.getAttribute = (attributeId) => getBecca().getAttribute(attributeId);
+    this.getAttachment = (attachmentId) => getBecca().getAttachment(attachmentId);
+    this.getRevision = (revisionId) => getBecca().getRevision(revisionId);
+    this.getEtapiToken = (etapiTokenId) => getBecca().getEtapiToken(etapiTokenId);
+    this.getEtapiTokens = () => getBecca().getEtapiTokens();
+    this.getOption = (optionName) => getBecca().getOption(optionName);
     this.getOptions = () => optionsService.getOptions();
-    this.getAttribute = (attributeId) => becca.getAttribute(attributeId);
+    this.getAttribute = (attributeId) => getBecca().getAttribute(attributeId);
 
     this.htmlToMarkdown = (html) => markdownExport.toMarkdown(html);
     this.markdownToHtml = (markdown) => markdownImport.renderToHtml(markdown, "");
@@ -540,7 +540,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
 
         const noteIds = searchService.findResultsWithQuery(query, new SearchContext(searchParams)).map((sr) => sr.noteId);
 
-        return becca.getNotes(noteIds);
+        return getBecca().getNotes(noteIds);
     };
 
     this.searchForNote = (query, searchParams = {}) => {
@@ -574,7 +574,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
     this.createNewNote = noteService.createNewNote;
 
     this.createNote = (parentNoteId, title, content = "", _extraOptions = {}) => {
-        const parentNote = becca.getNote(parentNoteId);
+        const parentNote = getBecca().getNote(parentNoteId);
         if (!parentNote) {
             throw new Error(`Unable to find parent note with ID ${parentNote}.`);
         }
@@ -698,7 +698,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
         const noteId = `al_${opts.id}`;
 
         const launcherNote =
-            becca.getNote(noteId) ||
+            getBecca().getNote(noteId) ||
             specialNotesService.createLauncher({
                 noteId,
                 parentNoteId,
@@ -782,7 +782,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
     this.duplicateSubtree = noteService.duplicateSubtree;
 
     this.__private = {
-        becca
+        becca: getBecca()
     };
 }
 

--- a/packages/trilium-core/src/services/blob.spec.ts
+++ b/packages/trilium-core/src/services/blob.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { NotFoundError } from "../errors.js";
 import blob from "./blob.js";
@@ -144,7 +144,7 @@ describe("blob", () => {
             expect(content).toBe("<p>blob spec body</p>");
             expect(typeof blobId).toBe("string");
             // The seeded note is the same instance retrieved by getEntity.
-            expect(becca.notes[noteId]).toBeDefined();
+            expect(getBecca().notes[noteId]).toBeDefined();
         });
 
         it("nulls out the content for a note with binary (non-string) content", () => {

--- a/packages/trilium-core/src/services/blob.ts
+++ b/packages/trilium-core/src/services/blob.ts
@@ -1,5 +1,5 @@
 import { BlobRow } from "@triliumnext/commons";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { NotFoundError } from "../errors";
 import protectedSessionService from "./protected_session.js";
 import { decodeUtf8 } from "./utils/binary.js";
@@ -7,12 +7,12 @@ import { hash } from "./utils/index.js";
 
 function getBlobPojo(entityName: string, entityId: string, opts?: { preview: boolean }) {
     // TODO: Unused opts.
-    const entity = becca.getEntity(entityName, entityId);
+    const entity = getBecca().getEntity(entityName, entityId);
     if (!entity) {
         throw new NotFoundError(`Entity ${entityName} '${entityId}' was not found.`);
     }
 
-    const blob = becca.getBlob(entity);
+    const blob = getBecca().getBlob(entity);
     if (!blob) {
         throw new NotFoundError(`Blob ${entity.blobId} for ${entityName} '${entityId}' was not found.`);
     }

--- a/packages/trilium-core/src/services/branches.spec.ts
+++ b/packages/trilium-core/src/services/branches.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BBranch from "../becca/entities/bbranch.js";
 import type BNote from "../becca/entities/bnote.js";
 import branchService from "./branches.js";
@@ -61,8 +61,8 @@ describe("branches service (real DB)", () => {
             expect(res.branch.noteId).toBe(child.note.noteId);
             expect(res.branch.notePosition).toBe(maxPos + 10);
 
-            // The freshly created branch is reachable through becca.
-            expect(becca.getBranchFromChildAndParent(child.note.noteId, parent.note.noteId)).toBe(res.branch);
+            // The freshly created branch is reachable through getBecca().
+            expect(getBecca().getBranchFromChildAndParent(child.note.noteId, parent.note.noteId)).toBe(res.branch);
             // The note is now a child of the target parent.
             expect(parent.note.getChildNotes().some((n) => n.noteId === child.note.noteId)).toBe(true);
             // The original branch (under root) has been deleted.
@@ -73,7 +73,7 @@ describe("branches service (real DB)", () => {
 
         it("refuses to move protected structural notes and returns the validation tuple", () => {
             // The root branch cannot be relocated; validateParentChild rejects it.
-            const rootBranch = becca.getBranchFromChildAndParent("root", "none");
+            const rootBranch = getBecca().getBranchFromChildAndParent("root", "none");
             expect(rootBranch).not.toBeNull();
 
             const someParent = createNote("root");
@@ -88,7 +88,7 @@ describe("branches service (real DB)", () => {
             expect(typeof res[1].message).toBe("string");
 
             // No clone was created under the candidate parent.
-            expect(becca.getBranchFromChildAndParent("root", someParent.note.noteId)).toBeNull();
+            expect(getBecca().getBranchFromChildAndParent("root", someParent.note.noteId)).toBeNull();
         });
 
         it("refuses a move that would create a tree cycle", () => {
@@ -156,7 +156,7 @@ describe("branches service (real DB)", () => {
 
         it("propagates a validation failure and does not expand the target", () => {
             const targetParent = createNote("root");
-            const rootBranch = becca.getBranchFromChildAndParent("root", "none");
+            const rootBranch = getBecca().getBranchFromChildAndParent("root", "none");
 
             targetParent.branch.isExpanded = false;
 

--- a/packages/trilium-core/src/services/bulk_actions.spec.ts
+++ b/packages/trilium-core/src/services/bulk_actions.spec.ts
@@ -1,7 +1,7 @@
 import type { BulkAction } from "@triliumnext/commons";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BBranch from "../becca/entities/bbranch.js";
 import type BNote from "../becca/entities/bnote.js";
 import bulkActionService from "./bulk_actions.js";
@@ -273,7 +273,7 @@ describe("bulk_actions service (real DB)", () => {
             );
 
             expect(target.note.getChildNotes().some((n) => n.noteId === note.note.noteId)).toBe(true);
-            expect(becca.getBranchFromChildAndParent(note.note.noteId, "root")).toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(note.note.noteId, "root")).toBeNull();
         });
 
         it("clones (rather than moves) a note that has multiple parents", () => {
@@ -295,8 +295,8 @@ describe("bulk_actions service (real DB)", () => {
             );
 
             // A clone is created under the target while the originals remain.
-            expect(becca.getBranchFromChildAndParent(note.note.noteId, target.note.noteId)).not.toBeNull();
-            expect(becca.getBranchFromChildAndParent(note.note.noteId, "root")).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(note.note.noteId, target.note.noteId)).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(note.note.noteId, "root")).not.toBeNull();
         });
 
         it("is a no-op when the target parent does not exist", () => {
@@ -312,7 +312,7 @@ describe("bulk_actions service (real DB)", () => {
             ).not.toThrow();
 
             // The note stays where it was.
-            expect(becca.getBranchFromChildAndParent(note.note.noteId, "root")).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(note.note.noteId, "root")).not.toBeNull();
         });
     });
 

--- a/packages/trilium-core/src/services/bulk_actions.ts
+++ b/packages/trilium-core/src/services/bulk_actions.ts
@@ -2,7 +2,7 @@ import { ActionHandlers, BulkAction, BulkActionData } from "@triliumnext/commons
 import branchService from "./branches";
 import eraseService from "./erase.js";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import cloningService from "./cloning.js";
 import { getLog } from "./log";
@@ -87,7 +87,7 @@ const ACTION_HANDLERS: ActionHandlerMap = {
         }
     },
     moveNote: (action, note) => {
-        const targetParentNote = becca.getNote(action.targetParentNoteId);
+        const targetParentNote = getBecca().getNote(action.targetParentNoteId);
 
         if (!targetParentNote) {
             getLog().info(`Cannot execute moveNote because note ${action.targetParentNoteId} doesn't exist.`);
@@ -169,7 +169,7 @@ function executeActionsFromNote(note: BNote, noteIds: string[] | Set<string>) {
 
 function executeActions(actions: BulkAction[], noteIds: string[] | Set<string>) {
     for (const resultNoteId of noteIds) {
-        const resultNote = becca.getNote(resultNoteId);
+        const resultNote = getBecca().getNote(resultNoteId);
 
         if (!resultNote) {
             continue;

--- a/packages/trilium-core/src/services/cloning.spec.ts
+++ b/packages/trilium-core/src/services/cloning.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BBranch from "../becca/entities/bbranch.js";
 import type BNote from "../becca/entities/bnote.js";
 import cloningService from "./cloning.js";
@@ -40,7 +40,7 @@ describe("cloning service (real DB)", () => {
             expect(res.success).toBe(true);
             expect(res.branchId).toBeDefined();
 
-            const branch = becca.getBranchFromChildAndParent(source.note.noteId, target.note.noteId);
+            const branch = getBecca().getBranchFromChildAndParent(source.note.noteId, target.note.noteId);
             expect(branch).not.toBeNull();
             expect(branch!.branchId).toBe(res.branchId);
             expect(branch!.prefix).toBe("my-prefix");
@@ -78,7 +78,7 @@ describe("cloning service (real DB)", () => {
 
             expect(res.success).toBe(false);
             expect(res.message).toBe("Can't clone into a search note");
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, search.note.noteId)).toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, search.note.noteId)).toBeNull();
         });
 
         it("propagates a validation failure (clone already present under the parent)", () => {
@@ -109,7 +109,7 @@ describe("cloning service (real DB)", () => {
             // The parent branch is expanded so the clone is immediately visible.
             expect(targetParent.branch.isExpanded).toBe(true);
 
-            const branch = becca.getBranchFromChildAndParent(source.note.noteId, targetParent.note.noteId);
+            const branch = getBecca().getBranchFromChildAndParent(source.note.noteId, targetParent.note.noteId);
             expect(branch).not.toBeNull();
             expect(branch!.prefix).toBe("px");
         });
@@ -187,16 +187,16 @@ describe("cloning service (real DB)", () => {
 
             // Add a second branch so removing it does not delete the note.
             getContext().init(() => cloningService.cloneNoteToParentNote(source.note.noteId, target.note.noteId));
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).not.toBeNull();
 
             const res = getContext().init(() =>
                 cloningService.ensureNoteIsAbsentFromParent(source.note.noteId, target.note.noteId)
             );
 
             expect(res).toEqual({ success: true });
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).toBeNull();
             // The note still exists via its original branch under root.
-            expect(becca.notes[source.note.noteId]).toBeDefined();
+            expect(getBecca().notes[source.note.noteId]).toBeDefined();
             expect(source.note.isDeleted).toBe(false);
         });
 
@@ -210,7 +210,7 @@ describe("cloning service (real DB)", () => {
             expect(res.success).toBe(false);
             expect(typeof res.message).toBe("string");
             // The branch is preserved.
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, "root")).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, "root")).not.toBeNull();
         });
 
         it("returns undefined when there is no matching branch to remove", () => {
@@ -234,14 +234,14 @@ describe("cloning service (real DB)", () => {
 
             expect(present.success).toBe(true);
             expect(present.branch).not.toBeNull();
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).not.toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).not.toBeNull();
 
             const absent = getContext().init(() =>
                 cloningService.toggleNoteInParent(false, source.note.noteId, target.note.noteId)
             );
 
             expect(absent).toEqual({ success: true });
-            expect(becca.getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).toBeNull();
+            expect(getBecca().getBranchFromChildAndParent(source.note.noteId, target.note.noteId)).toBeNull();
         });
     });
 
@@ -261,7 +261,7 @@ describe("cloning service (real DB)", () => {
             expect(res.success).toBe(true);
             expect(res.branchId).toBeDefined();
 
-            const newBranch = becca.getBranch(res.branchId!);
+            const newBranch = getBecca().getBranch(res.branchId!);
             expect(newBranch).not.toBeNull();
             expect(newBranch!.parentNoteId).toBe(parent.note.noteId);
             expect(newBranch!.noteId).toBe(source.note.noteId);

--- a/packages/trilium-core/src/services/cloning.ts
+++ b/packages/trilium-core/src/services/cloning.ts
@@ -3,17 +3,17 @@
 import eventChangesService from "./entity_changes.js";
 import treeService from "./tree.js";
 import BBranch from "../becca/entities/bbranch.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { getLog } from "./log.js";
 import { CloneResponse } from "@triliumnext/commons";
 import { getSql } from "./sql/index.js";
 
 function cloneNoteToParentNote(noteId: string, parentNoteId: string, prefix: string | null = null): CloneResponse {
-    if (!(noteId in becca.notes) || !(parentNoteId in becca.notes)) {
+    if (!(noteId in getBecca().notes) || !(parentNoteId in getBecca().notes)) {
         return { success: false, message: "Note cannot be cloned because either the cloned note or the intended parent is deleted." };
     }
 
-    const parentNote = becca.getNote(parentNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
     if (!parentNote) {
         return { success: false, message: "Note cannot be cloned because the parent note could not be found." };
     }
@@ -48,7 +48,7 @@ function cloneNoteToParentNote(noteId: string, parentNoteId: string, prefix: str
 }
 
 function cloneNoteToBranch(noteId: string, parentBranchId: string, prefix?: string) {
-    const parentBranch = becca.getBranch(parentBranchId);
+    const parentBranch = getBecca().getBranch(parentBranchId);
 
     if (!parentBranch) {
         return { success: false, message: `Parent branch '${parentBranchId}' does not exist.` };
@@ -63,13 +63,13 @@ function cloneNoteToBranch(noteId: string, parentBranchId: string, prefix?: stri
 }
 
 function ensureNoteIsPresentInParent(noteId: string, parentNoteId: string, prefix?: string) {
-    if (!(noteId in becca.notes)) {
+    if (!(noteId in getBecca().notes)) {
         return { branch: null, success: false, message: `Note '${noteId}' is deleted.` };
-    } else if (!(parentNoteId in becca.notes)) {
+    } else if (!(parentNoteId in getBecca().notes)) {
         return { branch: null, success: false, message: `Note '${parentNoteId}' is deleted.` };
     }
 
-    const parentNote = becca.getNote(parentNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
 
     if (!parentNote) {
         return { branch: null, success: false, message: "Can't find parent note." };
@@ -98,7 +98,7 @@ function ensureNoteIsPresentInParent(noteId: string, parentNoteId: string, prefi
 
 function ensureNoteIsAbsentFromParent(noteId: string, parentNoteId: string) {
     const branchId = getSql().getValue<string>(/*sql*/`SELECT branchId FROM branches WHERE noteId = ? AND parentNoteId = ? AND isDeleted = 0`, [noteId, parentNoteId]);
-    const branch = becca.getBranch(branchId);
+    const branch = getBecca().getBranch(branchId);
 
     if (branch) {
         if (!branch.isWeak && branch.getNote().getStrongParentBranches().length <= 1) {
@@ -129,7 +129,7 @@ function cloneNoteAfter(noteId: string, afterBranchId: string) {
         return { success: false, message: `Cloning the note '${noteId}' is forbidden.` };
     }
 
-    const afterBranch = becca.getBranch(afterBranchId);
+    const afterBranch = getBecca().getBranch(afterBranchId);
 
     if (!afterBranch) {
         return { success: false, message: `Branch '${afterBranchId}' does not exist.` };
@@ -139,15 +139,15 @@ function cloneNoteAfter(noteId: string, afterBranchId: string) {
         return { success: false, message: "Cannot clone after the hidden branch." };
     }
 
-    const afterNote = becca.getBranch(afterBranchId);
+    const afterNote = getBecca().getBranch(afterBranchId);
 
-    if (!(noteId in becca.notes)) {
+    if (!(noteId in getBecca().notes)) {
         return { success: false, message: `Note to be cloned '${noteId}' is deleted or does not exist.` };
-    } else if (!afterNote || !(afterNote.parentNoteId in becca.notes)) {
+    } else if (!afterNote || !(afterNote.parentNoteId in getBecca().notes)) {
         return { success: false, message: `After note '${afterNote?.parentNoteId}' is deleted or does not exist.` };
     }
 
-    const parentNote = becca.getNote(afterNote.parentNoteId);
+    const parentNote = getBecca().getNote(afterNote.parentNoteId);
 
     if (!parentNote || parentNote.type === "search") {
         return {

--- a/packages/trilium-core/src/services/consistency_checks.ts
+++ b/packages/trilium-core/src/services/consistency_checks.ts
@@ -1,7 +1,7 @@
 import type { BranchRow } from "@triliumnext/commons";
 import type { EntityChange } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BBranch from "../becca/entities/bbranch.js";
 import noteTypesService from "../services/note_types.js";
 import { hashedBlobId, randomString } from "../services/utils/index.js";
@@ -77,7 +77,7 @@ class ConsistencyChecks {
             for (const parentNoteId of childToParents[noteId]) {
                 if (path.includes(parentNoteId)) {
                     if (this.autoFix) {
-                        const branch = becca.getBranchFromChildAndParent(noteId, parentNoteId);
+                        const branch = getBecca().getBranchFromChildAndParent(noteId, parentNoteId);
                         if (branch) {
                             branch.markAsDeleted("cycle-autofix");
                             logFix(`Branch '${branch.branchId}' between child '${noteId}' and parent '${parentNoteId}' has been deleted since it was causing a tree cycle.`);
@@ -142,7 +142,7 @@ class ConsistencyChecks {
                     AND notes.noteId IS NULL`,
             ({ branchId, noteId }) => {
                 if (this.autoFix) {
-                    const branch = becca.getBranch(branchId);
+                    const branch = getBecca().getBranch(branchId);
                     if (!branch) {
                         return;
                     }
@@ -168,7 +168,7 @@ class ConsistencyChecks {
             ({ branchId, parentNoteId }) => {
                 if (this.autoFix) {
                     // Delete the old branch and recreate it with root as parent.
-                    const oldBranch = becca.getBranch(branchId);
+                    const oldBranch = getBecca().getBranch(branchId);
                     if (!oldBranch) {
                         return;
                     }
@@ -178,7 +178,7 @@ class ConsistencyChecks {
 
                     let message = `Branch '${branchId}' was missing parent note '${parentNoteId}', so it was deleted. `;
 
-                    const note = becca.getNote(noteId);
+                    const note = getBecca().getNote(noteId);
                     if (!note) {
                         return;
                     }
@@ -213,7 +213,7 @@ class ConsistencyChecks {
                     AND notes.noteId IS NULL`,
             ({ attributeId, noteId }) => {
                 if (this.autoFix) {
-                    const attribute = becca.getAttribute(attributeId);
+                    const attribute = getBecca().getAttribute(attributeId);
                     if (!attribute) {
                         return;
                     }
@@ -238,7 +238,7 @@ class ConsistencyChecks {
                     AND notes.noteId IS NULL`,
             ({ attributeId, noteId }) => {
                 if (this.autoFix) {
-                    const attribute = becca.getAttribute(attributeId);
+                    const attribute = getBecca().getAttribute(attributeId);
                     if (!attribute) {
                         return;
                     }
@@ -265,7 +265,7 @@ class ConsistencyChecks {
                     AND attachments.isDeleted = 0`,
             ({ attachmentId, ownerId }) => {
                 if (this.autoFix) {
-                    const attachment = becca.getAttachment(attachmentId);
+                    const attachment = getBecca().getAttachment(attachmentId);
                     if (!attachment) {
                         return;
                     }
@@ -298,7 +298,7 @@ class ConsistencyChecks {
                     AND branches.isDeleted = 0`,
             ({ branchId, noteId }) => {
                 if (this.autoFix) {
-                    const branch = becca.getBranch(branchId);
+                    const branch = getBecca().getBranch(branchId);
                     if (!branch) return;
                     branch.markAsDeleted();
 
@@ -322,7 +322,7 @@ class ConsistencyChecks {
         `,
             ({ branchId, parentNoteId }) => {
                 if (this.autoFix) {
-                    const branch = becca.getBranch(branchId);
+                    const branch = getBecca().getBranch(branchId);
                     if (!branch) {
                         return;
                     }
@@ -384,7 +384,7 @@ class ConsistencyChecks {
                         [noteId, parentNoteId]
                     );
 
-                    const branches = branchIds.map((branchId) => becca.getBranch(branchId));
+                    const branches = branchIds.map((branchId) => getBecca().getBranch(branchId));
 
                     // it's not necessarily "original" branch, it's just the only one which will survive
                     const origBranch = branches[0];
@@ -421,7 +421,7 @@ class ConsistencyChecks {
                     AND attachments.isDeleted = 0`,
             ({ attachmentId, noteId }) => {
                 if (this.autoFix) {
-                    const attachment = becca.getAttachment(attachmentId);
+                    const attachment = getBecca().getAttachment(attachmentId);
                     if (!attachment) return;
                     attachment.markAsDeleted();
 
@@ -447,7 +447,7 @@ class ConsistencyChecks {
                     AND type NOT IN (${noteTypesStr})`,
             ({ noteId, type }) => {
                 if (this.autoFix) {
-                    const note = becca.getNote(noteId);
+                    const note = getBecca().getNote(noteId);
                     if (!note) return;
                     note.type = "file"; // file is a safe option to recover notes if the type is not known
                     note.save();
@@ -528,7 +528,7 @@ class ConsistencyChecks {
                         AND content IS NULL`,
                 ({ noteId, type, mime }) => {
                     if (this.autoFix) {
-                        const note = becca.getNote(noteId);
+                        const note = getBecca().getNote(noteId);
                         const blankContent = getBlankContent(false, type, mime);
                         if (!note) return;
 
@@ -603,7 +603,7 @@ class ConsistencyChecks {
                         [parentNoteId]
                     );
 
-                    const branches = branchIds.map((branchId) => becca.getBranch(branchId));
+                    const branches = branchIds.map((branchId) => getBecca().getBranch(branchId));
 
                     for (const branch of branches) {
                         if (!branch) continue;
@@ -637,7 +637,7 @@ class ConsistencyChecks {
                     AND value = ''`,
             ({ attributeId }) => {
                 if (this.autoFix) {
-                    const relation = becca.getAttribute(attributeId);
+                    const relation = getBecca().getAttribute(attributeId);
                     if (!relation) return;
                     relation.markAsDeleted();
 
@@ -660,7 +660,7 @@ class ConsistencyChecks {
                     AND type != 'relation'`,
             ({ attributeId, type }) => {
                 if (this.autoFix) {
-                    const attribute = becca.getAttribute(attributeId);
+                    const attribute = getBecca().getAttribute(attributeId);
                     if (!attribute) return;
                     attribute.type = "label";
                     attribute.save();
@@ -684,7 +684,7 @@ class ConsistencyChecks {
                     AND notes.isDeleted = 1`,
             ({ attributeId, noteId }) => {
                 if (this.autoFix) {
-                    const attribute = becca.getAttribute(attributeId);
+                    const attribute = getBecca().getAttribute(attributeId);
                     if (!attribute) return;
                     attribute.markAsDeleted();
 
@@ -708,7 +708,7 @@ class ConsistencyChecks {
                     AND notes.isDeleted = 1`,
             ({ attributeId, targetNoteId }) => {
                 if (this.autoFix) {
-                    const attribute = becca.getAttribute(attributeId);
+                    const attribute = getBecca().getAttribute(attributeId);
                     if (!attribute) return;
                     attribute.markAsDeleted();
 

--- a/packages/trilium-core/src/services/entity_changes.ts
+++ b/packages/trilium-core/src/services/entity_changes.ts
@@ -1,6 +1,6 @@
 import type { BlobRow, EntityChange } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import dateUtils from "./utils/date.js";
 import { getLog } from "./log.js";
 import { randomString } from "./utils/index.js";
@@ -153,7 +153,7 @@ function fillEntityChanges(entityName: string, entityPrimaryKey: string, conditi
                 ec.utcDateChanged = blob.utcDateModified;
                 ec.isSynced = true; // blobs are always synced
             } else {
-                const entity = becca.getEntity(entityName, entityId);
+                const entity = getBecca().getEntity(entityName, entityId);
 
                 if (entity) {
                     ec.hash = entity.generateHash();

--- a/packages/trilium-core/src/services/erase.spec.ts
+++ b/packages/trilium-core/src/services/erase.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getContext } from "./context.js";
 import eraseService from "./erase.js";
@@ -213,7 +213,7 @@ describe("erase service (real DB)", () => {
             });
 
             // Nothing was touched; the note (and everything else) is intact.
-            expect(becca.notes[noteId]).toBeDefined();
+            expect(getBecca().notes[noteId]).toBeDefined();
             expect(rowCount("notes", "noteId", noteId)).toBe(1);
         });
     });

--- a/packages/trilium-core/src/services/export/opml.ts
+++ b/packages/trilium-core/src/services/export/opml.ts
@@ -1,6 +1,6 @@
 import type { Response } from "express";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BBranch from "../../becca/entities/bbranch.js";
 import type TaskContext from "../task_context.js";
 import { getContentDisposition } from "../utils/index.js";
@@ -9,7 +9,7 @@ function exportToOpml(taskContext: TaskContext<"export">, branch: BBranch, res: 
     const note = branch.getNote();
 
     function exportNoteInner(branchId: string) {
-        const branch = becca.getBranch(branchId);
+        const branch = getBecca().getBranch(branchId);
         if (!branch) {
             throw new Error("Unable to find branch.");
         }

--- a/packages/trilium-core/src/services/export/single.ts
+++ b/packages/trilium-core/src/services/export/single.ts
@@ -4,7 +4,7 @@ import type { Response } from "express";
 import html from "html";
 import mimeTypes from "mime-types";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BBranch from "../../becca/entities/bbranch.js";
 import type BNote from "../../becca/entities/bnote.js";
 import type TaskContext from "../task_context.js";
@@ -102,7 +102,7 @@ export function mapByNoteType(note: BNote, content: string | Uint8Array, format:
 
 function inlineAttachments(content: string) {
     content = content.replace(/src="[^"]*api\/images\/([a-zA-Z0-9_]+)\/?[^"]+"/g, (match, noteId) => {
-        const note = becca.getNote(noteId);
+        const note = getBecca().getNote(noteId);
         if (!note || !note.mime.startsWith("image/")) {
             return match;
         }
@@ -119,7 +119,7 @@ function inlineAttachments(content: string) {
     });
 
     content = content.replace(/src="[^"]*api\/attachments\/([a-zA-Z0-9_]+)\/image\/?[^"]+"/g, (match, attachmentId) => {
-        const attachment = becca.getAttachment(attachmentId);
+        const attachment = getBecca().getAttachment(attachmentId);
         if (!attachment || !attachment.mime.startsWith("image/")) {
             return match;
         }
@@ -136,7 +136,7 @@ function inlineAttachments(content: string) {
     });
 
     content = content.replace(/href="[^"]*#root[^"]*attachmentId=([a-zA-Z0-9_]+)\/?"/g, (match, attachmentId) => {
-        const attachment = becca.getAttachment(attachmentId);
+        const attachment = getBecca().getAttachment(attachmentId);
         if (!attachment) {
             return match;
         }

--- a/packages/trilium-core/src/services/export/zip.ts
+++ b/packages/trilium-core/src/services/export/zip.ts
@@ -2,7 +2,7 @@ import { NoteType } from "@triliumnext/commons";
 import sanitize from "sanitize-filename";
 
 import packageInfo from "../../../package.json" with { type: "json" };
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BBranch from "../../becca/entities/bbranch.js";
 import type BNote from "../../becca/entities/bnote.js";
 import dateUtils from "../utils/date.js";
@@ -332,7 +332,7 @@ async function exportToZip(taskContext: TaskContext<"export">, branch: BBranch, 
             return;
         }
 
-        const note = becca.getNote(noteMeta.noteId);
+        const note = getBecca().getNote(noteMeta.noteId);
         if (!note) {
             throw new Error("Unable to find note.");
         }
@@ -496,7 +496,7 @@ async function exportToZipFile(noteId: string, format: ExportFormat, zipFilePath
     const { destination, waitForFinish } = getZipProvider().createFileStream(zipFilePath);
     const taskContext = new TaskContext("no-progress-reporting", "export", null);
 
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
 
     if (!note) {
         throw new ValidationError(`Note ${noteId} not found.`);
@@ -515,7 +515,7 @@ async function exportToZipFile(noteId: string, format: ExportFormat, zipFilePath
  * routing a potentially multi-GB archive through an in-memory HTTP response.
  */
 async function exportBranchToZipFile(branchId: string, format: ExportFormat, zipFilePath: string, taskId: string) {
-    const branch = becca.getBranch(branchId);
+    const branch = getBecca().getBranch(branchId);
     if (!branch) {
         throw new ValidationError(`Branch ${branchId} not found.`);
     }

--- a/packages/trilium-core/src/services/handlers.spec.ts
+++ b/packages/trilium-core/src/services/handlers.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import BBranch from "../becca/entities/bbranch.js";
 import { buildNote } from "../test/becca_easy_mocking.js";
@@ -33,7 +33,7 @@ describe("handlers", () => {
     let scheduleExecution: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         buildNote({ id: "root", title: "root" });
         config.Security.backendScriptingEnabled = true;
 
@@ -94,7 +94,7 @@ describe("handlers", () => {
         it("re-sorts a sorted parent", () => {
             buildNote({ id: "par2", children: [{ id: "chld2" }] });
             addAttribute("par2", "label", "sorted", "");
-            const child = becca.notes["chld2"];
+            const child = getBecca().notes["chld2"];
             expect(child).toBeDefined();
 
             eventService.emit(eventService.NOTE_TITLE_CHANGED, child);

--- a/packages/trilium-core/src/services/handlers.ts
+++ b/packages/trilium-core/src/services/handlers.ts
@@ -3,7 +3,7 @@ import { isScriptingEnabled } from "./scripting_guard.js";
 import scriptService from "./script.js";
 import treeService from "./tree.js";
 import noteService from "./notes.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import hiddenSubtreeService from "./hidden_subtree.js";
 import oneTimeTimer from "./one_time_timer.js";
@@ -35,7 +35,7 @@ eventService.subscribe(eventService.NOTE_TITLE_CHANGED, (note) => {
     runAttachedRelations(note, "runOnNoteTitleChange", note);
 
     if (!note.isRoot()) {
-        const noteFromCache = becca.notes[note.noteId];
+        const noteFromCache = getBecca().notes[note.noteId];
 
         if (!noteFromCache) {
             return;
@@ -66,13 +66,13 @@ eventService.subscribe([eventService.ENTITY_CHANGED, eventService.ENTITY_DELETED
 
 eventService.subscribe(eventService.ENTITY_CHANGED, ({ entityName, entity }) => {
     if (entityName === "branches") {
-        const parentNote = becca.getNote(entity.parentNoteId);
+        const parentNote = getBecca().getNote(entity.parentNoteId);
 
         if (parentNote?.hasLabel("sorted")) {
             treeService.sortNotesIfNeeded(parentNote.noteId);
         }
 
-        const childNote = becca.getNote(entity.noteId);
+        const childNote = getBecca().getNote(entity.noteId);
 
         if (childNote) {
             runAttachedRelations(childNote, "runOnBranchChange", entity);
@@ -89,12 +89,12 @@ eventService.subscribe(eventService.ENTITY_CREATED, ({ entityName, entity }) => 
         runAttachedRelations(entity.getNote(), "runOnAttributeCreation", entity);
 
         if (entity.type === "relation" && entity.name === "template") {
-            const note = becca.getNote(entity.noteId);
+            const note = getBecca().getNote(entity.noteId);
             if (!note) {
                 return;
             }
 
-            const templateNote = becca.getNote(entity.value);
+            const templateNote = getBecca().getNote(entity.value);
 
             if (!templateNote) {
                 return;
@@ -168,7 +168,7 @@ function handleSortedAttribute(entity: BAttribute) {
     treeService.sortNotesIfNeeded(entity.noteId);
 
     if (entity.isInheritable) {
-        const note = becca.notes[entity.noteId];
+        const note = getBecca().notes[entity.noteId];
 
         if (note) {
             for (const noteId of note.getSubtreeNoteIds()) {
@@ -180,7 +180,7 @@ function handleSortedAttribute(entity: BAttribute) {
 
 function handleMaybeSortingLabel(entity: BAttribute) {
     // check if this label is used for sorting, if yes force re-sort
-    const note = becca.notes[entity.noteId];
+    const note = getBecca().notes[entity.noteId];
 
     // this will not work on deleted notes, but in that case we don't really need to re-sort
     if (note) {

--- a/packages/trilium-core/src/services/hidden_subtree.spec.ts
+++ b/packages/trilium-core/src/services/hidden_subtree.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getContext } from "./context.js";
 import hiddenSubtreeService, {
@@ -45,7 +45,7 @@ describe("hidden_subtree (real DB)", () => {
 
     describe("checkHiddenSubtree structure", () => {
         it("creates the hidden root and its top-level containers under the expected parents", () => {
-            const hidden = becca.notes["_hidden"];
+            const hidden = getBecca().notes["_hidden"];
             expect(hidden).toBeDefined();
             expect(hidden.type).toBe("doc");
             // The hidden root must be parented directly under the tree root.
@@ -54,7 +54,7 @@ describe("hidden_subtree (real DB)", () => {
             // A representative set of the declared children must exist and sit
             // directly under _hidden.
             for (const childId of ["_search", "_options", "_help", "_taskStates", "_lbRoot"]) {
-                const child = becca.notes[childId];
+                const child = getBecca().notes[childId];
                 expect(child, `${childId} should exist`).toBeDefined();
                 expect(
                     child.getParentBranches().some((b) => b.parentNoteId === "_hidden"),
@@ -63,7 +63,7 @@ describe("hidden_subtree (real DB)", () => {
             }
 
             // Nested children are placed under their declared parent, not the root.
-            const taskStateNone = becca.notes["_taskStateNone"];
+            const taskStateNone = getBecca().notes["_taskStateNone"];
             expect(taskStateNone).toBeDefined();
             expect(taskStateNone.getParentBranches().some((b) => b.parentNoteId === "_taskStates")).toBe(true);
         });
@@ -71,7 +71,7 @@ describe("hidden_subtree (real DB)", () => {
         it("derives an iconClass label from the item icon", () => {
             // _sqlConsole declares icon "bx-data"; the recursion turns the icon
             // into an iconClass label prefixed with "bx ".
-            const sqlConsole = becca.notes["_sqlConsole"];
+            const sqlConsole = getBecca().notes["_sqlConsole"];
             expect(sqlConsole).toBeDefined();
             const iconClass = sqlConsole.getOwnedLabelValue("iconClass");
             expect(iconClass).toBeTruthy();
@@ -81,17 +81,17 @@ describe("hidden_subtree (real DB)", () => {
 
         it("applies declared labels and relations, materialising launcher templates", () => {
             // The note launcher template carries a declared launcherType label.
-            const noteLauncher = becca.notes[LBTPL_NOTE_LAUNCHER];
+            const noteLauncher = getBecca().notes[LBTPL_NOTE_LAUNCHER];
             expect(noteLauncher).toBeDefined();
             expect(noteLauncher.getOwnedLabelValue("launcherType")).toBe("note");
 
             // The command launcher template likewise advertises its launcherType.
-            const commandLauncher = becca.notes[LBTPL_COMMAND];
+            const commandLauncher = getBecca().notes[LBTPL_COMMAND];
             expect(commandLauncher).toBeDefined();
             expect(commandLauncher.getOwnedLabelValue("launcherType")).toBe("command");
 
             // Every declared launchbar template note exists under the template root.
-            const templateRoot = becca.notes[LBTPL_ROOT];
+            const templateRoot = getBecca().notes[LBTPL_ROOT];
             expect(templateRoot).toBeDefined();
             for (const tplId of [
                 LBTPL_BASE,
@@ -102,7 +102,7 @@ describe("hidden_subtree (real DB)", () => {
                 LBTPL_SPACER,
                 LBTPL_CUSTOM_WIDGET
             ]) {
-                const tpl = becca.notes[tplId];
+                const tpl = getBecca().notes[tplId];
                 expect(tpl, `${tplId} should exist`).toBeDefined();
                 expect(tpl.getParentBranches().some((b) => b.parentNoteId === LBTPL_ROOT)).toBe(true);
             }
@@ -111,7 +111,7 @@ describe("hidden_subtree (real DB)", () => {
 
     describe("enforceAttributes", () => {
         it("removes attributes that are not part of the definition on an enforced note", () => {
-            const hidden = becca.notes["_hidden"];
+            const hidden = getBecca().notes["_hidden"];
             expect(hidden).toBeDefined();
 
             // Sanity: the declared docName label survives enforcement.
@@ -137,7 +137,7 @@ describe("hidden_subtree (real DB)", () => {
             // so `"" !== undefined` re-saved them on every run — and save() always emits a sync
             // entity change, which churned `entitiesReloaded` and tore down every open text editor.
             // The compare now normalizes undefined → "" to match what is actually written.
-            const snippet = becca.notes["_template_text_snippet"];
+            const snippet = getBecca().notes["_template_text_snippet"];
             expect(snippet).toBeDefined();
             const textSnippetAttr = snippet.getOwnedAttributes("label", "textSnippet")[0];
             expect(textSnippetAttr).toBeDefined();
@@ -150,7 +150,7 @@ describe("hidden_subtree (real DB)", () => {
         });
 
         it("repairs a modified value on an enforced attribute", () => {
-            const hidden = becca.notes["_hidden"];
+            const hidden = getBecca().notes["_hidden"];
             const docNameAttr = hidden.getOwnedAttributes("label", "docName")[0];
             expect(docNameAttr).toBeDefined();
 
@@ -174,7 +174,7 @@ describe("hidden_subtree (real DB)", () => {
             // enforceDeleted branch were removed.
             for (const deprecatedId of ["_optionsImages", "_optionsAi"]) {
                 materialiseDeprecatedNote(deprecatedId);
-                const note = becca.notes[deprecatedId] as BNote | undefined;
+                const note = getBecca().notes[deprecatedId] as BNote | undefined;
                 expect(note, `${deprecatedId} should have been created`).toBeDefined();
             }
 
@@ -182,7 +182,7 @@ describe("hidden_subtree (real DB)", () => {
 
             // The enforceDeleted branch must purge each materialised note.
             for (const deprecatedId of ["_optionsImages", "_optionsAi"]) {
-                const note = becca.notes[deprecatedId] as BNote | undefined;
+                const note = getBecca().notes[deprecatedId] as BNote | undefined;
                 expect(note, `${deprecatedId} should have been deleted`).toBeUndefined();
             }
         });
@@ -192,24 +192,24 @@ describe("hidden_subtree (real DB)", () => {
 
             // First reappearance: recreate the note and confirm a check deletes it.
             materialiseDeprecatedNote(deprecatedId);
-            expect(becca.notes[deprecatedId]).toBeDefined();
+            expect(getBecca().notes[deprecatedId]).toBeDefined();
 
             checkHiddenSubtree();
-            expect(becca.notes[deprecatedId]).toBeUndefined();
+            expect(getBecca().notes[deprecatedId]).toBeUndefined();
 
             // Second reappearance: the deletion path must run again, not just rely
             // on the note already being absent.
             materialiseDeprecatedNote(deprecatedId);
-            expect(becca.notes[deprecatedId]).toBeDefined();
+            expect(getBecca().notes[deprecatedId]).toBeDefined();
 
             checkHiddenSubtree();
-            expect(becca.notes[deprecatedId]).toBeUndefined();
+            expect(getBecca().notes[deprecatedId]).toBeUndefined();
         });
     });
 
     describe("type and idempotency", () => {
         it("restores a note type that was changed away from the definition", () => {
-            const options = becca.notes["_options"];
+            const options = getBecca().notes["_options"];
             expect(options).toBeDefined();
             // Declared as a book.
             expect(options.type).toBe("book");
@@ -218,15 +218,15 @@ describe("hidden_subtree (real DB)", () => {
                 options.type = "text";
                 options.save();
             });
-            expect(becca.notes["_options"].type).toBe("text");
+            expect(getBecca().notes["_options"].type).toBe("text");
 
             checkHiddenSubtree();
 
-            expect(becca.notes["_options"].type).toBe("book");
+            expect(getBecca().notes["_options"].type).toBe("book");
         });
 
         it("is idempotent: a repeated forced check does not duplicate branches", () => {
-            const searchNote = becca.notes["_search"];
+            const searchNote = getBecca().notes["_search"];
             expect(searchNote).toBeDefined();
 
             const beforeParents = searchNote
@@ -238,7 +238,7 @@ describe("hidden_subtree (real DB)", () => {
             checkHiddenSubtree(true);
             checkHiddenSubtree(true);
 
-            const afterParents = becca.notes["_search"]
+            const afterParents = getBecca().notes["_search"]
                 .getParentBranches()
                 .filter((b) => !b.isDeleted)
                 .map((b) => b.parentNoteId)

--- a/packages/trilium-core/src/services/hidden_subtree.ts
+++ b/packages/trilium-core/src/services/hidden_subtree.ts
@@ -1,7 +1,7 @@
 import type { HiddenSubtreeItem } from "@triliumnext/commons";
 import { t } from "i18next";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import BBranch from "../becca/entities/bbranch.js";
 import BNote from "../becca/entities/bnote.js";
@@ -346,7 +346,7 @@ function checkHiddenSubtree(force = false, extraOpts: CheckHiddenExtraOpts = {})
     }
 
     getSql().transactional(() => {
-        const taskStatesExisted = !!becca.notes["_taskStates"];
+        const taskStatesExisted = !!getBecca().notes["_taskStates"];
 
         checkHiddenSubtreeRecursively("root", hiddenSubtreeDefinition, extraOpts);
 
@@ -415,7 +415,7 @@ function checkHiddenSubtreeRecursively(parentNoteId: string, item: HiddenSubtree
         throw new Error(`ID has to start with underscore, given '${item.id}'`);
     }
 
-    let note = becca.notes[item.id] as BNote | undefined;
+    let note = getBecca().notes[item.id] as BNote | undefined;
     let branch: BBranch | undefined;
     const log = getLog();
 

--- a/packages/trilium-core/src/services/hoisted_note.spec.ts
+++ b/packages/trilium-core/src/services/hoisted_note.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getContext } from "./context.js";
 import hoistedNoteService from "./hoisted_note.js";
@@ -84,7 +84,7 @@ describe("hoisted_note service (real DB)", () => {
         it("returns the root note when hoisted on root", () => {
             withHoisted("root", () => {
                 const workspace = hoistedNoteService.getWorkspaceNote();
-                expect(workspace).toBe(becca.getRoot());
+                expect(workspace).toBe(getBecca().getRoot());
                 expect(workspace?.noteId).toBe("root");
             });
         });
@@ -105,14 +105,14 @@ describe("hoisted_note service (real DB)", () => {
 
             withHoisted(note.noteId, () => {
                 const workspace = hoistedNoteService.getWorkspaceNote();
-                expect(workspace).toBe(becca.getRoot());
+                expect(workspace).toBe(getBecca().getRoot());
                 expect(workspace?.noteId).toBe("root");
             });
         });
 
         it("falls back to the root note when the hoisted note does not exist", () => {
             withHoisted("nonExistentNote123", () => {
-                expect(hoistedNoteService.getWorkspaceNote()).toBe(becca.getRoot());
+                expect(hoistedNoteService.getWorkspaceNote()).toBe(getBecca().getRoot());
             });
         });
     });

--- a/packages/trilium-core/src/services/hoisted_note.ts
+++ b/packages/trilium-core/src/services/hoisted_note.ts
@@ -1,4 +1,4 @@
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import * as cls from "./context.js";
 
 function getHoistedNoteId() {
@@ -14,7 +14,7 @@ function isHoistedInHiddenSubtree() {
         return true;
     }
 
-    const hoistedNote = becca.getNote(hoistedNoteId);
+    const hoistedNote = getBecca().getNote(hoistedNoteId);
 
     if (!hoistedNote) {
         throw new Error(`Cannot find hoisted note '${hoistedNoteId}'`);
@@ -24,12 +24,12 @@ function isHoistedInHiddenSubtree() {
 }
 
 function getWorkspaceNote() {
-    const hoistedNote = becca.getNote(getHoistedNoteId());
+    const hoistedNote = getBecca().getNote(getHoistedNoteId());
 
     if (hoistedNote && (hoistedNote.isRoot() || hoistedNote.hasLabel("workspace"))) {
         return hoistedNote;
     } else {
-        return becca.getRoot();
+        return getBecca().getRoot();
     }
 }
 

--- a/packages/trilium-core/src/services/image.spec.ts
+++ b/packages/trilium-core/src/services/image.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getContext } from "./context.js";
 import imageService from "./image.js";
@@ -66,7 +66,7 @@ describe("image service (real DB)", () => {
                 `api/images/${result.noteId}/${encodeURIComponent(result.fileName)}`
             );
 
-            const note = becca.getNote(result.noteId);
+            const note = getBecca().getNote(result.noteId);
             expect(note).not.toBeNull();
             expect(note!.type).toBe("image");
             // The original (unsanitized-for-filename) name is recorded as a label.
@@ -82,7 +82,7 @@ describe("image service (real DB)", () => {
                 imageService.saveImage("root", fakeBuffer, longName, false, true)
             );
             expect(trimmed.fileName).toBe("image");
-            expect(becca.getNote(trimmed.noteId)!.getOwnedLabelValue("originalFileName")).toBe("image");
+            expect(getBecca().getNote(trimmed.noteId)!.getOwnedLabelValue("originalFileName")).toBe("image");
 
             const untrimmed = getContext().init(() =>
                 imageService.saveImage("root", fakeBuffer, longName, false, false)
@@ -107,7 +107,7 @@ describe("image service (real DB)", () => {
             );
             await flushAsync();
 
-            const note = becca.getNote(result.noteId)!;
+            const note = getBecca().getNote(result.noteId)!;
             expect(note.mime).toBe("image/png");
             expect(bytesOf(note.getContent())).toEqual(Array.from(fakeBuffer));
         });
@@ -122,7 +122,7 @@ describe("image service (real DB)", () => {
             );
             await flushAsync();
 
-            const note = becca.getNote(result.noteId)!;
+            const note = getBecca().getNote(result.noteId)!;
             expect(note.mime).toBe("image/svg+xml");
             // The name had no extension, so the detected one is appended to the label and title.
             expect(note.getOwnedLabelValue("originalFileName")).toBe(`${baseName}.svg`);
@@ -137,7 +137,7 @@ describe("image service (real DB)", () => {
             const { noteId } = getContext().init(() =>
                 imageService.saveImage("root", fakeBuffer, `host-${counter}.png`, false)
             );
-            return becca.getNote(noteId)!;
+            return getBecca().getNote(noteId)!;
         }
 
         it("creates an image attachment on the note and returns its title synchronously", () => {
@@ -150,7 +150,7 @@ describe("image service (real DB)", () => {
             expect(att.attachmentId).toBeTruthy();
             expect(att.title).toBe("att.png");
 
-            const attachment = becca.getAttachment(att.attachmentId!);
+            const attachment = getBecca().getAttachment(att.attachmentId!);
             expect(attachment).not.toBeNull();
             expect(attachment!.role).toBe("image");
             expect(attachment!.ownerId).toBe(host.noteId);
@@ -173,7 +173,7 @@ describe("image service (real DB)", () => {
             );
             await flushAsync();
 
-            const attachment = becca.getAttachment(att.attachmentId!)!;
+            const attachment = getBecca().getAttachment(att.attachmentId!)!;
             expect(attachment.mime).toBe("image/jpg");
             expect(attachment.title).toBe("nodotattach.jpg");
             expect(bytesOf(attachment.getContent())).toEqual(Array.from(fakeBuffer));
@@ -205,7 +205,7 @@ describe("image service (real DB)", () => {
 
             // Sanity-check the pre-update state so the post-update assertions below
             // genuinely discriminate updateImage's effect (and aren't already true).
-            const beforeUpdate = becca.getNote(noteId)!;
+            const beforeUpdate = getBecca().getNote(noteId)!;
             expect(beforeUpdate.mime).toBe("image/png");
             expect(bytesOf(beforeUpdate.getContent())).toEqual(Array.from(createdBuffer));
 
@@ -215,12 +215,12 @@ describe("image service (real DB)", () => {
             const updatedBuffer = new Uint8Array([9, 8, 7, 6]);
             stubProcessImage({ ext: "jpg" }, updatedBuffer);
 
-            const revisionSpy = vi.spyOn(becca.getNote(noteId)!, "saveRevision");
+            const revisionSpy = vi.spyOn(getBecca().getNote(noteId)!, "saveRevision");
 
             getContext().init(() => imageService.updateImage(noteId, fakeBuffer, "renamed.png"));
             await flushAsync();
 
-            const note = becca.getNote(noteId)!;
+            const note = getBecca().getNote(noteId)!;
             expect(revisionSpy).toHaveBeenCalledTimes(1);
             expect(note.getOwnedLabelValue("originalFileName")).toBe("renamed.png");
             // Mime/content now reflect updateImage's distinct provider output, which
@@ -235,7 +235,7 @@ describe("image service (real DB)", () => {
             // The child inherits protection only via
             // `parentNote.isProtected && isProtectedSessionAvailable()`, so the
             // parent MUST be protected for the session flag to matter at all.
-            const root = becca.getNote("root")!;
+            const root = getBecca().getNote("root")!;
             const originalRootProtected = root.isProtected;
             root.isProtected = true;
 
@@ -254,7 +254,7 @@ describe("image service (real DB)", () => {
                 const whenAvailable = getContext().init(() =>
                     imageService.saveImage("root", fakeBuffer, `prot-on-${counter}.png`, false)
                 );
-                expect(becca.getNote(whenAvailable.noteId)!.isProtected).toBe(true);
+                expect(getBecca().getNote(whenAvailable.noteId)!.isProtected).toBe(true);
                 // Let the protected note's fire-and-forget content save settle while
                 // the session is still "available", so its encryption branch doesn't
                 // run after we flip the mock below.
@@ -267,7 +267,7 @@ describe("image service (real DB)", () => {
                 const whenUnavailable = getContext().init(() =>
                     imageService.saveImage("root", fakeBuffer, `prot-off-${counter}.png`, false)
                 );
-                expect(becca.getNote(whenUnavailable.noteId)!.isProtected).toBe(false);
+                expect(getBecca().getNote(whenUnavailable.noteId)!.isProtected).toBe(false);
                 await flushAsync();
             } finally {
                 // Restore the shared fixture's root so sibling tests still attach

--- a/packages/trilium-core/src/services/image.ts
+++ b/packages/trilium-core/src/services/image.ts
@@ -5,7 +5,7 @@
 
 import sanitizeFilename from "sanitize-filename";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { getContext } from "./context.js";
 import { getLog } from "./log.js";
 import { getImageProvider } from "./image_provider.js";
@@ -24,7 +24,7 @@ function updateImage(noteId: string, uploadBuffer: Uint8Array, originalName: str
 
     originalName = sanitizeHtml(originalName);
 
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
     if (!note) {
         throw new Error("Unable to find note.");
     }
@@ -58,7 +58,7 @@ function saveImage(
     }
 
     const fileName = sanitizeFilename(originalName);
-    const parentNote = becca.getNote(parentNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
     if (!parentNote) {
         throw new Error("Unable to find parent note.");
     }
@@ -113,7 +113,7 @@ function saveImageToAttachment(
     }
 
     const fileName = sanitizeFilename(originalName);
-    const note = becca.getNoteOrThrow(noteId);
+    const note = getBecca().getNoteOrThrow(noteId);
 
     let attachment = note.saveAttachment({
         role: "image",
@@ -125,7 +125,7 @@ function saveImageToAttachment(
     setTimeout(() => {
         getContext().init(() => {
             getSql().transactional(() => {
-                const note = becca.getNoteOrThrow(noteId);
+                const note = getBecca().getNoteOrThrow(noteId);
                 noteService.asyncPostProcessContent(note, note.getContent());
             });
         });
@@ -139,7 +139,7 @@ function saveImageToAttachment(
                 if (!attachmentId) {
                     throw new Error("Missing attachment ID.");
                 }
-                attachment = becca.getAttachmentOrThrow(attachmentId);
+                attachment = getBecca().getAttachmentOrThrow(attachmentId);
 
                 attachment.mime = getImageMimeFromExtension(format.ext);
 

--- a/packages/trilium-core/src/services/import/anytype/importer.integration.spec.ts
+++ b/packages/trilium-core/src/services/import/anytype/importer.integration.spec.ts
@@ -2,7 +2,7 @@ import { ZipArchive } from "archiver";
 import { PassThrough } from "stream";
 import { describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { getContext } from "../../context.js";
 import TaskContext from "../../task_context.js";
@@ -31,7 +31,7 @@ async function importAnytype(files: Record<string, string | Buffer>, fileName?: 
     return new Promise<BNote>((resolve, reject) => {
         void getContext().init(async () => {
             try {
-                const root = becca.getNoteOrThrow("root");
+                const root = getBecca().getNoteOrThrow("root");
                 resolve(await anytypeImporter.importAnytype(taskContext, new Uint8Array(buffer), root, fileName));
             } catch (e) {
                 reject(e);

--- a/packages/trilium-core/src/services/import/enex.spec.ts
+++ b/packages/trilium-core/src/services/import/enex.spec.ts
@@ -3,7 +3,7 @@ import { default as path, dirname } from "path";
 import { fileURLToPath } from "url";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BNote from "../../becca/entities/bnote.js";
 import { getContext } from "../context.js";
 import sql_init from "../sql_init.js";
@@ -20,7 +20,7 @@ async function testImport(fileName: string) {
 
     return new Promise<{ importedNote: BNote; rootNote: BNote; taskContext: TaskContext<"importNotes"> }>((resolve, reject) => {
         getContext().init(async () => {
-            const rootNote = becca.getNote("root");
+            const rootNote = getBecca().getNote("root");
             if (!rootNote) {
                 expect(rootNote).toBeTruthy();
                 return;

--- a/packages/trilium-core/src/services/import/keep/importer.integration.spec.ts
+++ b/packages/trilium-core/src/services/import/keep/importer.integration.spec.ts
@@ -2,7 +2,7 @@ import { ZipArchive } from "archiver";
 import { PassThrough } from "stream";
 import { describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { getContext } from "../../context.js";
 import TaskContext from "../../task_context.js";
@@ -38,7 +38,7 @@ async function importNotes(files: Record<string, string | Buffer>): Promise<BNot
     return new Promise<BNote[]>((resolve, reject) => {
         void getContext().init(async () => {
             try {
-                const root = becca.getNoteOrThrow("root");
+                const root = getBecca().getNoteOrThrow("root");
                 const importRoot = await keepImporter.importKeep(taskContext, new Uint8Array(buffer), root);
                 resolve(importRoot.getChildNotes());
             } catch (e) {

--- a/packages/trilium-core/src/services/import/notion/importer.integration.spec.ts
+++ b/packages/trilium-core/src/services/import/notion/importer.integration.spec.ts
@@ -2,7 +2,7 @@ import { ZipArchive } from "archiver";
 import { PassThrough } from "stream";
 import { describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { getContext } from "../../context.js";
 import TaskContext from "../../task_context.js";
@@ -30,7 +30,7 @@ async function importNotion(files: Record<string, string | Buffer>): Promise<BNo
     return new Promise<BNote>((resolve, reject) => {
         void getContext().init(async () => {
             try {
-                const root = becca.getNoteOrThrow("root");
+                const root = getBecca().getNoteOrThrow("root");
                 resolve(await notionImporter.importNotion(taskContext, new Uint8Array(buffer), root));
             } catch (e) {
                 reject(e);
@@ -295,7 +295,7 @@ describe("Notion importer — integration", () => {
         const importRoot = await new Promise<BNote>((resolve, reject) => {
             void getContext().init(async () => {
                 try {
-                    resolve(await notionImporter.importNotion(taskContext, new Uint8Array(buffer), becca.getNoteOrThrow("root")));
+                    resolve(await notionImporter.importNotion(taskContext, new Uint8Array(buffer), getBecca().getNoteOrThrow("root")));
                 } catch (e) {
                     reject(e);
                 }

--- a/packages/trilium-core/src/services/import/obsidian/importer.integration.spec.ts
+++ b/packages/trilium-core/src/services/import/obsidian/importer.integration.spec.ts
@@ -3,7 +3,7 @@ import LZString from "lz-string";
 import { PassThrough } from "stream";
 import { describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { getContext } from "../../context.js";
 import TaskContext from "../../task_context.js";
@@ -52,7 +52,7 @@ async function importObsidian(files: Record<string, string | Buffer>, fileName?:
     return new Promise<BNote>((resolve, reject) => {
         void getContext().init(async () => {
             try {
-                const root = becca.getNoteOrThrow("root");
+                const root = getBecca().getNoteOrThrow("root");
                 resolve(await obsidianImporter.importObsidian(taskContext, new Uint8Array(buffer), root, fileName));
             } catch (e) {
                 reject(e);

--- a/packages/trilium-core/src/services/import/opml.spec.ts
+++ b/packages/trilium-core/src/services/import/opml.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import type BNote from "../../becca/entities/bnote.js";
 import { getContext } from "../context.js";
 import noteService from "../notes.js";
@@ -75,7 +75,7 @@ describe("importOpml (real DB)", () => {
 
         // The returned note is the first top-level outline.
         expect(returnNote.title).toBe("Parent");
-        expect(becca.notes[returnNote.noteId]).toBe(returnNote);
+        expect(getBecca().notes[returnNote.noteId]).toBe(returnNote);
 
         // v1 derives content from `text`, joining newlines into separate <p> blocks.
         expect(decodeUtf8(returnNote.getContent())).toBe("<p>line one</p><p>line two</p>");

--- a/packages/trilium-core/src/services/import/single.spec.ts
+++ b/packages/trilium-core/src/services/import/single.spec.ts
@@ -3,7 +3,7 @@ import ExcelJS from "exceljs";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BNote from "../../becca/entities/bnote.js";
 import TaskContext from "../task_context.js";
 import sql_init from "../sql_init.js";
@@ -25,7 +25,7 @@ async function testImport(fileName: string, mimetype: string, bufferOverride?: B
 
     return new Promise<{ buffer: Buffer; importedNote: BNote }>((resolve, reject) => {
         getContext().init(async () => {
-            const rootNote = becca.getNote("root");
+            const rootNote = getBecca().getNote("root");
             if (!rootNote) {
                 reject("Missing root note.");
                 return;

--- a/packages/trilium-core/src/services/import/zip.spec.ts
+++ b/packages/trilium-core/src/services/import/zip.spec.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { PassThrough } from "stream";
 import zip, { removeTriliumTags } from "./zip.js";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BNote from "../../becca/entities/bnote.js";
 import TaskContext from "../task_context.js";
 import sql_init from "../sql_init.js";
@@ -24,7 +24,7 @@ async function testImportBuffer(buffer: Buffer, taskId = "import-mdx", taskData:
 
     return new Promise<{ importedNote: BNote; rootNote: BNote }>((resolve, reject) => {
         getContext().init(async () => {
-            const rootNote = becca.getNote("root");
+            const rootNote = getBecca().getNote("root");
             if (!rootNote) {
                 expect(rootNote).toBeTruthy();
                 return;
@@ -239,7 +239,7 @@ describe("processNoteContent", () => {
 
         await new Promise<void>((resolve, reject) => {
             getContext().init(async () => {
-                const rootNote = becca.getNote("root");
+                const rootNote = getBecca().getNote("root");
                 if (!rootNote) {
                     reject(new Error("missing root note"));
                     return;
@@ -272,7 +272,7 @@ describe("processNoteContent", () => {
 
         await new Promise<void>((resolve, reject) => {
             getContext().init(async () => {
-                const rootNote = becca.getNote("root");
+                const rootNote = getBecca().getNote("root");
                 if (!rootNote) {
                     reject(new Error("missing root note"));
                     return;
@@ -340,7 +340,7 @@ describe("processNoteContent", () => {
 
         // No corruption: the system root keeps its own content and gains no self-referential branch.
         expect(rootNote.getContent().toString()).not.toContain("archived root content");
-        expect(becca.getBranchFromChildAndParent("root", "root")).toBeFalsy();
+        expect(getBecca().getBranchFromChildAndParent("root", "root")).toBeFalsy();
     });
 
     it("restoreAsRoot maps the archived root onto the destination root instead of wrapping it (demo-content shape)", async () => {
@@ -381,7 +381,7 @@ describe("processNoteContent", () => {
         expect(journal?.getParentNotes().map((n) => n.noteId)).toEqual(["root"]);
         expect(misc?.getParentNotes().map((n) => n.noteId)).toEqual(["root"]);
         // And no self-referential root branch.
-        expect(becca.getBranchFromChildAndParent("root", "root")).toBeFalsy();
+        expect(getBecca().getBranchFromChildAndParent("root", "root")).toBeFalsy();
     });
 
     it("restoreAsRoot merges an archived root that has its own content into the destination root", async () => {
@@ -418,7 +418,7 @@ describe("processNoteContent", () => {
         const child = rootNote.getChildNotes().find((n) => n.title === "Restored Child");
         expect(child?.getParentNotes().map((n) => n.noteId)).toEqual(["root"]);
         expect(child?.getContent().toString()).toContain("child content");
-        expect(becca.getBranchFromChildAndParent("root", "root")).toBeFalsy();
+        expect(getBecca().getBranchFromChildAndParent("root", "root")).toBeFalsy();
     });
 
     it("imports a CSV entry as a plain file note when the spreadsheet option is off", async () => {

--- a/packages/trilium-core/src/services/import/zip.ts
+++ b/packages/trilium-core/src/services/import/zip.ts
@@ -2,7 +2,7 @@ import { ALLOWED_NOTE_TYPES, type NoteType } from "@triliumnext/commons";
 import { basename, dirname } from "../utils/path.js";
 import { getZipProvider, type ZipSource } from "../zip_provider.js";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BAttachment from "../../becca/entities/battachment.js";
 import BAttribute from "../../becca/entities/battribute.js";
 import BBranch from "../../becca/entities/bbranch.js";
@@ -277,7 +277,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
 
         const noteId = getNoteId(noteMeta, filePath);
 
-        if (becca.getNote(noteId)) {
+        if (getBecca().getNote(noteId)) {
             return;
         }
 
@@ -567,7 +567,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
         }
 
         if (noteMeta?.isClone) {
-            if (!isImportRootNote && !becca.getBranchFromChildAndParent(noteId, parentNoteId)) {
+            if (!isImportRootNote && !getBecca().getBranchFromChildAndParent(noteId, parentNoteId)) {
                 new BBranch({
                     noteId,
                     parentNoteId,
@@ -611,7 +611,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
 
         content = processNoteContent(noteMeta, type, mime, content, noteTitle || "", filePath);
 
-        let note = becca.getNote(noteId);
+        let note = getBecca().getNote(noteId);
 
         const isProtected = importRootNote.isProtected && protectedSessionService.isProtectedSessionAvailable();
 
@@ -628,7 +628,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
 
             note.setContent(content);
 
-            if (!isImportRootNote && !becca.getBranchFromChildAndParent(noteId, parentNoteId)) {
+            if (!isImportRootNote && !getBecca().getBranchFromChildAndParent(noteId, parentNoteId)) {
                 new BBranch({
                     noteId,
                     parentNoteId,
@@ -841,7 +841,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
     taskContext.setTotalCount(createdNoteIds.size);
 
     for (const noteId of createdNoteIds) {
-        const note = becca.getNote(noteId);
+        const note = getBecca().getNote(noteId);
         if (!note) continue;
         const postStart = Date.now();
         await noteService.asyncPostProcessContent(note, note.getContent());
@@ -862,7 +862,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
     // are already in the database (we don't want to have "broken" relations, not even transitionally)
     timingMark = Date.now();
     for (const attr of attributes) {
-        if (attr.type !== "relation" || attr.value in becca.notes) {
+        if (attr.type !== "relation" || attr.value in getBecca().notes) {
             new BAttribute(attr).save();
         } else {
             getLog().info(`Relation not imported since the target note doesn't exist: ${JSON.stringify(attr)}`);

--- a/packages/trilium-core/src/services/in_app_help.spec.ts
+++ b/packages/trilium-core/src/services/in_app_help.spec.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
 import type { HiddenSubtreeItem } from "@triliumnext/commons";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { getContext } from "./context.js";
 import {
     cleanUpHelp,
@@ -91,17 +91,17 @@ describe("in_app_help - cleanUpHelp", () => {
         getContext().init(() => cleanUpHelp(definition));
 
         // The stale note is gone; the kept notes (incl. nested child and root) survive.
-        expect(becca.getNote("_helpStale")?.isDeleted ?? true).toBe(true);
-        expect(becca.getNote("_helpKeep")?.isDeleted).toBe(false);
-        expect(becca.getNote("_helpKeepChild")?.isDeleted).toBe(false);
-        expect(becca.getNote("_help")?.isDeleted).toBe(false);
+        expect(getBecca().getNote("_helpStale")?.isDeleted ?? true).toBe(true);
+        expect(getBecca().getNote("_helpKeep")?.isDeleted).toBe(false);
+        expect(getBecca().getNote("_helpKeepChild")?.isDeleted).toBe(false);
+        expect(getBecca().getNote("_help")?.isDeleted).toBe(false);
     });
 
     it("is a no-op when the _help subtree does not exist", () => {
-        // Remove the whole _help subtree, so becca.getNote("_help") is null and
+        // Remove the whole _help subtree, so getBecca().getNote("_help") is null and
         // the recursive flattener hits its empty-note short-circuit.
-        getContext().init(() => becca.getNote("_help")?.deleteNote());
-        expect(becca.getNote("_help")).toBeNull();
+        getContext().init(() => getBecca().getNote("_help")?.deleteNote());
+        expect(getBecca().getNote("_help")).toBeNull();
 
         expect(() => getContext().init(() => cleanUpHelp([]))).not.toThrow();
     });

--- a/packages/trilium-core/src/services/in_app_help.ts
+++ b/packages/trilium-core/src/services/in_app_help.ts
@@ -1,6 +1,6 @@
 import type { HiddenSubtreeItem } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 
 export abstract class InAppHelpProvider {
@@ -44,7 +44,7 @@ export abstract class InAppHelpProvider {
         }
 
         const definitionHelpIds = new Set(getFlatIds(helpDefinition));
-        const realHelpIds = getFlatIdsFromNote(becca.getNote("_help"));
+        const realHelpIds = getFlatIdsFromNote(getBecca().getNote("_help"));
 
         for (const realHelpId of realHelpIds) {
             if (realHelpId === "_help") {
@@ -52,7 +52,7 @@ export abstract class InAppHelpProvider {
             }
 
             if (!definitionHelpIds.has(realHelpId)) {
-                becca.getNote(realHelpId)?.deleteNote();
+                getBecca().getNote(realHelpId)?.deleteNote();
             }
         }
     }

--- a/packages/trilium-core/src/services/messaging/types.ts
+++ b/packages/trilium-core/src/services/messaging/types.ts
@@ -57,6 +57,13 @@ export interface MessagingProvider {
     onMessage?(handler: MessageHandler): () => void;
 
     /**
+     * Send a message only to connections belonging to a specific user.
+     * Not all transports support per-user routing (e.g. IPC has a single renderer),
+     * so this is optional. Broadcast routing via entity_changes.userId is Phase 3.
+     */
+    sendMessageToUserClients?(userId: string, message: WebSocketMessage): void;
+
+    /**
      * Get the number of connected clients.
      */
     getClientCount?(): number;

--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BBranch from "../becca/entities/bbranch.js";
 import type BNote from "../becca/entities/bnote.js";
 import { disableEntityEvents, getContext } from "./context.js";
@@ -50,7 +50,7 @@ describe("notes service (real DB)", () => {
         it("creates a text note under root with content, branch and derived mime", () => {
             const { note, branch } = createNote("root", { title: "spec-create-basic", content: "<p>body</p>" });
 
-            expect(becca.notes[note.noteId]).toBe(note);
+            expect(getBecca().notes[note.noteId]).toBe(note);
             expect(note.title).toBe("spec-create-basic");
             expect(note.type).toBe("text");
             expect(note.mime).toBe("text/html");
@@ -61,7 +61,7 @@ describe("notes service (real DB)", () => {
             // position derives from MAX existing position + 10 and is therefore positive.
             expect(branch.notePosition).toBeGreaterThan(0);
 
-            // The note row is persisted in the DB, not just becca.
+            // The note row is persisted in the DB, not just getBecca().
             const row = getSql().getRow<{ title: string }>("SELECT title FROM notes WHERE noteId = ?", [note.noteId]);
             expect(row.title).toBe("spec-create-basic");
         });

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -3,7 +3,7 @@ import { t } from "i18next";
 import { parse as parseHtml } from "node-html-parser";
 import url from "url";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttachment from "../becca/entities/battachment.js";
 import BAttribute from "../becca/entities/battribute.js";
 import BBranch from "../becca/entities/bbranch.js";
@@ -175,7 +175,7 @@ interface GetValidateParams {
 }
 
 function getAndValidateParent(params: GetValidateParams) {
-    const parentNote = becca.notes[params.parentNoteId];
+    const parentNote = getBecca().notes[params.parentNoteId];
 
     if (!parentNote) {
         throw new ValidationError(`Parent note '${params.parentNoteId}' was not found.`);
@@ -227,7 +227,7 @@ function createNewNote(params: NoteParams): {
     // When creating from a template, inherit the template's type and mime if not explicitly provided.
     // This ensures binary types (PDF, images, etc.) get the correct mime from the start.
     if (params.templateNoteId) {
-        const templateNote = becca.getNote(params.templateNoteId);
+        const templateNote = getBecca().getNote(params.templateNoteId);
         if (templateNote) {
             if (!params.mime) {
                 params.mime = templateNote.mime;
@@ -257,7 +257,8 @@ function createNewNote(params: NoteParams): {
                 type: params.type,
                 mime: deriveMime(params.type, params.mime),
                 dateCreated: params.dateCreated,
-                utcDateCreated: params.utcDateCreated
+                utcDateCreated: params.utcDateCreated,
+                ownerId: cls.getUserId() ?? optionService.getOptionOrNull("adminUserId")
             }).save();
 
             // Create attributes atomically.
@@ -286,7 +287,7 @@ function createNewNote(params: NoteParams): {
         }
 
         if (params.templateNoteId) {
-            const templateNote = becca.getNote(params.templateNoteId);
+            const templateNote = getBecca().getNote(params.templateNoteId);
             if (!templateNote) {
                 throw new Error(`Template note '${params.templateNoteId}' does not exist.`);
             }
@@ -332,7 +333,7 @@ function createNewNote(params: NoteParams): {
 
 function createNewNoteWithTarget(target: "into" | "after" | "before", targetBranchId: string | undefined, params: NoteParams) {
     if (!params.type) {
-        const parentNote = becca.notes[params.parentNoteId];
+        const parentNote = getBecca().notes[params.parentNoteId];
 
         // code note type can be inherited, otherwise "text" is the default
         params.type = parentNote.type === "code" ? "code" : "text";
@@ -342,7 +343,7 @@ function createNewNoteWithTarget(target: "into" | "after" | "before", targetBran
     if (target === "into") {
         return createNewNote(params);
     } else if (target === "after" && targetBranchId) {
-        const afterBranch = becca.branches[targetBranchId];
+        const afterBranch = getBecca().branches[targetBranchId];
 
         // not updating utcDateModified to avoid having to sync whole rows
         getSql().execute("UPDATE branches SET notePosition = notePosition + 10 WHERE parentNoteId = ? AND notePosition > ? AND isDeleted = 0", [params.parentNoteId, afterBranch.notePosition]);
@@ -355,7 +356,7 @@ function createNewNoteWithTarget(target: "into" | "after" | "before", targetBran
 
         return retObject;
     } else if (target === "before" && targetBranchId) {
-        const beforeBranch = becca.branches[targetBranchId];
+        const beforeBranch = getBecca().branches[targetBranchId];
 
         // not updating utcDateModified to avoid having to sync whole rows
         getSql().execute("UPDATE branches SET notePosition = notePosition - 10 WHERE parentNoteId = ? AND notePosition < ? AND isDeleted = 0", [params.parentNoteId, beforeBranch.notePosition]);
@@ -510,7 +511,7 @@ export function checkImageAttachments(note: BNote, content: string) {
 
     const existingAttachmentIds = new Set<string | undefined>(attachments.map((att) => att.attachmentId));
     const unknownAttachmentIds = Array.from(foundAttachmentIds).filter((foundAttId) => !existingAttachmentIds.has(foundAttId));
-    const unknownAttachments = becca.getAttachments(unknownAttachmentIds);
+    const unknownAttachments = getBecca().getAttachments(unknownAttachmentIds);
 
     for (const unknownAttachment of unknownAttachments) {
         // the attachment belongs to a different note (was copy-pasted). Attachments can be linked only from the note
@@ -846,7 +847,7 @@ function downloadImages(noteId: string, content: string) {
             }
 
             if (url in imageUrlToAttachmentIdMapping) {
-                const attachment = becca.getAttachment(imageUrlToAttachmentIdMapping[url]);
+                const attachment = getBecca().getAttachment(imageUrlToAttachmentIdMapping[url]);
 
                 if (!attachment) {
                     delete imageUrlToAttachmentIdMapping[url];
@@ -879,10 +880,10 @@ function downloadImages(noteId: string, content: string) {
 
             cls.getContext().init(() => {
                 getSql().transactional(() => {
-                const imageNotes = becca.getNotes(Object.values(imageUrlToAttachmentIdMapping), true);
+                const imageNotes = getBecca().getNotes(Object.values(imageUrlToAttachmentIdMapping), true);
                     const log = getLog();
 
-                const origNote = becca.getNote(noteId);
+                const origNote = getBecca().getNote(noteId);
 
                 if (!origNote) {
                     log.error(`Cannot find note '${noteId}' to replace image link.`);
@@ -1008,7 +1009,7 @@ export function saveLinks(note: BNote, content: string | Uint8Array) {
     const existingLinks = note.getRelations().filter((rel) => ["internalLink", "imageLink", "relationMapLink", "includeNoteLink"].includes(rel.name));
 
     for (const foundLink of foundLinks) {
-        const targetNote = becca.notes[foundLink.value];
+        const targetNote = getBecca().notes[foundLink.value];
         if (!targetNote) {
             continue;
         }
@@ -1059,7 +1060,7 @@ function saveRevisionIfNeeded(note: BNote) {
 }
 
 function updateNoteData(noteId: string, content: string, attachments: AttachmentRow[] = []) {
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
 
     if (!note || !note.isContentAvailable()) {
         throw new Error(`Note '${noteId}' is not available for change!`);
@@ -1133,7 +1134,7 @@ function undeleteBranch(branchId: string, deleteId: string, taskContext: TaskCon
 
     if (noteRow.isDeleted && noteRow.deleteId === deleteId) {
         // becca entity was already created as skeleton in "new Branch()" above
-        const noteEntity = becca.getNote(noteRow.noteId);
+        const noteEntity = getBecca().getNote(noteRow.noteId);
         if (!noteEntity) {
             throw new Error("Unable to find the just restored branch.");
         }
@@ -1254,7 +1255,7 @@ function duplicateSubtree(origNoteId: string, newParentNoteId: string) {
 
     getLog().info(`Duplicating '${origNoteId}' subtree into '${newParentNoteId}'`);
 
-    const origNote = becca.notes[origNoteId];
+    const origNote = getBecca().notes[origNoteId];
     // might be null if orig note is not in the target newParentNoteId
     const origBranch = origNote.getParentBranches().find((branch) => branch.parentNoteId === newParentNoteId);
 
@@ -1278,7 +1279,7 @@ function duplicateSubtreeWithoutRoot(origNoteId: string, newNoteId: string) {
         throw new Error("Duplicating root is not possible");
     }
 
-    const origNote = becca.getNote(origNoteId);
+    const origNote = getBecca().getNote(origNoteId);
     if (origNote == null) {
         throw new Error("Unable to find note to duplicate.");
     }
@@ -1352,7 +1353,7 @@ function duplicateSubtreeInner(origNote: BNote, origBranch: BBranch | null | und
         return newNote;
     }
 
-    const existingNote = becca.notes[newNoteId];
+    const existingNote = getBecca().notes[newNoteId];
 
     if (existingNote && existingNote.title !== undefined) {
         // checking that it's not just note's skeleton created because of Branch above

--- a/packages/trilium-core/src/services/options.spec.ts
+++ b/packages/trilium-core/src/services/options.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { getContext } from "./context.js";
 import optionService from "./options.js";
 import { getSql } from "./sql/index.js";
@@ -95,9 +95,9 @@ describe("options service (real DB)", () => {
                 optionService.createOption(localName as any, "local-value", false);
             });
 
-            expect(becca.getOption(syncedName)?.value).toBe("synced-value");
-            expect(becca.getOption(syncedName)?.isSynced).toBe(true);
-            expect(becca.getOption(localName)?.isSynced).toBe(false);
+            expect(getBecca().getOption(syncedName)?.value).toBe("synced-value");
+            expect(getBecca().getOption(syncedName)?.isSynced).toBe(true);
+            expect(getBecca().getOption(localName)?.isSynced).toBe(false);
 
             expect(readFromDb(syncedName)).toBe("synced-value");
             expect(readFromDb(localName)).toBe("local-value");
@@ -121,7 +121,7 @@ describe("options service (real DB)", () => {
             getContext().init(() => optionService.setOption(name as any, "created-by-set"));
 
             expect(optionService.getOption(name as any)).toBe("created-by-set");
-            expect(becca.getOption(name)?.isSynced).toBe(false);
+            expect(getBecca().getOption(name)?.isSynced).toBe(false);
             expect(readFromDb(name)).toBe("created-by-set");
         });
     });

--- a/packages/trilium-core/src/services/options.ts
+++ b/packages/trilium-core/src/services/options.ts
@@ -12,7 +12,7 @@
  * a theme on a device and it will not affect other devices.
  */
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BOption from "../becca/entities/boption.js";
 import type { OptionRow } from "@triliumnext/commons";
 import type { FilterOptionsByType, OptionDefinitions, OptionMap, OptionNames } from "@triliumnext/commons";
@@ -21,8 +21,8 @@ import { getSql } from "./sql/index.js";
 function getOptionOrNull(name: OptionNames): string | null {
     let option;
 
-    if (becca.loaded) {
-        option = becca.getOption(name);
+    if (getBecca().loaded) {
+        option = getBecca().getOption(name);
     } else {
         // e.g. in initial sync becca is not loaded because DB is not initialized
         try {
@@ -73,7 +73,7 @@ function getOptionBool(name: FilterOptionsByType<boolean>): boolean {
 }
 
 function setOption<T extends OptionNames>(name: T, value: string | OptionDefinitions[T]) {
-    const option = becca.getOption(name);
+    const option = getBecca().getOption(name);
 
     if (option) {
         option.value = value as string;
@@ -101,13 +101,13 @@ function createOption<T extends OptionNames>(name: T, value: string | OptionDefi
 }
 
 function getOptions() {
-    return Object.values(becca.options);
+    return Object.values(getBecca().options);
 }
 
 function getOptionMap() {
     const map: Record<string, string> = {};
 
-    for (const option of Object.values(becca.options)) {
+    for (const option of Object.values(getBecca().options)) {
         map[option.name] = option.value;
     }
 

--- a/packages/trilium-core/src/services/permission_service.spec.ts
+++ b/packages/trilium-core/src/services/permission_service.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import * as cls from "./context.js";
+import { getSql } from "./sql/index.js";
+import dateUtils from "./utils/date.js";
+import { newEntityId } from "./utils/index.js";
+import permissionService from "./permission_service.js";
+
+function now() {
+    return dateUtils.utcNowDateTime();
+}
+
+function insertUser(userId: string, isAdmin = 0) {
+    const n = now();
+    getSql().execute(
+        `INSERT OR IGNORE INTO users (userId, username, isAdmin, isDeleted, dateCreated, utcDateModified)
+         VALUES (?, ?, ?, 0, ?, ?)`,
+        [userId, `user-${userId.slice(0, 4)}`, isAdmin, n, n]
+    );
+}
+
+function insertNote(noteId: string, ownerId: string | null) {
+    const n = now();
+    getSql().execute(
+        `INSERT OR IGNORE INTO notes (noteId, title, type, mime, isProtected, isDeleted, dateCreated, dateModified, utcDateCreated, utcDateModified, ownerId)
+         VALUES (?, 'test', 'text', 'text/html', 0, 0, ?, ?, ?, ?, ?)`,
+        [noteId, n, n, n, n, ownerId]
+    );
+}
+
+function insertBranch(noteId: string, parentNoteId: string) {
+    const n = now();
+    getSql().execute(
+        `INSERT OR IGNORE INTO branches (branchId, noteId, parentNoteId, notePosition, isExpanded, isDeleted, utcDateModified)
+         VALUES (?, ?, ?, 10, 0, 0, ?)`,
+        [newEntityId(), noteId, parentNoteId, n]
+    );
+}
+
+function insertGroup(groupId: string, name: string) {
+    const n = now();
+    getSql().execute(
+        `INSERT OR IGNORE INTO user_groups (groupId, name, dateCreated, utcDateModified) VALUES (?, ?, ?, ?)`,
+        [groupId, name, n, n]
+    );
+}
+
+function addUserToGroup(userId: string, groupId: string) {
+    getSql().execute(
+        `INSERT OR IGNORE INTO user_group_members (userId, groupId, dateCreated) VALUES (?, ?, ?)`,
+        [userId, groupId, now()]
+    );
+}
+
+describe("permission_service", () => {
+    let userId: string;
+    let adminId: string;
+
+    beforeAll(() => {
+        expect(getSql()).toBeDefined();
+    });
+
+    beforeEach(() => {
+        userId = newEntityId();
+        adminId = newEntityId();
+        insertUser(userId, 0);
+        insertUser(adminId, 1);
+        permissionService.clearPermissionCache();
+    });
+
+    afterEach(() => {
+        permissionService.clearPermissionCache();
+    });
+
+    describe("canUserAccessNote", () => {
+        it("owner can access their own note", () => {
+            const noteId = newEntityId();
+            insertNote(noteId, userId);
+            const result = cls.init(() => permissionService.canUserAccessNote(noteId, userId));
+            expect(result).toBe(true);
+        });
+
+        it("non-owner without permission cannot access", () => {
+            const noteId = newEntityId();
+            const otherId = newEntityId();
+            insertUser(otherId, 0);
+            insertNote(noteId, userId);
+            const result = cls.init(() => permissionService.canUserAccessNote(noteId, otherId));
+            expect(result).toBe(false);
+        });
+
+        it("admin can access any note", () => {
+            const noteId = newEntityId();
+            insertNote(noteId, userId);
+            const result = cls.init(() => permissionService.canUserAccessNote(noteId, adminId));
+            expect(result).toBe(true);
+        });
+    });
+
+    describe("grantPermission / revokePermission", () => {
+        it("grants read-only access to another user", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+
+            cls.init(() => permissionService.grantPermission(noteId, guestId, null, false));
+
+            const canRead = cls.init(() => permissionService.canUserAccessNote(noteId, guestId));
+            const canWrite = cls.init(() => permissionService.canUserWriteNote(noteId, guestId));
+            expect(canRead).toBe(true);
+            expect(canWrite).toBe(false);
+        });
+
+        it("grants read+write access to another user", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+
+            cls.init(() => permissionService.grantPermission(noteId, guestId, null, true));
+
+            expect(cls.init(() => permissionService.canUserWriteNote(noteId, guestId))).toBe(true);
+        });
+
+        it("revoking permission removes access", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+
+            const permId = cls.init(() => permissionService.grantPermission(noteId, guestId, null, false));
+            expect(cls.init(() => permissionService.canUserAccessNote(noteId, guestId))).toBe(true);
+
+            cls.init(() => permissionService.revokePermission(permId));
+            expect(cls.init(() => permissionService.canUserAccessNote(noteId, guestId))).toBe(false);
+        });
+
+        it("throws when neither userId nor groupId provided", () => {
+            const noteId = newEntityId();
+            insertNote(noteId, userId);
+            expect(() =>
+                cls.init(() => permissionService.grantPermission(noteId, null, null, false))
+            ).toThrow();
+        });
+    });
+
+    describe("permission inheritance", () => {
+        it("grants access via ancestor note permission", () => {
+            const parentId = newEntityId();
+            const childId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(parentId, userId);
+            insertNote(childId, userId);
+            insertBranch(childId, parentId);
+
+            cls.init(() => permissionService.grantPermission(parentId, guestId, null, false));
+
+            expect(cls.init(() => permissionService.canUserAccessNote(childId, guestId))).toBe(true);
+        });
+
+        it("highest privilege wins across multiple matching permissions", () => {
+            const parentId = newEntityId();
+            const childId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(parentId, userId);
+            insertNote(childId, userId);
+            insertBranch(childId, parentId);
+
+            // Read-only on parent, write on child
+            cls.init(() => permissionService.grantPermission(parentId, guestId, null, false));
+            cls.init(() => permissionService.grantPermission(childId, guestId, null, true));
+
+            expect(cls.init(() => permissionService.canUserWriteNote(childId, guestId))).toBe(true);
+        });
+    });
+
+    describe("getPermissionsForNote", () => {
+        it("lists all permissions for a note", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+
+            cls.init(() => permissionService.grantPermission(noteId, guestId, null, true));
+            const rows = cls.init(() => permissionService.getPermissionsForNote(noteId));
+            expect(rows.length).toBe(1);
+            expect(rows[0].userId).toBe(guestId);
+            expect(rows[0].canWrite).toBe(1);
+        });
+    });
+
+    describe("group-based permissions", () => {
+        it("grants access via group membership", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            const groupId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+            insertGroup(groupId, "testers");
+            addUserToGroup(guestId, groupId);
+
+            cls.init(() => permissionService.grantPermission(noteId, null, groupId, false));
+
+            expect(cls.init(() => permissionService.canUserAccessNote(noteId, guestId))).toBe(true);
+            expect(cls.init(() => permissionService.canUserWriteNote(noteId, guestId))).toBe(false);
+        });
+    });
+
+    describe("multi-parent clone graphs", () => {
+        it("inherits permission from either parent of a cloned note", () => {
+            const parent1Id = newEntityId();
+            const parent2Id = newEntityId();
+            const cloneId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(parent1Id, userId);
+            insertNote(parent2Id, userId);
+            insertNote(cloneId, userId);
+            insertBranch(cloneId, parent1Id);
+            insertBranch(cloneId, parent2Id);
+
+            // Grant access only via parent2
+            cls.init(() => permissionService.grantPermission(parent2Id, guestId, null, true));
+
+            expect(cls.init(() => permissionService.canUserAccessNote(cloneId, guestId))).toBe(true);
+            expect(cls.init(() => permissionService.canUserWriteNote(cloneId, guestId))).toBe(true);
+        });
+    });
+
+    describe("cache correctness", () => {
+        it("cached result is returned on repeated calls", () => {
+            const noteId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(noteId, userId);
+
+            cls.init(() => permissionService.grantPermission(noteId, guestId, null, false));
+
+            const first = cls.init(() => permissionService.canUserAccessNote(noteId, guestId));
+            const second = cls.init(() => permissionService.canUserAccessNote(noteId, guestId));
+            expect(first).toBe(true);
+            expect(second).toBe(true);
+        });
+
+        it("cache is cleared after revoking permission on a parent affects child", () => {
+            const parentId = newEntityId();
+            const childId = newEntityId();
+            const guestId = newEntityId();
+            insertUser(guestId, 0);
+            insertNote(parentId, userId);
+            insertNote(childId, userId);
+            insertBranch(childId, parentId);
+
+            const permId = cls.init(() => permissionService.grantPermission(parentId, guestId, null, false));
+            expect(cls.init(() => permissionService.canUserAccessNote(childId, guestId))).toBe(true);
+
+            cls.init(() => permissionService.revokePermission(permId));
+            expect(cls.init(() => permissionService.canUserAccessNote(childId, guestId))).toBe(false);
+        });
+    });
+});

--- a/packages/trilium-core/src/services/permission_service.ts
+++ b/packages/trilium-core/src/services/permission_service.ts
@@ -29,44 +29,23 @@ function cacheKey(noteId: string, userId: string) {
     return `${noteId}\0${userId}`;
 }
 
-// Walks the full ancestor chain across every branch so clones are handled correctly.
+// Collects permissions from the note and all its ancestors across every branch (handles clones).
 function collectAncestorPermissions(noteId: string, userId: string): PermissionRow[] {
-    const sql = getSql();
-    const visited = new Set<string>();
-    const permissions: PermissionRow[] = [];
-
-    // Fetch once up front so each node's permission query doesn't repeat the subquery.
-    const groupIds = sql.getColumn<string>(
-        "SELECT groupId FROM user_group_members WHERE userId = ?", [userId]
+    return getSql().getRows<PermissionRow>(
+        `WITH RECURSIVE ancestors(noteId) AS (
+             SELECT ?
+             UNION
+             SELECT b.parentNoteId
+               FROM branches b
+               JOIN ancestors a ON b.noteId = a.noteId
+              WHERE b.isDeleted = 0 AND b.parentNoteId != 'none'
+         )
+         SELECT ${PERMISSION_COLS}
+           FROM note_permissions
+          WHERE noteId IN ancestors
+            AND (userId = ? OR groupId IN (SELECT groupId FROM user_group_members WHERE userId = ?))`,
+        [noteId, userId, userId]
     );
-    const groupPlaceholders = groupIds.length > 0 ? groupIds.map(() => "?").join(",") : "NULL";
-
-    function walk(id: string) {
-        if (visited.has(id)) return;
-        visited.add(id);
-
-        const rows = sql.getRows<PermissionRow>(
-            `SELECT ${PERMISSION_COLS}
-               FROM note_permissions
-              WHERE noteId = ?
-                AND (userId = ? OR groupId IN (${groupPlaceholders}))`,
-            [id, userId, ...groupIds]
-        );
-
-        permissions.push(...rows);
-
-        // Walk up through every parent branch (handles clones).
-        const parentIds = sql.getColumn<string>(
-            "SELECT DISTINCT parentNoteId FROM branches WHERE noteId = ? AND isDeleted = 0 AND parentNoteId != 'none'",
-            [id]
-        );
-        for (const parentId of parentIds) {
-            walk(parentId);
-        }
-    }
-
-    walk(noteId);
-    return permissions;
 }
 
 function getEffectivePermission(noteId: string, userId: string): EffectivePermission | null {

--- a/packages/trilium-core/src/services/permission_service.ts
+++ b/packages/trilium-core/src/services/permission_service.ts
@@ -3,6 +3,7 @@ import { getLog } from "./log.js";
 import { newEntityId } from "./utils/index.js";
 import dateUtils from "./utils/date.js";
 import userService from "./user_service.js";
+import { evictUser } from "../becca/becca_cache.js";
 
 interface PermissionRow {
     permissionId: string;
@@ -99,6 +100,20 @@ function canUserWriteNote(noteId: string, userId: string): boolean {
     return getEffectivePermission(noteId, userId)?.canWrite ?? false;
 }
 
+function evictAffectedUsers(userId: string | null, groupId: string | null): void {
+    if (userId) {
+        evictUser(userId);
+    }
+    if (groupId) {
+        const members = getSql().getColumn<string>(
+            "SELECT userId FROM user_group_members WHERE groupId = ?", [groupId]
+        );
+        for (const memberId of members) {
+            evictUser(memberId);
+        }
+    }
+}
+
 function grantPermission(
     noteId: string,
     userId: string | null,
@@ -120,12 +135,13 @@ function grantPermission(
 
     // Permission changes affect the whole inheritance chain; clear everything.
     clearPermissionCache();
+    evictAffectedUsers(userId, groupId);
     return permissionId;
 }
 
 function revokePermission(permissionId: string): void {
-    const row = getSql().getRowOrNull<{ noteId: string }>(
-        "SELECT noteId FROM note_permissions WHERE permissionId = ?",
+    const row = getSql().getRowOrNull<{ noteId: string; userId: string | null; groupId: string | null }>(
+        "SELECT noteId, userId, groupId FROM note_permissions WHERE permissionId = ?",
         [permissionId]
     );
 
@@ -137,6 +153,7 @@ function revokePermission(permissionId: string): void {
     getSql().execute("DELETE FROM note_permissions WHERE permissionId = ?", [permissionId]);
     // Permission changes affect the whole inheritance chain; clear everything.
     clearPermissionCache();
+    evictAffectedUsers(row.userId, row.groupId);
 }
 
 function getPermissionsForNote(noteId: string): PermissionRow[] {

--- a/packages/trilium-core/src/services/permission_service.ts
+++ b/packages/trilium-core/src/services/permission_service.ts
@@ -1,0 +1,183 @@
+import { getSql } from "./sql/index.js";
+import { getLog } from "./log.js";
+import { newEntityId } from "./utils/index.js";
+import dateUtils from "./utils/date.js";
+import userService from "./user_service.js";
+
+interface PermissionRow {
+    permissionId: string;
+    noteId: string;
+    userId: string | null;
+    groupId: string | null;
+    canRead: number;
+    canWrite: number;
+    dateCreated: string;
+    utcDateModified: string;
+}
+
+interface EffectivePermission {
+    canRead: boolean;
+    canWrite: boolean;
+}
+
+const PERMISSION_COLS = "permissionId, noteId, userId, groupId, canRead, canWrite, dateCreated, utcDateModified";
+
+// In-memory cache: noteId + "\0" + userId -> EffectivePermission | null (null = no access)
+const permCache = new Map<string, EffectivePermission | null>();
+
+function cacheKey(noteId: string, userId: string) {
+    return `${noteId}\0${userId}`;
+}
+
+// Walks the full ancestor chain across every branch so clones are handled correctly.
+function collectAncestorPermissions(noteId: string, userId: string): PermissionRow[] {
+    const sql = getSql();
+    const visited = new Set<string>();
+    const permissions: PermissionRow[] = [];
+
+    // Fetch once up front so each node's permission query doesn't repeat the subquery.
+    const groupIds = sql.getColumn<string>(
+        "SELECT groupId FROM user_group_members WHERE userId = ?", [userId]
+    );
+    const groupPlaceholders = groupIds.length > 0 ? groupIds.map(() => "?").join(",") : "NULL";
+
+    function walk(id: string) {
+        if (visited.has(id)) return;
+        visited.add(id);
+
+        const rows = sql.getRows<PermissionRow>(
+            `SELECT ${PERMISSION_COLS}
+               FROM note_permissions
+              WHERE noteId = ?
+                AND (userId = ? OR groupId IN (${groupPlaceholders}))`,
+            [id, userId, ...groupIds]
+        );
+
+        permissions.push(...rows);
+
+        // Walk up through every parent branch (handles clones).
+        const parentIds = sql.getColumn<string>(
+            "SELECT DISTINCT parentNoteId FROM branches WHERE noteId = ? AND isDeleted = 0 AND parentNoteId != 'none'",
+            [id]
+        );
+        for (const parentId of parentIds) {
+            walk(parentId);
+        }
+    }
+
+    walk(noteId);
+    return permissions;
+}
+
+function getEffectivePermission(noteId: string, userId: string): EffectivePermission | null {
+    if (userService.isUserAdmin(userId)) {
+        return { canRead: true, canWrite: true };
+    }
+
+    const note = getSql().getRowOrNull<{ ownerId: string | null }>(
+        "SELECT ownerId FROM notes WHERE noteId = ? AND isDeleted = 0",
+        [noteId]
+    );
+
+    if (!note) return null;
+
+    if (note.ownerId === userId) {
+        return { canRead: true, canWrite: true };
+    }
+
+    const key = cacheKey(noteId, userId);
+    if (permCache.has(key)) {
+        return permCache.get(key)!;
+    }
+
+    const rows = collectAncestorPermissions(noteId, userId);
+
+    if (rows.length === 0) {
+        permCache.set(key, null);
+        return null;
+    }
+
+    // Merge: highest privilege wins across all matching rows.
+    let canRead = false;
+    let canWrite = false;
+    for (const row of rows) {
+        if (row.canRead) canRead = true;
+        if (row.canWrite) canWrite = true;
+        if (canRead && canWrite) break;
+    }
+
+    // Write implies read; normalize so callers never see canWrite without canRead.
+    const result: EffectivePermission = { canRead: canRead || canWrite, canWrite };
+    permCache.set(key, result);
+    return result;
+}
+
+function canUserAccessNote(noteId: string, userId: string): boolean {
+    return getEffectivePermission(noteId, userId)?.canRead ?? false;
+}
+
+function canUserWriteNote(noteId: string, userId: string): boolean {
+    return getEffectivePermission(noteId, userId)?.canWrite ?? false;
+}
+
+function grantPermission(
+    noteId: string,
+    userId: string | null,
+    groupId: string | null,
+    canWrite: boolean
+): string {
+    if (!userId && !groupId) {
+        throw new Error("permission_service.grantPermission: userId or groupId is required");
+    }
+
+    const permissionId = newEntityId();
+    const now = dateUtils.utcNowDateTime();
+
+    getSql().execute(
+        `INSERT INTO note_permissions (permissionId, noteId, userId, groupId, canRead, canWrite, dateCreated, utcDateModified)
+         VALUES (?, ?, ?, ?, 1, ?, ?, ?)`,
+        [permissionId, noteId, userId, groupId, canWrite ? 1 : 0, now, now]
+    );
+
+    // Permission changes affect the whole inheritance chain; clear everything.
+    clearPermissionCache();
+    return permissionId;
+}
+
+function revokePermission(permissionId: string): void {
+    const row = getSql().getRowOrNull<{ noteId: string }>(
+        "SELECT noteId FROM note_permissions WHERE permissionId = ?",
+        [permissionId]
+    );
+
+    if (!row) {
+        getLog().warn(`permission_service.revokePermission: permissionId not found: ${permissionId}`);
+        return;
+    }
+
+    getSql().execute("DELETE FROM note_permissions WHERE permissionId = ?", [permissionId]);
+    // Permission changes affect the whole inheritance chain; clear everything.
+    clearPermissionCache();
+}
+
+function getPermissionsForNote(noteId: string): PermissionRow[] {
+    return getSql().getRows<PermissionRow>(
+        `SELECT ${PERMISSION_COLS}
+           FROM note_permissions WHERE noteId = ?`,
+        [noteId]
+    );
+}
+
+function clearPermissionCache(): void {
+    permCache.clear();
+}
+
+export default {
+    canUserAccessNote,
+    canUserWriteNote,
+    getEffectivePermission,
+    grantPermission,
+    revokePermission,
+    getPermissionsForNote,
+    clearPermissionCache
+};

--- a/packages/trilium-core/src/services/scheduler.spec.ts
+++ b/packages/trilium-core/src/services/scheduler.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { buildNote } from "../test/becca_easy_mocking.js";
 import attributeService from "./attributes.js";
 import config from "./config.js";
@@ -54,7 +54,7 @@ describe("scheduler", () => {
     let reloadFrontend: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         vi.useFakeTimers();
         vi.spyOn(console, "log").mockImplementation(() => {});
 

--- a/packages/trilium-core/src/services/script.spec.ts
+++ b/packages/trilium-core/src/services/script.spec.ts
@@ -1,7 +1,7 @@
 import { trimIndentation } from "@triliumnext/commons";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { buildNote } from "../test/becca_easy_mocking.js";
 import config from "./config.js";
 import { getContext } from "./context.js";
@@ -22,7 +22,7 @@ describe("Script", () => {
 
     beforeEach(() => {
 
-        becca.reset();
+        getBecca().reset();
         vi.spyOn(ws, "sendMessageToAllClients").mockImplementation(() => {}).mockClear();
 
         buildNote({ id: "root", title: "root" });
@@ -122,7 +122,7 @@ describe("Script", () => {
 
 describe("getScriptBundle", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("returns a bundle for a backend script", () => {
@@ -194,7 +194,7 @@ describe("getScriptBundle", () => {
 
 describe("executeNote", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         vi.spyOn(ws, "sendMessageToAllClients").mockImplementation(() => {}).mockClear();
     });
 
@@ -222,7 +222,7 @@ describe("executeNote", () => {
 
 describe("getScriptBundleForFrontend", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         vi.spyOn(ws, "sendMessageToAllClients").mockImplementation(() => {}).mockClear();
     });
 
@@ -379,14 +379,14 @@ describe("executeScript", () => {
     });
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("executes a frontend script excerpt in the backend context", () => {
         const note = buildNote({ type: "code", mime: "application/javascript;env=backend", content: "" });
 
         getContext().init(() => {
-            const result = scriptService.executeScript(`() => "hello from excerpt"`, [], note.noteId, note.noteId, "notes", note.noteId, becca);
+            const result = scriptService.executeScript(`() => "hello from excerpt"`, [], note.noteId, note.noteId, "notes", note.noteId, getBecca());
             expect(result).toBe("hello from excerpt");
         });
     });
@@ -395,14 +395,14 @@ describe("executeScript", () => {
         const note = buildNote({ type: "code", mime: "application/javascript;env=backend", content: "" });
 
         getContext().init(() => {
-            const result = scriptService.executeScript(`(count, label) => label + ":" + (count + 1)`, [4, "n"], note.noteId, note.noteId, "notes", note.noteId, becca);
+            const result = scriptService.executeScript(`(count, label) => label + ":" + (count + 1)`, [4, "n"], note.noteId, note.noteId, "notes", note.noteId, getBecca());
             expect(result).toBe("n:5");
         });
     });
 
     it("throws when the current note cannot be found", () => {
         getContext().init(() => {
-            expect(() => scriptService.executeScript(`() => 1`, [], "missing", "missing", "notes", "missing", becca)).toThrow(/Cannot find note/);
+            expect(() => scriptService.executeScript(`() => 1`, [], "missing", "missing", "notes", "missing", getBecca())).toThrow(/Cannot find note/);
         });
     });
 });
@@ -419,7 +419,7 @@ describe("executeNoteNoException", () => {
     });
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("swallows runtime errors thrown by the script", () => {

--- a/packages/trilium-core/src/services/script_context.spec.ts
+++ b/packages/trilium-core/src/services/script_context.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import { buildNote } from "../test/becca_easy_mocking.js";
 import BackendScriptApi from "./backend_script_api.js";
 import config from "./config.js";
@@ -19,7 +19,7 @@ describe("ScriptContext", () => {
     });
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("maps every note into the notes and apis objects keyed by noteId", () => {

--- a/packages/trilium-core/src/services/search/expressions/ancestor.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/ancestor.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -10,9 +10,9 @@ import AncestorExp from "./ancestor.js";
 // SearchContext-like argument is unused by execute(), so we pass an empty object.
 const dummySearchContext = {} as any;
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: AncestorExp, inputNoteSet = allNotesSet()) {
@@ -27,7 +27,7 @@ let rootNote: NoteBuilder;
 
 describe("AncestorExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/ancestor.ts
+++ b/packages/trilium-core/src/services/search/expressions/ancestor.ts
@@ -3,7 +3,7 @@
 import Expression from "./expression.js";
 import NoteSet from "../note_set.js";
 import log, { getLog } from "../../log.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type SearchContext from "../search_context.js";
 
 class AncestorExp extends Expression {
@@ -21,7 +21,7 @@ class AncestorExp extends Expression {
     }
 
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
-        const ancestorNote = becca.notes[this.ancestorNoteId];
+        const ancestorNote = getBecca().notes[this.ancestorNoteId];
 
         if (!ancestorNote) {
             getLog().error(`Subtree note '${this.ancestorNoteId}' was not not found.`);

--- a/packages/trilium-core/src/services/search/expressions/attribute_exists.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/attribute_exists.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -10,9 +10,9 @@ import AttributeExistsExp from "./attribute_exists.js";
 // SearchContext-like argument is unused by execute(), so we pass an empty object.
 const dummySearchContext = {} as any;
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: AttributeExistsExp, inputNoteSet = allNotesSet()) {
@@ -27,7 +27,7 @@ let rootNote: NoteBuilder;
 
 describe("AttributeExistsExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/attribute_exists.ts
+++ b/packages/trilium-core/src/services/search/expressions/attribute_exists.ts
@@ -3,7 +3,7 @@
 import NoteSet from "../note_set.js";
 import type SearchContext from "../search_context.js";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import Expression from "./expression.js";
 
 class AttributeExistsExp extends Expression {
@@ -23,7 +23,7 @@ class AttributeExistsExp extends Expression {
     }
 
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
-        const attrs = this.prefixMatch ? becca.findAttributesWithPrefix(this.attributeType, this.attributeName) : becca.findAttributes(this.attributeType, this.attributeName);
+        const attrs = this.prefixMatch ? getBecca().findAttributesWithPrefix(this.attributeType, this.attributeName) : getBecca().findAttributes(this.attributeType, this.attributeName);
 
         const resultNoteSet = new NoteSet();
 

--- a/packages/trilium-core/src/services/search/expressions/child_of.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/child_of.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -33,7 +33,7 @@ let rootNote: NoteBuilder;
 
 describe("ChildOfExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/descendant_of.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/descendant_of.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -29,16 +29,16 @@ function noteIds(noteSet: NoteSet) {
     return noteSet.notes.map((n) => n.noteId).sort();
 }
 
-/** A NoteSet containing every note currently registered in becca. */
+/** A NoteSet containing every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 let rootNote: NoteBuilder;
 
 describe("DescendantOfExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/descendant_of.ts
+++ b/packages/trilium-core/src/services/search/expressions/descendant_of.ts
@@ -2,7 +2,7 @@
 
 import Expression from "./expression.js";
 import NoteSet from "../note_set.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type SearchContext from "../search_context.js";
 
 class DescendantOfExp extends Expression {
@@ -15,7 +15,7 @@ class DescendantOfExp extends Expression {
     }
 
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
-        const subInputNoteSet = new NoteSet(Object.values(becca.notes));
+        const subInputNoteSet = new NoteSet(Object.values(getBecca().notes));
         const subResNoteSet = this.subExpression.execute(subInputNoteSet, executionContext, searchContext);
 
         const subTreeNoteSet = new NoteSet();

--- a/packages/trilium-core/src/services/search/expressions/is_hidden.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/is_hidden.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -10,9 +10,9 @@ import IsHiddenExp from "./is_hidden.js";
 // SearchContext-like argument is unused by execute(), so we pass an empty object.
 const dummySearchContext = {} as any;
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: IsHiddenExp, inputNoteSet = allNotesSet()) {
@@ -28,7 +28,7 @@ let hiddenNote: NoteBuilder;
 
 describe("IsHiddenExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/label_comparison.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/label_comparison.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -10,9 +10,9 @@ import LabelComparisonExp from "./label_comparison.js";
 // SearchContext-like argument is unused by execute(), so we pass an empty object.
 const dummySearchContext = {} as any;
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: LabelComparisonExp, inputNoteSet = allNotesSet()) {
@@ -27,7 +27,7 @@ let rootNote: NoteBuilder;
 
 describe("LabelComparisonExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/label_comparison.ts
+++ b/packages/trilium-core/src/services/search/expressions/label_comparison.ts
@@ -2,7 +2,7 @@
 
 import Expression from "./expression.js";
 import NoteSet from "../note_set.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type SearchContext from "../search_context.js";
 
 type Comparator = (value: string) => boolean;
@@ -21,7 +21,7 @@ class LabelComparisonExp extends Expression {
     }
 
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
-        const attrs = becca.findAttributes(this.attributeType, this.attributeName);
+        const attrs = getBecca().findAttributes(this.attributeType, this.attributeName);
         const resultNoteSet = new NoteSet();
 
         for (const attr of attrs) {

--- a/packages/trilium-core/src/services/search/expressions/not.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/not.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { note } from "../../../test/becca_mocking.js";
 import NoteSet from "../note_set.js";
@@ -35,7 +35,7 @@ let a: BNote, b: BNote, c: BNote;
 
 describe("NotExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         a = note("A").note;
         b = note("B").note;

--- a/packages/trilium-core/src/services/search/expressions/note_content_fulltext.ts
+++ b/packages/trilium-core/src/services/search/expressions/note_content_fulltext.ts
@@ -1,6 +1,6 @@
 import type { NoteRow } from "@triliumnext/commons";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import { getLog } from "../../log.js";
 import protectedSessionService from "../../protected_session.js";
 import NoteSet from "../note_set.js";
@@ -93,11 +93,11 @@ class NoteContentFulltextExp extends Expression {
         if (this.flatText && (this.operator === "=" || this.operator === "!=")) {
             for (const note of inputNoteSet.notes) {
                 // Skip if already found or doesn't exist
-                if (resultNoteSet.hasNoteId(note.noteId) || !(note.noteId in becca.notes)) {
+                if (resultNoteSet.hasNoteId(note.noteId) || !(note.noteId in getBecca().notes)) {
                     continue;
                 }
 
-                const noteFromBecca = becca.notes[note.noteId];
+                const noteFromBecca = getBecca().notes[note.noteId];
                 const flatText = noteFromBecca.getFlatText();
 
                 // For flatText, only check attribute values (format: #name=value or ~name=value)
@@ -192,7 +192,7 @@ class NoteContentFulltextExp extends Expression {
     }
 
     findInText({ noteId, isProtected, content, type, mime }: SearchRow, inputNoteSet: NoteSet, resultNoteSet: NoteSet) {
-        if (!inputNoteSet.hasNoteId(noteId) || !(noteId in becca.notes)) {
+        if (!inputNoteSet.hasNoteId(noteId) || !(noteId in getBecca().notes)) {
             return;
         }
 
@@ -230,14 +230,14 @@ class NoteContentFulltextExp extends Expression {
                 matches = this.containsExactWord(token, content);
                 // Also check flatText if enabled (includes attributes)
                 if (!matches && this.flatText) {
-                    const flatText = becca.notes[noteId].getFlatText();
+                    const flatText = getBecca().notes[noteId].getFlatText();
                     matches = this.containsExactPhrase([token], flatText, true);
                 }
             } else if (this.operator === "!=") {
                 matches = !this.containsExactWord(token, content);
                 // For negation, check flatText too
                 if (matches && this.flatText) {
-                    const flatText = becca.notes[noteId].getFlatText();
+                    const flatText = getBecca().notes[noteId].getFlatText();
                     matches = !this.containsExactPhrase([token], flatText, true);
                 }
             }
@@ -251,14 +251,14 @@ class NoteContentFulltextExp extends Expression {
                 (this.operator === "~=" && this.matchesWithFuzzy(content, noteId)) ||
                 (this.operator === "~*" && this.fuzzyMatchToken(normalizeSearchText(token), normalizeSearchText(content)))
             ) {
-                resultNoteSet.add(becca.notes[noteId]);
+                resultNoteSet.add(getBecca().notes[noteId]);
             }
         } else {
             // Multi-token matching with fuzzy support and phrase proximity
             if (this.operator === "~=" || this.operator === "~*") {
                 // Fuzzy phrase matching
                 if (this.matchesWithFuzzy(content, noteId)) {
-                    resultNoteSet.add(becca.notes[noteId]);
+                    resultNoteSet.add(getBecca().notes[noteId]);
                 }
             } else if (this.operator === "=" || this.operator === "!=") {
                 // Exact phrase matching for = and !=
@@ -266,13 +266,13 @@ class NoteContentFulltextExp extends Expression {
 
                 // Also check flatText if enabled (includes attributes)
                 if (!matches && this.flatText) {
-                    const flatText = becca.notes[noteId].getFlatText();
+                    const flatText = getBecca().notes[noteId].getFlatText();
                     matches = this.containsExactPhrase(this.tokens, flatText, true);
                 }
 
                 if ((this.operator === "=" && matches) ||
                     (this.operator === "!=" && !matches)) {
-                    resultNoteSet.add(becca.notes[noteId]);
+                    resultNoteSet.add(getBecca().notes[noteId]);
                 }
             } else {
                 // Other operators: check all tokens present (any order)
@@ -282,7 +282,7 @@ class NoteContentFulltextExp extends Expression {
                 );
 
                 if (!nonMatchingToken) {
-                    resultNoteSet.add(becca.notes[noteId]);
+                    resultNoteSet.add(getBecca().notes[noteId]);
                 }
             }
         }
@@ -302,7 +302,7 @@ class NoteContentFulltextExp extends Expression {
         }
 
         // Check flat text for default fulltext search
-        if (!this.flatText || !becca.notes[noteId].getFlatText().includes(token)) {
+        if (!this.flatText || !getBecca().notes[noteId].getFlatText().includes(token)) {
             return false;
         }
 
@@ -315,7 +315,7 @@ class NoteContentFulltextExp extends Expression {
     private matchesWithFuzzy(content: string, noteId: string): boolean {
         try {
             const normalizedContent = normalizeSearchText(content);
-            const flatText = this.flatText ? normalizeSearchText(becca.notes[noteId].getFlatText()) : "";
+            const flatText = this.flatText ? normalizeSearchText(getBecca().notes[noteId].getFlatText()) : "";
 
             // For phrase matching, check if tokens appear within reasonable proximity
             if (this.tokens.length > 1) {

--- a/packages/trilium-core/src/services/search/expressions/note_flat_text.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/note_flat_text.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -20,9 +20,9 @@ function searchContext(overrides: Record<string, unknown> = {}) {
     } as any;
 }
 
-/** Build a NoteSet containing every note currently registered in becca. */
+/** Build a NoteSet containing every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: NoteFlatTextExp, ctx = searchContext(), inputNoteSet = allNotesSet()) {
@@ -39,7 +39,7 @@ let rootNote: NoteBuilder;
 
 describe("NoteFlatTextExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/note_flat_text.ts
+++ b/packages/trilium-core/src/services/search/expressions/note_flat_text.ts
@@ -1,5 +1,5 @@
 import becca_service from "../../../becca/becca_service.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import NoteSet from "../note_set.js";
 import type SearchContext from "../search_context.js";
@@ -48,7 +48,7 @@ class NoteFlatTextExp extends Expression {
                     if (!resultNoteSet.hasNoteId(noteId)) {
                         // Snapshot takenPath since it's mutable
                         executionContext.noteIdToNotePath[noteId] = resultPath;
-                        resultNoteSet.add(becca.notes[noteId]);
+                        resultNoteSet.add(getBecca().notes[noteId]);
                     }
                 }
 
@@ -173,7 +173,7 @@ class NoteFlatTextExp extends Expression {
         } else {
             // this note is the closest to root containing the last matching token(s), thus completing the requirements
             // what's in this note's predecessors does not matter, thus we'll choose the best note path
-            const topMostMatchingTokenNotePath = becca.getNote(takenPath[0])?.getBestNotePath() || [];
+            const topMostMatchingTokenNotePath = getBecca().getNote(takenPath[0])?.getBestNotePath() || [];
 
             return [...topMostMatchingTokenNotePath, ...takenPath.slice(1)];
         }
@@ -188,7 +188,7 @@ class NoteFlatTextExp extends Expression {
         // Use the pre-built flat text index for fast scanning.
         // This provides pre-computed flat texts in a parallel array, avoiding
         // per-note property access overhead at large scale (50K+ notes).
-        const { notes: indexNotes, flatTexts } = becca.getFlatTextIndex();
+        const { notes: indexNotes, flatTexts } = getBecca().getFlatTextIndex();
 
         // Build a set for quick membership check when noteSet isn't the full set
         const isFullSet = noteSet.notes.length === indexNotes.length;

--- a/packages/trilium-core/src/services/search/expressions/ocr_content.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/ocr_content.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { getContext } from "../../context.js";
 import noteService from "../../notes.js";
@@ -71,9 +71,9 @@ function setTextRepresentationForBlob(blobId: string, textRepresentation: string
     ]);
 }
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(

--- a/packages/trilium-core/src/services/search/expressions/ocr_content.ts
+++ b/packages/trilium-core/src/services/search/expressions/ocr_content.ts
@@ -1,4 +1,4 @@
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import { getSql } from "../../sql/index.js";
 import NoteSet from "../note_set.js";
 import type SearchContext from "../search_context.js";
@@ -24,7 +24,7 @@ export default class OCRContentExpression extends Expression {
         const matchingNoteIds = this.findNoteIdsWithMatchingOCR();
 
         for (const noteId of matchingNoteIds) {
-            const note = becca.notes[noteId];
+            const note = getBecca().notes[noteId];
             if (note && inputNoteSet.hasNoteId(noteId)) {
                 resultNoteSet.add(note);
             }

--- a/packages/trilium-core/src/services/search/expressions/or.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/or.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { note } from "../../../test/becca_mocking.js";
 import Expression from "./expression.js";
@@ -35,7 +35,7 @@ let c: BNote;
 
 describe("OrExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         a = note("A").note;
         b = note("B").note;

--- a/packages/trilium-core/src/services/search/expressions/order_by_and_limit.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/order_by_and_limit.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { note } from "../../../test/becca_mocking.js";
 import NoteSet from "../note_set.js";
@@ -37,7 +37,7 @@ function extractorFor(values: Record<string, number | string | null>) {
 
 describe("OrderByAndLimitExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("derives smaller/larger comparison signs from the direction", () => {

--- a/packages/trilium-core/src/services/search/expressions/parent_of.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/parent_of.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
@@ -33,7 +33,7 @@ let rootNote: NoteBuilder;
 
 describe("ParentOfExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/property_comparison.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/property_comparison.spec.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../../test/becca_mocking.js";
 import NoteSet from "../note_set.js";
 import PropertyComparisonExp from "./property_comparison.js";
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: PropertyComparisonExp, searchContext: any = {}, inputNoteSet = allNotesSet()) {
@@ -24,7 +24,7 @@ let rootNote: NoteBuilder;
 
 describe("PropertyComparisonExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/expressions/relation_where.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/relation_where.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import BAttribute from "../../../becca/entities/battribute.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import BNote from "../../../becca/entities/bnote.js";
@@ -12,9 +12,9 @@ import RelationWhereExp from "./relation_where.js";
 // SearchContext-like argument is unused by execute(), so we pass an empty object.
 const dummySearchContext = {} as any;
 
-/** Build a NoteSet that contains every note currently registered in becca. */
+/** Build a NoteSet that contains every note currently registered in getBecca(). */
 function allNotesSet() {
-    return new NoteSet(Object.values(becca.notes));
+    return new NoteSet(Object.values(getBecca().notes));
 }
 
 function execute(exp: RelationWhereExp, inputNoteSet = allNotesSet()) {
@@ -52,7 +52,7 @@ let rootNote: NoteBuilder;
 
 describe("RelationWhereExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({
@@ -132,7 +132,7 @@ describe("RelationWhereExp", () => {
         // Build the relation against a note that is never attached to the tree and
         // then remove it from becca so attr.targetNote resolves to undefined.
         const ghostId = source.note.getRelationValue("author")!;
-        delete becca.notes[ghostId];
+        delete getBecca().notes[ghostId];
         rootNote.child(source);
 
         const exp = new RelationWhereExp("author", matchAll());

--- a/packages/trilium-core/src/services/search/expressions/relation_where.ts
+++ b/packages/trilium-core/src/services/search/expressions/relation_where.ts
@@ -2,7 +2,7 @@
 
 import Expression from "./expression.js";
 import NoteSet from "../note_set.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type SearchContext from "../search_context.js";
 
 class RelationWhereExp extends Expression {
@@ -19,7 +19,7 @@ class RelationWhereExp extends Expression {
     execute(inputNoteSet: NoteSet, executionContext: {}, searchContext: SearchContext) {
         const candidateNoteSet = new NoteSet();
 
-        for (const attr of becca.findAttributes("relation", this.relationName)) {
+        for (const attr of getBecca().findAttributes("relation", this.relationName)) {
             const note = attr.note;
 
             if (inputNoteSet.hasNoteId(note.noteId) && attr.targetNote) {

--- a/packages/trilium-core/src/services/search/expressions/true.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/true.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import { note } from "../../../test/becca_mocking.js";
 import Expression from "./expression.js";
@@ -15,7 +15,7 @@ let b: BNote;
 
 describe("TrueExp", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         a = note("A").note;
         b = note("B").note;

--- a/packages/trilium-core/src/services/search/note_set.spec.ts
+++ b/packages/trilium-core/src/services/search/note_set.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BNote from "../../becca/entities/bnote.js";
 import { buildNote } from "../../test/becca_easy_mocking.js";
 import NoteSet from "./note_set.js";
@@ -11,7 +11,7 @@ describe("NoteSet", () => {
     let c: BNote;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         a = buildNote({ id: "a", title: "A" });
         b = buildNote({ id: "b", title: "B" });
         c = buildNote({ id: "c", title: "C" });

--- a/packages/trilium-core/src/services/search/search_result.spec.ts
+++ b/packages/trilium-core/src/services/search/search_result.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BBranch from "../../becca/entities/bbranch.js";
 import BNote from "../../becca/entities/bnote.js";
 import { note, NoteBuilder } from "../../test/becca_mocking.js";
@@ -15,7 +15,7 @@ function resultFor(noteBuilder: NoteBuilder) {
 
 describe("SearchResult", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({

--- a/packages/trilium-core/src/services/search/search_result.ts
+++ b/packages/trilium-core/src/services/search/search_result.ts
@@ -1,4 +1,4 @@
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import becca_service from "../../becca/becca_service.js";
 import {
     calculateOptimizedEditDistance,
@@ -55,7 +55,7 @@ class SearchResult {
         this.score = 0;
         this.fuzzyScore = 0; // Reset fuzzy score tracking
 
-        const note = becca.notes[this.noteId];
+        const note = getBecca().notes[this.noteId];
         // normalizeSearchText already lowercases — no need for .toLowerCase() first
         const normalizedQuery = normalizeSearchText(fulltextQuery);
         const normalizedTitle = normalizeSearchText(note.title);

--- a/packages/trilium-core/src/services/search/search_result_ocr.spec.ts
+++ b/packages/trilium-core/src/services/search/search_result_ocr.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import BNote from "../../becca/entities/bnote.js";
 import { buildNote } from "../../test/becca_easy_mocking.js";
 import SearchResult from "./search_result.js";
@@ -9,7 +9,7 @@ describe("SearchResult", () => {
     let note: BNote;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
         note = buildNote({
             id: "test123",
             title: "Test Note"

--- a/packages/trilium-core/src/services/search/services/progressive_search.spec.ts
+++ b/packages/trilium-core/src/services/search/services/progressive_search.spec.ts
@@ -3,14 +3,14 @@ import searchService from "./search.js";
 import BNote from "../../../becca/entities/bnote.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import SearchContext from "../search_context.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import { findNoteByTitle, note, NoteBuilder } from "../../../test/becca_mocking.js";
 
 describe("Progressive Search Strategy", () => {
     let rootNote: any;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({
@@ -94,7 +94,7 @@ describe("Progressive Search Strategy", () => {
             expect(searchResults.length).toBe(4);
 
             // Get the note titles in result order
-            const resultTitles = searchResults.map(r => becca.notes[r.noteId].title);
+            const resultTitles = searchResults.map(r => getBecca().notes[r.noteId].title);
             
             // Find positions of exact and fuzzy matches
             const exactPositions = resultTitles.map((title, index) => 
@@ -181,8 +181,8 @@ describe("Progressive Search Strategy", () => {
             expect(searchResults.length).toBe(2);
             
             // Find the exact and fuzzy match results
-            const exactResult = searchResults.find(r => becca.notes[r.noteId].title === "Test Document");
-            const fuzzyResult = searchResults.find(r => becca.notes[r.noteId].title.includes("Tset"));
+            const exactResult = searchResults.find(r => getBecca().notes[r.noteId].title === "Test Document");
+            const fuzzyResult = searchResults.find(r => getBecca().notes[r.noteId].title.includes("Tset"));
 
             expect(exactResult).toBeTruthy();
             expect(fuzzyResult).toBeTruthy();

--- a/packages/trilium-core/src/services/search/services/search.spec.ts
+++ b/packages/trilium-core/src/services/search/services/search.spec.ts
@@ -4,14 +4,14 @@ import BNote from "../../../becca/entities/bnote.js";
 import BBranch from "../../../becca/entities/bbranch.js";
 import SearchContext from "../search_context.js";
 import dateUtils from "../../utils/date.js";
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import { findNoteByTitle, note, NoteBuilder } from "../../../test/becca_mocking.js";
 
 describe("Search", () => {
     let rootNote: any;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(new BNote({ noteId: "root", title: "root", type: "text" }));
         new BBranch({
@@ -632,29 +632,29 @@ describe("Search", () => {
 
         let searchResults = searchService.findResultsWithQuery("# note.parents.title = Europe orderBy note.title", searchContext);
         expect(searchResults.length).toEqual(4);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Austria");
-        expect(becca.notes[searchResults[1].noteId].title).toEqual("Italy");
-        expect(becca.notes[searchResults[2].noteId].title).toEqual("Slovakia");
-        expect(becca.notes[searchResults[3].noteId].title).toEqual("Ukraine");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Austria");
+        expect(getBecca().notes[searchResults[1].noteId].title).toEqual("Italy");
+        expect(getBecca().notes[searchResults[2].noteId].title).toEqual("Slovakia");
+        expect(getBecca().notes[searchResults[3].noteId].title).toEqual("Ukraine");
 
         searchResults = searchService.findResultsWithQuery("# note.parents.title = Europe orderBy note.labels.capital", searchContext);
         expect(searchResults.length).toEqual(4);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Slovakia");
-        expect(becca.notes[searchResults[1].noteId].title).toEqual("Ukraine");
-        expect(becca.notes[searchResults[2].noteId].title).toEqual("Italy");
-        expect(becca.notes[searchResults[3].noteId].title).toEqual("Austria");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Slovakia");
+        expect(getBecca().notes[searchResults[1].noteId].title).toEqual("Ukraine");
+        expect(getBecca().notes[searchResults[2].noteId].title).toEqual("Italy");
+        expect(getBecca().notes[searchResults[3].noteId].title).toEqual("Austria");
 
         searchResults = searchService.findResultsWithQuery("# note.parents.title = Europe orderBy note.labels.capital DESC", searchContext);
         expect(searchResults.length).toEqual(4);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Austria");
-        expect(becca.notes[searchResults[1].noteId].title).toEqual("Italy");
-        expect(becca.notes[searchResults[2].noteId].title).toEqual("Ukraine");
-        expect(becca.notes[searchResults[3].noteId].title).toEqual("Slovakia");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Austria");
+        expect(getBecca().notes[searchResults[1].noteId].title).toEqual("Italy");
+        expect(getBecca().notes[searchResults[2].noteId].title).toEqual("Ukraine");
+        expect(getBecca().notes[searchResults[3].noteId].title).toEqual("Slovakia");
 
         searchResults = searchService.findResultsWithQuery("# note.parents.title = Europe orderBy note.labels.capital DESC limit 2", searchContext);
         expect(searchResults.length).toEqual(2);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Austria");
-        expect(becca.notes[searchResults[1].noteId].title).toEqual("Italy");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Austria");
+        expect(getBecca().notes[searchResults[1].noteId].title).toEqual("Italy");
 
         searchResults = searchService.findResultsWithQuery("# note.parents.title = Europe orderBy #capital DESC limit 1", searchContext);
         expect(searchResults.length).toEqual(1);
@@ -673,11 +673,11 @@ describe("Search", () => {
 
         let searchResults = searchService.findResultsWithQuery("# not(#capital) and note.noteId != root", searchContext);
         expect(searchResults.length).toEqual(1);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Europe");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Europe");
 
         searchResults = searchService.findResultsWithQuery("#!capital and note.noteId != root", searchContext);
         expect(searchResults.length).toEqual(1);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Europe");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Europe");
     });
 
     it("test note.text *=* something", () => {
@@ -690,7 +690,7 @@ describe("Search", () => {
 
         let searchResults = searchService.findResultsWithQuery("# note.text *=* vaki and note.noteId != root", searchContext);
         expect(searchResults.length).toEqual(1);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Slovakia");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Slovakia");
     });
 
     it("test that fulltext does not match archived notes", () => {
@@ -703,7 +703,7 @@ describe("Search", () => {
 
         let searchResults = searchService.findResultsWithQuery("reddit", searchContext);
         expect(searchResults.length).toEqual(1);
-        expect(becca.notes[searchResults[0].noteId].title).toEqual("Reddit is bad");
+        expect(getBecca().notes[searchResults[0].noteId].title).toEqual("Reddit is bad");
     });
 
     it("search completes in reasonable time", () => {
@@ -747,7 +747,7 @@ describe("Search", () => {
         expect(searchResults.length).toEqual(5);
 
         // Get note titles in result order
-        const resultTitles = searchResults.map(r => becca.notes[r.noteId].title);
+        const resultTitles = searchResults.map(r => getBecca().notes[r.noteId].title);
 
         // Find all exact matches (contain "analysis")
         const exactMatchIndices = resultTitles.map((title, index) =>

--- a/packages/trilium-core/src/services/search/services/search.ts
+++ b/packages/trilium-core/src/services/search/services/search.ts
@@ -1,7 +1,7 @@
 import normalizeString from "normalize-strings";
 import striptags from "striptags";
 
-import becca from "../../../becca/becca.js";
+import { getBecca } from "../../../becca/becca.js";
 import becca_service from "../../../becca/becca_service.js";
 import type BNote from "../../../becca/entities/bnote.js";
 import hoistedNoteService from "../../hoisted_note.js";
@@ -139,13 +139,13 @@ function loadNeededInfoFromDatabase() {
         WHERE notes.isDeleted = 0`);
 
     for (const { noteId, blobId, length } of noteContentLengths) {
-        if (!(noteId in becca.notes)) {
-            log.error(`Note '${noteId}' not found in becca.`);
+        if (!(noteId in getBecca().notes)) {
+            log.error(`Note '${noteId}' not found in getBecca().`);
             continue;
         }
 
-        becca.notes[noteId].contentSize = length;
-        becca.notes[noteId].revisionCount = 0;
+        getBecca().notes[noteId].contentSize = length;
+        getBecca().notes[noteId].revisionCount = 0;
 
         noteBlobs[noteId] = { [blobId]: length };
     }
@@ -167,8 +167,8 @@ function loadNeededInfoFromDatabase() {
             AND notes.isDeleted = 0`);
 
     for (const { noteId, blobId, length } of attachmentContentLengths) {
-        if (!(noteId in becca.notes)) {
-            log.error(`Note '${noteId}' not found in becca.`);
+        if (!(noteId in getBecca().notes)) {
+            log.error(`Note '${noteId}' not found in getBecca().`);
             continue;
         }
 
@@ -181,7 +181,7 @@ function loadNeededInfoFromDatabase() {
     }
 
     for (const noteId in noteBlobs) {
-        becca.notes[noteId].contentAndAttachmentsSize = Object.values(noteBlobs[noteId]).reduce((acc, size) => acc + size, 0);
+        getBecca().notes[noteId].contentAndAttachmentsSize = Object.values(noteBlobs[noteId]).reduce((acc, size) => acc + size, 0);
     }
 
     type RevisionRow = {
@@ -213,8 +213,8 @@ function loadNeededInfoFromDatabase() {
             WHERE notes.isDeleted = 0`);
 
     for (const { noteId, blobId, length, isNoteRevision } of revisionContentLengths) {
-        if (!(noteId in becca.notes)) {
-            log.error(`Note '${noteId}' not found in becca.`);
+        if (!(noteId in getBecca().notes)) {
+            log.error(`Note '${noteId}' not found in getBecca().`);
             continue;
         }
 
@@ -226,7 +226,7 @@ function loadNeededInfoFromDatabase() {
         noteBlobs[noteId][blobId] = length;
 
         if (isNoteRevision) {
-            const noteRevision = becca.notes[noteId];
+            const noteRevision = getBecca().notes[noteId];
             if (noteRevision && noteRevision.revisionCount) {
                 noteRevision.revisionCount++;
             }
@@ -234,7 +234,7 @@ function loadNeededInfoFromDatabase() {
     }
 
     for (const noteId in noteBlobs) {
-        becca.notes[noteId].contentAndAttachmentsAndRevisionsSize = Object.values(noteBlobs[noteId]).reduce((acc, size) => acc + size, 0);
+        getBecca().notes[noteId].contentAndAttachmentsAndRevisionsSize = Object.values(noteBlobs[noteId]).reduce((acc, size) => acc + size, 0);
     }
 }
 
@@ -278,7 +278,7 @@ function findResultsWithExpression(expression: Expression, searchContext: Search
 }
 
 function performSearch(expression: Expression, searchContext: SearchContext, enableFuzzyMatching: boolean): SearchResult[] {
-    const allNoteSet = becca.getAllNoteSet();
+    const allNoteSet = getBecca().getAllNoteSet();
 
     const noteIdToNotePath: Record<string, string[]> = {};
     const executionContext = {
@@ -409,7 +409,7 @@ function parseQueryToExpression(query: string, searchContext: SearchContext) {
 function searchNotes(query: string, params: SearchParams = {}): BNote[] {
     const searchResults = findResultsWithQuery(query, new SearchContext(params));
 
-    return searchResults.map((sr) => becca.notes[sr.noteId]);
+    return searchResults.map((sr) => getBecca().notes[sr.noteId]);
 }
 
 function findResultsWithQuery(query: string, searchContext: SearchContext): SearchResult[] {
@@ -438,7 +438,7 @@ function findResultsWithQuery(query: string, searchContext: SearchContext): Sear
 function findFirstNoteWithQuery(query: string, searchContext: SearchContext): BNote | null {
     const searchResults = findResultsWithQuery(query, searchContext);
 
-    return searchResults.length > 0 ? becca.notes[searchResults[0].noteId] : null;
+    return searchResults.length > 0 ? getBecca().notes[searchResults[0].noteId] : null;
 }
 
 /**
@@ -462,7 +462,7 @@ function getTextRepresentationForNote(note: BNote): string | null {
 }
 
 function extractContentSnippet(noteId: string, searchTokens: string[], maxLength: number = 200): string {
-    const note = becca.notes[noteId];
+    const note = getBecca().notes[noteId];
     if (!note) {
         return "";
     }
@@ -591,7 +591,7 @@ function extractContentSnippet(noteId: string, searchTokens: string[], maxLength
 }
 
 function extractAttributeSnippet(noteId: string, searchTokens: string[], maxLength: number = 200): string {
-    const note = becca.notes[noteId];
+    const note = getBecca().notes[noteId];
     if (!note) {
         return "";
     }
@@ -638,7 +638,7 @@ function extractAttributeSnippet(noteId: string, searchTokens: string[], maxLeng
                 line = attr.value ? `#${attr.name}="${attr.value}"` : `#${attr.name}`;
             } else if (attr.type === "relation") {
                 // For relations, show the target note title if possible
-                const targetNote = attr.value ? becca.notes[attr.value] : null;
+                const targetNote = attr.value ? getBecca().notes[attr.value] : null;
                 const targetTitle = targetNote ? targetNote.title : attr.value;
                 line = `~${attr.name}="${targetTitle}"`;
             }

--- a/packages/trilium-core/src/services/search/value_extractor.spec.ts
+++ b/packages/trilium-core/src/services/search/value_extractor.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import ValueExtractor from "./value_extractor.js";
-import becca from "../../becca/becca.js";
+import { getBecca } from "../../becca/becca.js";
 import SearchContext from "./search_context.js";
 import { note } from "../../test/becca_mocking.js";
 
@@ -16,7 +16,7 @@ beforeAll(() => {
 
 describe("Value extractor", () => {
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
     });
 
     it("simple title extraction", async () => {

--- a/packages/trilium-core/src/services/setup.ts
+++ b/packages/trilium-core/src/services/setup.ts
@@ -6,7 +6,7 @@ import optionService from "./options.js";
 import syncOptions from "./sync_options.js";
 import appInfo from "./app_info.js";
 import { timeLimit } from "./utils/index.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type { SetupStatusResponse, SetupSyncFromServerResponse, SetupSyncSeedResponse } from "@triliumnext/commons";
 import request from "./request.js";
 
@@ -114,7 +114,7 @@ async function setupSyncFromSyncServer(syncServerHost: string, syncProxy: string
 }
 
 function getSyncSeedOptions() {
-    return [becca.getOption("documentId"), becca.getOption("documentSecret")];
+    return [getBecca().getOption("documentId"), getBecca().getOption("documentSecret")];
 }
 
 export default {

--- a/packages/trilium-core/src/services/special_notes.spec.ts
+++ b/packages/trilium-core/src/services/special_notes.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import attributeService from "./attributes.js";
 import { getContext } from "./context.js";
@@ -61,7 +61,7 @@ describe("special_notes (core, real DB)", () => {
 
             expect(result.success).toBe(true);
             expect(result.branchId).toBeTruthy();
-            expect(becca.getBranch(result.branchId!)).toBeTruthy();
+            expect(getBecca().getBranch(result.branchId!)).toBeTruthy();
 
             // After saving, the console must no longer hang off the hidden subtree.
             const liveParents = note.getParentBranches().filter((b) => !b.isDeleted);
@@ -71,7 +71,7 @@ describe("special_notes (core, real DB)", () => {
 
         it("uses an explicit #sqlConsoleHome target note when present", async () => {
             // A real, root-anchored note used as the clone target.
-            const home = becca.getNoteOrThrow("root").getChildNotes()[0];
+            const home = getBecca().getNoteOrThrow("root").getChildNotes()[0];
             vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(home);
 
             const note = getContext().init(() => specialNotes.createSqlConsole());
@@ -132,7 +132,7 @@ describe("special_notes (core, real DB)", () => {
 
             expect(result.success).toBe(true);
             expect(result.branchId).toBeTruthy();
-            expect(becca.getBranch(result.branchId!)).toBeTruthy();
+            expect(getBecca().getBranch(result.branchId!)).toBeTruthy();
 
             const liveParents = note.getParentBranches().filter((b) => !b.isDeleted);
             expect(liveParents.length).toBeGreaterThan(0);
@@ -147,7 +147,7 @@ describe("special_notes (core, real DB)", () => {
         });
 
         it("returns the #inbox-labelled note when at the root workspace", () => {
-            const inbox = becca.getNoteOrThrow("root").getChildNotes()[0];
+            const inbox = getBecca().getNoteOrThrow("root").getChildNotes()[0];
             vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(inbox);
 
             const result = specialNotes.getInboxNote("2026-05-29");
@@ -165,8 +165,8 @@ describe("special_notes (core, real DB)", () => {
         });
 
         it("prefers #workspaceInbox over #inbox within a non-root workspace", () => {
-            const workspaceInbox = becca.getNoteOrThrow("root").getChildNotes()[0];
-            const plainInbox = becca.getNoteOrThrow("root").getChildNotes()[1];
+            const workspaceInbox = getBecca().getNoteOrThrow("root").getChildNotes()[0];
+            const plainInbox = getBecca().getNoteOrThrow("root").getChildNotes()[1];
             const workspace = makeWorkspaceStub({
                 "#workspaceInbox": workspaceInbox,
                 "#inbox": plainInbox
@@ -243,7 +243,7 @@ describe("special_notes (core, real DB)", () => {
 
             getContext().init(() => specialNotes.resetLauncher(note.noteId));
 
-            expect(becca.getNote(note.noteId)?.isDeleted ?? true).toBe(true);
+            expect(getBecca().getNote(note.noteId)?.isDeleted ?? true).toBe(true);
         });
 
         it("only resets the children (not the root note itself) for the launchbar roots", () => {
@@ -256,7 +256,7 @@ describe("special_notes (core, real DB)", () => {
                 deleteNote: vi.fn(),
                 getChildNotes: () => [childA, childB]
             };
-            vi.spyOn(becca, "getNote").mockReturnValue(rootNote as any);
+            vi.spyOn(getBecca(), "getNote").mockReturnValue(rootNote as any);
 
             getContext().init(() => specialNotes.resetLauncher("_lbRoot"));
 
@@ -272,7 +272,7 @@ describe("special_notes (core, real DB)", () => {
             getContext().init(() => specialNotes.resetLauncher(plain.noteId));
 
             // Search notes are not launchbar config, so they are left intact.
-            expect(becca.getNote(plain.noteId)?.isDeleted).toBe(false);
+            expect(getBecca().getNote(plain.noteId)?.isDeleted).toBe(false);
         });
     });
 
@@ -367,7 +367,7 @@ describe("special_notes (core, real DB)", () => {
  * searchNoteInSubtree is global, so genuine labels would collide between tests).
  */
 function makeWorkspaceStub(found: Record<string, unknown>) {
-    const real = becca.getNoteOrThrow("root").getChildNotes()[0];
+    const real = getBecca().getNoteOrThrow("root").getChildNotes()[0];
     return new Proxy(real, {
         get(target, prop) {
             if (prop === "isRoot") {

--- a/packages/trilium-core/src/services/special_notes.ts
+++ b/packages/trilium-core/src/services/special_notes.ts
@@ -1,6 +1,6 @@
 import attributeService from "./attributes.js";
 import dateNoteService from "./date_notes.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import noteService from "./notes.js";
 import dateUtils from "./utils/date.js";
 import { getLog } from "./log.js";
@@ -53,7 +53,7 @@ function createSqlConsole() {
 }
 
 async function saveSqlConsole(sqlConsoleNoteId: string) {
-    const sqlConsoleNote = becca.getNote(sqlConsoleNoteId);
+    const sqlConsoleNote = getBecca().getNote(sqlConsoleNoteId);
     if (!sqlConsoleNote) throw new Error(`Unable to find SQL console note ID: ${sqlConsoleNoteId}`);
     const today = dateUtils.localNowDate();
 
@@ -105,7 +105,7 @@ function getSearchHome() {
 }
 
 function saveSearchNote(searchNoteId: string) {
-    const searchNote = becca.getNote(searchNoteId);
+    const searchNote = getBecca().getNote(searchNoteId);
     if (!searchNote) {
         throw new Error("Unable to find search note");
     }
@@ -212,7 +212,7 @@ function createLauncher({ parentNoteId, launcherType, noteId }: LauncherConfig) 
 }
 
 function resetLauncher(noteId: string) {
-    const note = becca.getNote(noteId);
+    const note = getBecca().getNote(noteId);
 
     if (note?.isLaunchBarConfig()) {
         if (note) {
@@ -253,7 +253,7 @@ function createOrUpdateScriptLauncherFromApi(opts: { id: string; title: string; 
         throw new Error("Title is mandatory property to create or update a launcher.");
     }
 
-    const launcherNote = becca.getNote(launcherId) || createScriptLauncher("_lbVisibleLaunchers", launcherId);
+    const launcherNote = getBecca().getNote(launcherId) || createScriptLauncher("_lbVisibleLaunchers", launcherId);
 
     launcherNote.title = opts.title;
     launcherNote.setContent(`(${opts.action})()`);

--- a/packages/trilium-core/src/services/sql_init.ts
+++ b/packages/trilium-core/src/services/sql_init.ts
@@ -16,6 +16,7 @@ import passwordService from "./encryption/password";
 import dateUtils from "./utils/date";
 import { newEntityId } from "./utils/index";
 import { SqlService } from "./sql/sql";
+import { evictIdle } from "../becca/becca_cache.js";
 
 export const dbReady = deferred<void>();
 
@@ -160,6 +161,8 @@ function initializeDb() {
         setTimeout(() => optimize(), 60 * 60 * 1000);
 
         setInterval(() => optimize(), 10 * 60 * 60 * 1000);
+
+        setInterval(() => evictIdle(), 5 * 60 * 1000);
     });
 }
 

--- a/packages/trilium-core/src/services/sync.ts
+++ b/packages/trilium-core/src/services/sync.ts
@@ -1,6 +1,6 @@
 import type { EntityChange, EntityChangeRecord, EntityRow } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import appInfo from "./app_info.js";
 import * as cls from "./context.js";
 import consistency_checks from "./consistency_checks.js";
@@ -429,7 +429,7 @@ function getLastSyncedPull() {
 }
 
 function setLastSyncedPull(entityChangeId: number) {
-    const lastSyncedPullOption = becca.getOption("lastSyncedPull");
+    const lastSyncedPullOption = getBecca().getOption("lastSyncedPull");
 
     if (lastSyncedPullOption) {
         // might be null in initial sync when becca is not loaded
@@ -451,7 +451,7 @@ function getLastSyncedPush() {
 function setLastSyncedPush(entityChangeId: number) {
     ws.setLastSyncedPush(entityChangeId);
 
-    const lastSyncedPushOption = becca.getOption("lastSyncedPush");
+    const lastSyncedPushOption = getBecca().getOption("lastSyncedPush");
 
     if (lastSyncedPushOption) {
         // might be null in initial sync when becca is not loaded

--- a/packages/trilium-core/src/services/task_states.spec.ts
+++ b/packages/trilium-core/src/services/task_states.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@triliumnext/commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getContext } from "./context.js";
@@ -83,13 +83,13 @@ describe("task_states (real DB)", () => {
         });
 
         it("falls back to DEFAULT_TASK_STATES when the container note is missing", () => {
-            const realContainer = becca.notes[TASK_STATES_CONTAINER_ID];
+            const realContainer = getBecca().notes[TASK_STATES_CONTAINER_ID];
             try {
                 // Temporarily hide the container so the early-return branch is hit.
-                delete becca.notes[TASK_STATES_CONTAINER_ID];
+                delete getBecca().notes[TASK_STATES_CONTAINER_ID];
                 expect(getTaskStates()).toBe(DEFAULT_TASK_STATES);
             } finally {
-                becca.notes[TASK_STATES_CONTAINER_ID] = realContainer;
+                getBecca().notes[TASK_STATES_CONTAINER_ID] = realContainer;
             }
         });
     });
@@ -140,7 +140,7 @@ describe("task_states (real DB)", () => {
 
             expect(note.noteId).toBe(noteId);
             expect(note.title).toBe("Overridden title");
-            expect(becca.notes[noteId]).toBe(note);
+            expect(getBecca().notes[noteId]).toBe(note);
         });
 
         it("round-trips a created custom state through getTaskStates", () => {

--- a/packages/trilium-core/src/services/task_states.ts
+++ b/packages/trilium-core/src/services/task_states.ts
@@ -2,7 +2,7 @@ import { DEFAULT_CUSTOM_TASK_STATES, DEFAULT_TASK_STATES, DONE_STATE_ID, DONE_TA
 import Color from "color";
 import { t } from "i18next";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getIconPacks } from "./icon_packs.js";
@@ -16,7 +16,7 @@ import noteService from "./notes.js";
  * missing or empty.
  */
 export function getTaskStates(): TaskStateDef[] {
-    const container = becca.notes[TASK_STATES_CONTAINER_ID];
+    const container = getBecca().notes[TASK_STATES_CONTAINER_ID];
     if (!container) {
         return DEFAULT_TASK_STATES;
     }
@@ -105,7 +105,7 @@ export function seedDefaultTaskStates() {
 
     // Apply the default ordering (None, Doing, Done, Maybe, Cancelled) across all states.
     DEFAULT_TASK_STATES.forEach((state, index) => {
-        const note = state.id ? becca.notes[state.id] : undefined;
+        const note = state.id ? getBecca().notes[state.id] : undefined;
         const branch = note?.getParentBranches().find((b) => b.parentNoteId === TASK_STATES_CONTAINER_ID);
         if (branch) {
             branch.notePosition = index * 10;

--- a/packages/trilium-core/src/services/tree.spec.ts
+++ b/packages/trilium-core/src/services/tree.spec.ts
@@ -1,6 +1,6 @@
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import {note, NoteBuilder} from "../test/becca_mocking.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BBranch from "../becca/entities/bbranch.js";
 import BNote from "../becca/entities/bnote.js";
 import tree from "./tree.js";
@@ -11,7 +11,7 @@ describe("Tree", () => {
     let rootNote!: NoteBuilder;
 
     beforeEach(() => {
-        becca.reset();
+        getBecca().reset();
 
         rootNote = new NoteBuilder(
             new BNote({

--- a/packages/trilium-core/src/services/tree.ts
+++ b/packages/trilium-core/src/services/tree.ts
@@ -3,7 +3,7 @@
 import { getLog } from "./log.js";
 import BBranch from "../becca/entities/bbranch.js";
 import entityChangesService from "./entity_changes.js";
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import type BNote from "../becca/entities/bnote.js";
 import { getSql } from "./sql/index.js";
 
@@ -23,11 +23,11 @@ function validateParentChild(parentNoteId: string, childNoteId: string, branchId
         return { branch: null, success: false, message: `Cannot move anything into 'none' parent.` };
     }
 
-    const existingBranch = becca.getBranchFromChildAndParent(childNoteId, parentNoteId);
+    const existingBranch = getBecca().getBranchFromChildAndParent(childNoteId, parentNoteId);
 
     if (existingBranch && existingBranch.branchId !== branchId) {
-        const parentNote = becca.getNote(parentNoteId);
-        const childNote = becca.getNote(childNoteId);
+        const parentNote = getBecca().getNote(parentNoteId);
+        const childNote = getBecca().getNote(childNoteId);
 
         return {
             branch: existingBranch,
@@ -44,7 +44,7 @@ function validateParentChild(parentNoteId: string, childNoteId: string, branchId
         };
     }
 
-    if (parentNoteId !== "_lbBookmarks" && becca.getNote(parentNoteId)?.type === "launcher") {
+    if (parentNoteId !== "_lbBookmarks" && getBecca().getNote(parentNoteId)?.type === "launcher") {
         return {
             branch: null,
             success: false,
@@ -63,8 +63,8 @@ function wouldAddingBranchCreateCycle(parentNoteId: string, childNoteId: string)
         return true;
     }
 
-    const childNote = becca.getNote(childNoteId);
-    const parentNote = becca.getNote(parentNoteId);
+    const childNote = getBecca().getNote(childNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
 
     if (!childNote || !parentNote) {
         return false;
@@ -87,7 +87,7 @@ function sortNotes(parentNoteId: string, customSortBy: string = "title", reverse
 
     const sql = getSql();
     sql.transactional(() => {
-        const note = becca.getNote(parentNoteId);
+        const note = getBecca().getNote(parentNoteId);
         if (!note) {
             throw new Error("Unable to find note");
         }
@@ -203,7 +203,7 @@ function sortNotes(parentNoteId: string, customSortBy: string = "title", reverse
 }
 
 function sortNotesIfNeeded(parentNoteId: string) {
-    const parentNote = becca.getNote(parentNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
     if (!parentNote) {
         return;
     }
@@ -226,7 +226,7 @@ function sortNotesIfNeeded(parentNoteId: string) {
  * @deprecated this will be removed in the future
  */
 function setNoteToParent(noteId: string, prefix: string, parentNoteId: string) {
-    const parentNote = becca.getNote(parentNoteId);
+    const parentNote = getBecca().getNote(parentNoteId);
 
     if (parentNoteId && !parentNote) {
         // null parentNoteId is a valid value
@@ -235,7 +235,7 @@ function setNoteToParent(noteId: string, prefix: string, parentNoteId: string) {
 
     // case where there might be more such branches is ignored. It's expected there should be just one
     const branchId = getSql().getValue<string>("SELECT branchId FROM branches WHERE isDeleted = 0 AND noteId = ? AND prefix = ?", [noteId, prefix]);
-    const branch = becca.getBranch(branchId);
+    const branch = getBecca().getBranch(branchId);
 
     if (branch) {
         if (!parentNoteId) {
@@ -249,7 +249,7 @@ function setNoteToParent(noteId: string, prefix: string, parentNoteId: string) {
             branch.markAsDeleted();
         }
     } else if (parentNoteId) {
-        const note = becca.getNote(noteId);
+        const note = getBecca().getNote(noteId);
         if (!note) {
             throw new Error(`Cannot find note '${noteId}.`);
         }
@@ -259,7 +259,7 @@ function setNoteToParent(noteId: string, prefix: string, parentNoteId: string) {
         }
 
         const branchId = getSql().getValue<string>("SELECT branchId FROM branches WHERE isDeleted = 0 AND noteId = ? AND parentNoteId = ?", [noteId, parentNoteId]);
-        const branch = becca.getBranch(branchId);
+        const branch = getBecca().getBranch(branchId);
 
         if (branch) {
             branch.prefix = prefix;

--- a/packages/trilium-core/src/services/user_service.ts
+++ b/packages/trilium-core/src/services/user_service.ts
@@ -33,6 +33,12 @@ function getUserById(userId: string): User | null {
     ) ?? null;
 }
 
+function isUserAdmin(userId: string): boolean {
+    return !!getSql().getValue<number>(
+        "SELECT isAdmin FROM users WHERE userId = ? AND isDeleted = 0", [userId]
+    );
+}
+
 function listUsers(): User[] {
     return getSql().getRows<User>(
         `SELECT userId, username, email, isAdmin, isDeleted, dateCreated, utcDateModified
@@ -62,4 +68,4 @@ function deleteUser(userId: string): void {
     );
 }
 
-export default { getAdminUserId, getUserById, listUsers, createUser, deleteUser };
+export default { getAdminUserId, getUserById, isUserAdmin, listUsers, createUser, deleteUser };

--- a/packages/trilium-core/src/services/ws.spec.ts
+++ b/packages/trilium-core/src/services/ws.spec.ts
@@ -1,7 +1,7 @@
 import type { WebSocketMessage } from "@triliumnext/commons";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import * as cls from "./context.js";
 import { initMessaging } from "./messaging/index.js";
 import type { ClientMessageHandler } from "./messaging/types.js";
@@ -69,7 +69,7 @@ describe("ws service (real DB)", () => {
                 [now, now, now, now]
             );
             // Attachments need a matching blob for the JOIN to return a row. They are
-            // marked deleted so becca.getAttachment() (which filters isDeleted=0) misses
+            // marked deleted so getBecca().getAttachment() (which filters isDeleted=0) misses
             // them, forcing the DB-fallback path in fillInAdditionalProperties (whose
             // query has no isDeleted filter).
             getSql().execute(
@@ -85,7 +85,7 @@ describe("ws service (real DB)", () => {
         });
 
         // becca-hit changes (reuse the existing fixture rows).
-        const branchId = becca.getNote("root")?.getChildBranches()[0]?.branchId ?? "root_root";
+        const branchId = getBecca().getNote("root")?.getChildBranches()[0]?.branchId ?? "root_root";
         const attrEC = getSql().getRow<{ id: number; entityId: string }>(
             `SELECT ec.id, ec.entityId FROM entity_changes ec
              JOIN attributes a ON a.attributeId = ec.entityId

--- a/packages/trilium-core/src/services/ws.ts
+++ b/packages/trilium-core/src/services/ws.ts
@@ -1,6 +1,6 @@
 import { type EntityChange, WebSocketMessage } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import * as cls from "./context.js";
 import { getLog } from "./log.js";
 import protectedSessionService from "./protected_session.js";
@@ -48,19 +48,19 @@ function fillInAdditionalProperties(entityChange: EntityChange) {
     // only when that fails, try to load from the database
     const sql = getSql();
     if (entityChange.entityName === "attributes") {
-        entityChange.entity = becca.getAttribute(entityChange.entityId);
+        entityChange.entity = getBecca().getAttribute(entityChange.entityId);
 
         if (!entityChange.entity) {
             entityChange.entity = sql.getRow(/*sql*/`SELECT * FROM attributes WHERE attributeId = ?`, [entityChange.entityId]);
         }
     } else if (entityChange.entityName === "branches") {
-        entityChange.entity = becca.getBranch(entityChange.entityId);
+        entityChange.entity = getBecca().getBranch(entityChange.entityId);
 
         if (!entityChange.entity) {
             entityChange.entity = sql.getRow(/*sql*/`SELECT * FROM branches WHERE branchId = ?`, [entityChange.entityId]);
         }
     } else if (entityChange.entityName === "notes") {
-        entityChange.entity = becca.getNote(entityChange.entityId);
+        entityChange.entity = getBecca().getNote(entityChange.entityId);
 
         if (!entityChange.entity) {
             entityChange.entity = sql.getRow(/*sql*/`SELECT * FROM notes WHERE noteId = ?`, [entityChange.entityId]);
@@ -79,7 +79,7 @@ function fillInAdditionalProperties(entityChange: EntityChange) {
     } else if (entityChange.entityName === "note_reordering") {
         entityChange.positions = {};
 
-        const parentNote = becca.getNote(entityChange.entityId);
+        const parentNote = getBecca().getNote(entityChange.entityId);
 
         if (parentNote) {
             for (const childBranch of parentNote.getChildBranches()) {
@@ -89,13 +89,13 @@ function fillInAdditionalProperties(entityChange: EntityChange) {
             }
         }
     } else if (entityChange.entityName === "options") {
-        entityChange.entity = becca.getOption(entityChange.entityId);
+        entityChange.entity = getBecca().getOption(entityChange.entityId);
 
         if (!entityChange.entity) {
             entityChange.entity = sql.getRow(/*sql*/`SELECT * FROM options WHERE name = ?`, [entityChange.entityId]);
         }
     } else if (entityChange.entityName === "attachments") {
-        entityChange.entity = becca.getAttachment(entityChange.entityId);
+        entityChange.entity = getBecca().getAttachment(entityChange.entityId);
 
         if (!entityChange.entity) {
             entityChange.entity = sql.getRow(
@@ -142,7 +142,7 @@ function buildFrontendUpdateMessage(entityChangeIds: number[]): WebSocketMessage
 
     // sort entity changes since froca expects "referential order", i.e. referenced entities should already exist
     // in froca.
-    // Froca needs this since it is an incomplete copy, it can't create "skeletons" like becca.
+    // Froca needs this since it is an incomplete copy, it can't create "skeletons" like getBecca().
     entityChanges.sort((a, b) => ORDERING[a.entityName] - ORDERING[b.entityName]);
 
     for (const entityChange of entityChanges) {

--- a/packages/trilium-core/src/test/becca_mocking.ts
+++ b/packages/trilium-core/src/test/becca_mocking.ts
@@ -1,6 +1,6 @@
 import type { NoteRow, NoteType } from "@triliumnext/commons";
 
-import becca from "../becca/becca.js";
+import { getBecca } from "../becca/becca.js";
 import BAttribute from "../becca/entities/battribute.js";
 import BBranch from "../becca/entities/bbranch.js";
 import BNote from "../becca/entities/bnote.js";
@@ -8,7 +8,7 @@ import { randomString } from "../services/utils/index.js";
 import SearchResult from "../services/search/search_result.js";
 
 export function findNoteByTitle(searchResults: Array<SearchResult>, title: string): BNote | undefined {
-    return searchResults.map((sr) => becca.notes[sr.noteId]).find((note) => note.title === title);
+    return searchResults.map((sr) => getBecca().notes[sr.noteId]).find((note) => note?.title === title);
 }
 
 export class NoteBuilder {


### PR DESCRIPTION
Continuation of #10273, part of #4956.

Phase 1 gave users an identity. This is where they actually stop seeing each other's notes!

I stamped `ownerId` on notes at creation time and made Becca per-user. Each request gets a filtered view of only the notes that user owns or has access to, warmed before the route handler runs and cached for 30 minutes.

Permission inheritance walks the full ancestor chain across all branches so clones work correctly. A note living in two places inherits from both parents. Write always implies read. The cache clears on any grant or revoke because a single change can affect an entire subtree.

WebSocket connections record `userId` at handshake time. Per-user routing is wired at the provider level, broadcast filtering lands in phase 3.

`/api/permissions` covers listing, granting, and revoking, admin only for now. As agreed with @eliandoran in #4956: attributes inherit note permissions naturally and search index filtering is phase 3.

@deajan the permission inheritance model and the phase boundaries are the main things worth a logical read here if you have time.
