### PR TITLE
fix(scripting): rebind api.transactional to the SQL service (closes #10386)

### DIFF
--- a/packages/trilium-core/src/services/backend_script_api.spec.ts
+++ b/packages/trilium-core/src/services/backend_script_api.spec.ts
@@ -33,6 +33,24 @@ describe("BackendScriptApi.log", () => {
     });
 });
 
+describe("BackendScriptApi.transactional", () => {
+    beforeEach(() => becca.reset());
+
+    it("runs the callback inside a transaction and returns its result", () => {
+        const startNote = buildNote({ type: "code", mime: "application/javascript;env=backend", content: "" });
+        const api = new BackendScriptApi(startNote, { startNote });
+
+        let executed = false;
+        const result = api.transactional(() => {
+            executed = true;
+            return 42;
+        });
+
+        expect(executed).toBe(true);
+        expect(result).toBe(42);
+    });
+});
+
 describe("BackendScriptApi markdown conversion", () => {
     beforeEach(() => becca.reset());
 

--- a/packages/trilium-core/src/services/backend_script_api.ts
+++ b/packages/trilium-core/src/services/backend_script_api.ts
@@ -661,7 +661,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
     this.sortNotes = (parentNoteId, sortConfig = {}) => treeService.sortNotes(parentNoteId, sortConfig.sortBy || "title", !!sortConfig.reverse, !!sortConfig.foldersFirst);
 
     this.setNoteToParent = treeService.setNoteToParent;
-    this.transactional = sql.transactional;
+    this.transactional = (func) => sql.transactional(func);
     this.randomString = randomString;
     this.escapeHtml = escapeHtml;
     this.unescapeHtml = unescapeHtml;

--- a/packages/trilium-core/src/services/backend_script_api.ts
+++ b/packages/trilium-core/src/services/backend_script_api.ts
@@ -661,7 +661,7 @@ function BackendScriptApi(this: Api, currentNote: BNote, apiParams: ApiParams) {
     this.sortNotes = (parentNoteId, sortConfig = {}) => treeService.sortNotes(parentNoteId, sortConfig.sortBy || "title", !!sortConfig.reverse, !!sortConfig.foldersFirst);
 
     this.setNoteToParent = treeService.setNoteToParent;
-    this.transactional = (func) => sql.transactional(func);
+    this.transactional = sql.transactional.bind(sql);
     this.randomString = randomString;
     this.escapeHtml = escapeHtml;
     this.unescapeHtml = unescapeHtml;


### PR DESCRIPTION
## Summary

Fixes the 0.103 regression where any backend script calling `api.transactional()` fails with `Cannot read properties of undefined (reading 'transaction')` (closes #10386).

## Root cause

The January SQL refactor (`ea31d2f446`) turned the SQL layer into a `SqlService` class, making `transactional()` an instance method that reads `this.dbConnection` and `this.params`. The backend script API still assigned it unbound:

```ts
this.transactional = sql.transactional;
```

so user scripts invoked it with `this` pointing at the API object: `this.dbConnection` is `undefined` → the reported TypeError, and the `catch` block then hits `this.params.onTransactionRollback()` — which is the second error in the issue's log and the one that actually surfaces to the user.

## Fix

Wrap the call so the receiver is preserved:

```ts
this.transactional = (func) => sql.transactional(func);
```

## Tests

- Added a `BackendScriptApi.transactional` unit test that reproduces the exact failure before the fix and passes after it.
- Swept the repo for other unbound extractions of methods from the class-based core services (`SqlService`, log, CLS execution context, becca) — this was the only occurrence. The other bare assignments in the script APIs all point at plain object-literal modules that don't use `this`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)