### PR TITLE
feat(options): add "Wipe database" action to Advanced settings

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1422,6 +1422,22 @@
     "vacuuming_database": "Vacuuming database...",
     "database_vacuumed": "Database has been vacuumed"
   },
+  "wipe_database": {
+    "title": "Wipe database",
+    "description": "Permanently delete every note and start over with an empty database. Useful for resetting a device without reinstalling.",
+    "wipe_label": "Wipe the database",
+    "wipe_description": "Deletes all notes, attachments, revisions and settings from this device, then rebuilds an empty database. This cannot be undone.",
+    "wipe_button": "Wipe database…",
+    "dialog_title": "Wipe the database?",
+    "warning_heading": "This permanently deletes everything and cannot be undone.",
+    "warning_body": "All notes, attachments, revisions, attributes and settings on this device will be erased and replaced with a fresh, empty database.",
+    "backup_hint": "If you are not completely sure, make a backup first. Anything not synced elsewhere will be lost forever.",
+    "cancel": "Cancel",
+    "confirm_button": "Wipe everything",
+    "confirm_button_countdown": "Wipe everything ({{seconds}})",
+    "wipe_succeeded": "Database wiped. Reloading…",
+    "wipe_failed": "Could not wipe the database, check the logs for details."
+  },
   "experimental_features": {
     "title": "Experimental Options",
     "disclaimer": "These options are experimental and may cause instability. Use with caution.",

--- a/apps/client/src/widgets/type_widgets/options/advanced.tsx
+++ b/apps/client/src/widgets/type_widgets/options/advanced.tsx
@@ -11,6 +11,7 @@ import DatabaseFileList from "./components/DatabaseFileList";
 import OptionsPageHeader from "./components/OptionsPageHeader";
 import { OptionsRowWithButton, OptionsRowWithToggle } from "./components/OptionsRow";
 import OptionsSection from "./components/OptionsSection";
+import WipeDatabaseOptions from "./wipe_database";
 
 export default function AdvancedSettings() {
     return <>
@@ -19,6 +20,7 @@ export default function AdvancedSettings() {
         <DatabaseAnonymizationOptions />
         <ExperimentalOptions />
         <AdvancedSyncOptions />
+        <WipeDatabaseOptions />
     </>;
 }
 

--- a/apps/client/src/widgets/type_widgets/options/wipe_database.css
+++ b/apps/client/src/widgets/type_widgets/options/wipe_database.css
@@ -1,0 +1,18 @@
+/* Destructive action styling, tinted with the shared danger colour to set the wipe apart from the
+   neighbouring, non-destructive database maintenance buttons. */
+.wipe-database-button.btn,
+.wipe-database-confirm-button.btn {
+    --color: var(--icon-button-danger-color, #d9534f);
+    color: var(--color);
+    border-color: var(--color);
+}
+
+.wipe-database-button.btn:hover:not(:disabled),
+.wipe-database-confirm-button.btn:hover:not(:disabled) {
+    background-color: var(--color);
+    color: white;
+}
+
+.modal.wipe-database-dialog .admonition p {
+    margin-bottom: 0;
+}

--- a/apps/client/src/widgets/type_widgets/options/wipe_database.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/options/wipe_database.spec.tsx
@@ -1,0 +1,100 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { reloadFrontendApp } = vi.hoisted(() => ({
+    reloadFrontendApp: vi.fn()
+}));
+
+// `server` is already globally mocked in the client test setup; here we only override
+// reloadFrontendApp so the success path doesn't actually reload the page.
+vi.mock("../../../services/utils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/utils")>()),
+    reloadFrontendApp
+}));
+
+// Render a lightweight stand-in for the bootstrap-backed Modal so the test exercises the wipe
+// dialog's own logic (countdown + confirm) without pulling in jQuery/bootstrap.
+vi.mock("../../react/Modal", () => ({
+    default: ({ show, children, footer }: { show: boolean; children: unknown; footer: unknown }) =>
+        show ? <div className="mock-modal">{children}{footer}</div> : null
+}));
+
+import server from "../../../services/server";
+import WipeDatabaseOptions from "./wipe_database";
+
+const post = vi.spyOn(server, "post");
+
+let container: HTMLDivElement | undefined;
+
+async function openDialog() {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    container = target;
+    await act(async () => {
+        render(<WipeDatabaseOptions />, target);
+    });
+    // Open the confirmation dialog.
+    await act(async () => {
+        document.body.querySelector<HTMLButtonElement>(".wipe-database-button")?.click();
+    });
+}
+
+function confirmButton() {
+    return document.body.querySelector<HTMLButtonElement>(".wipe-database-confirm-button");
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    if (container) {
+        render(null, container);
+        container.remove();
+        container = undefined;
+    }
+    post.mockReset();
+    reloadFrontendApp.mockReset();
+});
+
+describe("WipeDatabaseOptions", () => {
+    it("keeps the confirm button disabled until the countdown elapses", async () => {
+        await openDialog();
+
+        // Immediately after opening, the destructive button is gated by the countdown.
+        expect(confirmButton()?.disabled).toBe(true);
+
+        // Half-way through, it is still disabled.
+        await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+        expect(confirmButton()?.disabled).toBe(true);
+
+        // Once the full delay has elapsed, it becomes actionable.
+        await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+        expect(confirmButton()?.disabled).toBe(false);
+    });
+
+    it("posts the wipe request with the confirmation token and reloads on success", async () => {
+        post.mockResolvedValue({ success: true });
+        await openDialog();
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+        await act(async () => { confirmButton()?.click(); });
+
+        expect(post).toHaveBeenCalledOnce();
+        expect(post.mock.calls[0][0]).toBe("database/wipe?really=yesIReallyWantToDeleteEverythingAndCannotUndoThis");
+        expect(reloadFrontendApp).toHaveBeenCalledOnce();
+    });
+
+    it("does not reload if the wipe request fails", async () => {
+        post.mockResolvedValue({ success: false });
+        await openDialog();
+
+        await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+        await act(async () => { confirmButton()?.click(); });
+
+        expect(post).toHaveBeenCalledOnce();
+        expect(reloadFrontendApp).not.toHaveBeenCalled();
+    });
+});

