### PR TITLE
Mind map: fix UI freeze on every save by replacing snapdom with the native SVG exporter

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -43,7 +43,6 @@
     "@univerjs/preset-sheets-note": "0.25.1",
     "@univerjs/preset-sheets-sort": "0.25.1",
     "@univerjs/presets": "0.25.1",
-    "@zumer/snapdom": "2.15.0",
     "autocomplete.js": "0.38.1",
     "bootstrap": "5.3.8",
     "boxicons": "2.1.4",

--- a/apps/client/src/services/utils.spec.ts
+++ b/apps/client/src/services/utils.spec.ts
@@ -683,15 +683,16 @@ describe("SVG downloads (default export)", () => {
         return blobs;
     }
 
-    it("downloadSvg downloads the SVG string as a blob URL", async () => {
+    it("downloadSvg downloads the SVG string as a data URL (a blob-URL anchor click after " +
+        "the export's awaits is silently blocked without user activation)", () => {
         const downloads = captureDownload();
-        const blobs = captureObjectUrls();
         utils.downloadSvg("diagram", `<svg><text>a & b</text></svg>`);
 
-        expect(downloads).toEqual([ { name: "diagram.svg", href: "blob:mock-1" } ]);
-        expect(blobs).toHaveLength(1);
-        expect(blobs[0].type).toContain("image/svg+xml");
-        expect(await blobs[0].text()).toBe(`<svg><text>a & b</text></svg>`);
+        expect(downloads).toHaveLength(1);
+        expect(downloads[0].name).toBe("diagram.svg");
+        const href = downloads[0].href ?? "";
+        expect(href.startsWith("data:image/svg+xml;charset=utf-8,")).toBe(true);
+        expect(decodeURIComponent(href.split(",")[1])).toBe(`<svg><text>a & b</text></svg>`);
     });
 
     it("downloadSvgAsPng rasterizes at the given scale and downloads a PNG", async () => {

--- a/apps/client/src/services/utils.spec.ts
+++ b/apps/client/src/services/utils.spec.ts
@@ -31,16 +31,6 @@ import utils, {
     toggleBodyClass
 } from "./utils.js";
 
-// `snapdom` is used by downloadAsSvg / downloadAsPng; stub it so no real rendering happens.
-vi.mock("@zumer/snapdom", () => ({
-    snapdom: vi.fn(async () => ({
-        url: "data:image/svg+xml;base64,AAA",
-        toPng: vi.fn(async () => ({ src: "data:image/png;base64,BBB" }))
-    }))
-}));
-
-import { snapdom } from "@zumer/snapdom";
-
 // `logInfo` / `logError` are normally attached to window/globalThis by ws.ts, which is mocked
 // out by the test setup. Provide no-op globals so the few code paths that log don't crash.
 beforeEach(() => {
@@ -674,34 +664,55 @@ describe("createImageSrcUrl", () => {
     });
 });
 
-describe("snapdom downloads (default export)", () => {
-    it("downloadAsSvg parses an SVG string with the SVG mime type, renders it and triggers a download", async () => {
-        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
-        // happy-dom's image/svg+xml documentElement lacks a writable `.style`, so return a real
-        // HTML element from the parser while still asserting the SVG mime branch was taken.
-        const parseSpy = vi.spyOn(DOMParser.prototype, "parseFromString").mockImplementation(() => {
-            const doc = document.implementation.createHTMLDocument("");
-            return doc;
+describe("SVG downloads (default export)", () => {
+    function captureDownload() {
+        const downloads: { name: string | null, href: string | null }[] = [];
+        vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function(this: HTMLAnchorElement) {
+            downloads.push({ name: this.getAttribute("download"), href: this.getAttribute("href") });
         });
-        await utils.downloadAsSvg("diagram", "  <svg><rect/></svg>");
-        expect(parseSpy).toHaveBeenCalledWith("  <svg><rect/></svg>", "image/svg+xml");
-        expect(snapdom).toHaveBeenCalled();
-        expect(clickSpy).toHaveBeenCalled();
+        return downloads;
+    }
+
+    it("downloadSvg downloads the SVG string as a data URL", () => {
+        const downloads = captureDownload();
+        utils.downloadSvg("diagram", `<svg><text>a & b</text></svg>`);
+
+        expect(downloads).toHaveLength(1);
+        expect(downloads[0].name).toBe("diagram.svg");
+        const href = downloads[0].href ?? "";
+        expect(href.startsWith("data:image/svg+xml;charset=utf-8,")).toBe(true);
+        expect(decodeURIComponent(href.split(",")[1])).toBe(`<svg><text>a & b</text></svg>`);
     });
 
-    it("downloadAsSvg accepts an existing element without attaching it", async () => {
-        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
-        const el = document.createElement("div");
-        await utils.downloadAsSvg("diagram", el);
-        expect(snapdom).toHaveBeenCalled();
-        expect(clickSpy).toHaveBeenCalled();
+    it("downloadSvgAsPng rasterizes at the given scale and downloads a PNG", async () => {
+        const downloads = captureDownload();
+        const drawImage = vi.fn();
+        const canvasSizes: { width: number, height: number }[] = [];
+        vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({ drawImage } as unknown as RenderingContext);
+        vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockImplementation(function(this: HTMLCanvasElement) {
+            canvasSizes.push({ width: this.width, height: this.height });
+            return "data:image/png;base64,BBB";
+        });
+        vi.stubGlobal("Image", class {
+            src = "";
+            decode = vi.fn(async () => {});
+        });
+
+        try {
+            await utils.downloadSvgAsPng("diagram", `<svg width="100" height="50"></svg>`);
+        } finally {
+            vi.unstubAllGlobals();
+        }
+
+        expect(canvasSizes).toEqual([{ width: 200, height: 100 }]); // default scale is 2
+        expect(drawImage).toHaveBeenCalled();
+        expect(downloads).toEqual([{ name: "diagram.png", href: "data:image/png;base64,BBB" }]);
     });
 
-    it("downloadAsPng renders an HTML string to PNG and downloads it", async () => {
-        const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
-        await utils.downloadAsPng("diagram", "<div>hello</div>");
-        expect(snapdom).toHaveBeenCalled();
-        expect(clickSpy).toHaveBeenCalled();
+    it("downloadSvgAsPng rejects when the SVG has no usable dimensions", async () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        await expect(utils.downloadSvgAsPng("diagram", `<svg xmlns="http://www.w3.org/2000/svg"/>`))
+            .rejects.toThrow("dimensions");
     });
 });
 

--- a/apps/client/src/services/utils.spec.ts
+++ b/apps/client/src/services/utils.spec.ts
@@ -673,19 +673,30 @@ describe("SVG downloads (default export)", () => {
         return downloads;
     }
 
-    it("downloadSvg downloads the SVG string as a data URL", () => {
+    function captureObjectUrls() {
+        const blobs: Blob[] = [];
+        vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+            blobs.push(blob as Blob);
+            return `blob:mock-${blobs.length}`;
+        });
+        vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+        return blobs;
+    }
+
+    it("downloadSvg downloads the SVG string as a blob URL", async () => {
         const downloads = captureDownload();
+        const blobs = captureObjectUrls();
         utils.downloadSvg("diagram", `<svg><text>a & b</text></svg>`);
 
-        expect(downloads).toHaveLength(1);
-        expect(downloads[0].name).toBe("diagram.svg");
-        const href = downloads[0].href ?? "";
-        expect(href.startsWith("data:image/svg+xml;charset=utf-8,")).toBe(true);
-        expect(decodeURIComponent(href.split(",")[1])).toBe(`<svg><text>a & b</text></svg>`);
+        expect(downloads).toEqual([ { name: "diagram.svg", href: "blob:mock-1" } ]);
+        expect(blobs).toHaveLength(1);
+        expect(blobs[0].type).toContain("image/svg+xml");
+        expect(await blobs[0].text()).toBe(`<svg><text>a & b</text></svg>`);
     });
 
     it("downloadSvgAsPng rasterizes at the given scale and downloads a PNG", async () => {
         const downloads = captureDownload();
+        captureObjectUrls();
         const drawImage = vi.fn();
         const canvasSizes: { width: number, height: number }[] = [];
         vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({ drawImage } as unknown as RenderingContext);
@@ -704,9 +715,9 @@ describe("SVG downloads (default export)", () => {
             vi.unstubAllGlobals();
         }
 
-        expect(canvasSizes).toEqual([{ width: 200, height: 100 }]); // default scale is 2
+        expect(canvasSizes).toEqual([ { width: 200, height: 100 } ]); // default scale is 2
         expect(drawImage).toHaveBeenCalled();
-        expect(downloads).toEqual([{ name: "diagram.png", href: "data:image/png;base64,BBB" }]);
+        expect(downloads).toEqual([ { name: "diagram.png", href: "data:image/png;base64,BBB" } ]);
     });
 
     it("downloadSvgAsPng rejects when the SVG has no usable dimensions", async () => {

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -616,8 +616,11 @@ export function createImageSrcUrl(note: FNote) {
  * @param svgContent the content of the SVG file to download.
  */
 function downloadSvg(nameWithoutExtension: string, svgContent: string) {
-    const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
-    triggerDownload(`${nameWithoutExtension}.svg`, dataUrl);
+    const blob = new Blob([ svgContent ], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    triggerDownload(`${nameWithoutExtension}.svg`, url);
+    // Defer revocation so the in-flight download isn't cancelled (as downloadImage in image.ts).
+    setTimeout(() => URL.revokeObjectURL(url), 10_000);
 }
 
 /**
@@ -657,10 +660,17 @@ async function downloadSvgAsPng(nameWithoutExtension: string, svgContent: string
         throw new Error("Could not determine the dimensions of the SVG.");
     }
 
-    // Decode through an <img> element — the browser's own SVG renderer.
+    // Decode through an <img> element — the browser's own SVG renderer. A blob URL avoids the
+    // encoding overhead and URL length limits of a data: URL for large diagrams.
+    const blob = new Blob([ svgContent ], { type: "image/svg+xml;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
     const image = new Image();
-    image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
-    await image.decode();
+    image.src = url;
+    try {
+        await image.decode();
+    } finally {
+        URL.revokeObjectURL(url);
+    }
 
     const canvas = document.createElement("canvas");
     canvas.width = Math.round(size.width * scale);

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -610,65 +610,14 @@ export function createImageSrcUrl(note: FNote) {
 
 
 /**
- * Helper function to prepare an element for snapdom rendering.
- * Handles string parsing and temporary DOM attachment for style computation.
- *
- * @param source - Either an SVG/HTML string to be parsed, or an existing SVG/HTML element.
- * @returns An object containing the prepared element and a cleanup function.
- *          The cleanup function removes temporarily attached elements from the DOM,
- *          or is a no-op if the element was already in the DOM.
- */
-function prepareElementForSnapdom(source: string | SVGElement | HTMLElement): {
-    element: SVGElement | HTMLElement;
-    cleanup: () => void;
-} {
-    if (typeof source === 'string') {
-        const parser = new DOMParser();
-
-        // Detect if content is SVG or HTML
-        const isSvg = source.trim().startsWith('<svg');
-        const mimeType = isSvg ? SVG_MIME : 'text/html';
-
-        const doc = parser.parseFromString(source, mimeType);
-        const element = doc.documentElement;
-
-        // Temporarily attach to DOM for proper style computation
-        element.style.position = 'absolute';
-        element.style.left = '-9999px';
-        element.style.top = '-9999px';
-        document.body.appendChild(element);
-
-        return {
-            element,
-            cleanup: () => document.body.removeChild(element)
-        };
-    }
-
-    return {
-        element: source,
-        cleanup: () => {} // No-op for existing elements
-    };
-}
-
-/**
- * Downloads an SVG using snapdom for proper rendering. Can accept either an SVG string, an SVG element, or an HTML element.
+ * Given a string representation of an SVG, triggers a download of the file on the client device.
  *
  * @param nameWithoutExtension the name of the file. The .svg suffix is automatically added to it.
- * @param svgSource either an SVG string, an SVGElement, or an HTMLElement to be downloaded.
+ * @param svgContent the content of the SVG file to download.
  */
-async function downloadAsSvg(nameWithoutExtension: string, svgSource: string | SVGElement | HTMLElement) {
-    const { snapdom } = await import("@zumer/snapdom");
-    const { element, cleanup } = prepareElementForSnapdom(svgSource);
-
-    try {
-        const result = await snapdom(element, {
-            backgroundColor: "transparent",
-            scale: 2
-        });
-        triggerDownload(`${nameWithoutExtension}.svg`, result.url);
-    } finally {
-        cleanup();
-    }
+function downloadSvg(nameWithoutExtension: string, svgContent: string) {
+    const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+    triggerDownload(`${nameWithoutExtension}.svg`, dataUrl);
 }
 
 /**
@@ -690,32 +639,51 @@ function triggerDownload(fileName: string, dataUrl: string) {
     document.body.removeChild(element);
 }
 /**
- * Downloads an SVG as PNG using snapdom. Can accept either an SVG string, an SVG element, or an HTML element.
+ * Given a string representation of an SVG, rasterizes it to PNG and triggers a download of the
+ * file on the client device.
+ *
+ * The SVG must carry usable dimensions (numeric `width`/`height` attributes or a `viewBox`).
+ * Note that rasterization happens in the browser's SVG-as-image context: document fonts are not
+ * applied (only system fonts resolve) and external resources referenced by the SVG are not
+ * loaded, so any embedded images must use data URLs.
  *
  * @param nameWithoutExtension the name of the file. The .png suffix is automatically added to it.
- * @param svgSource either an SVG string, an SVGElement, or an HTMLElement to be converted to PNG.
+ * @param svgContent the content of the SVG file to rasterize.
+ * @param scale the rasterization scale factor (2 doubles the resolution).
  */
-async function downloadAsPng(nameWithoutExtension: string, svgSource: string | SVGElement | HTMLElement) {
-    const { snapdom } = await import("@zumer/snapdom");
-    const { element, cleanup } = prepareElementForSnapdom(svgSource);
-
-    try {
-        const result = await snapdom(element, {
-            backgroundColor: "transparent",
-            scale: 2
-        });
-        const pngImg = await result.toPng();
-        await triggerDownload(`${nameWithoutExtension}.png`, pngImg.src);
-    } finally {
-        cleanup();
+async function downloadSvgAsPng(nameWithoutExtension: string, svgContent: string, scale = 2) {
+    const size = getSizeFromSvg(svgContent);
+    if (!size) {
+        throw new Error("Could not determine the dimensions of the SVG.");
     }
+
+    // Decode through an <img> element — the browser's own SVG renderer.
+    const image = new Image();
+    image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+    await image.decode();
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(size.width * scale);
+    canvas.height = Math.round(size.height * scale);
+    const context = canvas.getContext("2d");
+    if (!context || !canvas.width || !canvas.height) {
+        throw new Error("The SVG has no drawable dimensions.");
+    }
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    triggerDownload(`${nameWithoutExtension}.png`, canvas.toDataURL("image/png"));
 }
 export function getSizeFromSvg(svgContent: string) {
     const svgDocument = (new DOMParser()).parseFromString(svgContent, SVG_MIME);
 
-    // Try to use width & height attributes if available.
+    // Try to use width & height attributes if available. Relative units (e.g. mermaid's
+    // width="100%") carry no absolute size, so fall through to the viewBox for those.
     let width = svgDocument.documentElement?.getAttribute("width");
     let height = svgDocument.documentElement?.getAttribute("height");
+    if (width?.includes("%") || height?.includes("%")) {
+        width = null;
+        height = null;
+    }
 
     // If not, use the viewbox.
     if (!width || !height) {
@@ -728,10 +696,10 @@ export function getSizeFromSvg(svgContent: string) {
     }
 
     if (width && height) {
-        return {
-            width: parseFloat(width),
-            height: parseFloat(height)
-        };
+        const size = { width: parseFloat(width), height: parseFloat(height) };
+        if (Number.isFinite(size.width) && Number.isFinite(size.height)) {
+            return size;
+        }
     }
     console.warn("SVG export error", svgDocument.documentElement);
     return null;
@@ -926,8 +894,8 @@ export default {
     areObjectsEqual,
     copyHtmlToClipboard,
     createImageSrcUrl,
-    downloadAsSvg,
-    downloadAsPng,
+    downloadSvg,
+    downloadSvgAsPng,
     triggerDownload,
     compareVersions,
     isUpdateAvailable,

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -616,11 +616,11 @@ export function createImageSrcUrl(note: FNote) {
  * @param svgContent the content of the SVG file to download.
  */
 function downloadSvg(nameWithoutExtension: string, svgContent: string) {
-    const blob = new Blob([ svgContent ], { type: "image/svg+xml;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    triggerDownload(`${nameWithoutExtension}.svg`, url);
-    // Defer revocation so the in-flight download isn't cancelled (as downloadImage in image.ts).
-    setTimeout(() => URL.revokeObjectURL(url), 10_000);
+    // The download MUST go through a data: URL, not a blob URL: export runs after awaits have
+    // consumed the transient user-activation, and a blob-URL anchor click without activation is
+    // silently blocked (same constraint documented in spreadsheet/export.tsx `download()`).
+    const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgContent)}`;
+    triggerDownload(`${nameWithoutExtension}.svg`, dataUrl);
 }
 
 /**

--- a/apps/client/src/widgets/type_widgets/MindMap.tsx
+++ b/apps/client/src/widgets/type_widgets/MindMap.tsx
@@ -5,7 +5,6 @@ import "./MindMap.css";
 // allow node-menu plugin css to be bundled by webpack
 import nodeMenu from "@mind-elixir/node-menu";
 import { NOTE_TYPE_IMAGE_ATTACHMENTS } from "@triliumnext/commons";
-import { snapdom } from "@zumer/snapdom";
 import { t } from "i18next";
 import { DARK_THEME, default as VanillaMindElixir, MindElixirData, MindElixirInstance, Operation, THEME as LIGHT_THEME } from "mind-elixir";
 import type { LangPack } from "mind-elixir/i18n";
@@ -16,6 +15,7 @@ import { sanitizeNoteContentHtml } from "../../services/sanitize_content";
 import utils from "../../services/utils";
 import { useColorScheme, useEditorSpacedUpdate, useEffectiveReadOnly, useSyncedRef, useTriliumEvent, useTriliumEvents, useTriliumOption } from "../react/hooks";
 import { refToJQuerySelector } from "../react/react_utils";
+import { renderMindMapPreviewSvg } from "./helpers/mind_map_export";
 import { TypeWidgetProps } from "./type_widget";
 
 const NEW_TOPIC_NAME = "";
@@ -103,16 +103,6 @@ export default function MindMap({ note, ntxId, noteContext }: TypeWidgetProps) {
         getData: async () => {
             if (!apiRef.current) return;
 
-            const result = await snapdom(apiRef.current.nodes, {
-                backgroundColor: "transparent",
-                scale: 2
-            });
-
-            // a data URL in the format: "data:image/svg+xml;charset=utf-8,<url-encoded-svg>"
-            // We need to extract the content after the comma and decode the URL encoding (%3C to <, %20 to space, etc.)
-            // to get raw SVG content that Trilium's backend can store as an attachment
-            const svgContent = decodeURIComponent(result.url.split(',')[1]);
-
             return {
                 content: apiRef.current.getDataString(),
                 attachments: [
@@ -120,7 +110,7 @@ export default function MindMap({ note, ntxId, noteContext }: TypeWidgetProps) {
                         role: "image",
                         title: NOTE_TYPE_IMAGE_ATTACHMENTS.mindMap,
                         mime: "image/svg+xml",
-                        content: svgContent,
+                        content: await renderMindMapPreviewSvg(apiRef.current),
                         position: 0
                     }
                 ]

--- a/apps/client/src/widgets/type_widgets/MindMap.tsx
+++ b/apps/client/src/widgets/type_widgets/MindMap.tsx
@@ -12,6 +12,7 @@ import { HTMLAttributes, RefObject } from "preact";
 import { useCallback, useEffect, useRef } from "preact/hooks";
 
 import { sanitizeNoteContentHtml } from "../../services/sanitize_content";
+import toast from "../../services/toast";
 import utils from "../../services/utils";
 import { useColorScheme, useEditorSpacedUpdate, useEffectiveReadOnly, useSyncedRef, useTriliumEvent, useTriliumEvents, useTriliumOption } from "../react/hooks";
 import { refToJQuerySelector } from "../react/react_utils";
@@ -143,11 +144,16 @@ export default function MindMap({ note, ntxId, noteContext }: TypeWidgetProps) {
     // Export as PNG or SVG.
     useTriliumEvents([ "exportSvg", "exportPng" ], async ({ ntxId: eventNtxId }, eventName) => {
         if (eventNtxId !== ntxId || !apiRef.current) return;
-        const svg = await renderMindMapPreviewSvg(apiRef.current);
-        if (eventName === "exportSvg") {
-            utils.downloadSvg(note.title, svg);
-        } else {
-            await utils.downloadSvgAsPng(note.title, svg);
+        try {
+            const svg = await renderMindMapPreviewSvg(apiRef.current);
+            if (eventName === "exportSvg") {
+                utils.downloadSvg(note.title, svg);
+            } else {
+                await utils.downloadSvgAsPng(note.title, svg);
+            }
+        } catch (e) {
+            console.warn(e);
+            toast.showError(t(eventName === "exportSvg" ? "svg.export_to_svg" : "svg.export_to_png"));
         }
     });
 

--- a/apps/client/src/widgets/type_widgets/MindMap.tsx
+++ b/apps/client/src/widgets/type_widgets/MindMap.tsx
@@ -143,13 +143,12 @@ export default function MindMap({ note, ntxId, noteContext }: TypeWidgetProps) {
     // Export as PNG or SVG.
     useTriliumEvents([ "exportSvg", "exportPng" ], async ({ ntxId: eventNtxId }, eventName) => {
         if (eventNtxId !== ntxId || !apiRef.current) return;
-        const nodes = apiRef.current.nodes;
+        const svg = await renderMindMapPreviewSvg(apiRef.current);
         if (eventName === "exportSvg") {
-            await utils.downloadAsSvg(note.title, nodes);
+            utils.downloadSvg(note.title, svg);
         } else {
-            await utils.downloadAsPng(note.title, nodes);
+            await utils.downloadSvgAsPng(note.title, svg);
         }
-
     });
 
     const onKeyDown = useCallback((e: KeyboardEvent) => {

--- a/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
+++ b/apps/client/src/widgets/type_widgets/helpers/SvgSplitEditor.tsx
@@ -89,14 +89,13 @@ export default function SvgSplitEditor({ ntxId, note, attachmentTitle, renderSvg
         }).catch(e => console.error("Failed to get attachments for SVGSplitEditor", e));
     }, [ note, svg, attachmentTitle, onSave ]);
 
-    // Import/export
-    useTriliumEvent("exportSvg", async({ ntxId: eventNtxId }) => {
+    // Import/export. The renderer's `svg` string is exported rather than the on-screen element,
+    // which svg-pan-zoom has wrapped in a viewport transform reflecting the current pan/zoom.
+    useTriliumEvent("exportSvg", ({ ntxId: eventNtxId }) => {
         if (eventNtxId !== ntxId || !svg) return;
 
         try {
-            const svgEl = containerRef.current?.querySelector("svg");
-            if (!svgEl) throw new Error("SVG element not found");
-            await utils.downloadAsSvg(note.title, svgEl);
+            utils.downloadSvg(note.title, svg);
         } catch (e) {
             console.warn(e);
             toast.showError(t("svg.export_to_svg"));
@@ -106,9 +105,7 @@ export default function SvgSplitEditor({ ntxId, note, attachmentTitle, renderSvg
     useTriliumEvent("exportPng", async ({ ntxId: eventNtxId }) => {
         if (eventNtxId !== ntxId || !svg) return;
         try {
-            const svgEl = containerRef.current?.querySelector("svg");
-            if (!svgEl) throw new Error("SVG element not found");
-            await utils.downloadAsPng(note.title, svgEl);
+            await utils.downloadSvgAsPng(note.title, svg);
         } catch (e) {
             console.warn(e);
             toast.showError(t("svg.export_to_png"));

--- a/apps/client/src/widgets/type_widgets/helpers/mind_map_export.spec.ts
+++ b/apps/client/src/widgets/type_widgets/helpers/mind_map_export.spec.ts
@@ -5,7 +5,7 @@
 import MindElixir, { type MindElixirData, type MindElixirInstance } from "mind-elixir";
 import { describe, expect, it } from "vitest";
 
-import { injectSvgLabels, renderMindMapPreviewSvg } from "./mind_map_export";
+import { postProcessExportedSvg, renderMindMapPreviewSvg } from "./mind_map_export";
 
 // mind-elixir touches these browser APIs at construction time; jsdom lacks them.
 window.matchMedia = window.matchMedia ?? ((query: string) => ({
@@ -53,11 +53,11 @@ function buildMind({ labels = [] as string[], exportedSvg = buildExportedSvg() }
     } as unknown as MindElixirInstance;
 }
 
-describe("injectSvgLabels", () => {
+describe("postProcessExportedSvg", () => {
     it("appends a foreignObject per label to the inner svg, carrying the label content", () => {
         const mind = buildMind({ labels: [ "first label", "second <b>label</b>" ] });
 
-        const result = injectSvgLabels(mind, buildExportedSvg());
+        const result = postProcessExportedSvg(mind, buildExportedSvg());
         const doc = new DOMParser().parseFromString(result, "image/svg+xml");
         const innerSvg = doc.documentElement.querySelector(":scope > svg");
         const foreignObjects = innerSvg?.querySelectorAll("foreignObject") ?? [];
@@ -73,20 +73,38 @@ describe("injectSvgLabels", () => {
         const dirtyLabel = `safe<img src="x" onerror="alert(1)"><script>alert(2)</script>`;
         const mind = buildMind({ labels: [ dirtyLabel ] });
 
-        const result = injectSvgLabels(mind, buildExportedSvg());
+        const result = postProcessExportedSvg(mind, buildExportedSvg());
 
         expect(result).toContain("safe");
         expect(result).not.toContain("onerror");
         expect(result).not.toContain("<script>");
     });
 
-    it("returns the input unchanged when there are no labels or no inner svg", () => {
-        const noLabels = buildMind();
-        expect(injectSvgLabels(noLabels, buildExportedSvg())).toBe(buildExportedSvg());
+    it("adds anti-clipping slack to the exporter's exact-fit foreignObject sizes", () => {
+        // Exact-fit boxes + pre-wrap clip text when rasterization resolves fonts a hair
+        // wider than the page did ("Hi there" → "Hi") — sizes must gain slack.
+        const exportedSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="400px"
+            height="300px"><rect x="0" y="0" width="400" height="300" fill="#fff"/>
+            <svg x="100" y="100" overflow="visible"><foreignObject x="10" y="10"
+            width="86.3167px" height="37.5px"><div>Hi there</div></foreignObject></svg></svg>`;
+        const result = postProcessExportedSvg(buildMind(), exportedSvg);
+
+        const doc = new DOMParser().parseFromString(result, "image/svg+xml");
+        const foreignObject = doc.querySelector("foreignObject");
+        expect(foreignObject?.getAttribute("width")).toBe(String(Math.ceil(86.3167 * 1.02 + 2)));
+        expect(foreignObject?.getAttribute("height")).toBe(String(Math.ceil(37.5 * 1.02 + 2)));
+        // The background rect and the svg dimensions must stay untouched.
+        expect(doc.querySelector("rect")?.getAttribute("width")).toBe("400");
+    });
+
+    it("adds no labels when the map has none, and returns unparseable input unchanged", () => {
+        const noLabels = postProcessExportedSvg(buildMind(), buildExportedSvg());
+        const doc = new DOMParser().parseFromString(noLabels, "image/svg+xml");
+        expect(doc.querySelectorAll("foreignObject")).toHaveLength(0);
 
         const withLabels = buildMind({ labels: [ "a label" ] });
         const flatSvg = `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`;
-        expect(injectSvgLabels(withLabels, flatSvg)).toBe(flatSvg);
+        expect(postProcessExportedSvg(withLabels, flatSvg)).toBe(flatSvg);
     });
 });
 
@@ -215,14 +233,18 @@ describe("renderMindMapPreviewSvg (real mind-elixir)", () => {
         expect(labelDivs).toContain(`label & "quoted"`);
     });
 
-    it("a map without arrows or summaries exports without injection", async () => {
+    it("a map without arrows or summaries exports without label injection", async () => {
         const mind = initRealMindMap({
             nodeData: { id: "root", topic: "Just a root", children: [] }
         });
         const result = await renderMindMapPreviewSvg(mind);
+        const rawExport = await mind.exportSvg().text();
 
         expect(result).toContain("Just a root");
-        expect(result).not.toContain("foreignObject><div"); // no injected labels
-        expect(await mind.exportSvg().text()).toBe(result);
+        // Post-processing must not add foreignObjects beyond the exporter's own
+        // (it only resizes them).
+        const countForeignObjects = (svg: string) => new DOMParser()
+            .parseFromString(svg, "image/svg+xml").querySelectorAll("foreignObject").length;
+        expect(countForeignObjects(result)).toBe(countForeignObjects(rawExport));
     });
 });

--- a/apps/client/src/widgets/type_widgets/helpers/mind_map_export.spec.ts
+++ b/apps/client/src/widgets/type_widgets/helpers/mind_map_export.spec.ts
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+// The label injection relies on sanitizeNoteContentHtml (DOMPurify), which happy-dom
+// breaks (NodeIterator mishandling — see sanitize_content.spec.ts). jsdom matches
+// real-browser behavior.
+import MindElixir, { type MindElixirData, type MindElixirInstance } from "mind-elixir";
+import { describe, expect, it } from "vitest";
+
+import { injectSvgLabels, renderMindMapPreviewSvg } from "./mind_map_export";
+
+// mind-elixir touches these browser APIs at construction time; jsdom lacks them.
+window.matchMedia = window.matchMedia ?? ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false
+}));
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? class {
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+
+};
+
+/**
+ * Reproduces the structure of mind-elixir's `exportSvg()` output:
+ * an outer svg holding a background rect and an inner svg with the map layers.
+ */
+function buildExportedSvg() {
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="400px" height="300px">` +
+        `<rect x="0" y="0" width="400" height="300" fill="#fff"/>` +
+        `<svg x="100" y="100" overflow="visible"><g class="topiclinks"></g></svg>` +
+        `</svg>`;
+}
+
+function buildMind({ labels = [] as string[], exportedSvg = buildExportedSvg() } = {}) {
+    const nodes = document.createElement("me-nodes");
+    for (const labelHtml of labels) {
+        const label = document.createElement("div");
+        label.className = "svg-label";
+        label.innerHTML = labelHtml;
+        nodes.appendChild(label);
+    }
+    document.body.appendChild(nodes);
+
+    return {
+        nodes,
+        exportSvg: () => new Blob([ exportedSvg ], { type: "image/svg+xml" })
+    } as unknown as MindElixirInstance;
+}
+
+describe("injectSvgLabels", () => {
+    it("appends a foreignObject per label to the inner svg, carrying the label content", () => {
+        const mind = buildMind({ labels: [ "first label", "second <b>label</b>" ] });
+
+        const result = injectSvgLabels(mind, buildExportedSvg());
+        const doc = new DOMParser().parseFromString(result, "image/svg+xml");
+        const innerSvg = doc.documentElement.querySelector(":scope > svg");
+        const foreignObjects = innerSvg?.querySelectorAll("foreignObject") ?? [];
+
+        expect(foreignObjects).toHaveLength(2);
+        expect(foreignObjects[0].textContent).toBe("first label");
+        expect(foreignObjects[1].querySelector("b")?.textContent).toBe("label");
+        // The outer svg must only gain content inside the inner svg.
+        expect(doc.documentElement.querySelectorAll(":scope > foreignObject")).toHaveLength(0);
+    });
+
+    it("sanitizes label HTML before embedding it", () => {
+        const dirtyLabel = `safe<img src="x" onerror="alert(1)"><script>alert(2)</script>`;
+        const mind = buildMind({ labels: [ dirtyLabel ] });
+
+        const result = injectSvgLabels(mind, buildExportedSvg());
+
+        expect(result).toContain("safe");
+        expect(result).not.toContain("onerror");
+        expect(result).not.toContain("<script>");
+    });
+
+    it("returns the input unchanged when there are no labels or no inner svg", () => {
+        const noLabels = buildMind();
+        expect(injectSvgLabels(noLabels, buildExportedSvg())).toBe(buildExportedSvg());
+
+        const withLabels = buildMind({ labels: [ "a label" ] });
+        const flatSvg = `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`;
+        expect(injectSvgLabels(withLabels, flatSvg)).toBe(flatSvg);
+    });
+});
+
+describe("renderMindMapPreviewSvg", () => {
+    it("exports the map and injects the labels", async () => {
+        const mind = buildMind({ labels: [ "arrow label" ] });
+
+        const result = await renderMindMapPreviewSvg(mind);
+
+        expect(result).toContain("topiclinks");
+        expect(result).toContain("arrow label");
+    });
+});
+
+/**
+ * Non-regression tests against a real mind-elixir instance, guarding the internals the
+ * label injection depends on (labels as `.svg-label` divs inside `mind.nodes`, the
+ * nested-svg export structure). If these fail after a mind-elixir upgrade, re-verify
+ * mind_map_export.ts against the new internals — see the module comment there.
+ */
+describe("renderMindMapPreviewSvg (real mind-elixir)", () => {
+    function initRealMindMap(data: MindElixirData): MindElixirInstance {
+        const el = document.createElement("div");
+        document.body.appendChild(el);
+        const mind = new MindElixir({ el });
+        mind.init(data);
+        return mind;
+    }
+
+    const MAP_WITH_LABELS: MindElixirData = {
+        nodeData: {
+            id: "root",
+            topic: "Root topic",
+            children: [
+                { id: "a", topic: "Topic A", children: [] },
+                { id: "b", topic: "Topic B", children: [] }
+            ]
+        },
+        arrows: [
+            {
+                id: "arrow1",
+                label: "my arrow label",
+                from: "a",
+                to: "b",
+                delta1: { x: 50, y: -50 },
+                delta2: { x: -50, y: 50 }
+            }
+        ],
+        summaries: [
+            { id: "sum1", label: "my summary label", parent: "root", start: 0, end: 1 }
+        ]
+    };
+
+    it("renders arrow and summary labels as .svg-label elements inside mind.nodes", () => {
+        const mind = initRealMindMap(MAP_WITH_LABELS);
+        const labels = mind.nodes.querySelectorAll(".svg-label");
+
+        expect(labels).toHaveLength(2);
+        const labelTexts = Array.from(labels).map((label) => label.textContent);
+        expect(labelTexts).toContain("my arrow label");
+        expect(labelTexts).toContain("my summary label");
+    });
+
+    it("exportSvg() alone still misses the labels (the upstream gap we patch)", async () => {
+        // If this starts failing, upstream fixed SSShooter/mind-elixir-core#359 and
+        // injectSvgLabels may duplicate labels — re-evaluate whether it is still needed.
+        const mind = initRealMindMap(MAP_WITH_LABELS);
+        const rawExport = await mind.exportSvg().text();
+
+        expect(rawExport).toContain("Topic A");
+        expect(rawExport).not.toContain("my arrow label");
+        expect(rawExport).not.toContain("my summary label");
+    });
+
+    it("the preview contains topics and both labels, and parses as valid SVG", async () => {
+        const mind = initRealMindMap(MAP_WITH_LABELS);
+        const result = await renderMindMapPreviewSvg(mind);
+
+        const doc = new DOMParser().parseFromString(result, "image/svg+xml");
+        expect(doc.querySelector("parsererror")).toBeNull();
+
+        const expectedTexts = [
+            "Root topic", "Topic A", "Topic B", "my arrow label", "my summary label"
+        ];
+        for (const text of expectedTexts) {
+            expect(result).toContain(text);
+        }
+
+        // Both labels must land inside the inner (map layers) svg as foreignObjects.
+        const innerSvg = doc.documentElement.querySelector(":scope > svg");
+        const labelDivs = Array.from(innerSvg?.querySelectorAll("foreignObject > div") ?? [])
+            .map((div) => div.textContent);
+        expect(labelDivs).toContain("my arrow label");
+        expect(labelDivs).toContain("my summary label");
+    });
+
+    it("XML-special characters in topics and labels survive export as valid SVG", async () => {
+        const mind = initRealMindMap({
+            nodeData: {
+                id: "root",
+                topic: "Both l & r <tags>",
+                children: [
+                    { id: "a", topic: "A", children: [] },
+                    { id: "b", topic: "B", children: [] }
+                ]
+            },
+            arrows: [
+                {
+                    id: "arrow1",
+                    label: `label & <b>"quoted"</b>`,
+                    from: "a",
+                    to: "b",
+                    delta1: { x: 50, y: -50 },
+                    delta2: { x: -50, y: 50 }
+                }
+            ]
+        });
+        const result = await renderMindMapPreviewSvg(mind);
+
+        const doc = new DOMParser().parseFromString(result, "image/svg+xml");
+        expect(doc.querySelector("parsererror")).toBeNull();
+        expect(result).toContain("Both l &amp; r");
+
+        const labelDivs = Array.from(doc.querySelectorAll("foreignObject > div"))
+            .map((div) => div.textContent);
+        expect(labelDivs).toContain(`label & "quoted"`);
+    });
+
+    it("a map without arrows or summaries exports without injection", async () => {
+        const mind = initRealMindMap({
+            nodeData: { id: "root", topic: "Just a root", children: [] }
+        });
+        const result = await renderMindMapPreviewSvg(mind);
+
+        expect(result).toContain("Just a root");
+        expect(result).not.toContain("foreignObject><div"); // no injected labels
+        expect(await mind.exportSvg().text()).toBe(result);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
+++ b/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
@@ -1,0 +1,94 @@
+import type { MindElixirInstance } from "mind-elixir";
+
+import { sanitizeNoteContentHtml } from "../../../services/sanitize_content";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const XHTML_NS = "http://www.w3.org/1999/xhtml";
+
+/**
+ * Renders the mind map to an SVG string for the preview attachment (share pages,
+ * include-note, `api/images`) using mind-elixir's native exporter.
+ *
+ * The native exporter clones the map's SVG layers directly, which makes it orders of
+ * magnitude faster than a DOM screenshot library (~7ms vs ~1100ms with snapdom for the
+ * demo map, see #10478) — but it has one known gap: labels of arrows ("custom links")
+ * and summaries live in an HTML overlay (`.label-container`) rather than in the SVG
+ * layers it clones, so they are missing from its output (the reason the preview was
+ * previously generated with snapdom). {@link injectSvgLabels} re-adds them.
+ *
+ * Note that upstream considers `exportSvg()` deprecated in favor of DOM screenshot
+ * libraries and will not fix the label gap (see
+ * https://github.com/SSShooter/mind-elixir-core/issues/359) — that advice is intended
+ * for user-triggered exports (where Trilium does use snapdom, see the exportSvg/exportPng
+ * handlers in MindMap.tsx), but a screenshot pass is far too slow to run on every save.
+ * We deliberately keep the native exporter here for performance; if a future mind-elixir
+ * release removes it (a loud, type-level break), vendor the exporter instead of
+ * switching the save path back to a screenshot library.
+ */
+export async function renderMindMapPreviewSvg(mind: MindElixirInstance): Promise<string> {
+    const svgText = await mind.exportSvg().text();
+    return injectSvgLabels(mind, svgText);
+}
+
+/**
+ * Re-adds the arrow/summary labels missing from mind-elixir's `exportSvg()` output.
+ *
+ * Labels are absolutely positioned `div.svg-label` elements inside `mind.nodes`
+ * (their offset parent is the `position: relative` `me-nodes` element), so their
+ * `offsetLeft`/`offsetTop` are in the same coordinate space as the exported SVG
+ * layers. Each label is appended to the exporter's inner `<svg>` (the one holding
+ * the map layers) as a `<foreignObject>` replicating the label's box and text style.
+ *
+ * @param mind the live mind map instance the SVG was exported from.
+ * @param svgText the output of `mind.exportSvg().text()`.
+ * @returns the SVG with the labels injected, or the input unchanged if there are no
+ *          labels or it cannot be parsed.
+ */
+export function injectSvgLabels(mind: MindElixirInstance, svgText: string): string {
+    const labels = mind.nodes.querySelectorAll<HTMLElement>(".svg-label");
+    if (labels.length === 0) {
+        return svgText;
+    }
+
+    const doc = new DOMParser().parseFromString(svgText, "image/svg+xml");
+    // The exporter produces <svg> [ <rect background>, <svg map layers> ] — label
+    // coordinates are relative to the inner svg.
+    const contentSvg = doc.documentElement?.querySelector(":scope > svg");
+    if (!contentSvg) {
+        return svgText;
+    }
+
+    for (const label of Array.from(labels)) {
+        contentSvg.appendChild(doc.importNode(buildLabelForeignObject(label), true));
+    }
+
+    return new XMLSerializer().serializeToString(doc);
+}
+
+/**
+ * Builds a `<foreignObject>` mirroring an on-screen `.svg-label` element, carrying
+ * over its box (position, size, background, border radius) and text styling. Built in
+ * the page's document so the label HTML is parsed leniently as HTML; the caller
+ * imports it into the SVG document.
+ */
+function buildLabelForeignObject(label: HTMLElement): SVGElement {
+    const style = getComputedStyle(label);
+
+    const foreignObject = document.createElementNS(SVG_NS, "foreignObject");
+    foreignObject.setAttribute("x", String(label.offsetLeft));
+    foreignObject.setAttribute("y", String(label.offsetTop));
+    foreignObject.setAttribute("width", style.width);
+    foreignObject.setAttribute("height", style.height);
+
+    const div = document.createElementNS(XHTML_NS, "div") as HTMLElement;
+    div.setAttribute("style",
+        "box-sizing: border-box; width: 100%; height: 100%; " +
+        `font-family: ${style.fontFamily}; font-size: ${style.fontSize}; ` +
+        `font-weight: ${style.fontWeight}; line-height: ${style.lineHeight}; ` +
+        `color: ${style.color}; padding: ${style.padding}; ` +
+        `background-color: ${style.backgroundColor}; border-radius: ${style.borderRadius};`);
+    div.innerHTML = sanitizeNoteContentHtml(label.innerHTML);
+
+    foreignObject.appendChild(div);
+    return foreignObject;
+}

--- a/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
+++ b/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
@@ -14,7 +14,8 @@ const XHTML_NS = "http://www.w3.org/1999/xhtml";
  * demo map, see #10478) — but it has one known gap: labels of arrows ("custom links")
  * and summaries live in an HTML overlay (`.label-container`) rather than in the SVG
  * layers it clones, so they are missing from its output (the reason the preview was
- * previously generated with snapdom). {@link injectSvgLabels} re-adds them.
+ * previously generated with snapdom). {@link postProcessExportedSvg} re-adds them and
+ * relaxes the exporter's exact-fit text boxes so rasterization cannot clip them.
  *
  * Note that upstream considers `exportSvg()` deprecated in favor of DOM screenshot
  * libraries and will not fix the label gap (see
@@ -27,29 +28,35 @@ const XHTML_NS = "http://www.w3.org/1999/xhtml";
  */
 export async function renderMindMapPreviewSvg(mind: MindElixirInstance): Promise<string> {
     const svgText = await mind.exportSvg().text();
-    return injectSvgLabels(mind, svgText);
+    return postProcessExportedSvg(mind, svgText);
 }
 
+// The exporter emits exact-fit foreignObject boxes: the text's measured width in the
+// page's font, to the third decimal, with `white-space: pre-wrap`. Any context that
+// resolves fonts even fractionally wider — PNG rasterization at scale, an <img> on a
+// machine with different fonts — soft-wraps the text and the exact-fit height clips the
+// wrapped line ("Hi there" renders as "Hi"). The boxes are invisible and the text is
+// left-anchored, so widening them slightly is visually free.
+const SIZE_SLACK_RATIO = 1.02;
+const SIZE_SLACK_PX = 2;
+
 /**
- * Re-adds the arrow/summary labels missing from mind-elixir's `exportSvg()` output.
+ * Post-processes mind-elixir's `exportSvg()` output to make it robust and complete:
  *
- * Labels are absolutely positioned `div.svg-label` elements inside `mind.nodes`
- * (their offset parent is the `position: relative` `me-nodes` element), so their
- * `offsetLeft`/`offsetTop` are in the same coordinate space as the exported SVG
- * layers. Each label is appended to the exporter's inner `<svg>` (the one holding
- * the map layers) as a `<foreignObject>` replicating the label's box and text style.
+ * - Re-adds the arrow/summary labels the exporter misses. Labels are absolutely
+ *   positioned `div.svg-label` elements inside `mind.nodes` (their offset parent is the
+ *   `position: relative` `me-nodes` element), so their `offsetLeft`/`offsetTop` are in
+ *   the same coordinate space as the exported SVG layers. Each label is appended to the
+ *   exporter's inner `<svg>` (the one holding the map layers) as a `<foreignObject>`
+ *   replicating the label's box and text style.
+ * - Adds slack to every `<foreignObject>`'s exact-fit size so text is not clipped when
+ *   the SVG is rasterized with slightly different font metrics (see the slack constants).
  *
  * @param mind the live mind map instance the SVG was exported from.
  * @param svgText the output of `mind.exportSvg().text()`.
- * @returns the SVG with the labels injected, or the input unchanged if there are no
- *          labels or it cannot be parsed.
+ * @returns the post-processed SVG, or the input unchanged if it cannot be parsed.
  */
-export function injectSvgLabels(mind: MindElixirInstance, svgText: string): string {
-    const labels = mind.nodes.querySelectorAll<HTMLElement>(".svg-label");
-    if (labels.length === 0) {
-        return svgText;
-    }
-
+export function postProcessExportedSvg(mind: MindElixirInstance, svgText: string): string {
     const doc = new DOMParser().parseFromString(svgText, "image/svg+xml");
     // The exporter produces <svg> [ <rect background>, <svg map layers> ] — label
     // coordinates are relative to the inner svg.
@@ -58,11 +65,25 @@ export function injectSvgLabels(mind: MindElixirInstance, svgText: string): stri
         return svgText;
     }
 
+    const labels = mind.nodes.querySelectorAll<HTMLElement>(".svg-label");
     for (const label of Array.from(labels)) {
         contentSvg.appendChild(doc.importNode(buildLabelForeignObject(label), true));
     }
 
+    for (const foreignObject of Array.from(doc.querySelectorAll("foreignObject"))) {
+        addSizeSlack(foreignObject, "width");
+        addSizeSlack(foreignObject, "height");
+    }
+
     return new XMLSerializer().serializeToString(doc);
+}
+
+function addSizeSlack(element: Element, attribute: "width" | "height") {
+    const value = Number.parseFloat(element.getAttribute(attribute) ?? "");
+    if (!Number.isFinite(value) || value <= 0) {
+        return;
+    }
+    element.setAttribute(attribute, String(Math.ceil(value * SIZE_SLACK_RATIO + SIZE_SLACK_PX)));
 }
 
 /**
@@ -76,15 +97,15 @@ function buildLabelForeignObject(label: HTMLElement): SVGElement {
 
     // The computed width/height carry the fractional used value, but degrade to "auto" when the
     // element is not rendered (e.g. a hidden tab) — fall back to the always-numeric offset size
-    // then. Round up so the foreignObject is never narrower than the text it must fit.
+    // then. The anti-clipping slack is applied later by the shared foreignObject pass.
     const width = Number.parseFloat(style.width) || label.offsetWidth;
     const height = Number.parseFloat(style.height) || label.offsetHeight;
 
     const foreignObject = document.createElementNS(SVG_NS, "foreignObject");
     foreignObject.setAttribute("x", String(label.offsetLeft));
     foreignObject.setAttribute("y", String(label.offsetTop));
-    foreignObject.setAttribute("width", String(Math.ceil(width)));
-    foreignObject.setAttribute("height", String(Math.ceil(height)));
+    foreignObject.setAttribute("width", String(width));
+    foreignObject.setAttribute("height", String(height));
 
     const div = document.createElementNS(XHTML_NS, "div") as HTMLElement;
     div.setAttribute("style",

--- a/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
+++ b/apps/client/src/widgets/type_widgets/helpers/mind_map_export.ts
@@ -18,12 +18,12 @@ const XHTML_NS = "http://www.w3.org/1999/xhtml";
  *
  * Note that upstream considers `exportSvg()` deprecated in favor of DOM screenshot
  * libraries and will not fix the label gap (see
- * https://github.com/SSShooter/mind-elixir-core/issues/359) — that advice is intended
- * for user-triggered exports (where Trilium does use snapdom, see the exportSvg/exportPng
- * handlers in MindMap.tsx), but a screenshot pass is far too slow to run on every save.
- * We deliberately keep the native exporter here for performance; if a future mind-elixir
- * release removes it (a loud, type-level break), vendor the exporter instead of
- * switching the save path back to a screenshot library.
+ * https://github.com/SSShooter/mind-elixir-core/issues/359) — but a screenshot pass is
+ * far too slow to run on every save (it once did, via snapdom — see #10478), so Trilium
+ * deliberately uses the native exporter everywhere: this helper also feeds the
+ * user-triggered SVG/PNG export actions in MindMap.tsx. If a future mind-elixir release
+ * removes `exportSvg()` (a loud, type-level break), vendor the exporter instead of
+ * switching back to a screenshot library.
  */
 export async function renderMindMapPreviewSvg(mind: MindElixirInstance): Promise<string> {
     const svgText = await mind.exportSvg().text();
@@ -74,11 +74,17 @@ export function injectSvgLabels(mind: MindElixirInstance, svgText: string): stri
 function buildLabelForeignObject(label: HTMLElement): SVGElement {
     const style = getComputedStyle(label);
 
+    // The computed width/height carry the fractional used value, but degrade to "auto" when the
+    // element is not rendered (e.g. a hidden tab) — fall back to the always-numeric offset size
+    // then. Round up so the foreignObject is never narrower than the text it must fit.
+    const width = Number.parseFloat(style.width) || label.offsetWidth;
+    const height = Number.parseFloat(style.height) || label.offsetHeight;
+
     const foreignObject = document.createElementNS(SVG_NS, "foreignObject");
     foreignObject.setAttribute("x", String(label.offsetLeft));
     foreignObject.setAttribute("y", String(label.offsetTop));
-    foreignObject.setAttribute("width", style.width);
-    foreignObject.setAttribute("height", style.height);
+    foreignObject.setAttribute("width", String(Math.ceil(width)));
+    foreignObject.setAttribute("height", String(Math.ceil(height)));
 
     const div = document.createElementNS(XHTML_NS, "div") as HTMLElement;
     div.setAttribute("style",

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -34,7 +34,6 @@
     "@triliumnext/highlightjs": "workspace:*",
     "@triliumnext/share-theme": "workspace:*",
     "@triliumnext/split.js": "workspace:*",
-    "@zumer/snapdom": "2.15.0",
     "autocomplete.js": "0.38.1",
     "bootstrap": "5.3.8",
     "boxicons": "2.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,9 +275,6 @@ importers:
       '@univerjs/presets':
         specifier: 0.25.1
         version: 0.25.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
-      '@zumer/snapdom':
-        specifier: 2.15.0
-        version: 2.15.0
       autocomplete.js:
         specifier: 0.38.1
         version: 0.38.1
@@ -882,9 +879,6 @@ importers:
       '@triliumnext/split.js':
         specifier: workspace:*
         version: link:../../packages/splitjs
-      '@zumer/snapdom':
-        specifier: 2.15.0
-        version: 2.15.0
       aes-js:
         specifier: 3.1.2
         version: 3.1.2
@@ -6678,9 +6672,6 @@ packages:
   '@zip.js/zip.js@2.8.26':
     resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
     engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
-
-  '@zumer/snapdom@2.15.0':
-    resolution: {integrity: sha512-rdayfg832lYhy2v2DRr4LwzhIT0ZMeGKYicVmtzbji95KhUd7Z1g6/5jTsDEU4q32a6ywbIpAixO45hubsEftQ==}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -20750,8 +20741,6 @@ snapshots:
   '@xtuc/long@4.2.2': {}
 
   '@zip.js/zip.js@2.8.26': {}
-
-  '@zumer/snapdom@2.15.0': {}
 
   abbrev@1.1.1: {}
 


### PR DESCRIPTION
## Summary

Closes #10478.

Editing a mind map froze the UI on every save: the spaced update regenerated the SVG preview attachment with **snapdom**, a full DOM-screenshot pass (computed-style inlining over every element and pseudo-element) that blocked the main thread for **~1.1s** even on the bundled demo map and re-uploaded a **~395KB** attachment each time.

mind-elixir's native `exportSvg()` produces the same preview in **~7ms** at **~44KB** (measured on the same map). This PR switches the save path back to it and cleans up the remaining snapdom usages.

### Why snapdom was there

The native exporter was used originally and was swapped for snapdom in ce1fd64aa9 because it drops the labels of arrows and summaries — they live in an HTML overlay (`.label-container` inside `me-nodes`) that the exporter doesn't clone. Upstream considers `exportSvg()` deprecated in favor of screenshot libraries and won't fix the gap (SSShooter/mind-elixir-core#359) — reasonable advice for one-off user exports, but a screenshot pass is the wrong tool for something that runs on every save.

### What this PR does

- **`renderMindMapPreviewSvg()`** (new helper): runs the native exporter, then re-injects each `.svg-label` into the exported SVG as a `foreignObject` replicating its box and text style, sanitized through `sanitizeNoteContentHtml`. Label offsets are already in the exported coordinate space (their offset parent is the `position: relative` `me-nodes`), so positioning carries over 1:1.
- **Save path** (`MindMap.tsx` `getData`): content save + preview regeneration now costs ~7ms instead of ~1.1s.
- **User-triggered SVG/PNG exports**: restored the pre-ce1fd64aa9 string-based path — `downloadSvg()` (data-URL download) and `downloadSvgAsPng()` (Image + canvas rasterization at 2× scale). Mind map exports render through the same helper as the preview, so download = stored preview = share page. Mermaid exports use the pristine renderer output again, fixing exports that previously captured the on-screen element *after* svg-pan-zoom wrapped it in a viewport transform (exports depended on the current pan/zoom state).
- **`getSizeFromSvg()`** hardened: relative dimensions (e.g. mermaid's `width="100%"`) no longer parse as 100px — it falls back to the `viewBox`.
- **`@zumer/snapdom` removed** from client and standalone dependencies — no call sites remain.

Note the exported background is the theme's `--bgcolor` rect again (as pre-December) instead of snapdom's transparent — intentional, since dark-theme exports with transparent backgrounds render light text unreadably on light surfaces.

### Tests

- Unit tests for the label injection (structure, sanitization, passthrough fallbacks).
- Non-regression tests driving a **real mind-elixir instance under jsdom**, including a canary that fails if upstream ever fixes the label gap (so the injection can be re-evaluated) and a guard on the internals the injection relies on (`.svg-label` inside `mind.nodes`).
- Tests for `downloadSvg`/`downloadSvgAsPng` (data-URL round-trip, 2× canvas sizing, dimension-failure rejection).

Timing was measured live against the dev server (the ~7ms vs ~1.1s numbers above). The SVG/PNG download buttons (mind map + mermaid) still deserve a quick manual pass — canvas rasterization is mocked in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
