### PR TITLE
fix(client): don't let Enter select from a closed autocomplete dropdown

### DIFF
--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -607,6 +607,55 @@ describe("initNoteAutocomplete wiring", () => {
         expect(selected).not.toHaveBeenCalled();
     });
 
+    // Issue #5669: autocomplete.js empties its suggestion list only a tick after closing
+    // it, and its Enter handler selects from the closed-but-not-yet-emptied dropdown, so
+    // a fast second Enter right after a selection would consume a stale suggestion row.
+    // Plain Enter must never reach the library while the dropdown is closed (the library
+    // keeps aria-expanded in sync with its open/close state).
+    it("does not deliver a plain Enter to autocomplete while the dropdown is closed", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        // simulates the library's own keydown handler, which is bound after init
+        const autocompleteKeydown = vi.fn((event: JQuery.KeyDownEvent) => event.preventDefault());
+        $el.on("keydown.aa", autocompleteKeydown);
+
+        // aria-expanded not yet set (before the first open), then explicitly closed
+        for (const expanded of [undefined, "false"]) {
+            if (expanded) {
+                $el.attr("aria-expanded", expanded);
+            }
+            const event = $.Event("keydown", { key: "Enter" });
+            $el.trigger(event);
+            // the default action (form submission) must stay intact
+            expect(event.isDefaultPrevented()).toBe(false);
+        }
+        expect(autocompleteKeydown).not.toHaveBeenCalled();
+    });
+
+    it("delivers a plain Enter to autocomplete while the dropdown is open", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        const autocompleteKeydown = vi.fn();
+        $el.on("keydown.aa", autocompleteKeydown);
+
+        $el.attr("aria-expanded", "true");
+        $el.trigger($.Event("keydown", { key: "Enter" }));
+
+        expect(autocompleteKeydown).toHaveBeenCalledOnce();
+    });
+
+    it("leaves modified Enter presses alone even when the dropdown is closed", () => {
+        const $el = makeEl();
+        noteAutocomplete.initNoteAutocomplete($el);
+        const autocompleteKeydown = vi.fn();
+        $el.on("keydown.aa", autocompleteKeydown);
+
+        $el.attr("aria-expanded", "false");
+        $el.trigger($.Event("keydown", { key: "Enter", ctrlKey: true }));
+
+        expect(autocompleteKeydown).toHaveBeenCalledOnce();
+    });
+
     it("composition end re-sets the autocomplete value", () => {
         const $el = makeEl();
         noteAutocomplete.initNoteAutocomplete($el);

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -282,6 +282,18 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             fullTextSearch($el, options);
         }
     });
