### PR TITLE
fix(notes): strip stale external srcset from localized images

### DIFF
--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -353,7 +353,22 @@ describe("notes service (real DB)", () => {
 
             const { content: newContent } = getContext().init(() => saveLinks(source.note, content));
 
-            expect(newContent).toContain("srcset=");
+            // Assert the full srcset value survived intact, not merely that a srcset= token is present.
+            expect(newContent).toContain(`srcset="https://example.com/a.png 1290w, https://example.com/a-300.png 300w"`);
+        });
+
+        it("strips a srcset containing the opposite quote character without corrupting the tag", () => {
+            const source = createNote("root", { title: "spec-srcset-quote" });
+
+            // A single quote inside the double-quoted srcset value must not truncate the strip
+            // (a naive [^"']* would stop at the apostrophe and leave a dangling fragment).
+            const content =
+                `<p><img src="api/attachments/aBc/image/x.png" ` +
+                `srcset="https://example.com/it's-a-photo.png 1x"> after</p>`;
+
+            const { content: newContent } = getContext().init(() => saveLinks(source.note, content));
+
+            expect(newContent).toBe(`<p><img src="api/attachments/aBc/image/x.png"> after</p>`);
         });
 
         it("extracts an inline base64 attachment, deriving its title via prepareTitle", () => {

--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -318,6 +318,44 @@ describe("notes service (real DB)", () => {
             expect(code.note.getRelations().some((r) => r.name === "internalLink")).toBe(false);
         });
 
+        it("strips a stale external srcset from an image already pointing at a local attachment (#srcset)", () => {
+            const source = createNote("root", { title: "spec-srcset" });
+
+            // Real-world paste: the image was saved as a local attachment (src rewritten),
+            // but the copied HTML still carries a srcset of external URLs. Browsers prefer
+            // srcset over src, so once upstream removes those URLs the image vanishes even
+            // though the local attachment is still valid.
+            const content =
+                `<figure class="image image_resized" style="width:49.35%;">` +
+                `<img style="aspect-ratio:1290/238;" src="api/attachments/gbsXLfqQwo4a/image/asas.png" alt="" ` +
+                `srcset="https://example.com/wp-content/uploads/2025/02/asas.png 1290w, ` +
+                `https://example.com/wp-content/uploads/2025/02/asas-300x55.png 300w" ` +
+                `sizes="100vw" width="1290" height="238"></figure>`;
+
+            const { content: newContent } = getContext().init(() => saveLinks(source.note, content));
+
+            // The local src is preserved…
+            expect(newContent).toContain(`src="api/attachments/gbsXLfqQwo4a/image/asas.png"`);
+            // …but the external srcset/sizes are removed so the browser falls back to it.
+            expect(newContent).not.toContain("srcset=");
+            expect(newContent).not.toContain("example.com");
+            expect(newContent).not.toContain("sizes=");
+        });
+
+        it("keeps the srcset on an image whose src is still an external URL", () => {
+            const source = createNote("root", { title: "spec-srcset-external" });
+
+            // Nothing was localized here (e.g. downloadImagesAutomatically off): the src is
+            // still external, so the srcset is the legitimate/only source and must survive.
+            const content =
+                `<img src="https://example.com/a.png" ` +
+                `srcset="https://example.com/a.png 1290w, https://example.com/a-300.png 300w" sizes="100vw">`;
+
+            const { content: newContent } = getContext().init(() => saveLinks(source.note, content));
+
+            expect(newContent).toContain("srcset=");
+        });
+
         it("extracts an inline base64 attachment, deriving its title via prepareTitle", () => {
             const source = createNote("root", { title: "spec-inline-attachment" });
 

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -963,7 +963,29 @@ function saveAttachments(note: BNote, content: string) {
     // we also omit / at the beginning to keep the paths relative
     content = content.replace(/src="[^"]*\/api\/attachments\//g, 'src="api/attachments/');
 
+    content = stripStaleSrcset(content);
+
     return content;
+}
+
+/**
+ * When an image is pasted from the web its `src` is localized to a Trilium
+ * attachment, but the copied HTML often still carries the original `srcset`
+ * (and its companion `sizes`) pointing at external URLs. Browsers prefer
+ * `srcset` over `src`, so once those external URLs disappear the image breaks
+ * even though the local attachment is intact. Drop `srcset`/`sizes` from any
+ * `<img>` already backed by a local attachment so the valid `src` is used.
+ * Images whose `src` is still external keep their `srcset` — there it is the
+ * legitimate (and only) source.
+ */
+function stripStaleSrcset(content: string): string {
+    return content.replace(/<img\b[^>]*>/gi, (imgTag) => {
+        if (!/\ssrc=["']api\/attachments\/[^"']+["']/i.test(imgTag)) {
+            return imgTag;
+        }
+
+        return imgTag.replace(/\s(?:srcset|sizes)=["'][^"']*["']/gi, "");
+    });
 }
 
 

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -980,11 +980,13 @@ function saveAttachments(note: BNote, content: string) {
  */
 function stripStaleSrcset(content: string): string {
     return content.replace(/<img\b[^>]*>/gi, (imgTag) => {
-        if (!/\ssrc=["']api\/attachments\/[^"']+["']/i.test(imgTag)) {
+        // Match quotes as balanced pairs (and allow optional whitespace around `=`) so a value
+        // containing the opposite quote character doesn't truncate the match and corrupt the tag.
+        if (!/\ssrc\s*=\s*(?:"api\/attachments\/[^"]+"|'api\/attachments\/[^']+')/i.test(imgTag)) {
             return imgTag;
         }
 
-        return imgTag.replace(/\s(?:srcset|sizes)=["'][^"']*["']/gi, "");
+        return imgTag.replace(/\s(?:srcset|sizes)\s*=\s*(?:"[^"]*"|'[^']*')/gi, "");
     });
 }
 


### PR DESCRIPTION
## Problem

When an image is pasted from the web, its `src` is rewritten to a local Trilium attachment, but the copied HTML often still carries the original `srcset` (and its companion `sizes`) pointing at the source site's external URLs. Per the HTML spec, browsers resolve the image from `srcset` when present and ignore `src` — so the note keeps loading the image from the external site. Once upstream removes those files, the image disappears even though the local attachment is perfectly intact.

Example of the offending pasted markup (note the local `src` shadowed by an external `srcset`):

```html
<figure class="image image_resized" style="width:49.35%;">
  <img src="api/attachments/gbsXLfqQwo4a/image/asas.png" alt=""
       srcset="https://example.com/.../asas.png 1290w, https://example.com/.../asas-300x55.png 300w"
       sizes="100vw" width="1290" height="238">
</figure>
```

Nothing in the server/import path ever inspected `srcset` — `saveLinks`/`downloadImages`/`saveAttachments` only rewrite/normalize `src`.

## Fix

`saveAttachments` (`packages/trilium-core/src/services/notes.ts`) now strips `srcset` and `sizes` from any `<img>` whose `src` already points at a local `api/attachments/…` attachment, so the valid local `src` is used. Images whose `src` is still external keep their `srcset` untouched — there it is the legitimate (and only) source. This runs at the single chokepoint that covers paste, web-clipper, and import.

## Tests

Two tests added to `notes.spec.ts`:
- The real-world pasted `<figure>` → asserts the local `src` survives while the external `srcset`/`sizes` are removed (fails without the fix).
- An `<img>` whose `src` is still external → asserts its `srcset` is preserved (guards against over-stripping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)