### PR TITLE
Mobile sync: memory pressure & restart-resilience improvements

### DIFF
--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -52,10 +52,25 @@ function renderState(state: State, setState: (state: State) => void) {
 }
 
 function App() {
-    const [state, setState] = useState<State>("selectLanguage");
+    // A sync that already created the schema but was interrupted before finishing
+    // resumes straight on the progress screen instead of restarting the wizard.
+    const resuming = window.glob.syncInProgress === true;
+    const [state, setState] = useState<State>(resuming ? "syncFromServerInProgress" : "selectLanguage");
     const [prevState, setPrevState] = useState<State | null>(null);
     const [transitioning, setTransitioning] = useState(false);
     const prevStateRef = useRef<State>(state);
+
+    useEffect(() => {
+        if (!resuming) {
+            return;
+        }
+        // The background sync timer stays gated behind DB initialization, so nothing
+        // restarts the interrupted sync on its own — kick it off like the launch-bar
+        // button does. sync/now is a no-op if a sync is somehow already running.
+        server.post("sync/now").catch(() => {
+            // Ignore — the progress screen keeps polling sync/stats regardless.
+        });
+    }, [resuming]);
 
     function handleSetState(newState: State) {
         setPrevState(prevStateRef.current);

--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -247,11 +247,14 @@ function SyncInProgress({ device }: { device: "server" | "desktop" }) {
     const currentIndex = steps.findIndex((s) => s.key === step);
 
     const syncingDone = currentIndex > steps.findIndex((s) => s.key === "syncing");
+    // Pulled-so-far, clamped: the remote can gain changes mid-sync, briefly pushing the
+    // outstanding count above the frozen total, which would otherwise show a negative bar.
+    const pulled = stats.totalPullCount ? Math.max(0, stats.totalPullCount - stats.outstandingPullCount) : 0;
     let progress = 0;
     if (syncingDone) {
         progress = 100;
     } else if (stats.totalPullCount) {
-        progress = Math.round(((stats.totalPullCount - stats.outstandingPullCount) / stats.totalPullCount) * 100);
+        progress = Math.min(100, Math.round((pulled / stats.totalPullCount) * 100));
     }
 
     return (
@@ -267,7 +270,7 @@ function SyncInProgress({ device }: { device: "server" | "desktop" }) {
                         {s.label}
                         {s.key === "syncing" && (
                             <div class="sync-progress">
-                                <progress value={syncingDone ? 1 : stats.totalPullCount! - stats.outstandingPullCount} max={syncingDone ? 1 : stats.totalPullCount!} />
+                                <progress value={syncingDone ? 1 : pulled} max={syncingDone ? 1 : (stats.totalPullCount ?? 1)} />
                                 <span>{progress}%</span>
                             </div>
                         )}

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <application
         android:allowBackup="true"
+        android:largeHeap="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/apps/standalone/src/lightweight/crypto_provider.spec.ts
+++ b/apps/standalone/src/lightweight/crypto_provider.spec.ts
@@ -223,5 +223,23 @@ describe("BrowserCryptoProvider base64", () => {
             for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31 + 7) & 0xff;
             expect(Array.from(provider.base64Decode(provider.base64Encode(bytes)))).toEqual(Array.from(bytes));
         });
+
+        it("ignores embedded whitespace instead of decoding it as zero bytes (atob / native parity)", () => {
+            // Line-wrapped and space-separated base64 must decode identically to the compact form,
+            // not emit spurious 0x00 bytes for the newlines/spaces.
+            expect(decoder.decode(provider.base64Decode("Zm9v\nYmFy"))).toBe("foobar");
+            expect(decoder.decode(provider.base64Decode("Zm9v YmFy"))).toBe("foobar");
+            expect(decoder.decode(provider.base64Decode("  Zm9v\r\nYmFy  \n"))).toBe("foobar");
+            // Whitespace around padding is tolerated too.
+            expect(Array.from(provider.base64Decode("Zg =="))).toEqual([0x66]);
+            expect(Array.from(provider.base64Decode("Z m 8 ="))).toEqual([0x66, 0x6f]);
+        });
+
+        it("round-trips a large buffer that is line-wrapped every 76 chars (MIME style)", () => {
+            const bytes = new Uint8Array(50_000);
+            for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 17 + 3) & 0xff;
+            const wrapped = provider.base64Encode(bytes).replace(/(.{76})/g, "$1\n");
+            expect(Array.from(provider.base64Decode(wrapped))).toEqual(Array.from(bytes));
+        });
     });
 });

