### PR TITLE
perf(sync): fill the pull response byte cap across row fetches

### DIFF
--- a/apps/server/e2e/sync/sync-instance.ts
+++ b/apps/server/e2e/sync/sync-instance.ts
@@ -1,0 +1,253 @@
+import { type ChildProcess, spawn } from "child_process";
+import { join } from "path";
+
+/**
+ * A real Trilium server instance (the production `dist/main.cjs` bundle, same as the e2e
+ * webServer) spawned against its own data directory, plus the HTTP plumbing needed to drive
+ * the sync protocol end-to-end: document setup, password, ETAPI seeding, sync-from-server and
+ * completion polling.
+ *
+ * Reused by sync e2e specs; extend it rather than hand-rolling fetch calls in tests.
+ */
+export default class SyncInstance {
+    readonly dataDir: string;
+    readonly port: number;
+    readonly baseUrl: string;
+
+    private child?: ChildProcess;
+    private etapiToken?: string;
+
+    constructor(dataDir: string, port: number) {
+        this.dataDir = dataDir;
+        this.port = port;
+        this.baseUrl = `http://127.0.0.1:${port}`;
+    }
+
+    /** Spawns the server and waits until it responds. Safe to call again after {@link stop}. */
+    async start() {
+        const serverDir = join(__dirname, "..", "..");
+
+        this.child = spawn(process.execPath, ["dist/main.cjs"], {
+            cwd: serverDir,
+            env: {
+                ...process.env,
+                TRILIUM_DATA_DIR: this.dataDir,
+                TRILIUM_PORT: String(this.port),
+                TRILIUM_ENV: "production",
+                // ensure the file-backed DB is used even if the caller's env says otherwise
+                TRILIUM_INTEGRATION_TEST: ""
+            },
+            stdio: "ignore"
+        });
+
+        await this.waitFor(async () => {
+            const res = await this.fetchJson<{ schemaExists: boolean }>("/api/setup/status");
+            return res !== null;
+        }, "server did not start", 120_000);
+    }
+
+    async stop() {
+        const child = this.child;
+        if (!child || child.exitCode !== null) {
+            return;
+        }
+
+        await new Promise<void>((resolve) => {
+            child.once("exit", () => resolve());
+            child.kill("SIGTERM");
+            // fallback if SIGTERM is ignored
+            setTimeout(() => {
+                if (child.exitCode === null) child.kill("SIGKILL");
+            }, 10_000).unref();
+        });
+    }
+
+    /**
+     * Restarts the instance. On startup the sync timer schedules a sync cycle a few seconds
+     * after load, so this doubles as a deterministic, auth-free "sync now" trigger.
+     */
+    async restart() {
+        await this.stop();
+        await this.start();
+    }
+
+    /** Initializes a brand-new document (schema + demo content) on a fresh instance. */
+    async initNewDocument() {
+        await this.postJson("/api/setup/new-document", {});
+        await this.waitFor(async () => {
+            const res = await this.fetchJson<{ isInitialized: boolean }>("/api/setup/status");
+            return res?.isInitialized === true;
+        }, "document was not initialized", 120_000);
+    }
+
+    /** Sets the initial password (needed for the sync seed exchange and ETAPI logins). */
+    async setPassword(password: string) {
+        const res = await fetch(`${this.baseUrl}/set-password`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({ password1: password, password2: password }),
+            redirect: "manual"
+        });
+        if (res.status >= 400) {
+            throw new Error(`set-password failed: ${res.status} ${await res.text()}`);
+        }
+    }
+
+    /** Points this (uninitialized) instance at a sync server and starts the initial sync. */
+    async setupSyncFromServer(sourceUrl: string, password: string) {
+        const res = await this.postJson<{ result: string; error?: string }>("/api/setup/sync-from-server", {
+            syncServerHost: sourceUrl,
+            syncProxy: "",
+            password
+        });
+        if (res?.result !== "success") {
+            throw new Error(`sync-from-server failed: ${res?.error}`);
+        }
+    }
+
+    /** Polls /api/sync/stats (auth-free) until the initial sync has fully converged. */
+    async waitForInitialSyncDone(timeoutMs = 180_000) {
+        await this.waitFor(async () => {
+            const stats = await this.fetchJson<{ initialized: boolean; outstandingPullCount: number }>("/api/sync/stats");
+            return stats?.initialized === true && stats?.outstandingPullCount === 0;
+        }, "initial sync did not converge", timeoutMs);
+    }
+
+    async etapiLogin(password: string) {
+        const res = await this.postJson<{ authToken: string }>("/etapi/auth/login", { password });
+        if (!res?.authToken) {
+            throw new Error("ETAPI login failed");
+        }
+        this.etapiToken = res.authToken;
+    }
+
+    async createNote(opts: { parentNoteId?: string; title: string; content: string; type?: string }) {
+        const res = await this.etapi<{ note: { noteId: string } }>("POST", "/etapi/create-note", {
+            parentNoteId: opts.parentNoteId ?? "root",
+            title: opts.title,
+            type: opts.type ?? "text",
+            content: opts.content
+        });
+        return res.note.noteId;
+    }
+
+    async createLabel(noteId: string, name: string, value: string) {
+        await this.etapi("POST", "/etapi/attributes", { noteId, type: "label", name, value });
+    }
+
+    /** Returns the noteId of a note with the exact title, or null. */
+    async findNoteByTitle(title: string): Promise<string | null> {
+        const res = await this.etapi<{ results: Array<{ noteId: string; title: string }> }>(
+            "GET", `/etapi/notes?search=${encodeURIComponent(`note.title = '${title}'`)}`);
+        return res.results.find((n) => n.title === title)?.noteId ?? null;
+    }
+
+    async getNoteContent(noteId: string): Promise<string> {
+        const res = await fetch(`${this.baseUrl}/etapi/notes/${noteId}/content`, {
+            headers: { Authorization: this.requireToken() }
+        });
+        if (!res.ok) {
+            throw new Error(`get content failed: ${res.status}`);
+        }
+        return await res.text();
+    }
+
+    /**
+     * Seeds a metadata-and-content fixture through the real write path (ETAPI): `parents`
+     * top-level notes each holding `childrenPerParent` labelled children with unique content,
+     * plus one large note of `largeContentBytes` (exercises a byte-cap-crossing sync record).
+     * Sized so the seeded entity changes cross the server's 1000-row fetch batches many times.
+     */
+    async seedFixture({ parents = 15, childrenPerParent = 60, largeContentBytes = 2_500_000 } = {}) {
+        const parentIds: string[] = [];
+        for (let p = 0; p < parents; p++) {
+            parentIds.push(await this.createNote({ title: `sync-fixture parent ${p}`, content: `<p>parent ${p}</p>` }));
+        }
+
+        const tasks: Array<() => Promise<void>> = [];
+        for (let p = 0; p < parents; p++) {
+            for (let c = 0; c < childrenPerParent; c++) {
+                tasks.push(async () => {
+                    const noteId = await this.createNote({
+                        parentNoteId: parentIds[p],
+                        title: `sync-fixture note ${p}-${c}`,
+                        content: `<p>unique content ${p}-${c} ${"x".repeat(100 + ((p * childrenPerParent + c) % 400))}</p>`
+                    });
+                    await this.createLabel(noteId, "syncFixture", `${p}-${c}`);
+                });
+            }
+        }
+        await runConcurrently(tasks, 8);
+
+        await this.createNote({
+            title: "sync-fixture large note",
+            content: `<p>${"L".repeat(largeContentBytes)}</p>`
+        });
+
+        return { parents, childrenPerParent, totalNotes: parents * childrenPerParent + parents + 1 };
+    }
+
+    private requireToken(): string {
+        if (!this.etapiToken) throw new Error("etapiLogin() must be called first");
+        return this.etapiToken;
+    }
+
+    private async etapi<T>(method: string, path: string, body?: unknown): Promise<T> {
+        const res = await fetch(`${this.baseUrl}${path}`, {
+            method,
+            headers: {
+                Authorization: this.requireToken(),
+                ...(body ? { "Content-Type": "application/json" } : {})
+            },
+            body: body ? JSON.stringify(body) : undefined
+        });
+        if (!res.ok) {
+            throw new Error(`ETAPI ${method} ${path} failed: ${res.status} ${await res.text()}`);
+        }
+        return (await res.json()) as T;
+    }
+
+    private async postJson<T>(path: string, body: unknown): Promise<T | null> {
+        try {
+            const res = await fetch(`${this.baseUrl}${path}`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body)
+            });
+            return (await res.json()) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    private async fetchJson<T>(path: string): Promise<T | null> {
+        try {
+            const res = await fetch(`${this.baseUrl}${path}`);
+            if (!res.ok) return null;
+            return (await res.json()) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    private async waitFor(condition: () => Promise<boolean>, message: string, timeoutMs: number) {
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+            if (await condition()) return;
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+        throw new Error(`Timed out after ${timeoutMs}ms: ${message}`);
+    }
+}
+
+/** Runs async tasks with bounded concurrency (seeding hundreds of notes serially is slow). */
+async function runConcurrently(tasks: Array<() => Promise<void>>, concurrency: number) {
+    const queue = [...tasks];
+    await Promise.all(
+        Array.from({ length: concurrency }, async () => {
+            for (let task = queue.shift(); task; task = queue.shift()) {
+                await task();
+            }
+        })
+    );
+}

--- a/apps/server/e2e/sync/sync.spec.ts
+++ b/apps/server/e2e/sync/sync.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+import Database from "better-sqlite3";
+import { join } from "path";
+
+import SyncInstance from "./sync-instance";
+
+/**
+ * End-to-end test of the sync protocol between two real server instances (production bundle,
+ * real HTTP, real HMAC login/paging/batching): a seeded source, a fresh target doing a full
+ * initial sync, then incremental sync in both directions, and finally an offline comparison
+ * of the two databases.
+ *
+ * The fixture is seeded through ETAPI (the real write path) and is deliberately sized so the
+ * pull crosses the server's 1000-row fetch batches many times and includes one record larger
+ * than the response byte cap — the two regressions most likely to be reintroduced by future
+ * sync work.
+ */
+
+const PASSWORD = "sync-e2e-password";
+
+test.describe("sync protocol", () => {
+    test.skip(!!process.env.TRILIUM_DOCKER, "spawns local server processes; not available against a Docker target");
+
+    test("initial sync reproduces the source; incremental sync works both ways", async ({}, testInfo) => {
+        test.setTimeout(600_000);
+
+        const basePort = 8300 + testInfo.workerIndex * 2;
+        const source = new SyncInstance(testInfo.outputPath("source-data"), basePort);
+        const target = new SyncInstance(testInfo.outputPath("target-data"), basePort + 1);
+
+        try {
+            let fixture = { totalNotes: 0 };
+
+            await test.step("seed the source instance", async () => {
+                await source.start();
+                await source.initNewDocument();
+                await source.setPassword(PASSWORD);
+                await source.etapiLogin(PASSWORD);
+                fixture = await source.seedFixture();
+            });
+
+            await test.step("initial sync into a fresh target", async () => {
+                await target.start();
+                await target.setupSyncFromServer(source.baseUrl, PASSWORD);
+                await target.waitForInitialSyncDone();
+            });
+
+            await test.step("target reproduces the seeded content", async () => {
+                // the password (and ETAPI credentials) are themselves synced options
+                await target.etapiLogin(PASSWORD);
+
+                for (const title of ["sync-fixture note 0-0", "sync-fixture note 7-31", "sync-fixture parent 3"]) {
+                    const sourceNoteId = await source.findNoteByTitle(title);
+                    const targetNoteId = await target.findNoteByTitle(title);
+                    expect(targetNoteId, `note "${title}" should exist on the target`).not.toBeNull();
+                    expect(targetNoteId).toBe(sourceNoteId);
+
+                    if (sourceNoteId && targetNoteId) {
+                        expect(await target.getNoteContent(targetNoteId)).toBe(await source.getNoteContent(sourceNoteId));
+                    }
+                }
+
+                // the large note crosses the pull response byte cap as a single record
+                const largeId = await target.findNoteByTitle("sync-fixture large note");
+                expect(largeId).not.toBeNull();
+                if (largeId) {
+                    const sourceId = await source.findNoteByTitle("sync-fixture large note");
+                    expect(sourceId).not.toBeNull();
+                    if (sourceId) {
+                        const [targetContent, sourceContent] = [await target.getNoteContent(largeId), await source.getNoteContent(sourceId)];
+                        expect(targetContent.length).toBe(sourceContent.length);
+                        expect(targetContent).toBe(sourceContent);
+                    }
+                }
+            });
+
+            await test.step("incremental sync: source -> target", async () => {
+                await source.createNote({ title: "sync-incremental from source", content: "<p>made on source</p>" });
+
+                // a restart deterministically triggers the target's sync cycle
+                await target.restart();
+
+                await expect
+                    .poll(async () => await target.findNoteByTitle("sync-incremental from source"), { timeout: 120_000 })
+                    .not.toBeNull();
+            });
+
+            await test.step("incremental sync: target -> source (push)", async () => {
+                await target.createNote({ title: "sync-incremental from target", content: "<p>made on target</p>" });
+
+                // the target's sync cycle pushes local changes before pulling
+                await target.restart();
+
+                await expect
+                    .poll(async () => await source.findNoteByTitle("sync-incremental from target"), { timeout: 120_000 })
+                    .not.toBeNull();
+            });
+
+            await test.step("offline database comparison", async () => {
+                await source.stop();
+                await target.stop();
+
+                const counts = (dataDir: string) => {
+                    const db = new Database(join(dataDir, "document.db"), { readonly: true });
+                    try {
+                        return {
+                            notes: db.prepare("SELECT COUNT(*) c FROM notes WHERE isDeleted = 0").get() as { c: number },
+                            branches: db.prepare("SELECT COUNT(*) c FROM branches WHERE isDeleted = 0").get() as { c: number },
+                            attributes: db.prepare("SELECT COUNT(*) c FROM attributes WHERE isDeleted = 0").get() as { c: number },
+                            // CAST to BLOB so LENGTH() counts bytes on both sides: locally-saved text
+                            // notes are stored as TEXT (LENGTH = characters) while synced content is
+                            // stored as a Buffer (LENGTH = bytes) — same bytes, different column type.
+                            blobs: db.prepare("SELECT COUNT(*) c, COALESCE(SUM(LENGTH(CAST(content AS BLOB))), 0) bytes FROM blobs").get() as { c: number; bytes: number }
+                        };
+                    } finally {
+                        db.close();
+                    }
+                };
+
+                const sourceCounts = counts(source.dataDir);
+                const targetCounts = counts(target.dataDir);
+
+                expect(targetCounts.notes.c).toBe(sourceCounts.notes.c);
+                expect(targetCounts.branches.c).toBe(sourceCounts.branches.c);
+                expect(targetCounts.attributes.c).toBe(sourceCounts.attributes.c);
+                expect(targetCounts.blobs.c).toBe(sourceCounts.blobs.c);
+                expect(targetCounts.blobs.bytes).toBe(sourceCounts.blobs.bytes);
+
+                // sanity: the fixture actually made it in (not comparing two empty databases)
+                expect(sourceCounts.notes.c).toBeGreaterThan(fixture.totalNotes);
+            });
+        } finally {
+            await source.stop();
+            await target.stop();
+        }
+    });
+});

--- a/apps/server/e2e/sync/sync.spec.ts
+++ b/apps/server/e2e/sync/sync.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import Database from "better-sqlite3";
+import { existsSync } from "fs";
 import { join } from "path";
 
 import SyncInstance from "./sync-instance";
@@ -19,7 +20,13 @@ import SyncInstance from "./sync-instance";
 const PASSWORD = "sync-e2e-password";
 
 test.describe("sync protocol", () => {
-    test.skip(!!process.env.TRILIUM_DOCKER, "spawns local server processes; not available against a Docker target");
+    // This spec spawns its own local server instances from the production bundle, so it only
+    // needs `dist/main.cjs` to exist — which every CI e2e job guarantees (they all build the
+    // server first), regardless of whether the *main* e2e target is local or Docker-hosted.
+    test.skip(
+        !existsSync(join(__dirname, "..", "..", "dist", "main.cjs")),
+        "requires the built server bundle (dist/main.cjs)"
+    );
 
     test("initial sync reproduces the source; incremental sync works both ways", async ({}, testInfo) => {
         test.setTimeout(600_000);

--- a/packages/trilium-core/src/routes/api/sync.spec.ts
+++ b/packages/trilium-core/src/routes/api/sync.spec.ts
@@ -199,6 +199,41 @@ describe("Sync API (core)", () => {
             sql.execute("DELETE FROM options WHERE name = 'otst_opt'");
         });
 
+        it("fills the response across multiple 1000-row fetches instead of stopping at the row limit", async () => {
+            // 1100 metadata-only rows estimate to ~0.33 MB — far below the 8 MB byte cap — so a
+            // single pull must now return all of them in one response (two LIMIT-1000 fetches)
+            // rather than capping at 1000 rows per round-trip.
+            const sql = getSql();
+            const maxId = sql.getValue<number>("SELECT COALESCE(MAX(id), 0) FROM entity_changes");
+            const COUNT = 1100;
+
+            sql.transactional(() => {
+                for (let i = 0; i < COUNT; i++) {
+                    sql.execute("INSERT INTO options (name, value, isSynced, utcDateModified) VALUES (?, 'v', 1, '2020-01-01T00:00:00.000Z')", [`rowcap_opt_${i}`]);
+                    sql.execute(
+                        `INSERT INTO entity_changes (id, entityName, entityId, hash, isErased, changeId, componentId, instanceId, isSynced, utcDateChanged)
+                         VALUES (?, 'options', ?, 'h', 0, ?, 'cmp', 'OTHER', 1, '2020-01-01T00:00:00.000Z')`,
+                        [maxId + 1 + i, `rowcap_opt_${i}`, `rowcap_chg_${i}`]
+                    );
+                }
+            });
+
+            const res = await api.get<{ entityChanges: unknown[]; lastEntityChangeId: number; outstandingPullCount: number }>(
+                "/api/sync/changed",
+                { query: { instanceId: "CLIENTX", lastEntityChangeId: String(maxId) } }
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.body.entityChanges.length).toBe(COUNT); // > 1000: the row limit no longer binds
+            expect(res.body.lastEntityChangeId).toBe(maxId + COUNT);
+            expect(res.body.outstandingPullCount).toBe(0);
+
+            sql.transactional(() => {
+                sql.execute("DELETE FROM entity_changes WHERE id BETWEEN ? AND ?", [maxId + 1, maxId + COUNT]);
+                sql.execute("DELETE FROM options WHERE name LIKE 'rowcap_opt_%'");
+            });
+        });
+
         it("getEntityChangeRecords stops accumulating once the response byte cap is reached", () => {
             const sql = getSql();
             const maxId = sql.getValue<number>("SELECT COALESCE(MAX(id), 0) FROM entity_changes");

--- a/packages/trilium-core/src/routes/api/sync.ts
+++ b/packages/trilium-core/src/routes/api/sync.ts
@@ -1,4 +1,4 @@
-import { type EntityChange, SyncTestResponse } from "@triliumnext/commons";
+import { type EntityChange, type EntityChangeRecord, SyncTestResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 import { t } from "i18next";
 
@@ -9,7 +9,7 @@ import { getLog } from "../../services/log.js";
 import optionService from "../../services/options.js";
 import { getSql } from "../../services/sql/index.js";
 import sqlInit from "../../services/sql_init.js";
-import syncService from "../../services/sync.js";
+import syncService, { estimateEntityChangeRecordSize, MAX_PULL_RESPONSE_BYTES } from "../../services/sync.js";
 import syncOptions from "../../services/sync_options.js";
 import syncUpdateService from "../../services/sync_update.js";
 import * as utils from "../../services/utils/index.js";
@@ -117,7 +117,7 @@ function forceFullSync() {
  *         description: Marker to identify this request in server log
  *     responses:
  *       '200':
- *         description: Sync changes, limited to approximately one megabyte.
+ *         description: Sync changes, limited to approximately eight megabytes.
  *         content:
  *           application/json:
  *             schema:
@@ -146,12 +146,23 @@ function getChanged(req: Request) {
         throw new ValidationError("Missing or invalid last entity change ID.");
     }
 
-    let lastEntityChangeId: number | null | undefined = parseInt(req.query.lastEntityChangeId);
+    let lastEntityChangeId = parseInt(req.query.lastEntityChangeId);
     const clientInstanceId = req.query.instanceId;
-    let filteredEntityChanges: EntityChange[] = [];
 
     const sql = getSql();
-    do {
+    const entityChangeRecords: EntityChangeRecord[] = [];
+    let estimatedResponseBytes = 0;
+    // Where the next row fetch starts. Advances over every fetched row, unlike
+    // `lastEntityChangeId` (the cursor returned to the client), which only advances over rows the
+    // client can safely skip: records included in the response and batches consisting entirely of
+    // the client's own changes.
+    let fetchCursor = lastEntityChangeId;
+
+    // Accumulate rows across LIMIT-1000 fetches until the response byte estimate crosses the cap
+    // (or the table is exhausted). Metadata-only records are ~300 bytes, so a single 1000-row fetch
+    // fills only ~4% of the byte budget — without this loop the row limit binds long before the
+    // byte cap on metadata-dense ranges, costing many extra round-trips.
+    while (estimatedResponseBytes < MAX_PULL_RESPONSE_BYTES) {
         const entityChanges: EntityChange[] = sql.getRows<EntityChange>(
             `
             SELECT *
@@ -160,25 +171,45 @@ function getChanged(req: Request) {
             AND id > ?
             ORDER BY id
             LIMIT 1000`,
-            [lastEntityChangeId]
+            [fetchCursor]
         );
 
         if (entityChanges.length === 0) {
             break;
         }
 
-        filteredEntityChanges = entityChanges.filter((ec) => ec.instanceId !== clientInstanceId);
+        // rows fetched from entity_changes always carry an id
+        fetchCursor = entityChanges[entityChanges.length - 1].id ?? fetchCursor;
 
-        if (filteredEntityChanges.length === 0) {
-            lastEntityChangeId = entityChanges[entityChanges.length - 1].id;
+        const foreignEntityChanges = entityChanges.filter((ec) => ec.instanceId !== clientInstanceId);
+
+        if (foreignEntityChanges.length === 0) {
+            // the whole batch is the client's own changes — skip the client's cursor past it
+            lastEntityChangeId = fetchCursor;
+            continue;
         }
-    } while (filteredEntityChanges.length === 0);
 
-    const entityChangeRecords = syncService.getEntityChangeRecords(filteredEntityChanges);
+        const records = syncService.getEntityChangeRecords(foreignEntityChanges, MAX_PULL_RESPONSE_BYTES - estimatedResponseBytes);
+
+        for (const record of records) {
+            estimatedResponseBytes += estimateEntityChangeRecordSize(record);
+        }
+
+        entityChangeRecords.push(...records);
+
+        if (records.length > 0) {
+            // rows fetched from entity_changes always carry an id
+            lastEntityChangeId = records[records.length - 1].entityChange.id ?? lastEntityChangeId;
+        }
+
+        if (records.length < foreignEntityChanges.length) {
+            // the byte budget was reached mid-batch (or trailing records were skipped) — anything
+            // not included must be re-served next request, so stop without advancing further
+            break;
+        }
+    }
 
     if (entityChangeRecords.length > 0) {
-        lastEntityChangeId = entityChangeRecords[entityChangeRecords.length - 1].entityChange.id;
-
         getLog().info(`Returning ${entityChangeRecords.length} entity changes in ${Date.now() - startTime}ms`);
     }
 

--- a/packages/trilium-core/src/services/sync.ts
+++ b/packages/trilium-core/src/services/sync.ts
@@ -468,7 +468,7 @@ function getEntityChangeRow(entityChange: EntityChange) {
  * receiver's peak memory. It is a soft cap: a response is at least one record, and the record that
  * crosses the threshold is still included.
  */
-const MAX_PULL_RESPONSE_BYTES = 8 * 1024 * 1024;
+export const MAX_PULL_RESPONSE_BYTES = 8 * 1024 * 1024;
 
 function getEntityChangeRecords(entityChanges: EntityChange[], maxResponseBytes = MAX_PULL_RESPONSE_BYTES) {
     const records: EntityChangeRecord[] = [];


### PR DESCRIPTION
## Summary

Follow-up to #10351. That PR raised the pull response cap to 8 MB, but `getChanged` still fetches a single `LIMIT 1000` batch per request — so on metadata-dense ranges (notes/branches/attributes at ~300 bytes each) a response carries only ~0.3 MB, and the **row limit, not the byte cap, determines the number of round-trips**. This was directly observable in #10351's benchmarks: request count fell sublinearly with cap size, and 105 chunks in the 1 MB baseline returned exactly 1000 rows at ~0.75 MB.

This loops the 1000-row fetch inside `getChanged` until the response byte estimate crosses the cap or the range is exhausted. Cursor semantics are preserved: the client-visible `lastEntityChangeId` only advances over records actually included in the response (plus batches consisting entirely of the client's own changes, as before), so a byte-capped mid-batch stop re-serves the remainder on the next request.

## Benchmarks (initial sync, request counts)

| Database shape | Before | After |
|---|---:|---:|
| **Metadata-heavy fixture** (180k small changes: 60k notes + branches + attributes) | 184 requests | **8 requests (23×)** |
| **Blob-heavy 2 GB document** (from #10351) | 332 requests | **207 requests (1.6×)** |

The blob-heavy case is near its byte-bound floor (~311 responses must carry blob content that already fills the cap), so the win there is modest — the target of this change is metadata-heavy databases (many notes, few attachments), where round-trips over a high-latency link are the dominant initial-sync cost. Both benchmark targets reproduce their source exactly (entity counts and content bytes verified).

## Testing

- New route test: 1100 metadata rows come back in **one** response (two LIMIT-1000 fetches), with correct cursor and outstanding count — fails on the old single-fetch code.
- Existing cursor-semantics tests (own-instance skip, byte-cap boundary, empty-batch cursor advance) all pass unchanged: 47/47 sync specs, full server suite 3786 passed, core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)