### PR TITLE
fix(e2e): run server E2E tests with a single worker

### DIFF
--- a/apps/server/playwright.config.ts
+++ b/apps/server/playwright.config.ts
@@ -26,6 +26,12 @@ export default createBaseConfig({
     appDir: __dirname,
     localTestDir: "e2e",
     projectName: "server",
+    // All workers share a single server instance and user account, and some state is
+    // global to the account — e.g. the openNoteContexts option holding the open tabs.
+    // With parallel workers, every test that opens a note overwrites that state for the
+    // others, which chronically flaked "Tabs are restored in right order". Same setting
+    // as the standalone app, which runs the identical shared suite without flaking.
+    workers: 1,
     webServer: !process.env.TRILIUM_DOCKER ? {
         command: "pnpm start-prod-no-dir",
         url: baseURL,


### PR DESCRIPTION
## Problem

`Tabs are restored in right order` ([tab_bar.spec.ts:64](https://github.com/TriliumNext/Trilium/blob/main/packages/trilium-e2e/src/layout/tab_bar.spec.ts#L64)) is the dominant chronic flake in the server E2E suite: 4 of the last 5 failed `playwright` runs on `main` are this one test failing its initial attempt plus all 3 retries. Five past commits (`e7521fe30c`, `66364f5ce0`, `6b57ee5654`, `53739ee8d4`, `fc16ab5d19`) tried to stabilize it from inside the test — timeouts, extra assertions, proxy waits — without lasting success.

## Root cause

The suite runs its Playwright workers (2 on CI runners) against **one shared server instance and one user account**, and the open-tab set is **global account state**: every client window persists its tabs to the single `openNoteContexts` option via a debounced `PUT /api/options` ([tab_manager.ts:49–63](https://github.com/TriliumNext/Trilium/blob/main/apps/client/src/components/tab_manager.ts#L49-L63)), and restore reads that same option back. Last writer wins.

So while this test sets up its three tabs and reloads with `preserveTabs`, any test in the other worker that opens a note overwrites the state — the restored tab bar is whatever the neighbor saved last. The failure diffs prove it directly: the "restored" tabs contain titles owned by concurrently running specs, e.g. `"Flowchart ELK on"` from `mermaid.spec.ts` ([failing run](https://github.com/TriliumNext/Trilium/actions/runs/29195269750/job/86657003895)). Retries re-enter the same race, which is why they never save it. ARM runners just widen the timing windows; the failure history hits both architectures.

No amount of in-test waiting can fix a race against another worker process — only isolation can.

## Fix

`workers: 1` for the server project — mirroring [apps/standalone/playwright.config.ts](https://github.com/TriliumNext/Trilium/blob/main/apps/standalone/playwright.config.ts), which runs the **identical shared suite** single-worker and where this same test has been stable (passing in ~11s in recent runs, absent from the flake history). That's about as clean a control experiment as it gets.

Cost: roughly +2 minutes of E2E wall time. Proper per-worker server isolation (a server + data dir per worker) could bring parallelism back later; tracked as a possible follow-up, along with waiting on the actual `PUT /api/options` instead of `/api/recent-notes` inside the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)