--- a/apps/client/src/widgets/type_widgets/options/wipe_database.tsx
+++ b/apps/client/src/widgets/type_widgets/options/wipe_database.tsx
@@ -52,16 +52,24 @@ function WipeDatabaseModal({ show, onHidden }: WipeDatabaseModalProps) {
     const [secondsLeft, setSecondsLeft] = useState(COUNTDOWN_SECONDS);
     const [wiping, setWiping] = useState(false);
 
-    // Restart the countdown every time the dialog is opened so the delay can't be skipped by
-    // reopening, and tick it down once per second while the dialog is visible.
+    // Reset state every time the dialog opens: restart the countdown (so the delay can't be skipped
+    // by reopening) and clear any stale `wiping` flag left behind if a previous attempt's dialog was
+    // dismissed while its request was still pending. The interval stops itself once it reaches zero.
     useEffect(() => {
         if (!show) {
             return;
         }
 
         setSecondsLeft(COUNTDOWN_SECONDS);
+        setWiping(false);
+
+        let remaining = COUNTDOWN_SECONDS;
         const interval = setInterval(() => {
-            setSecondsLeft((prev) => (prev > 0 ? prev - 1 : 0));
+            remaining -= 1;
+            setSecondsLeft(remaining);
+            if (remaining <= 0) {
+                clearInterval(interval);
+            }
         }, 1000);
 
         return () => clearInterval(interval);

--- a/apps/client/src/widgets/type_widgets/options/wipe_database.tsx
+++ b/apps/client/src/widgets/type_widgets/options/wipe_database.tsx
@@ -1,0 +1,119 @@
+import "./wipe_database.css";
+
+import { WipeDatabaseResponse } from "@triliumnext/commons";
+import { createPortal } from "preact/compat";
+import { useEffect, useState } from "preact/hooks";
+
+import { t } from "../../../services/i18n";
+import server from "../../../services/server";
+import toast from "../../../services/toast";
+import { reloadFrontendApp } from "../../../services/utils";
+import Admonition from "../../react/Admonition";
+import Button from "../../react/Button";
+import FormText from "../../react/FormText";
+import Modal from "../../react/Modal";
+import { OptionsRowWithButton } from "./components/OptionsRow";
+import OptionsSection from "./components/OptionsSection";
+
+/** Verbose confirmation token — must match `WIPE_DATABASE_CONFIRMATION` on the server route. */
+const WIPE_DATABASE_CONFIRMATION = "yesIReallyWantToDeleteEverythingAndCannotUndoThis";
+
+/** Seconds the confirm button stays disabled, forcing the user to pause and read the warning. */
+const COUNTDOWN_SECONDS = 5;
+
+export default function WipeDatabaseOptions() {
+    const [showModal, setShowModal] = useState(false);
+
+    return (
+        <OptionsSection title={t("wipe_database.title")} description={t("wipe_database.description")}>
+            <OptionsRowWithButton
+                label={t("wipe_database.wipe_label")}
+                description={t("wipe_database.wipe_description")}
+                buttonText={t("wipe_database.wipe_button")}
+                buttonClassName="wipe-database-button"
+                icon="bx-trash"
+                onClick={() => setShowModal(true)}
+            />
+
+            {createPortal(
+                <WipeDatabaseModal show={showModal} onHidden={() => setShowModal(false)} />,
+                document.body
+            )}
+        </OptionsSection>
+    );
+}
+
+interface WipeDatabaseModalProps {
+    show: boolean;
+    onHidden: () => void;
+}
+
+function WipeDatabaseModal({ show, onHidden }: WipeDatabaseModalProps) {
+    const [secondsLeft, setSecondsLeft] = useState(COUNTDOWN_SECONDS);
+    const [wiping, setWiping] = useState(false);
+
+    // Restart the countdown every time the dialog is opened so the delay can't be skipped by
+    // reopening, and tick it down once per second while the dialog is visible.
+    useEffect(() => {
+        if (!show) {
+            return;
+        }
+
+        setSecondsLeft(COUNTDOWN_SECONDS);
+        const interval = setInterval(() => {
+            setSecondsLeft((prev) => (prev > 0 ? prev - 1 : 0));
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [show]);
+
+    const wipe = async () => {
+        setWiping(true);
+        try {
+            const { success } = await server.post<WipeDatabaseResponse>(`database/wipe?really=${WIPE_DATABASE_CONFIRMATION}`);
+            if (!success) {
+                toast.showError(t("wipe_database.wipe_failed"));
+                setWiping(false);
+                return;
+            }
+            toast.showMessage(t("wipe_database.wipe_succeeded"));
+            // The document is now empty and any protected session / login is invalidated; reload so the
+            // client rebuilds its own caches (froca) and lands on the fresh setup/login flow.
+            reloadFrontendApp("database wiped");
+        } catch {
+            toast.showError(t("wipe_database.wipe_failed"));
+            setWiping(false);
+        }
+    };
+
+    const countingDown = secondsLeft > 0;
+
+    return (
+        <Modal
+            className="wipe-database-dialog"
+            size="md"
+            stackable
+            title={t("wipe_database.dialog_title")}
+            onHidden={onHidden}
+            show={show}
+            footer={<>
+                <Button text={t("wipe_database.cancel")} onClick={onHidden} disabled={wiping} />
+                <Button
+                    className="wipe-database-confirm-button"
+                    text={countingDown
+                        ? t("wipe_database.confirm_button_countdown", { seconds: secondsLeft })
+                        : t("wipe_database.confirm_button")}
+                    icon="bx-trash"
+                    disabled={countingDown || wiping}
+                    onClick={() => void wipe()}
+                />
+            </>}
+        >
+            <Admonition type="caution">
+                <strong>{t("wipe_database.warning_heading")}</strong>
+                <p>{t("wipe_database.warning_body")}</p>
+            </Admonition>
+            <FormText>{t("wipe_database.backup_hint")}</FormText>
+        </Modal>
+    );
+}

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -86,6 +86,10 @@ export interface DatabaseAnonymizeResponse {
     anonymizedFilePath: string;
 }
 
+export interface WipeDatabaseResponse {
+    success: boolean;
+}
+
 export interface AnonymizedDbResponse {
     filePath: string;
     fileName: string;

--- a/packages/trilium-core/src/routes/api/database.spec.ts
+++ b/packages/trilium-core/src/routes/api/database.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import sqlInit from "../../services/sql_init";
+import { getSql } from "../../services/sql/index";
+import { CoreApiTester } from "../../test/api_tester";
+import { WIPE_DATABASE_CONFIRMATION } from "./database";
+
+/**
+ * Drives the shared core database routes through {@link CoreApiTester} (no Express), so this spec
+ * runs under both the node (better-sqlite3) and standalone (WASM) suites. The actual wiping is
+ * covered by sql_init.spec.ts; here we only exercise the route's confirmation guard, mocking
+ * {@link sqlInit.wipeDatabase} so the shared fixture DB is left intact.
+ */
+let api: CoreApiTester;
+
+describe("Database API (core)", () => {
+    beforeAll(() => {
+        api = CoreApiTester.build();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("rejects a wipe with an incorrect confirmation (400) and does not touch the database", async () => {
+        const wipe = vi.spyOn(sqlInit, "wipeDatabase").mockResolvedValue(undefined);
+
+        const res = await api.post("/api/database/wipe", { query: { really: "nope" } });
+
+        expect(res.status).toBe(400);
+        expect(wipe).not.toHaveBeenCalled();
+        // The fixture DB is still initialized and populated.
+        expect(sqlInit.isDbInitialized()).toBe(true);
+        expect(getSql().getValue<number>("SELECT COUNT(*) FROM notes")).toBeGreaterThan(0);
+    });
+
+    it("wipes the database when the correct confirmation magic string is provided", async () => {
+        const wipe = vi.spyOn(sqlInit, "wipeDatabase").mockResolvedValue(undefined);
+
+        const res = await api.post<{ success: boolean }>("/api/database/wipe", {
+            query: { really: WIPE_DATABASE_CONFIRMATION }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(wipe).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/trilium-core/src/routes/api/database.ts
+++ b/packages/trilium-core/src/routes/api/database.ts
@@ -1,0 +1,25 @@
+import type { Request } from "express";
+
+import { ValidationError } from "../../errors.js";
+import sqlInit from "../../services/sql_init.js";
+
+/**
+ * Verbose confirmation token required to wipe the database. Mirrors the password-reset endpoint's
+ * approach: it guards against an accidental/mistaken call, it is not a security measure (the route
+ * still relies on the usual auth middleware for that).
+ */
+export const WIPE_DATABASE_CONFIRMATION = "yesIReallyWantToDeleteEverythingAndCannotUndoThis";
+
+async function wipeDatabase(req: Request) {
+    if (req.query.really !== WIPE_DATABASE_CONFIRMATION) {
+        throw new ValidationError("Incorrect database wipe confirmation");
+    }
+
+    await sqlInit.wipeDatabase();
+
+    return { success: true };
+}
+
+export default {
+    wipeDatabase
+};

--- a/packages/trilium-core/src/routes/index.ts
+++ b/packages/trilium-core/src/routes/index.ts
@@ -32,6 +32,7 @@ import backendLogRoute from "./api/backend_log";
 import backupRoute from "./api/backup";
 import passwordApiRoute from "./api/password";
 import loginApiRoute from "./api/login";
+import databaseApiRoute from "./api/database";
 
 // TODO: Deduplicate with routes.ts
 const GET = "get",
@@ -212,6 +213,11 @@ export function buildSharedApiRoutes({ route, asyncRoute, apiRoute, asyncApiRout
     asyncApiRoute(GET, "/api/database/backups", backupRoute.getExistingBackups);
     asyncApiRoute(PST, "/api/database/backup-database", backupRoute.backupDatabase);
     asyncRoute(GET, "/api/database/backup/download", [checkApiAuthOrElectron], backupRoute.downloadBackup);
+
+    // Wipe the whole document and rebuild an empty database. Registered in the shared builder so it
+    // is available on every platform (server, desktop and standalone/mobile). Mirrors the setup route
+    // in that it (re)creates the initial database via createInitialDatabase.
+    asyncRoute(PST, "/api/database/wipe", [checkApiAuthOrElectron, csrfMiddleware], databaseApiRoute.wipeDatabase, apiResultHandler);
 
     apiRoute(GET, "/api/other/icon-usage", otherRoute.getIconUsage);
     apiRoute(PST, "/api/other/render-markdown", otherRoute.renderMarkdown);

--- a/packages/trilium-core/src/services/sql_init.spec.ts
+++ b/packages/trilium-core/src/services/sql_init.spec.ts
@@ -93,4 +93,25 @@ describe("sql_init (real DB)", () => {
             await expect(Promise.resolve(sqlInit.dbReady)).resolves.toBeUndefined();
         });
     });
+
+    // Runs last: it destroys the fixture DB for this file. Vitest's forks pool gives each spec file
+    // its own in-memory copy, so this does not leak into other files.
+    describe("wipeDatabase", () => {
+        it("drops all user data and rebuilds an empty, initialized database", async () => {
+            const userNoteCount = () =>
+                getSql().getValue<number>("SELECT COUNT(*) FROM notes WHERE noteId != 'root' AND noteId NOT LIKE '\\_%' ESCAPE '\\'");
+
+            // The fixture ships with demo content, so there are real user notes to wipe.
+            expect(userNoteCount()).toBeGreaterThan(0);
+
+            await getContext().init(() => sqlInit.wipeDatabase());
+
+            // All non-system user content is gone, but the database is a valid, initialized shell:
+            // the root note remains and the schema/initialized flag are intact.
+            expect(userNoteCount()).toBe(0);
+            expect(getSql().getValue("SELECT noteId FROM notes WHERE noteId = 'root'")).toBe("root");
+            expect(sqlInit.schemaExists()).toBe(true);
+            expect(sqlInit.isDbInitialized()).toBe(true);
+        });
+    });
 });

--- a/packages/trilium-core/src/services/sql_init.ts
+++ b/packages/trilium-core/src/services/sql_init.ts
@@ -235,6 +235,12 @@ async function createInitialDatabase(skipDemoDb?: boolean, locale?: string) {
  *
  * This is destructive and irreversible: there is no undo. It works identically on every platform
  * (server, desktop and standalone/mobile) because it operates purely through the SQL layer.
+ *
+ * On standalone/mobile the whole route runs inside a single transaction (the browser router wraps it
+ * in `transactionalAsync`), so the drop-and-rebuild is atomic. On the multi-request server build the
+ * drop commits before {@link createInitialDatabase} rebuilds the schema, leaving a brief window where
+ * a concurrent request could observe missing tables — an acceptable trade-off for a deliberate,
+ * one-off reset that immediately reloads the whole application.
  */
 async function wipeDatabase() {
     const sql = getSql();

--- a/packages/trilium-core/src/services/sql_init.ts
+++ b/packages/trilium-core/src/services/sql_init.ts
@@ -224,6 +224,41 @@ async function createInitialDatabase(skipDemoDb?: boolean, locale?: string) {
     log.info("Database initialization completed, emitted DB_INITIALIZED event");
 }
 
+/**
+ * Wipes all data from the current document and rebuilds an empty database from scratch.
+ *
+ * Every user table is dropped and the initial database is recreated (schema, root note, default
+ * options and the hidden subtree) via {@link createInitialDatabase}, leaving the application in the
+ * same state as a fresh install — but without the demo content. Becca is reloaded in-process, so the
+ * running server/desktop-main/standalone-worker immediately reflects the empty database; callers on
+ * the client are still expected to reload the page afterwards to reset their own caches.
+ *
+ * This is destructive and irreversible: there is no undo. It works identically on every platform
+ * (server, desktop and standalone/mobile) because it operates purely through the SQL layer.
+ */
+async function wipeDatabase() {
+    const sql = getSql();
+    const log = getLog();
+
+    log.info("Wiping database ...");
+
+    sql.transactional(() => {
+        // Dropping a table also drops its indexes; the schema has no views or standalone triggers,
+        // so dropping every non-internal table clears the whole document. `IF EXISTS` guards against
+        // an already-empty database. Names are quoted to survive any exotic identifiers.
+        const tableNames = sql.getColumn<string>(/*sql*/`SELECT name FROM sqlite_master
+            WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`);
+        for (const tableName of tableNames) {
+            sql.execute(`DROP TABLE IF EXISTS "${tableName}"`);
+        }
+    });
+
+    // Skip the demo content: a wipe is meant to leave an empty document, not reintroduce sample notes.
+    await createInitialDatabase(true);
+
+    log.info("Database has been wiped and reinitialized.");
+}
+
 async function createDatabaseForSync(options: OptionRow[], syncServerHost = "", syncProxy = "", syncMaxBlobContentSize = 0) {
     const log = getLog();
     const sql = getSql();
@@ -250,4 +285,4 @@ async function createDatabaseForSync(options: OptionRow[], syncServerHost = "", 
     log.info("Schema and not synced options generated.");
 }
 
-export default { isDbInitialized, createDatabaseForSync, setDbAsInitialized, schemaExists, getDbSize, initDbConnection, dbReady, initializeDb, createInitialDatabase };
+export default { isDbInitialized, createDatabaseForSync, setDbAsInitialized, schemaExists, getDbSize, initDbConnection, dbReady, initializeDb, createInitialDatabase, wipeDatabase };


### PR DESCRIPTION
## What

Adds a **"Wipe the database"** action to the **Advanced** options page. It permanently deletes every note, attachment, revision, attribute and setting and rebuilds an empty database — a clean reset without reinstalling.

This is especially useful on **standalone/mobile**, where the database lives in the WebView's OPFS with no filesystem access, so there's no easy way to reset a device today.

## How it works

- **Purely at the SQL layer** — drops all tables, then rebuilds an empty document via `createInitialDatabase` (skipping demo content) and reloads becca in-process. This single code path works identically on **server, desktop and standalone/mobile**.
- The route is registered in the **shared core route builder** (`buildSharedApiRoutes`), so it is exposed by both the Express server and the standalone browser router — no per-platform plumbing.
- Guarded by a verbose confirmation token (`?really=…`), mirroring the existing `password/reset` endpoint (guards against accidental calls; the usual auth middleware handles security).

## UX

- Destructive-tinted button in a dedicated **"Wipe database"** section of Advanced options.
- Confirmation modal with a caution admonition, a "make a backup first" hint, and a **5-second countdown** that keeps the confirm button disabled — the user has to pause and read before it becomes actionable.
- On success, the client reloads so it rebuilds its own caches (froca) and lands on the fresh setup/login flow.

## Testing

- `sql_init.spec.ts` — real-DB wipe: proves user content is gone and the DB is left valid/initialized (root note, schema, `initialized` flag).
- `database.spec.ts` — route confirmation guard (rejects wrong token, wipes on correct token). Runs under **both** the node (better-sqlite3) and standalone (WASM) suites via `CoreApiTester`.
- `wipe_database.spec.tsx` — client dialog: countdown gating, posts with the token + reloads on success, no reload on failure.

`pnpm typecheck` clean; the full core suite (2956 tests) passes under the WASM/standalone runtime, confirming the cross-platform path.

## Notes / open questions

- Shown on all builds (like the neighbouring vacuum/integrity/anonymize actions). On a shared multi-user **server** a wipe is inherently dangerous; happy to gate it to standalone+desktop if preferred.
- Sync clusters: a wipe currently clears local data and would re-pull on next sync. If "truly forget everything" semantics are wanted for synced instances, that can be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
