### PR TITLE
feat(oidc): refresh the access token in-place when it expires

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -18,7 +18,7 @@ import mcpRoutes from "./routes/mcp.js";
 import routes from "./routes/routes.js";
 import config from "./services/config.js";
 import { getLog } from "@triliumnext/core";
-import { createReactiveOidcMiddleware } from "./services/open_id.js";
+import { createReactiveOidcMiddleware, refreshOidcTokenIfNeeded } from "./services/open_id.js";
 import { RESOURCE_DIR } from "./services/resource_dir.js";
 import utils, { getResourceDir, isDev } from "./services/utils.js";
 
@@ -115,6 +115,10 @@ export default async function buildApp() {
     // effect without a server restart; the underlying express-openid-connect handler is built lazily on
     // first use, so it costs nothing while OAuth is unselected. See createReactiveOidcMiddleware.
     app.use(createReactiveOidcMiddleware());
+    // Refresh an expired OIDC access token before the request is handled. Mounted immediately after the
+    // OIDC middleware so `req.oidc` is populated; it no-ops for non-OIDC requests and when no refresh
+    // token is present, so it is safe to mount unconditionally alongside the reactive OIDC middleware.
+    app.use(refreshOidcTokenIfNeeded);
 
     await assets.register(app);
     routes.register(app);

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -1,10 +1,10 @@
 import { cls, options } from "@triliumnext/core";
 import type { NextFunction, Request as ExpressRequest, RequestHandler, Response as ExpressResponse } from "express";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import config from "./config.js";
 import openIDEncryption from "./encryption/open_id_encryption.js";
-import openID, { createReactiveOidcMiddleware, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
+import openID, { _resetInFlightRefreshesForTesting, createReactiveOidcMiddleware, refreshOidcTokenIfNeeded, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
 import sql from "./sql.js";
 import sqlInit from "./sql_init.js";
 
@@ -212,6 +212,22 @@ describe("open_id", () => {
             expect(cfg.session?.rolling).toBe(true);
             expect(cfg.session?.rollingDuration).toBe(config.Session.cookieMaxAge);
             expect(cfg.session?.absoluteDuration).toBe(config.Session.cookieMaxAge);
+        });
+
+        it("requests offline access only when the scope opts into it", () => {
+            setOauthConfig(true);
+
+            // Default scope: no offline access params — matches the standard sign-in flow.
+            mfa.oauthScope = "openid profile email";
+            const plain = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(plain.access_type).toBeUndefined();
+            expect(plain.prompt).toBeUndefined();
+
+            // offline_access requested: add access_type=offline + prompt=consent so a refresh token is issued.
+            mfa.oauthScope = "openid profile email offline_access";
+            const offline = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(offline.access_type).toBe("offline");
+            expect(offline.prompt).toBe("consent");
         });
 
         it("returns the session unchanged when the DB is not initialized", async () => {
@@ -605,5 +621,148 @@ describe("createReactiveOidcMiddleware", () => {
         const { req, res } = await run(t.middleware);
         expect(t.buildAuth).toHaveBeenCalledOnce();
         expect(t.oidcHandler).toHaveBeenCalledWith(req, res, expect.any(Function));
+    });
+});
+
+describe("refreshOidcTokenIfNeeded", () => {
+    const res = {} as ExpressResponse;
+    let sessionCounter = 0;
+
+    beforeEach(() => {
+        _resetInFlightRefreshesForTesting();
+    });
+
+    // Waits for the microtask chain (refreshPromise.then/catch → next) to settle.
+    function flushMicrotasks() {
+        return new Promise((resolve) => setImmediate(resolve));
+    }
+
+    function makeReq(oidc: Record<string, unknown> | undefined, session: Record<string, unknown> | undefined, sessionID?: string) {
+        sessionCounter += 1;
+        const req = { oidc, session, sessionID: sessionID ?? `sid-${sessionCounter}` } as unknown as ExpressRequest;
+        return { req, session };
+    }
+
+    function expiredOidc(refresh: ReturnType<typeof vi.fn>) {
+        // refresh() lives on the AccessToken, matching the library API the middleware calls.
+        return {
+            isAuthenticated: vi.fn(() => true),
+            accessToken: { isExpired: vi.fn(() => true), refresh },
+            refreshToken: "rt"
+        };
+    }
+
+    it("passes through without refreshing when the user is not OIDC-authenticated", () => {
+        const refresh = vi.fn();
+        const next = vi.fn();
+        const { req } = makeReq({ isAuthenticated: vi.fn(() => false), refresh }, { loggedIn: true });
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("passes through when the local session is not logged in", () => {
+        const refresh = vi.fn();
+        const next = vi.fn();
+        const { req } = makeReq({ isAuthenticated: vi.fn(() => true), refresh }, { loggedIn: false });
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("passes through when the access token is still valid", () => {
+        const refresh = vi.fn();
+        const next = vi.fn();
+        const { req } = makeReq(
+            { isAuthenticated: vi.fn(() => true), accessToken: { isExpired: vi.fn(() => false) }, refreshToken: "rt", refresh },
+            { loggedIn: true }
+        );
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("passes through when no refresh token is present (offline_access not granted)", () => {
+        const refresh = vi.fn();
+        const next = vi.fn();
+        // Built inline: passing undefined to expiredOidc's defaulted param would resurrect the default.
+        const { req } = makeReq(
+            { isAuthenticated: vi.fn(() => true), accessToken: { isExpired: vi.fn(() => true), refresh }, refreshToken: undefined },
+            { loggedIn: true }
+        );
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it("refreshes the token and calls next on success", async () => {
+        const refresh = vi.fn().mockResolvedValue(undefined);
+        const next = vi.fn();
+        const { req } = makeReq(expiredOidc(refresh), { loggedIn: true });
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        await flushMicrotasks();
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+    });
+
+    it("soft-fails on a transient refresh error so the local session survives an IdP outage", async () => {
+        const refresh = vi.fn().mockRejectedValue(new Error("network down"));
+        const next = vi.fn();
+        const { req, session } = makeReq(expiredOidc(refresh), { loggedIn: true });
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        await flushMicrotasks();
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+        expect(session?.loggedIn).toBe(true);
+    });
+
+    it("forces re-authentication on invalid_grant by marking the session not-logged-in", async () => {
+        const invalidGrant = Object.assign(new Error("Token revoked"), { error: "invalid_grant" });
+        const refresh = vi.fn().mockRejectedValue(invalidGrant);
+        const next = vi.fn();
+        const { req, session } = makeReq(expiredOidc(refresh), { loggedIn: true });
+
+        refreshOidcTokenIfNeeded(req, res, next as NextFunction);
+        await flushMicrotasks();
+
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledOnce();
+        // checkAuth (downstream) sees !loggedIn and redirects to /login.
+        expect(session?.loggedIn).toBe(false);
+    });
+
+    it("coalesces concurrent refreshes for the same session into a single IdP call", async () => {
+        let resolveRefresh: () => void = () => undefined;
+        const refresh1 = vi.fn(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+        const refresh2 = vi.fn();
+        const next1 = vi.fn();
+        const next2 = vi.fn();
+        const { req: req1 } = makeReq(expiredOidc(refresh1), { loggedIn: true }, "shared-sid");
+        const { req: req2 } = makeReq(expiredOidc(refresh2), { loggedIn: true }, "shared-sid");
+
+        refreshOidcTokenIfNeeded(req1, res, next1 as NextFunction);
+        refreshOidcTokenIfNeeded(req2, res, next2 as NextFunction);
+
+        // Only the first request hits the IdP; the second piggy-backs on the in-flight promise.
+        expect(refresh1).toHaveBeenCalledOnce();
+        expect(refresh2).not.toHaveBeenCalled();
+
+        resolveRefresh();
+        await flushMicrotasks();
+
+        expect(next1).toHaveBeenCalledOnce();
+        expect(next2).toHaveBeenCalledOnce();
     });
 });

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -214,20 +214,38 @@ describe("open_id", () => {
             expect(cfg.session?.absoluteDuration).toBe(config.Session.cookieMaxAge);
         });
 
-        it("requests offline access only when the scope opts into it", () => {
+        it("requests offline access per-issuer, and only when the scope opts into it", () => {
             setOauthConfig(true);
 
             // Default scope: no offline access params — matches the standard sign-in flow.
             mfa.oauthScope = "openid profile email";
             const plain = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(plain.scope).toBe("openid profile email");
             expect(plain.access_type).toBeUndefined();
             expect(plain.prompt).toBeUndefined();
 
-            // offline_access requested: add access_type=offline + prompt=consent so a refresh token is issued.
+            // Spec-compliant issuer: the offline_access scope IS the refresh-token request. No
+            // Google-specific params — prompt=consent would force the consent screen on every login.
             mfa.oauthScope = "openid profile email offline_access";
-            const offline = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
-            expect(offline.access_type).toBe("offline");
-            expect(offline.prompt).toBe("consent");
+            const spec = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(spec.scope).toBe("openid profile email offline_access");
+            expect(spec.access_type).toBeUndefined();
+            expect(spec.prompt).toBeUndefined();
+
+            // Google: offline_access is not a valid Google scope (invalid_scope), so it is stripped
+            // and replaced with Google's own mechanism (access_type=offline + prompt=consent).
+            mfa.oauthIssuerBaseUrl = "https://accounts.google.com/";
+            const google = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(google.scope).toBe("openid profile email");
+            expect(google.access_type).toBe("offline");
+            expect(google.prompt).toBe("consent");
+
+            // Google without the opt-in: untouched.
+            mfa.oauthScope = "openid profile email";
+            const googlePlain = openID.generateOAuthConfig().authorizationParams as Record<string, unknown>;
+            expect(googlePlain.scope).toBe("openid profile email");
+            expect(googlePlain.access_type).toBeUndefined();
+            expect(googlePlain.prompt).toBeUndefined();
         });
 
         it("returns the session unchanged when the DB is not initialized", async () => {
@@ -741,6 +759,43 @@ describe("refreshOidcTokenIfNeeded", () => {
         expect(next).toHaveBeenCalledOnce();
         // checkAuth (downstream) sees !loggedIn and redirects to /login.
         expect(session?.loggedIn).toBe(false);
+    });
+
+    it("propagates rotated tokens into piggybacking requests' appSession", async () => {
+        // Each request decodes its own copy of the appSession cookie; the library's refresh() only
+        // updates the initiator's copy. The middleware must copy the rotated tokens into piggybackers
+        // so their (rolling) response cookies don't clobber the fresh pair with the consumed one.
+        const staleTokens = { access_token: "at-old", refresh_token: "rt-old", id_token: "idt-old", token_type: "Bearer", expires_at: 1 };
+        const appSession1 = { ...staleTokens };
+        const appSession2 = { ...staleTokens };
+
+        let resolveRefresh: () => void = () => undefined;
+        const refresh1 = vi.fn(() => new Promise<void>((resolve) => { resolveRefresh = resolve; }));
+        const req1 = {
+            ...makeReq(expiredOidc(refresh1), { loggedIn: true }, "shared-sid").req,
+            appSession: appSession1
+        } as unknown as ExpressRequest;
+        const req2 = {
+            ...makeReq(expiredOidc(vi.fn()), { loggedIn: true }, "shared-sid").req,
+            appSession: appSession2
+        } as unknown as ExpressRequest;
+        const next1 = vi.fn();
+        const next2 = vi.fn();
+
+        refreshOidcTokenIfNeeded(req1, res, next1 as NextFunction);
+        refreshOidcTokenIfNeeded(req2, res, next2 as NextFunction);
+
+        // Simulate the library: refresh() writes the rotated tokens into the initiator's appSession.
+        Object.assign(appSession1, { access_token: "at-new", refresh_token: "rt-new", expires_at: 999 });
+        resolveRefresh();
+        await flushMicrotasks();
+
+        expect(next1).toHaveBeenCalledOnce();
+        expect(next2).toHaveBeenCalledOnce();
+        // The piggybacker's session now carries the rotated pair, not the consumed one.
+        expect(appSession2.access_token).toBe("at-new");
+        expect(appSession2.refresh_token).toBe("rt-new");
+        expect(appSession2.expires_at).toBe(999);
     });
 
     it("coalesces concurrent refreshes for the same session into a single IdP call", async () => {

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -78,6 +78,83 @@ function getOAuthStatus() {
     };
 }
 
+/**
+ * In-flight refresh promises keyed by trilium.sid session ID, so concurrent expired-token requests
+ * share a single network call to the IdP. Without this, refresh-token rotation (Authentik, Auth0,
+ * Okta default) breaks under load: the first request consumes the refresh token, the rest see
+ * invalid_grant on a now-stale token and would (per the policy below) be force-logged-out.
+ */
+const inFlightRefreshes = new Map<string, Promise<void>>();
+
+/** Test-only: clear the in-flight refresh cache between cases. */
+export function _resetInFlightRefreshesForTesting() {
+    inFlightRefreshes.clear();
+}
+
+/**
+ * Express middleware that refreshes the OIDC access token in-place when it is expired.
+ *
+ * Why this exists: express-openid-connect stores `access_token` and `refresh_token` in the appSession
+ * cookie but does not auto-refresh on expiry. Without this middleware the access token goes stale after
+ * the IdP-configured TTL (typically 1 hour) even though the appSession cookie itself lives for
+ * `cookieMaxAge` (21 days), and Trilium never learns about an upstream revocation until the next manual
+ * logout.
+ *
+ * Behavior:
+ *   - Skipped when the user is not OIDC-authenticated, the access token is still valid, or no refresh
+ *     token is present (the configured `oauthScope` didn't include `offline_access`, so the provider
+ *     never issued one — the common case, and a no-op here).
+ *   - On `invalid_grant` (RFC 6749: refresh token revoked / expired / consent withdrawn): marks the
+ *     local session as not-authenticated. The downstream `auth.checkAuth` sees `!loggedIn` and redirects
+ *     to /login. This matches Auth0/Okta/Logto guidance that invalid_grant is terminal.
+ *   - On other errors (network blip, IdP 5xx): logs and proceeds. The local trilium.sid session is the
+ *     source of truth for "is this user logged in," so a transient IdP outage doesn't bounce the user.
+ *   - Concurrent requests with the same trilium.sid share one in-flight refresh promise, preventing
+ *     refresh-token-rotation races.
+ */
+export function refreshOidcTokenIfNeeded(req: Request, res: Response, next: NextFunction) {
+    if (!req.oidc?.isAuthenticated() || !req.session?.loggedIn) {
+        return next();
+    }
+
+    const accessToken = req.oidc.accessToken;
+    if (!accessToken || !accessToken.isExpired()) {
+        return next();
+    }
+
+    if (!req.oidc.refreshToken) {
+        return next();
+    }
+
+    const sessionId = req.sessionID;
+    let refreshPromise = inFlightRefreshes.get(sessionId);
+    if (!refreshPromise) {
+        // The library exposes refresh() on the AccessToken (it performs the refresh_token grant and
+        // updates the appSession in place), not on req.oidc itself.
+        refreshPromise = accessToken
+            .refresh()
+            .then(() => undefined)
+            .finally(() => {
+                inFlightRefreshes.delete(sessionId);
+            });
+        inFlightRefreshes.set(sessionId, refreshPromise);
+    }
+
+    refreshPromise
+        .then(() => next())
+        .catch((err: unknown) => {
+            const oauthError = (err as { error?: string })?.error;
+            const message = err instanceof Error ? err.message : String(err);
+            if (oauthError === "invalid_grant") {
+                getLog().info(`OIDC refresh token rejected by IdP (invalid_grant): ${message}. Forcing re-authentication.`);
+                req.session.loggedIn = false;
+                return next();
+            }
+            getLog().info(`OIDC token refresh failed: ${message}. Continuing with the expired access token.`);
+            next();
+        });
+}
+
 async function isTokenValid(req: Request, res: Response, next: NextFunction) {
     const userStatus = openIDEncryption.isSubjectIdentifierSaved();
 
@@ -144,6 +221,19 @@ function generateOAuthConfig(endSessionSupported = false) {
     const logoutParams = {
     };
 
+    // Refresh tokens are only issued when the operator opts in by adding `offline_access` to oauthScope.
+    // Only then do we ask for offline access at the authorization endpoint: `access_type=offline` is
+    // required for Google to return a refresh token, and `prompt=consent` makes Google re-issue one on
+    // subsequent logins (it otherwise returns a refresh token only on the very first consent). Both are
+    // omitted by default so the standard sign-in flow stays clean — matching upstream's removal of the
+    // unconditional offline params — and are added back only for the refresh-token use case.
+    const wantsOfflineAccess = config.MultiFactorAuthentication.oauthScope
+        .split(/\s+/)
+        .includes("offline_access");
+    const offlineAccessParams = wantsOfflineAccess
+        ? { access_type: "offline", prompt: "consent" }
+        : {};
+
     const authConfig = {
         authRequired: false,
         auth0Logout: false,
@@ -156,6 +246,7 @@ function generateOAuthConfig(endSessionSupported = false) {
         authorizationParams: {
             response_type: "code",
             scope: config.MultiFactorAuthentication.oauthScope,
+            ...offlineAccessParams,
         },
         // Override the library's default 5000 ms timeout for discovery / token-exchange / userinfo requests.
         // Cold-start IdP responses (e.g. a scaled-to-zero provider) routinely exceed 5s and manifest as a
@@ -348,6 +439,7 @@ export default {
     isTokenValid,
     isUserSaved,
     isRpInitiatedLogoutSupported,
+    refreshOidcTokenIfNeeded,
 };
 
 const GOOGLE_ISSUER = "https://accounts.google.com";

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -83,12 +83,45 @@ function getOAuthStatus() {
  * share a single network call to the IdP. Without this, refresh-token rotation (Authentik, Auth0,
  * Okta default) breaks under load: the first request consumes the refresh token, the rest see
  * invalid_grant on a now-stale token and would (per the policy below) be force-logged-out.
+ *
+ * Each promise resolves with a snapshot of the refreshed token fields so piggybacking requests can
+ * copy them into their own appSession (see {@link snapshotRefreshedTokens}).
  */
-const inFlightRefreshes = new Map<string, Promise<void>>();
+const inFlightRefreshes = new Map<string, Promise<Record<string, unknown> | undefined>>();
 
 /** Test-only: clear the in-flight refresh cache between cases. */
 export function _resetInFlightRefreshesForTesting() {
     inFlightRefreshes.clear();
+}
+
+/**
+ * The token fields express-openid-connect persists in the appSession cookie and updates on refresh
+ * (see the library's context.js `refresh()`).
+ */
+const OIDC_TOKEN_FIELDS = ["id_token", "access_token", "refresh_token", "token_type", "expires_at"] as const;
+
+/**
+ * The library keeps each request's decoded session at `req.appSession` (the default
+ * `config.session.name`); it is not part of the typed public API, hence the indexed access.
+ */
+function getAppSession(req: Request): Record<string, unknown> | undefined {
+    const session = (req as unknown as Record<string, unknown>).appSession;
+    return typeof session === "object" && session !== null ? session as Record<string, unknown> : undefined;
+}
+
+/** Captures the post-refresh token fields from the initiating request's appSession. */
+function snapshotRefreshedTokens(req: Request): Record<string, unknown> | undefined {
+    const session = getAppSession(req);
+    if (!session) {
+        return undefined;
+    }
+    const tokens: Record<string, unknown> = {};
+    for (const field of OIDC_TOKEN_FIELDS) {
+        if (session[field] !== undefined) {
+            tokens[field] = session[field];
+        }
+    }
+    return tokens;
 }
 
 /**
@@ -133,7 +166,7 @@ export function refreshOidcTokenIfNeeded(req: Request, res: Response, next: Next
         // updates the appSession in place), not on req.oidc itself.
         refreshPromise = accessToken
             .refresh()
-            .then(() => undefined)
+            .then(() => snapshotRefreshedTokens(req))
             .finally(() => {
                 inFlightRefreshes.delete(sessionId);
             });
@@ -141,7 +174,18 @@ export function refreshOidcTokenIfNeeded(req: Request, res: Response, next: Next
     }
 
     refreshPromise
-        .then(() => next())
+        .then((refreshedTokens) => {
+            // Each coalesced request decodes its *own* copy of the appSession cookie, and the library
+            // re-encrypts that copy into a Set-Cookie on every response (rolling sessions). Copy the
+            // refreshed tokens into this request's session too — otherwise a piggybacking response
+            // written after the initiator's would clobber the rotated tokens with the stale,
+            // already-consumed pair, and the next request would hit invalid_grant.
+            const session = getAppSession(req);
+            if (session && refreshedTokens) {
+                Object.assign(session, refreshedTokens);
+            }
+            next();
+        })
         .catch((err: unknown) => {
             const oauthError = (err as { error?: string })?.error;
             const message = err instanceof Error ? err.message : String(err);
@@ -222,15 +266,23 @@ function generateOAuthConfig(endSessionSupported = false) {
     };
 
     // Refresh tokens are only issued when the operator opts in by adding `offline_access` to oauthScope.
-    // Only then do we ask for offline access at the authorization endpoint: `access_type=offline` is
-    // required for Google to return a refresh token, and `prompt=consent` makes Google re-issue one on
-    // subsequent logins (it otherwise returns a refresh token only on the very first consent). Both are
-    // omitted by default so the standard sign-in flow stays clean — matching upstream's removal of the
-    // unconditional offline params — and are added back only for the refresh-token use case.
-    const wantsOfflineAccess = config.MultiFactorAuthentication.oauthScope
-        .split(/\s+/)
-        .includes("offline_access");
-    const offlineAccessParams = wantsOfflineAccess
+    // How that opt-in is expressed to the provider differs by issuer:
+    //   - Spec-compliant providers (Keycloak, Authentik, Okta, Auth0, ...): the `offline_access` scope
+    //     itself is the request for a refresh token — no extra parameters, and no `prompt=consent`,
+    //     which would otherwise force the consent screen on every single login.
+    //   - Google: does not accept `offline_access` as a scope (the authorization request fails with
+    //     invalid_scope), so the scope token is stripped and replaced with Google's own mechanism:
+    //     `access_type=offline` plus `prompt=consent` (without which Google only issues a refresh token
+    //     on the very first consent).
+    // Without the opt-in, neither is sent — the standard sign-in flow is unchanged, matching upstream's
+    // earlier removal of the unconditional offline params.
+    const scopeTokens = config.MultiFactorAuthentication.oauthScope.split(/\s+/);
+    const wantsOfflineAccess = scopeTokens.includes("offline_access");
+    const google = isGoogleIssuer();
+    const scope = wantsOfflineAccess && google
+        ? scopeTokens.filter((token) => token !== "offline_access").join(" ")
+        : config.MultiFactorAuthentication.oauthScope;
+    const offlineAccessParams = wantsOfflineAccess && google
         ? { access_type: "offline", prompt: "consent" }
         : {};
 
@@ -245,7 +297,7 @@ function generateOAuthConfig(endSessionSupported = false) {
         clientAuthMethod: resolveClientAuthMethod(),
         authorizationParams: {
             response_type: "code",
-            scope: config.MultiFactorAuthentication.oauthScope,
+            scope,
             ...offlineAccessParams,
         },
         // Override the library's default 5000 ms timeout for discovery / token-exchange / userinfo requests.
@@ -516,8 +568,13 @@ export function supportsRpInitiatedLogout(metadata: unknown) {
  *   mismatched method).
  */
 function resolveClientAuthMethod() {
-    const issuer = config.MultiFactorAuthentication.oauthIssuerBaseUrl.replace(/\/+$/, "");
-    return issuer === GOOGLE_ISSUER ? "client_secret_post" : "client_secret_basic";
+    return isGoogleIssuer() ? "client_secret_post" : "client_secret_basic";
+}
+
+/** Whether the configured issuer is Google (trailing slashes tolerated), which deviates from the OIDC
+ * spec in several places (Basic-auth credential encoding, offline-access mechanics). */
+function isGoogleIssuer() {
+    return config.MultiFactorAuthentication.oauthIssuerBaseUrl.replace(/\/+$/, "") === GOOGLE_ISSUER;
 }
 
 /**

--- a/docs/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.md
@@ -59,6 +59,19 @@ To do so:
 4.  This will redirect you to your authentication provider, where you can sign in or confirm the action if needed.
 5.  Once you are authenticated you will be redirected back to the Trilium application.
 
+## Refreshing tokens (offline access)
+
+By default Trilium requests only the `openid profile email` scopes, and the access token it receives from your provider is not automatically refreshed — it simply expires after the provider-configured lifetime (often an hour), which is harmless because Trilium's own session cookie is the source of truth for whether you are signed in.
+
+If you want Trilium to keep a valid provider access token — for example so it can detect when your provider revokes your session — request offline access:
+
+1.  Add `offline_access` to the `oauthScope` setting (e.g. `oauthScope=openid profile email offline_access`, or the `TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE` / `TRILIUM_OAUTH_SCOPE` environment variable).
+2.  Restart the server and reconnect your account so the provider issues a refresh token.
+
+When offline access is requested, Trilium additionally sends `access_type=offline` and `prompt=consent` to the authorization endpoint (required for Google to issue and re-issue a refresh token). These parameters are **not** sent otherwise, so the normal sign-in flow is unaffected.
+
+With a refresh token present, Trilium transparently refreshes an expired access token on the next request. If the provider rejects the refresh token (`invalid_grant` — e.g. the session was revoked or consent was withdrawn), you are signed out and redirected to the login screen. Transient provider errors (network blips, 5xx) do **not** sign you out — your local Trilium session remains valid.
+
 ## Logging out
 
 When logging out of Trilium, a request is made to the authentication provider to log out from there as well. This feature depends on the authentication provider, so it may not be honored (Google and Authelia are known cases in which they don't respect the logout feature).

--- a/docs/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.md
@@ -68,7 +68,7 @@ If you want Trilium to keep a valid provider access token — for example so it 
 1.  Add `offline_access` to the `oauthScope` setting (e.g. `oauthScope=openid profile email offline_access`, or the `TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE` / `TRILIUM_OAUTH_SCOPE` environment variable).
 2.  Restart the server and reconnect your account so the provider issues a refresh token.
 
-When offline access is requested, Trilium additionally sends `access_type=offline` and `prompt=consent` to the authorization endpoint (required for Google to issue and re-issue a refresh token). These parameters are **not** sent otherwise, so the normal sign-in flow is unaffected.
+How the request is made depends on your provider. For spec-compliant providers (Authelia, Authentik, Keycloak, Okta, Auth0, …) the `offline_access` scope itself is the refresh-token request and is passed through as-is. For **Google**, which does not accept `offline_access` as a scope, Trilium strips it from the requested scopes and instead sends Google's own mechanism: `access_type=offline` and `prompt=consent` (required for Google to issue and re-issue a refresh token). Without `offline_access` in the scope, none of this happens and the normal sign-in flow is unaffected.
 
 With a refresh token present, Trilium transparently refreshes an expired access token on the next request. If the provider rejects the refresh token (`invalid_grant` — e.g. the session was revoked or consent was withdrawn), you are signed out and redirected to the login screen. Transient provider errors (network blips, 5xx) do **not** sign you out — your local Trilium session remains valid.
 


### PR DESCRIPTION
## What this does

Adds an Express middleware, `refreshOidcTokenIfNeeded`, that refreshes an expired OIDC **access token** in place using the stored **refresh token**, so a long-lived Trilium SSO session can keep a valid provider token instead of silently going stale after the provider's (often 1-hour) access-token TTL.

> [!NOTE]
> **Stacked on #9635.** This PR is based on `feat/fix-oidc-take1` (#9635) and its diff shows only the refresh-token changes. #9635 makes the OIDC scope configurable, which is the prerequisite for requesting `offline_access`. Merge #9635 first (or retarget this to `main` after it lands).
>
> This was split out of the original combined OIDC branch at the maintainer's request so the hardening (#9635) and the refresh feature can be reviewed independently.

## How it works

`app.ts` mounts `refreshOidcTokenIfNeeded` immediately after the reactive OIDC middleware, so `req.oidc` is populated when it runs. The middleware:

- **No-ops** unless the user is OIDC-authenticated **and** the access token is expired **and** a refresh token is present. In the default configuration (no `offline_access`) the provider never issues a refresh token, so this is completely inert.
- Calls **`accessToken.refresh()`** — the library exposes `refresh()` on the `AccessToken` object (it performs the `refresh_token` grant and updates the appSession), not on `req.oidc`.
- On **`invalid_grant`** (RFC 6749 — refresh token revoked / expired / consent withdrawn): marks the local session `loggedIn = false`, so the downstream `checkAuth` redirects to `/login`. This is the only way Trilium learns of an upstream revocation between logins.
- On **transient errors** (network blip, IdP 5xx): logs and continues on the existing session — a provider outage must not bounce a logged-in user, since `trilium.sid` is the source of truth for "is this user signed in."
- **Coalesces concurrent refreshes**: expired-token requests sharing one `trilium.sid` share a single in-flight refresh promise, so refresh-token *rotation* (Authentik/Auth0/Okta default) doesn't race — the first request consumes the RT and the rest piggy-back instead of racing on a now-stale token. The rotated tokens are then **copied into each piggybacking request's `appSession`**: every request decodes its own copy of the (stateless, rolling) session cookie and the library re-encrypts that copy on every response, so without the copy a piggybacker's stale `Set-Cookie` could clobber the initiator's refreshed one and force `invalid_grant` on the next request (caught by Greptile in review).

## Requesting offline access (opt-in)

Refresh tokens are only issued when the operator adds `offline_access` to `oauthScope`. How that opt-in reaches the provider is issuer-aware (refined from review feedback):

- **Spec-compliant providers** (Authelia, Authentik, Keycloak, Okta, Auth0, …): the `offline_access` scope itself is the refresh-token request and is passed through as-is. No extra parameters — unconditionally sending `prompt=consent` would force the consent screen on every single login.
- **Google**: does not accept `offline_access` as a scope (fails with `invalid_scope`), so the scope token is stripped and replaced with Google's own mechanism: `access_type=offline` + `prompt=consent` (without which Google only issues a refresh token on the very first consent).

Without the opt-in, neither is sent — the default sign-in flow is byte-for-byte identical to `main`, matching its earlier removal of the unconditional offline params (`c23d567`). Documented in the "Signing in with OpenID Connect" User Guide page.

## Note during extraction

The original version of this middleware called `req.oidc.refresh()`, which does not exist — the library puts `refresh()` on the `AccessToken`, so it would have thrown `req.oidc.refresh is not a function` the first time a token expired. Rebasing onto current `main` and typechecking caught it; fixed here to `accessToken.refresh()`, with a unit test that exercises the success path against the correct API.

## Tests

`open_id.spec.ts` covers all middleware branches (not authenticated, not logged in, token still valid, no refresh token, successful refresh, transient soft-fail keeps the session, `invalid_grant` forces re-auth, concurrent coalescing, rotated-token propagation into piggybackers) plus the per-issuer offline-access gating in `generateOAuthConfig` (spec provider passes the scope through with no params; Google strips the scope and gets `access_type`/`prompt`; no opt-in → untouched). All server `open_id`/`config` unit tests pass (68/68); typecheck is clean.