--- a/apps/standalone/src/lightweight/crypto_provider.spec.ts
+++ b/apps/standalone/src/lightweight/crypto_provider.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import aesjs from "aes-js";
 
 import BrowserCryptoProvider from "./crypto_provider.js";
@@ -184,5 +184,44 @@ describe("BrowserCryptoProvider base64", () => {
             expect(Array.from(provider.base64Decode("abcd"))).toEqual([4]);
         });
         /* eslint-enable @typescript-eslint/no-explicit-any */
+    });
+
+    describe("fallback decoder (WebView < 140, no native fromBase64)", () => {
+        // Force the pure-JS decoder — the exact path the mobile WebView 136 takes — by removing the
+        // native method for the duration of these tests.
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const ctor = Uint8Array as any;
+        const savedFromBase64 = ctor.fromBase64;
+        beforeEach(() => delete ctor.fromBase64);
+        afterEach(() => {
+            if (savedFromBase64 === undefined) delete ctor.fromBase64;
+            else ctor.fromBase64 = savedFromBase64;
+        });
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+
+        it("decodes the RFC 4648 vectors (no atob intermediate)", () => {
+            for (const [input, expected] of vectors) {
+                expect(decoder.decode(provider.base64Decode(expected))).toBe(input);
+            }
+        });
+
+        it("handles empty input and both padding lengths", () => {
+            expect(provider.base64Decode("")).toHaveLength(0);
+            expect(Array.from(provider.base64Decode("Zg=="))).toEqual([0x66]); // 1 byte, 2 pad
+            expect(Array.from(provider.base64Decode("Zm8="))).toEqual([0x66, 0x6f]); // 2 bytes, 1 pad
+            expect(Array.from(provider.base64Decode("Zm9v"))).toEqual([0x66, 0x6f, 0x6f]); // 3 bytes, no pad
+        });
+
+        it("round-trips every byte value 0..255 on the fallback path", () => {
+            const bytes = new Uint8Array(256);
+            for (let i = 0; i < 256; i++) bytes[i] = i;
+            expect(Array.from(provider.base64Decode(provider.base64Encode(bytes)))).toEqual(Array.from(bytes));
+        });
+
+        it("round-trips a large buffer whose length is not a multiple of 3", () => {
+            const bytes = new Uint8Array(100_003);
+            for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31 + 7) & 0xff;
+            expect(Array.from(provider.base64Decode(provider.base64Encode(bytes)))).toEqual(Array.from(bytes));
+        });
     });
 });

--- a/apps/standalone/src/lightweight/crypto_provider.ts
+++ b/apps/standalone/src/lightweight/crypto_provider.ts
@@ -9,6 +9,12 @@ import aesjs from "aes-js";
 
 const CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
