### PR TITLE
ci: pin vedantmgoyal9/winget-releaser to a full commit SHA

### DIFF
--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish to WinGet
-        uses: vedantmgoyal9/winget-releaser@main
+        uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main
         with:
           identifier: TriliumNext.Notes
           token: ${{ secrets.WINGET_PAT  }}


### PR DESCRIPTION
### What
Pin `vedantmgoyal9/winget-releaser@main` → `7bd472b…` in `release-winget.yml` (tag kept in a comment).

### Why
`@main` is a moving ref. This step is handed `secrets.WINGET_PAT` — a personal access token used to open
the release PR to `microsoft/winget-pkgs` on the project's behalf. If the action's `main` were moved
(compromise or an accidental change), the new code would run with that PAT — the class behind the 2025
`tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of main). Renovate/Dependabot can bump it. Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow, the WINGET_PAT exposure, and the pinned SHA myself.</sub>