+    $el.on("keydown", (event) => {
+        const isPlainEnter = event.key === "Enter"
+            && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey;
+        // autocomplete.js empties its suggestion list only a tick after closing it, and its
+        // Enter handler selects from the closed-but-not-yet-emptied dropdown — so a fast second
+        // Enter after a selection consumes a stale row (#5669). Enter must never select from a
+        // dropdown the user cannot see; the library keeps aria-expanded in sync with open/close.
+        if (isPlainEnter && $el.attr("aria-expanded") !== "true") {
+            // Stop autocomplete from seeing the keypress, but leave form submission intact.
+            event.stopImmediatePropagation();
+        }
+    });
 
     $el.autocomplete(
         {

--- a/apps/server/e2e/add_link_double_enter.spec.ts
+++ b/apps/server/e2e/add_link_double_enter.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+
+import App from "../../../packages/trilium-e2e/src/support/app";
+
+// Repro for https://github.com/TriliumNext/Trilium/issues/5669
+//
+// Mechanism: after Enter selects a note, autocomplete.js closes the dropdown but
+// only *defers* emptying it (setTimeout 0). Until that timer fires, the stale
+// suggestion rows are still in the DOM, and _onEnterKeyed happily selects
+// getDatumForCursor()/getDatumForTopSuggestion() even though the dropdown is
+// closed. A second Enter landing inside that window is therefore consumed by
+// autocomplete (re-selecting a stale row — or, when the create-note row is on
+// top, opening the "Choose note type" dialog) instead of submitting the form.
+//
+// Dispatching both Enter keydowns in a single synchronous task makes the race
+// deterministic: the deferred empty() can never run between them. (Humans hit
+// the same window when the second keypress is dispatched ahead of the pending
+// 0 ms timer — input events are prioritized over timers, especially with a
+// busy main thread right after the dialog re-renders.)
+test("fast double-Enter in add-link dialog is not consumed by a stale suggestion", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+
+    // Open a text note via the tree and focus its editor.
+    await page.locator(".tree-wrapper .fancytree-title", { hasText: "Text notes" }).first().click();
+    const editor = app.currentNoteSplit.locator(".note-detail-editable-text.visible .ck-editor__editable");
+    await editor.waitFor();
+    await editor.click();
+    await page.keyboard.press("Control+l");
+
+    const dialog = page.locator(".add-link-dialog");
+    await expect(dialog).toBeVisible();
+
+    const input = dialog.locator("input.note-autocomplete");
+    await input.pressSequentially("Highlights");
+
+    // Row 0 is the prepended "Create note 'Highlights'" row; wait for a real note row too.
+    await expect(page.locator(".aa-dropdown-menu:visible .aa-suggestion").nth(1)).toBeVisible();
+
+    // Move the cursor onto a real note row, as in the issue's repro steps, and
+    // let the re-query the arrows can trigger settle.
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(300);
+
+    // Fire both Enters in one synchronous task — zero timers can interleave —
+    // and record what each one did.
+    const result = await page.evaluate(() => {
+        const el = document.querySelector<HTMLInputElement>(".add-link-dialog input.note-autocomplete");
+        if (!el) throw new Error("autocomplete input not found");
+
+        const selections: string[] = [];
+        const jq = (window as unknown as { $: (el: HTMLElement) => { on: (ev: string, cb: (e: unknown, s?: { action?: string; noteTitle?: string }) => void) => void } }).$;
+        jq(el).on("autocomplete:selected", (_e, s) => selections.push(`${s?.action ?? "note"}:${s?.noteTitle}`));
+
+        const fire = () => {
+            const e = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+            Object.defineProperty(e, "keyCode", { value: 13 });
+            Object.defineProperty(e, "which", { value: 13 });
+            el.dispatchEvent(e);
+            return e.defaultPrevented;
+        };
+        const firstPrevented = fire();
+        const secondPrevented = fire();
+        return { selections, firstPrevented, secondPrevented };
+    });
+
+    // The first Enter must select the note under the cursor…
+    expect(result.selections.length).toBe(1);
+    expect(result.firstPrevented).toBe(true);
+
+    // …and the second Enter must NOT be consumed by autocomplete: no second
+    // selection, no "Choose note type" dialog, and the default action (form
+    // submission = adding the link) left intact.
+    expect(result.secondPrevented).toBe(false);
+    await expect(page.locator(".note-type-chooser-dialog")).not.toBeVisible({ timeout: 2000 });
+    await expect(input).toHaveAttribute("data-note-path", /.+/);
+});


### PR DESCRIPTION
## Summary

Fixes the "Add link" dialog dropping the link when Enter is pressed twice quickly (#5669): the second Enter would consume a stale suggestion row — opening the "Choose note type" dialog when the stale top row was the prepended create-note row — instead of submitting the form.

## Root cause

After Enter selects a suggestion, autocomplete.js closes the dropdown but only **defers** emptying it (`_select` → `_.defer(dropdown.empty)` = `setTimeout(0)`), and its `_onEnterKeyed` selects `getDatumForCursor()`/`getDatumForTopSuggestion()` from the rendered DOM **even while the dropdown is closed**. A second Enter landing before that deferred `empty()` runs is therefore consumed by a stale row. Real users hit this tiny window because browsers dispatch pending input events ahead of due timers, especially with a busy main thread right after the dialog re-renders — which is also why it's hard to reproduce by hand on a fast machine.

## The fix

One stateless keydown handler, bound before the library initializes, enforcing the actual invariant — **plain Enter must never select from a dropdown the user cannot see**:

- if the dropdown is closed (`aria-expanded !== "true"`, which the library toggles synchronously in `_onOpened`/`_onClosed`), `stopImmediatePropagation()` keeps the keypress away from autocomplete.js while leaving the default action (form submission = adding the link) intact;
- if the dropdown is visibly open (including when arrow keys reopened it after a selection), Enter reaches the library and selects the highlighted row as usual.

This covers the note, external-link, create-note, and command flows uniformly, with no selection-state bookkeeping.

Alternative to #10477, which fixes the same issue by tracking a terminal-selection flag on the element; that flag must be cleared by every code path that starts a fresh query (input events plus five programmatic helpers), and it stays armed when arrow keys reopen the dropdown (no `input` event fires), so Enter on a newly highlighted row gets swallowed and the dialog submits the previous selection. Reading the dropdown's visibility directly avoids the lifecycle entirely.

## Testing

- **E2E** (`apps/server/e2e/add_link_double_enter.spec.ts`): reproduces the race deterministically by dispatching both Enter keydowns in a single synchronous task, so the deferred `empty()` can never run between them. Fails on `main` (the second Enter fires a second `autocomplete:selected` on a stale row and is `preventDefault`-ed), passes with the fix (one selection; the second Enter falls through to form submission; no note-type-chooser).
- **Unit** (`pnpm --filter client test src/services/note_autocomplete.spec.ts`, 57 pass): plain Enter with the dropdown closed is not delivered to a later-bound `keydown.aa` handler and keeps its default action; plain Enter with the dropdown open is delivered; modified Enter (e.g. Ctrl+Enter) is untouched even when closed.
- **Manually verified** (real keys, dev server): select note → ArrowDown reopens the dropdown → ArrowDown → Enter selects the newly highlighted row; fast double-Enter adds the link.

Closes #5669

🤖 Generated with [Claude Code](https://claude.com/claude-code)