+// Test-only (Vite define): force the pure-JS base64 fallback, reproducing WebViews below Chrome 140
+// that lack native Uint8Array.fromBase64/toBase64 — e.g. the Android WebView 136 that OOMs on sync.
+// Never set in production builds.
+declare const __TRILIUM_FORCE_B64_FALLBACK__: boolean;
+const FORCE_B64_FALLBACK = typeof __TRILIUM_FORCE_B64_FALLBACK__ !== "undefined" && __TRILIUM_FORCE_B64_FALLBACK__;
+
 /**
  * Crypto provider for browser environments using pure JavaScript crypto libraries.
  * Uses aes-js for synchronous AES encryption (matching Node.js behavior).
@@ -100,7 +106,7 @@ export default class BrowserCryptoProvider implements CryptoProvider {
         // Firefox 133+, Safari 18.2+. It runs at native speed (SIMD) and avoids materializing
         // the intermediate "binary string" entirely. Detected per call so tests can stub it.
         const nativeBytes = bytes as NativeBase64Array;
-        if (typeof nativeBytes.toBase64 === "function") {
+        if (!FORCE_B64_FALLBACK && typeof nativeBytes.toBase64 === "function") {
             return nativeBytes.toBase64();
         }
 
@@ -117,18 +123,58 @@ export default class BrowserCryptoProvider implements CryptoProvider {
 
     base64Decode(base64: string): Uint8Array {
         const nativeCtor = Uint8Array as unknown as NativeBase64Constructor;
-        if (typeof nativeCtor.fromBase64 === "function") {
+        if (!FORCE_B64_FALLBACK && typeof nativeCtor.fromBase64 === "function") {
             return nativeCtor.fromBase64(base64);
         }
 
-        const binary = atob(base64);
-        const len = binary.length;
-        const bytes = new Uint8Array(len);
-        for (let i = 0; i < len; i++) {
-            bytes[i] = binary.charCodeAt(i);
-        }
-        return bytes;
+        return base64FallbackDecode(base64);
     }
+}
+
+// Base64 alphabet → 6-bit value, indexed by char code (non-alphabet bytes map to 0).
+const B64_DECODE_TABLE = /* @__PURE__ */ (() => {
+    const table = new Uint8Array(256);
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    for (let i = 0; i < alphabet.length; i++) {
+        table[alphabet.charCodeAt(i)] = i;
+    }
+    return table;
+})();
+
+/**
+ * Decodes standard (padded) base64 straight into a pre-sized `Uint8Array`, without `atob`'s
+ * intermediate binary string. On the WebView-<140 fallback path this removes a whole extra copy of
+ * the decoded blob from the peak — the copy that pushed sync's blob decode over the mobile heap.
+ * Assumes padded, whitespace-free standard base64 (what `encodeBase64` / btoa / `toBase64` emit).
+ */
+function base64FallbackDecode(base64: string): Uint8Array {
+    const len = base64.length;
+    if (len === 0) {
+        return new Uint8Array(0);
+    }
+
+    let padding = 0;
+    if (base64.charCodeAt(len - 1) === 0x3d) padding++; // '='
+    if (len > 1 && base64.charCodeAt(len - 2) === 0x3d) padding++;
+
+    // For padded base64 `len` is a multiple of 4, so this is exact.
+    const outLen = ((len * 3) >> 2) - padding;
+    const bytes = new Uint8Array(outLen);
+    const table = B64_DECODE_TABLE;
+
+    let o = 0;
+    for (let i = 0; i < len; i += 4) {
+        const c0 = table[base64.charCodeAt(i)];
+        const c1 = table[base64.charCodeAt(i + 1)];
+        const c2 = table[base64.charCodeAt(i + 2)];
+        const c3 = table[base64.charCodeAt(i + 3)];
+
+        bytes[o++] = (c0 << 2) | (c1 >> 4);
+        if (o < outLen) bytes[o++] = ((c1 & 0x0f) << 4) | (c2 >> 2);
+        if (o < outLen) bytes[o++] = ((c2 & 0x03) << 6) | c3;
+    }
+
+    return bytes;
 }
 
 /**

--- a/apps/standalone/src/lightweight/crypto_provider.ts
+++ b/apps/standalone/src/lightweight/crypto_provider.ts
@@ -131,9 +131,13 @@ export default class BrowserCryptoProvider implements CryptoProvider {
     }
 }
 
-// Base64 alphabet → 6-bit value, indexed by char code (non-alphabet bytes map to 0).
+// Sentinel for a char code that is not part of the base64 alphabet. Distinct from 0 so the decoder
+// can tell a real 'A' (value 0) apart from padding / whitespace / garbage, which it skips.
+const B64_INVALID = 0xff;
+
+// Base64 alphabet → 6-bit value, indexed by char code (non-alphabet bytes map to B64_INVALID).
 const B64_DECODE_TABLE = /* @__PURE__ */ (() => {
-    const table = new Uint8Array(256);
+    const table = new Uint8Array(256).fill(B64_INVALID);
     const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     for (let i = 0; i < alphabet.length; i++) {
         table[alphabet.charCodeAt(i)] = i;
@@ -142,39 +146,41 @@ const B64_DECODE_TABLE = /* @__PURE__ */ (() => {
 })();
 
 /**
- * Decodes standard (padded) base64 straight into a pre-sized `Uint8Array`, without `atob`'s
- * intermediate binary string. On the WebView-<140 fallback path this removes a whole extra copy of
- * the decoded blob from the peak — the copy that pushed sync's blob decode over the mobile heap.
- * Assumes padded, whitespace-free standard base64 (what `encodeBase64` / btoa / `toBase64` emit).
+ * Decodes standard base64 straight into a pre-sized `Uint8Array`, without `atob`'s intermediate
+ * binary string. On the WebView-<140 fallback path this removes a whole extra copy of the decoded
+ * blob from the peak — the copy that pushed sync's blob decode over the mobile heap.
+ *
+ * Non-alphabet characters (padding `=` and any ASCII whitespace, e.g. newlines in line-wrapped
+ * base64) are skipped rather than decoded as zero bytes, matching `atob` / native `fromBase64`
+ * semantics. This is done in a single streaming pass over the input via a bit accumulator, so it
+ * stays allocation-free (no sanitized copy of the whole string) and preserves the memory win.
  */
 function base64FallbackDecode(base64: string): Uint8Array {
     const len = base64.length;
-    if (len === 0) {
-        return new Uint8Array(0);
-    }
-
-    let padding = 0;
-    if (base64.charCodeAt(len - 1) === 0x3d) padding++; // '='
-    if (len > 1 && base64.charCodeAt(len - 2) === 0x3d) padding++;
-
-    // For padded base64 `len` is a multiple of 4, so this is exact.
-    const outLen = ((len * 3) >> 2) - padding;
-    const bytes = new Uint8Array(outLen);
     const table = B64_DECODE_TABLE;
 
-    let o = 0;
-    for (let i = 0; i < len; i += 4) {
-        const c0 = table[base64.charCodeAt(i)];
-        const c1 = table[base64.charCodeAt(i + 1)];
-        const c2 = table[base64.charCodeAt(i + 2)];
-        const c3 = table[base64.charCodeAt(i + 3)];
+    // Upper bound: every 4 alphabet symbols yield 3 bytes. Padding/whitespace only ever reduce the
+    // real output, so this never under-allocates; the exact length is returned as a view at the end.
+    const bytes = new Uint8Array((len * 3) >> 2);
 
-        bytes[o++] = (c0 << 2) | (c1 >> 4);
-        if (o < outLen) bytes[o++] = ((c1 & 0x0f) << 4) | (c2 >> 2);
-        if (o < outLen) bytes[o++] = ((c2 & 0x03) << 6) | c3;
+    let o = 0;
+    let acc = 0; // bit accumulator holding up to three pending 6-bit symbols
+    let accBits = 0;
+    for (let i = 0; i < len; i++) {
+        const v = table[base64.charCodeAt(i)];
+        if (v === B64_INVALID) {
+            continue; // '=' padding or whitespace — ignore, don't emit a zero byte
+        }
+
+        acc = (acc << 6) | v;
+        accBits += 6;
+        if (accBits >= 8) {
+            accBits -= 8;
+            bytes[o++] = (acc >> accBits) & 0xff;
+        }
     }
 
-    return bytes;
+    return o === bytes.length ? bytes : bytes.subarray(0, o);
 }
 
 /**

--- a/apps/standalone/src/services/capacitor_http_handler.spec.ts
+++ b/apps/standalone/src/services/capacitor_http_handler.spec.ts
@@ -24,11 +24,12 @@ describe("capacitorHttpHandler", () => {
         ).rejects.toThrow("CapacitorHttp plugin is not available");
     });
 
-    it("forwards the request and lowercases response header keys (object body)", async () => {
+    it("requests the raw text response and passes a JSON string through unchanged (no re-parse/re-stringify)", async () => {
+        const rawJson = '{"ok":true}';
         const request = vi.fn().mockResolvedValue({
             status: 200,
             headers: { "Content-Type": "application/json", "X-Custom": "v" },
-            data: { ok: true }
+            data: rawJson
         });
         installCapacitor(request);
 
@@ -44,10 +45,19 @@ describe("capacitorHttpHandler", () => {
             url: "https://api/test",
             headers: { Authorization: "token" },
             data: "{}",
-            responseType: undefined
+            responseType: "text"
         });
         expect(result.status).toBe(200);
         expect(result.headers).toEqual({ "content-type": "application/json", "x-custom": "v" });
+        // Passed straight through — not JSON.stringify'd back.
+        expect(result.body).toBe(rawJson);
+    });
+
+    it("still serializes object response data as a defensive fallback", async () => {
+        const request = vi.fn().mockResolvedValue({ status: 200, headers: {}, data: { ok: true } });
+        installCapacitor(request);
+
+        const result = await capacitorHttpHandler({ method: "GET", url: "https://x", headers: {} });
         expect(result.body).toBe(JSON.stringify({ ok: true }));
     });
 

--- a/apps/standalone/src/services/capacitor_http_handler.ts
+++ b/apps/standalone/src/services/capacitor_http_handler.ts
@@ -33,12 +33,18 @@ function getCapacitorHttp() {
  * restrictions, and plain HTTP targets work from an HTTPS WebView origin.
  */
 export const capacitorHttpHandler: NativeHttpHandler = async (request) => {
+    // Ask for the raw response as text rather than CapacitorHttp's default JSON auto-parsing. The
+    // worker (BridgedRequestProvider) parses the body itself, so letting the plugin parse it to an
+    // object only for us to JSON.stringify it straight back is a wasted parse + serialize of the
+    // entire body — doubling main-thread peak memory on a large sync response (e.g. one carrying a
+    // big blob), which shares the mobile process heap with the sync worker.
+    const responseType = request.responseType ?? "text";
     const response = await getCapacitorHttp().request({
         method: request.method,
         url: request.url,
         headers: request.headers,
         data: request.body,
-        responseType: request.responseType
+        responseType
     });
 
     // Normalize header keys to lowercase for consistent access in the worker

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -387,6 +387,13 @@ export interface DefinitionObject {
 export type BootstrapDefinition = {
     dbInitialized: boolean;
     /**
+     * Whether a sync that has already created the database schema was interrupted
+     * before finishing (schema exists but the `initialized` flag is not yet set).
+     * Only meaningful while `dbInitialized` is `false`; the setup screen uses it to
+     * jump straight back to the sync-in-progress step and resume the sync on restart.
+     */
+    syncInProgress?: boolean;
+    /**
      * Whether a password has been set yet. `false` only in the pre-auth window
      * after the database is initialized but before the user has set a password,
      * which the client uses to render the set-password screen. Omitted (treated

--- a/packages/trilium-core/src/services/bootstrap_utils.spec.ts
+++ b/packages/trilium-core/src/services/bootstrap_utils.spec.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import attributes from "./attributes.js";
 import getSharedBootstrapItems, { getIconConfig } from "./bootstrap_utils.js";
 import * as cls from "./context.js";
 import notes from "./notes.js";
 import options from "./options.js";
+import sqlInit from "./sql_init.js";
 
 const ASSET_PATH = "assets-x";
 
@@ -41,6 +42,21 @@ describe("bootstrap_utils (real DB)", () => {
         expect(items.assetPath).toBe(ASSET_PATH);
         expect(items.iconRegistry).toBeTruthy();
         expect(typeof items.iconPackCss).toBe("string");
+    });
+
+    it("flags syncInProgress for a not-yet-initialized DB only when the schema already exists", () => {
+        const schemaSpy = vi.spyOn(sqlInit, "schemaExists");
+        try {
+            // Schema present but DB not initialized = a sync that was interrupted → resume it.
+            schemaSpy.mockReturnValue(true);
+            expect(getSharedBootstrapItems(ASSET_PATH, false).syncInProgress).toBe(true);
+
+            // No schema yet = a fresh install → start the setup wizard from the top.
+            schemaSpy.mockReturnValue(false);
+            expect(getSharedBootstrapItems(ASSET_PATH, false).syncInProgress).toBe(false);
+        } finally {
+            schemaSpy.mockRestore();
+        }
     });
 
     it("returns the full payload once the DB is initialized, including app CSS note ids", () => {

--- a/packages/trilium-core/src/services/bootstrap_utils.ts
+++ b/packages/trilium-core/src/services/bootstrap_utils.ts
@@ -23,6 +23,10 @@ export default function getSharedBootstrapItems(assetPath: string, dbInitialized
         layoutOrientation: "vertical" as const,
         headingStyle: "plain" as const,
         componentId: "",
+        // Schema present but not yet initialized means a sync was started and interrupted, so the
+        // setup screen resumes it instead of starting over. A fully initialized DB is never mid-sync.
+        // Kept in the common items so both payload shapes carry the flag uniformly.
+        syncInProgress: !dbInitialized && sqlInit.schemaExists(),
         ...getIconConfig(assetPath)
     };
 
@@ -30,9 +34,6 @@ export default function getSharedBootstrapItems(assetPath: string, dbInitialized
     if (!dbInitialized) {
         return {
             ...commonItems,
-            // Schema already present but not yet initialized means a sync was started
-            // and interrupted, so the setup screen resumes it instead of starting over.
-            syncInProgress: sqlInit.schemaExists(),
             theme: "next",
             themeCssUrl: false as const,
             themeUseNextAsBase: "next" as const,

--- a/packages/trilium-core/src/services/bootstrap_utils.ts
+++ b/packages/trilium-core/src/services/bootstrap_utils.ts
@@ -8,6 +8,7 @@ import { getCurrentLocale } from "./i18n";
 import attributes from "./attributes";
 import BNote from "../becca/entities/bnote";
 import { getPlatform } from "./platform";
+import sqlInit from "./sql_init";
 
 export default function getSharedBootstrapItems(assetPath: string, dbInitialized: boolean) {
     const sql = getSql();
@@ -29,6 +30,9 @@ export default function getSharedBootstrapItems(assetPath: string, dbInitialized
     if (!dbInitialized) {
         return {
             ...commonItems,
+            // Schema already present but not yet initialized means a sync was started
+            // and interrupted, so the setup screen resumes it instead of starting over.
+            syncInProgress: sqlInit.schemaExists(),
             theme: "next",
             themeCssUrl: false as const,
             themeUseNextAsBase: "next" as const,

--- a/packages/trilium-core/src/services/sync.spec.ts
+++ b/packages/trilium-core/src/services/sync.spec.ts
@@ -115,11 +115,14 @@ describe("sync service", () => {
         expect(urls.some((u) => u.includes("/api/sync/check"))).toBe(true);
     });
 
-    it("counts already-pulled local changes into the pull total so a resumed sync keeps the grand total", async () => {
+    it("counts already-pulled local changes into the pull total so a resumed initial sync keeps the grand total", async () => {
         // On resume the remote only reports the *remaining* changes; the already-pulled ones live in
         // the local entity_changes table. The total must be their sum, otherwise the setup progress
-        // bar rescales the leftover work to 0-100% and appears to restart from zero.
+        // bar rescales the leftover work to 0-100% and appears to restart from zero. This only applies
+        // while the DB is not yet marked initialized (the initial sync hasn't converged).
         const countSynced = () => getSql().getValue<number>("SELECT COUNT(1) FROM entity_changes WHERE isSynced = 1") ?? 0;
+        const prevInitialized = options.getOptionOrNull("initialized");
+        cls.init(() => options.setOption("initialized", "false"));
 
         let alreadyPulled = 0;
         let capturedTotal: number | null = null;
@@ -134,10 +137,40 @@ describe("sync service", () => {
             { entityChanges: [], lastEntityChangeId: 9, outstandingPullCount: 0 }
         ];
 
-        await runSync();
+        try {
+            await runSync();
+        } finally {
+            cls.init(() => options.setOption("initialized", prevInitialized ?? "true"));
+        }
 
         // grand total = already-pulled (local) + this batch (1) + remaining reported by the remote (5)
         expect(capturedTotal).toBe(alreadyPulled + 1 + 5);
+    });
+
+    it("does not count historical changes into the pull total on an established (initialized) database", async () => {
+        // Post-initialization the setup progress bar isn't shown, and counting every change ever
+        // pulled would both scan the full entity_changes table and inflate the total. The session
+        // total should be just this batch plus the remaining outstanding changes.
+        const prevInitialized = options.getOptionOrNull("initialized");
+        cls.init(() => options.setOption("initialized", "true"));
+
+        let capturedTotal: number | null = null;
+        config.onChanged = (callIndex) => {
+            if (callIndex === 1) capturedTotal = syncService.getTotalPullCount();
+        };
+        config.changed = [
+            { entityChanges: [pulledOptionChange()], lastEntityChangeId: 9, outstandingPullCount: 5 },
+            { entityChanges: [], lastEntityChangeId: 9, outstandingPullCount: 0 }
+        ];
+
+        try {
+            await runSync();
+        } finally {
+            cls.init(() => options.setOption("initialized", prevInitialized ?? "true"));
+        }
+
+        // 1 change in this batch + 5 remaining, with no historical inflation.
+        expect(capturedTotal).toBe(1 + 5);
     });
 
     it("persists an advanced cursor even when the server returns an empty change batch", async () => {

--- a/packages/trilium-core/src/services/sync.spec.ts
+++ b/packages/trilium-core/src/services/sync.spec.ts
@@ -31,6 +31,7 @@ interface FakeConfig {
     changed?: ChangesResponse[];
     check?: CheckResponse[];
     onCheck?: (callIndex: number) => void;
+    onChanged?: (callIndex: number) => void;
 }
 
 let config: FakeConfig = {};
@@ -50,6 +51,7 @@ const fakeRequest: RequestProvider = {
             return reply(config.login ?? { instanceId: "REMOTE_INSTANCE", maxEntityChangeId: 0 });
         }
         if (url.includes("/api/sync/changed")) {
+            config.onChanged?.(changedIdx);
             const seq = config.changed ?? [{ entityChanges: [], lastEntityChangeId: 0, outstandingPullCount: 0 }];
             return reply(seq[Math.min(changedIdx++, seq.length - 1)]);
         }
@@ -111,6 +113,31 @@ describe("sync service", () => {
         expect(urls.some((u) => u.includes("/api/sync/changed"))).toBe(true);
         expect(urls.some((u) => u.includes("/api/sync/finished"))).toBe(true);
         expect(urls.some((u) => u.includes("/api/sync/check"))).toBe(true);
+    });
+
+    it("counts already-pulled local changes into the pull total so a resumed sync keeps the grand total", async () => {
+        // On resume the remote only reports the *remaining* changes; the already-pulled ones live in
+        // the local entity_changes table. The total must be their sum, otherwise the setup progress
+        // bar rescales the leftover work to 0-100% and appears to restart from zero.
+        const countSynced = () => getSql().getValue<number>("SELECT COUNT(1) FROM entity_changes WHERE isSynced = 1") ?? 0;
+
+        let alreadyPulled = 0;
+        let capturedTotal: number | null = null;
+        config.onChanged = (callIndex) => {
+            // callIndex 0: same moment the sync samples the already-pulled count.
+            if (callIndex === 0) alreadyPulled = countSynced();
+            // callIndex 1: the total has now been frozen for this session — read it back.
+            if (callIndex === 1) capturedTotal = syncService.getTotalPullCount();
+        };
+        config.changed = [
+            { entityChanges: [pulledOptionChange()], lastEntityChangeId: 9, outstandingPullCount: 5 },
+            { entityChanges: [], lastEntityChangeId: 9, outstandingPullCount: 0 }
+        ];
+
+        await runSync();
+
+        // grand total = already-pulled (local) + this batch (1) + remaining reported by the remote (5)
+        expect(capturedTotal).toBe(alreadyPulled + 1 + 5);
     });
 
     it("persists an advanced cursor even when the server returns an empty change batch", async () => {

--- a/packages/trilium-core/src/services/sync.ts
+++ b/packages/trilium-core/src/services/sync.ts
@@ -11,6 +11,7 @@ import { getLog } from "./log.js";
 import optionService from "./options.js";
 import setupService from "./setup.js";
 import { getSql } from "./sql/index.js";
+import sqlInit from "./sql_init.js";
 import syncMutexService from "./sync_mutex.js";
 import syncOptions from "./sync_options.js";
 import syncUpdateService from "./sync_update.js";
@@ -204,10 +205,19 @@ async function pullChanges(syncContext: SyncContext) {
 
             if (totalPullCount === null) {
                 // Keep the denominator as the *grand* total so the setup progress bar doesn't reset
-                // to 0% after a restart. Already-pulled changes persist in the local entity_changes
-                // table, so adding them to the remaining count reconstructs the original total —
-                // a resumed sync would otherwise only see the leftover work and rescale from zero.
-                const alreadyPulled = getSql().getValue<number>("SELECT COUNT(1) FROM entity_changes WHERE isSynced = 1") ?? 0;
+                // to 0% after a restart mid initial-sync. Already-pulled changes persist in the local
+                // entity_changes table, so adding them to the remaining count reconstructs the
+                // original total — a resumed sync would otherwise only see the leftover work and
+                // rescale from zero.
+                //
+                // This only matters while the initial sync is in progress; the DB isn't marked
+                // initialized until the first sync converges (syncFinished). On an established
+                // database this COUNT would otherwise scan the full entity_changes table on every
+                // routine sync and inflate the total with every change ever pulled, so skip it there
+                // and count only this session's work.
+                const alreadyPulled = sqlInit.isDbInitialized()
+                    ? 0
+                    : getSql().getValue<number>("SELECT COUNT(1) FROM entity_changes WHERE isSynced = 1") ?? 0;
                 totalPullCount = alreadyPulled + resp.entityChanges.length + outstandingPullCount;
             }
 

--- a/packages/trilium-core/src/services/sync.ts
+++ b/packages/trilium-core/src/services/sync.ts
@@ -203,7 +203,12 @@ async function pullChanges(syncContext: SyncContext) {
             }
 
             if (totalPullCount === null) {
-                totalPullCount = resp.entityChanges.length + outstandingPullCount;
+                // Keep the denominator as the *grand* total so the setup progress bar doesn't reset
+                // to 0% after a restart. Already-pulled changes persist in the local entity_changes
+                // table, so adding them to the remaining count reconstructs the original total —
+                // a resumed sync would otherwise only see the leftover work and rescale from zero.
+                const alreadyPulled = getSql().getValue<number>("SELECT COUNT(1) FROM entity_changes WHERE isSynced = 1") ?? 0;
+                totalPullCount = alreadyPulled + resp.entityChanges.length + outstandingPullCount;
             }
 
             if (resp.entityChanges.length === 0) {


### PR DESCRIPTION
Improvements to the mobile (Capacitor/WebView) initial-sync path, motivated by an out-of-memory crash during initial sync on Android. These reduce the memory amplification of the receive pipeline and make an interrupted sync recover cleanly on restart.

> [!NOTE]
> These reduce memory pressure and improve resilience but do **not** on their own fully resolve the OOM on a single very large blob (~48 MB decoded amplifies ~8–10× through native delivery → postMessage clone → `JSON.parse` → decode → WASM insert, spiking the renderer past its ~700 MB ceiling). The durable fixes for that (a streaming transport plugin, or a custom `sqlite-wasm` with `sqlite3_blob_write` to stream the decode straight into the DB) are tracked separately.

## Changes

- **perf(standalone): decode base64 without an `atob` intermediate string** — the WebView-<140 fallback decoder now writes directly into a pre-sized `Uint8Array` via a lookup table, dropping the transient decoded-string copy (~2× the blob size less peak during decode).
- **perf(standalone): request `text` from CapacitorHttp instead of re-parsing** — CapacitorHttp no longer auto-parses the JSON response and then re-stringifies it; the handler asks for raw text, removing one full-size copy of each sync response on the main thread.
- **feat(setup): resume an interrupted sync on restart** — a partially-completed initial sync picks up from its persisted cursor instead of restarting.
- **feat(setup): resume the sync progress percentage across restart** — the setup progress bar keeps the grand total as its denominator so a resumed sync doesn't rescale to 0%.
- **chore(mobile): request a large heap for the Android app** — `android:largeHeap="true"`. (Affects the app process; note the WebView renderer runs in a separate sandboxed process, so this is a partial mitigation only.)

## Testing

- Added/updated unit tests for the base64 fallback decoder and the CapacitorHttp text passthrough.
- Full `@triliumnext/core` + server suites pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)