### PR TITLE
fix(client): add-link dialog drops the link on a fast double-Enter

### DIFF
--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -607,6 +607,20 @@ describe("initNoteAutocomplete wiring", () => {
         expect(selected).not.toHaveBeenCalled();
     });
 
+    it("leaves Enter available for form submission after a terminal selection", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        ($el as any).trigger("autocomplete:selected", { notePath: "root/n", noteTitle: "N" });
+
+        const autocompleteKeydown = vi.fn((event: JQuery.KeyDownEvent) => event.preventDefault());
+        $el.on("keydown.aa", autocompleteKeydown);
+        const event = $.Event("keydown", { key: "Enter" });
+        $el.trigger(event);
+
+        expect(autocompleteKeydown).not.toHaveBeenCalled();
+        expect(event.isDefaultPrevented()).toBe(false);
+    });
+
     it("composition end re-sets the autocomplete value", () => {
         const $el = makeEl();
         noteAutocomplete.initNoteAutocomplete($el);
@@ -689,6 +703,26 @@ describe("autocomplete:selected handler", () => {
         expect(handlers["autocomplete:externallinkselected"]).toBeDefined();
     });
 
+    it("ignores a stale create-note selection after selecting an external link", async () => {
+        chooseNoteType.mockResolvedValue({ success: false });
+        const { $el } = initWithSelected();
+        const externalLinkSelected = vi.fn();
+        $el.on("autocomplete:externallinkselected", externalLinkSelected);
+
+        ($el as any).trigger("autocomplete:selected", {
+            action: "external-link",
+            externalLink: "https://e.com"
+        });
+        await fireSelected($el, {
+            action: "create-note",
+            noteTitle: "https://e.com",
+            parentNoteId: "parent"
+        });
+
+        expect(externalLinkSelected).toHaveBeenCalledOnce();
+        expect(chooseNoteType).not.toHaveBeenCalled();
+    });
+
     it("handles a search-notes selection by triggering searchNotes", async () => {
         const { $el } = initWithSelected();
         await fireSelected($el, { action: "search-notes", noteTitle: "query" });
@@ -701,7 +735,7 @@ describe("autocomplete:selected handler", () => {
         createNote.mockResolvedValue({ note: { getBestNotePathString: () => "root/created" } });
         const { $el, handlers } = initWithSelected();
         await fireSelected($el, { action: "create-note", noteTitle: "Created", parentNoteId: "parent" });
-        expect(chooseNoteType).toHaveBeenCalled();
+        expect(chooseNoteType).toHaveBeenCalledOnce();
         expect(createNote).toHaveBeenCalledWith("parent", expect.objectContaining({ title: "Created", type: "text" }));
         expect(handlers["autocomplete:noteselected"]).toBeDefined();
         expect(handlers["autocomplete:noteselected"].notePath).toBe("root/created");
@@ -737,6 +771,34 @@ describe("autocomplete:selected handler", () => {
         await fireSelected($el, { action: undefined, notePath: "root/n", noteTitle: "N" });
         expect($el.attr("data-note-path")).toBe("root/n");
         expect(handlers["autocomplete:noteselected"]).toBeDefined();
+    });
+
+    it("ignores a stale create-note selection after selecting a note", async () => {
+        chooseNoteType.mockResolvedValue({ success: false });
+        const { $el } = initWithSelected();
+        const noteSelected = vi.fn();
+        $el.on("autocomplete:noteselected", noteSelected);
+
+        ($el as any).trigger("autocomplete:selected", { notePath: "root/n", noteTitle: "N" });
+        await fireSelected($el, { action: "create-note", noteTitle: "N", parentNoteId: "parent" });
+
+        expect(noteSelected).toHaveBeenCalledOnce();
+        expect(chooseNoteType).not.toHaveBeenCalled();
+    });
+
+    it("re-enables create-note selection after the input is edited", async () => {
+        chooseNoteType.mockResolvedValue({ success: false });
+        const { $el } = initWithSelected();
+
+        await fireSelected($el, { notePath: "root/n", noteTitle: "N" });
+        $el.val("New note").trigger("input");
+        await fireSelected($el, {
+            action: "create-note",
+            noteTitle: "New note",
+            parentNoteId: "parent"
+        });
+
+        expect(chooseNoteType).toHaveBeenCalledOnce();
     });
 });
 

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -607,6 +607,52 @@ describe("initNoteAutocomplete wiring", () => {
         expect(selected).not.toHaveBeenCalled();
     });
 
+    // Issue #5669 round-2: the terminal-selection guard (which stops the stale
+    // create-note Enter right after a selection) must not persist across a fresh
+    // programmatic query. autocomplete.js's setVal does not emit "input", so the
+    // input handler that normally clears the guard never fires for these helpers;
+    // each fresh-query helper must clear it explicitly. Otherwise, after selecting
+    // a note, clicking Recent Notes (or running a full-text search) would leave
+    // Enter swallowed until the user manually edited the field.
+    it("showRecentNotes clears the terminal-selection guard from a prior selection", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        $el.data("terminalSelection", true); // post-selection terminal state
+        noteAutocomplete.showRecentNotes($el);
+        expect($el.data("terminalSelection")).toBe(false);
+    });
+
+    it("setText and showAllCommands clear the terminal-selection guard", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        $el.data("terminalSelection", true);
+        noteAutocomplete.setText($el, "hello");
+        expect($el.data("terminalSelection")).toBe(false);
+
+        $el.data("terminalSelection", true);
+        noteAutocomplete.showAllCommands($el);
+        expect($el.data("terminalSelection")).toBe(false);
+    });
+
+    it("full-text search (Shift+Enter) clears the terminal-selection guard", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        $el.autocomplete("val", "some text");
+        $el.data("terminalSelection", true);
+        $el.trigger($.Event("keydown", { shiftKey: true, key: "Enter" }));
+        expect($el.data("terminalSelection")).toBe(false);
+    });
+
+    it("the terminal-selection guard persists until a fresh query clears it", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        $el.data("terminalSelection", true);
+        // A plain Enter must NOT clear the guard (it is what the guard swallows);
+        // only a fresh query or real user input clears it.
+        $el.trigger($.Event("keydown", { key: "Enter" }));
+        expect($el.data("terminalSelection")).toBe(true);
+    });
+
     it("leaves Enter available for form submission after a terminal selection", () => {
         const $el = makeEl();
         noteAutocomplete.initNoteAutocomplete($el);

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -163,19 +163,29 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
     cb(results);
 }
 
+// Starting a fresh query programmatically re-enables keyboard selection: clear the
+// terminal-selection guard so Enter is not swallowed after a prior selection (autocomplete.js's
+// setVal does not emit "input", so the input handler that normally clears it never fires here).
+function clearTerminalSelection($el: JQuery<HTMLElement>) {
+    $el.data("terminalSelection", false);
+}
+
 function clearText($el: JQuery<HTMLElement>) {
     searchDelay = 0;
+    clearTerminalSelection($el);
     $el.setSelectedNotePath("");
     $el.autocomplete("val", "").trigger("change");
 }
 
 function setText($el: JQuery<HTMLElement>, text: string) {
+    clearTerminalSelection($el);
     $el.setSelectedNotePath("");
     $el.autocomplete("val", text.trim()).autocomplete("open");
 }
 
 function showRecentNotes($el: JQuery<HTMLElement>) {
     searchDelay = 0;
+    clearTerminalSelection($el);
     $el.setSelectedNotePath("");
     $el.autocomplete("val", "");
     $el.autocomplete("open");
@@ -184,6 +194,7 @@ function showRecentNotes($el: JQuery<HTMLElement>) {
 
 function showAllCommands($el: JQuery<HTMLElement>) {
     searchDelay = 0;
+    clearTerminalSelection($el);
     $el.setSelectedNotePath("");
     $el.autocomplete("val", ">").autocomplete("open");
 }
@@ -193,6 +204,7 @@ function fullTextSearch($el: JQuery<HTMLElement>, options: Options) {
     if (options.fastSearch === false || searchString?.trim().length === 0) {
         return;
     }
+    clearTerminalSelection($el);
     $el.trigger("focus");
     options.fastSearch = false;
     $el.autocomplete("val", "");
@@ -214,10 +226,12 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
     // Used to track whether the user is performing character composition with an input method (such as Chinese Pinyin, Japanese, Korean, etc.) and to avoid triggering a search during the composition process.
     let isComposingInput = false;
     // Setting the selected value can re-query and auto-select a stale create-note row before the
-    // dropdown finishes closing.
-    let hasTerminalSelection = false;
+    // dropdown finishes closing. Stored on the element (not a closure) so the module-level
+    // programmatic query helpers (clearText/setText/showRecentNotes/showAllCommands/fullTextSearch)
+    // can clear it when they start a fresh query -- autocomplete.js's setVal does not emit "input".
+    $el.data("terminalSelection", false);
     $el.on("input", () => {
-        hasTerminalSelection = false;
+        $el.data("terminalSelection", false);
     });
     $el.on("compositionstart", () => {
         isComposingInput = true;
@@ -291,7 +305,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
     $el.on("keydown", (event) => {
         const isPlainEnter = event.key === "Enter"
             && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey;
-        if (hasTerminalSelection && isPlainEnter) {
+        if ($el.data("terminalSelection") === true && isPlainEnter) {
             // Stop autocomplete from consuming the stale create-note row, but leave the default
             // form submission intact.
             event.stopImmediatePropagation();
@@ -391,7 +405,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             $el.setSelectedExternalLink(suggestion.externalLink);
 
             $el.autocomplete("val", suggestion.externalLink);
-            hasTerminalSelection = true;
+            $el.data("terminalSelection", true);
 
             $el.autocomplete("close");
 
@@ -401,7 +415,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
         }
 
         if (suggestion.action === "create-note") {
-            if (hasTerminalSelection) {
+            if ($el.data("terminalSelection") === true) {
                 return;
             }
 
@@ -430,7 +444,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
         $el.setSelectedExternalLink(null);
 
         $el.autocomplete("val", suggestion.noteTitle);
-        hasTerminalSelection = true;
+        $el.data("terminalSelection", true);
 
         $el.autocomplete("close");
 

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -213,6 +213,12 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
 
     // Used to track whether the user is performing character composition with an input method (such as Chinese Pinyin, Japanese, Korean, etc.) and to avoid triggering a search during the composition process.
     let isComposingInput = false;
+    // Setting the selected value can re-query and auto-select a stale create-note row before the
+    // dropdown finishes closing.
+    let hasTerminalSelection = false;
+    $el.on("input", () => {
+        hasTerminalSelection = false;
+    });
     $el.on("compositionstart", () => {
         isComposingInput = true;
     });
@@ -280,6 +286,15 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             event.stopImmediatePropagation();
             event.preventDefault();
             fullTextSearch($el, options);
+        }
+    });
+    $el.on("keydown", (event) => {
+        const isPlainEnter = event.key === "Enter"
+            && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey;
+        if (hasTerminalSelection && isPlainEnter) {
+            // Stop autocomplete from consuming the stale create-note row, but leave the default
+            // form submission intact.
+            event.stopImmediatePropagation();
         }
     });
 
@@ -376,6 +391,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             $el.setSelectedExternalLink(suggestion.externalLink);
 
             $el.autocomplete("val", suggestion.externalLink);
+            hasTerminalSelection = true;
 
             $el.autocomplete("close");
 
@@ -385,6 +401,10 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
         }
 
         if (suggestion.action === "create-note") {
+            if (hasTerminalSelection) {
+                return;
+            }
+
             const { success, noteType, templateNoteId, notePath } = await noteCreateService.chooseNoteType();
             if (!success) {
                 return;
@@ -410,6 +430,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
         $el.setSelectedExternalLink(null);
 
         $el.autocomplete("val", suggestion.noteTitle);
+        hasTerminalSelection = true;
 
         $el.autocomplete("close");
 


### PR DESCRIPTION
## Summary

Fixes the "Add link" dialog dropping the link when Enter is pressed twice quickly. Pressing Enter a second time before the autocomplete dropdown finished closing let a stale "create-note" row get auto-selected, so instead of creating the link the "Choose note type" dialog opened.

## Why

Selecting a suggestion sets the field value and closes the dropdown asynchronously; a second fast Enter arrived while a re-query had re-populated the create-note row and consumed the keypress. The fix records a terminal-selection state the moment a note or external link is selected and, on a plain Enter, stops autocomplete from consuming that stale create-note row while leaving normal form submission intact.

Because the guard would otherwise persist across a later programmatic query (autocomplete.js's `setVal` does not emit an `input` event), it is stored on the element and cleared whenever a fresh query starts -- `clearText`, `setText`, `showRecentNotes`, `showAllCommands`, and `fullTextSearch`. Without that reset, selecting a note and then opening Recent Notes would leave Enter swallowed until the field was manually edited.

## Testing

`pnpm --filter client test src/services/note_autocomplete.spec.ts` -- 62 tests pass. New coverage:

- a stale create-note Enter right after selecting a note is ignored, and create-note selection re-enables once the input is edited;
- each programmatic query helper (Recent Notes, set text, show-all-commands, full-text search) clears the terminal-selection guard so keyboard selection works again;
- the guard persists on a bare Enter (it is what the guard swallows) until a fresh query clears it.

Closes #5669
