### PR TITLE
fix(spreadsheet): data-validation XLSX round-trip + single-note export fixes

### DIFF
--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
@@ -58,17 +58,17 @@
     Only the structure present at the time of note creation is considered.</p>
 </aside>
 <h2>Regarding note types</h2>
-<p>By default, newly created notes are&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_iPIMuisry3hd">Text</a>&nbsp;notes.
+<p>By default, newly created notes are&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes.
   If a parent note defines a <code spellcheck="false">child:template</code> pointing
   to a template of a different type (e.g. a Code note), the behavior depends
   on how the new note is created:</p>
 <ul>
   <li>If no note type is explicitly chosen (e.g. the + button in the&nbsp;
     <a
-    class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/Vc8PjrjAGuOp/_help_oPVyFC7WL2Lp">Note Tree</a>), the template is applied and the new note takes the type
+    class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>), the template is applied and the new note takes the type
       and content of the template.</li>
   <li>If a note type is explicitly selected (e.g.&nbsp;<a class="reference-link"
-    href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/Vc8PjrjAGuOp/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;→ <em>Insert note after</em> / <em>Insert child note</em>):
+    href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;→ <em>Insert note after</em> / <em>Insert child note</em>):
     <ul>
       <li>If the selected type matches the template's type, the template is applied.</li>
       <li>If the selected type differs, the template is disregarded entirely — the
@@ -83,11 +83,11 @@
   <code
   spellcheck="false">#cssClass</code>attributes, allowing all instance notes (e.g., books)
     to display a specific icon and CSS style.</p>
-<p>Explore the concept further in the&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/wX4HbRucYSDD/_help_6tZeKvSHEUiB">Demo Notes</a>,
-  including examples like the&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_iRwzGnHPzonm">Relation Map</a>,&nbsp;
+<p>Explore the concept further in the&nbsp;<a class="reference-link" href="#root/_help_6tZeKvSHEUiB">Demo Notes</a>,
+  including examples like the&nbsp;<a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>,&nbsp;
   <a
-  class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/5668rwcirq1t/_help_xYjQUYhpbUEW">Task Manager</a>, and&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/5668rwcirq1t/_help_l0tKav7yLHGF">Day Notes</a>.</p>
-<p>Additionally, see&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/_help_47ZrP6FNuoG8">Default Note Title</a>&nbsp;for
+  class="reference-link" href="#root/_help_xYjQUYhpbUEW">Task Manager</a>, and&nbsp;<a class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>.</p>
+<p>Additionally, see&nbsp;<a class="reference-link" href="#root/_help_47ZrP6FNuoG8">Default Note Title</a>&nbsp;for
   creating title templates. Note templates and title templates can be combined
   by creating a <code spellcheck="false">#titleTemplate</code> for a template
   note.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
@@ -62,10 +62,16 @@
         class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>.</li>
       <li>For the old layout, choose the corresponding buttons in the&nbsp;<a class="reference-link"
         href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;area.</li>
-      <li>The export is intentionally a different process than the normal&nbsp;
-        <a
-        class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>&nbsp;functionality because it does conversion
-          to multiple formats with varying degrees of compatibility.</li>
+      <li>If exported as a single file via&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/_help_mHbBMPDPkVV5">Import &amp; Export</a>,
+        the resulting file will be a custom <code spellcheck="false">.triliumsheet</code> file
+        that preserves the spreadsheet as-is.
+        <ul>
+          <li>The export is intentionally a different process than the normal&nbsp;
+            <a
+            class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>&nbsp;functionality because it does conversion
+              to multiple formats with varying degrees of compatibility.</li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
@@ -62,7 +62,7 @@
         class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>.</li>
       <li>For the old layout, choose the corresponding buttons in the&nbsp;<a class="reference-link"
         href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;area.</li>
-      <li>If exported as a single file via&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/_help_mHbBMPDPkVV5">Import &amp; Export</a>,
+      <li>If exported as a single file via&nbsp;<a class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>,
         the resulting file will be a custom <code spellcheck="false">.triliumsheet</code> file
         that preserves the spreadsheet as-is.
         <ul>

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -15742,6 +15742,55 @@
                                     "position": 30
                                 },
                                 {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "iPIMuisry3hd",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "oPVyFC7WL2Lp",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "6tZeKvSHEUiB",
+                                    "isInheritable": false,
+                                    "position": 60
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "iRwzGnHPzonm",
+                                    "isInheritable": false,
+                                    "position": 70
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "xYjQUYhpbUEW",
+                                    "isInheritable": false,
+                                    "position": 80
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "l0tKav7yLHGF",
+                                    "isInheritable": false,
+                                    "position": 90
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "47ZrP6FNuoG8",
+                                    "isInheritable": false,
+                                    "position": 100
+                                },
+                                {
                                     "type": "label",
                                     "name": "shareAlias",
                                     "value": "template",
@@ -15754,55 +15803,6 @@
                                     "value": "bx bx-copy",
                                     "isInheritable": false,
                                     "position": 110
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "47ZrP6FNuoG8",
-                                    "isInheritable": false,
-                                    "position": 120
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "6tZeKvSHEUiB",
-                                    "isInheritable": false,
-                                    "position": 130
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "iRwzGnHPzonm",
-                                    "isInheritable": false,
-                                    "position": 140
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "xYjQUYhpbUEW",
-                                    "isInheritable": false,
-                                    "position": 150
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "l0tKav7yLHGF",
-                                    "isInheritable": false,
-                                    "position": 160
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "iPIMuisry3hd",
-                                    "isInheritable": false,
-                                    "position": 170
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "oPVyFC7WL2Lp",
-                                    "isInheritable": false,
-                                    "position": 180
                                 }
                             ],
                             "format": "markdown",

--- a/docs/User Guide/User Guide/Note Types/Spreadsheets.md
+++ b/docs/User Guide/User Guide/Note Types/Spreadsheets.md
@@ -34,7 +34,8 @@ Both [import and export](../Basic%20Concepts%20and%20Features/Import%20%26%20Exp
 *   Unlike importing, exporting is on a per-note basis:
     *   In the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Note%20buttons.md">Note buttons</a>, choose the _Export to Excel_ or _Export to CSV_ options for the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/New%20Layout.md">New Layout</a>.
     *   For the old layout, choose the corresponding buttons in the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Floating%20buttons.md">Floating buttons</a> area.
-    *   The export is intentionally a different process than the normal <a class="reference-link" href="../Basic%20Concepts%20and%20Features/Import%20%26%20Export.md">Import &amp; Export</a> functionality because it does conversion to multiple formats with varying degrees of compatibility.
+    *   If exported as a single file via <a class="reference-link" href="../Basic%20Concepts%20and%20Features/Import%20%26%20Export.md">Import &amp; Export</a>, the resulting file will be a custom `.triliumsheet` file that preserves the spreadsheet as-is.
+        *   The export is intentionally a different process than the normal <a class="reference-link" href="../Basic%20Concepts%20and%20Features/Import%20%26%20Export.md">Import &amp; Export</a> functionality because it does conversion to multiple formats with varying degrees of compatibility.
 
 > [!IMPORTANT]
 > Import & export for both .xlsx and .csv files are supported on a best-effort basis. It does not support advanced features (data validation, scripting, etc.). If you notice a particular issue, it can be [reported](../Troubleshooting/Reporting%20issues.md), however all bug reports must contain a sample file in order to be taken into consideration.

--- a/packages/commons/src/lib/spreadsheet/exceljs_augmentation.ts
+++ b/packages/commons/src/lib/spreadsheet/exceljs_augmentation.ts
@@ -1,0 +1,25 @@
+/**
+ * exceljs exposes `Worksheet#dataValidations` at runtime — an instance of its `DataValidations`
+ * class (`lib/doc/data-validations.js`) — but omits it from its published typings, where the field
+ * is commented out of `WorksheetModel`. Declare it so the XLSX importer/exporter can read and write
+ * validation rules without casting through `any`.
+ *
+ * This is a module rather than a free-floating `.d.ts` so that importing it pulls the augmentation
+ * into the program; an unreferenced declaration file is only picked up by projects whose `include`
+ * globs it, which is not every project that compiles these sources.
+ */
+import "exceljs";
+
+declare module "exceljs" {
+    interface DataValidations {
+        /** Validation config keyed by cell address; exceljs expands a range's `sqref` per cell. */
+        model: Record<string, DataValidation | undefined>;
+        add(address: string, validation: DataValidation): DataValidation;
+        find(address: string): DataValidation | undefined;
+        remove(address: string): void;
+    }
+
+    interface Worksheet {
+        readonly dataValidations: DataValidations;
+    }
+}

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
@@ -5,6 +5,7 @@ import { excelColorToRgb, parseRange, parseXlsxToWorkbook, toArrayBuffer } from 
 import {
     BorderStyle,
     CellValueType,
+    type DataValidationRule,
     HorizontalAlign,
     type ICellData,
     type IStyleData,
@@ -545,6 +546,133 @@ describe("parseXlsxToWorkbook images", () => {
         const sheet = workbook.sheets[workbook.sheetOrder[0]];
         expect(sheet.rowHeader).toEqual({ width: 46, hidden: 0 });
         expect(sheet.columnHeader).toEqual({ height: 20, hidden: 0 });
+    });
+});
+
+describe("parseXlsxToWorkbook data validation", () => {
+    // Reads the SHEET_DATA_VALIDATION_PLUGIN resource for a sheet back into a typed shape.
+    function validationsOf(
+        workbook: { sheetOrder: string[]; resources?: { name: string; data: string }[] },
+        sheetIndex = 0
+    ): DataValidationRule[] | null {
+        const resource = workbook.resources?.find((r) => r.name === "SHEET_DATA_VALIDATION_PLUGIN");
+        if (!resource) return null;
+        const parsed = JSON.parse(resource.data) as Record<string, DataValidationRule[]>;
+        return parsed[workbook.sheetOrder[sheetIndex]] ?? null;
+    }
+
+    it("imports an inline dropdown list, coalescing the cell range and JSON-encoding the options", async () => {
+        // Mirrors the real file: a single sqref rectangle that exceljs expands to individual cells.
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("A1").value = "x";
+        ws.dataValidations.add("D2:E3", {
+            type: "list",
+            allowBlank: true,
+            formulae: ['"0 - Below Expectations ,1 - Meets Expectations,2 - Strong Performance"']
+        });
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rules = validationsOf(workbook);
+        expect(rules).toHaveLength(1);
+        const rule = rules?.[0];
+        expect(rule?.type).toBe("list");
+        // Univer's list validator JSON-parses formula1 (deserializeListOptions); the exporter
+        // JSON.stringifies. The inline options keep their exact text, including the trailing space.
+        expect(rule?.formula1).toBe(
+            JSON.stringify(["0 - Below Expectations ", "1 - Meets Expectations", "2 - Strong Performance"])
+        );
+        // The 2x2 block collapses back into a single rectangle, not four 1x1 ranges.
+        expect(rule?.ranges).toEqual([{ startRow: 1, endRow: 2, startColumn: 3, endColumn: 4 }]);
+        expect(rule?.uid).toBeTruthy();
+    });
+
+    it("carries the operator and both formulae for a numeric (whole between) validation", async () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("B2").dataValidation = { type: "whole", operator: "between", formulae: [1, 10] };
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rule = validationsOf(workbook)?.[0];
+        expect(rule?.type).toBe("whole");
+        expect(rule?.operator).toBe("between");
+        expect(rule?.formula1).toBe("1");
+        expect(rule?.formula2).toBe("10");
+        expect(rule?.ranges).toEqual([{ startRow: 1, endRow: 1, startColumn: 1, endColumn: 1 }]);
+    });
+
+    it("emits no validation resource for a sheet without any", async () => {
+        const wb = new ExcelJS.Workbook();
+        wb.addWorksheet("S").getCell("A1").value = "x";
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+        expect(workbook.resources?.some((r) => r.name === "SHEET_DATA_VALIDATION_PLUGIN")).toBeFalsy();
+    });
+
+    it("keeps distinct configs as separate rules on the same sheet", async () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.dataValidations.add("A1:A2", { type: "list", formulae: ['"a,b"'] });
+        ws.dataValidations.add("C1:C2", { type: "list", formulae: ['"x,y"'] });
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rules = validationsOf(workbook);
+        expect(rules).toHaveLength(2);
+        const formula1s = rules?.map((r) => r.formula1).sort();
+        expect(formula1s).toEqual([JSON.stringify(["a", "b"]), JSON.stringify(["x", "y"])]);
+    });
+
+    it("passes a range-referenced list through as the formula, not a JSON option array", async () => {
+        // A dropdown whose options come from a cell range ($A$1:$A$3) rather than inline text:
+        // there are no literal options to encode, so the reference is carried as formula1 verbatim.
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("C1").dataValidation = { type: "list", formulae: ["$A$1:$A$3"] };
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rule = validationsOf(workbook)?.[0];
+        expect(rule?.type).toBe("list");
+        expect(rule?.formula1).toBe("$A$1:$A$3");
+    });
+
+    it("carries a single-bound numeric constraint (greaterThan) with just formula1", async () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("B2").dataValidation = { type: "decimal", operator: "greaterThan", formulae: [5] };
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rule = validationsOf(workbook)?.[0];
+        expect(rule?.operator).toBe("greaterThan");
+        expect(rule?.formula1).toBe("5");
+        expect(rule?.formula2).toBeUndefined();
+    });
+
+    it("carries a custom-formula validation (a formula, no operator)", async () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("B2").dataValidation = { type: "custom", formulae: ["=B2>0"] };
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+
+        const rule = validationsOf(workbook)?.[0];
+        expect(rule?.type).toBe("custom");
+        expect(rule?.formula1).toBe("=B2>0");
+        expect(rule?.operator).toBeUndefined();
+    });
+
+    it("drops a list validation that carries no options", async () => {
+        const wb = new ExcelJS.Workbook();
+        const ws = wb.addWorksheet("S");
+        ws.getCell("A1").value = "x";
+        ws.getCell("B1").dataValidation = { type: "list", formulae: [] };
+        const buffer = await wb.xlsx.writeBuffer();
+        const { workbook } = await parseXlsxToWorkbook(buffer as ArrayBuffer);
+        expect(workbook.resources?.some((r) => r.name === "SHEET_DATA_VALIDATION_PLUGIN")).toBeFalsy();
     });
 });
 

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
@@ -9,8 +9,9 @@
  * heavy lifting (unzip + XML) is delegated to `exceljs`.
  *
  * Known fidelity gaps (Excel features Univer's cell model — and our exporter — don't carry):
- * conditional formatting, data validation, filters, charts, embedded images, comments,
- * frozen panes and defined names are dropped. Rich text is flattened to plain text and
+ * conditional formatting, filters, charts, comments, frozen panes and defined names are dropped.
+ * Data validation is carried for the common constraint types (dropdown lists, numeric/date/text
+ * bounds) via the SHEET_DATA_VALIDATION_PLUGIN resource. Rich text is flattened to plain text and
  * hyperlinks keep their display text but lose the link. Theme/indexed colors are resolved
  * against the standard Office palette (see `THEME_COLORS`), which is approximate when the
  * file ships a custom theme.
@@ -21,6 +22,7 @@ import ExcelJS from "exceljs";
 import {
     BorderStyle,
     CellValueType,
+    type DataValidationRule,
     HorizontalAlign,
     type IBorderData,
     type IBorderStyleData,
@@ -32,6 +34,7 @@ import {
     type IWorkbookData,
     type IWorksheetData,
     type PersistedData,
+    SHEET_DATA_VALIDATION_RESOURCE,
     SHEET_DRAWING_RESOURCE,
     VerticalAlign,
     WrapStrategy
@@ -61,6 +64,7 @@ export async function parseXlsxToWorkbook(input: ArrayBuffer | Uint8Array): Prom
     const sheetOrder: string[] = [];
     const sheets: Record<string, IWorksheetData> = {};
     const drawingsBySheet: Record<string, SheetDrawings> = {};
+    const validationsBySheet: Record<string, DataValidationRule[]> = {};
 
     wb.eachSheet((ws, sheetIndex) => {
         // Deterministic ids keyed off position; the workbook id/locale are reassigned on load
@@ -72,15 +76,25 @@ export async function parseXlsxToWorkbook(input: ArrayBuffer | Uint8Array): Prom
 
         const drawings = readImages(wb, ws, sheet, id);
         if (drawings) drawingsBySheet[id] = drawings;
+
+        const validations = readDataValidations(ws, id);
+        if (validations.length > 0) validationsBySheet[id] = validations;
     });
 
     const workbook: IWorkbookData = { sheetOrder, styles: {}, sheets };
 
-    // Floating images go in the SHEET_DRAWING_PLUGIN resource (a JSON string keyed by sheet id),
-    // the same shape the editor persists; Univer reconciles the drawing unitId on load.
+    // Both plugin payloads are JSON strings keyed by sheet id, matching the shape the editor
+    // persists; Univer reconciles their unit ids on load.
+    const resources: IWorkbookData["resources"] = [];
+    // Floating images go in the SHEET_DRAWING_PLUGIN resource.
     if (Object.keys(drawingsBySheet).length > 0) {
-        workbook.resources = [{ name: SHEET_DRAWING_RESOURCE, data: JSON.stringify(drawingsBySheet) }];
+        resources.push({ name: SHEET_DRAWING_RESOURCE, data: JSON.stringify(drawingsBySheet) });
     }
+    // Data-validation rules (dropdowns, numeric/date bounds) go in the SHEET_DATA_VALIDATION_PLUGIN resource.
+    if (Object.keys(validationsBySheet).length > 0) {
+        resources.push({ name: SHEET_DATA_VALIDATION_RESOURCE, data: JSON.stringify(validationsBySheet) });
+    }
+    if (resources.length > 0) workbook.resources = resources;
 
     return { version: 1, workbook };
 }
@@ -305,6 +319,133 @@ function bytesToBase64(bytes: Uint8Array): string {
         binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
     }
     return btoa(binary);
+}
+
+// #endregion
+
+// #region Data validation
+
+/** A 0-based cell coordinate, used while coalescing per-cell validations back into ranges. */
+interface CellRef {
+    row: number;
+    column: number;
+}
+
+/**
+ * Reads a worksheet's data-validation rules into Univer rules. exceljs expands a rule's `sqref`
+ * (e.g. `D2:I6`) into one entry per cell, so cells sharing an identical config are grouped and
+ * their addresses coalesced back into rectangular ranges. Only constraint types Univer understands
+ * are emitted; a validation with no usable constraint is skipped. Returns an empty array when the
+ * sheet has none.
+ */
+function readDataValidations(ws: ExcelJS.Worksheet, sheetId: string): DataValidationRule[] {
+    const model = (ws.dataValidations as { model?: Record<string, ExcelJS.DataValidation | undefined> } | undefined)?.model;
+    /* v8 ignore next -- defensive: exceljs always exposes a (possibly empty) dataValidations model */
+    if (!model) return [];
+
+    // Group cells by an identical validation config; the key is order-stable across the sheet.
+    const groups = new Map<string, { config: ExcelJS.DataValidation; cells: CellRef[] }>();
+    for (const [address, config] of Object.entries(model)) {
+        /* v8 ignore next -- defensive: exceljs model entries always carry a type */
+        if (!config?.type) continue;
+        const cell = parseAddress(address);
+        /* v8 ignore next -- defensive: exceljs validation keys are always well-formed addresses */
+        if (!cell) continue;
+        const key = JSON.stringify([config.type, config.operator ?? null, config.formulae ?? null]);
+        const group = groups.get(key) ?? { config, cells: [] };
+        group.cells.push({ row: cell.row, column: cell.col });
+        groups.set(key, group);
+    }
+
+    const rules: DataValidationRule[] = [];
+    let index = 0;
+    for (const { config, cells } of groups.values()) {
+        const rule = buildValidationRule(config, coalesceRanges(cells), `dv-${sheetId}-${index}`);
+        if (rule) {
+            rules.push(rule);
+            index++;
+        }
+    }
+    return rules;
+}
+
+/**
+ * Translates one exceljs validation config into a Univer rule, or null when its constraint can't be
+ * represented (an empty list). exceljs's type/operator strings already match Univer's enums; a
+ * `list`'s inline options are JSON-encoded the way Univer's list validator expects, while numeric,
+ * date, text-length and custom constraints carry their formula bounds and operator verbatim.
+ */
+function buildValidationRule(config: ExcelJS.DataValidation, ranges: IRange[], uid: string): DataValidationRule | null {
+    const rule: DataValidationRule = { uid, type: config.type, ranges };
+
+    if (config.type === "list") {
+        const raw = config.formulae?.[0];
+        if (raw == null) return null;
+        const inline = parseInlineListOptions(String(raw));
+        // An inline list ("a,b,c") becomes a JSON option array; a range reference ($A$1:$A$3) is
+        // passed through as the formula, which Univer resolves the same way.
+        rule.formula1 = inline ? JSON.stringify(inline) : String(raw);
+        return rule;
+    }
+
+    /* v8 ignore next -- defensive: exceljs's DataValidation.formulae is always an array */
+    const [formula1, formula2] = config.formulae ?? [];
+    if (formula1 != null) rule.formula1 = String(formula1);
+    if (formula2 != null) rule.formula2 = String(formula2);
+    if (config.operator) rule.operator = config.operator;
+    return rule;
+}
+
+/**
+ * Parses Excel's inline list syntax — a single comma-separated string wrapped in double quotes,
+ * e.g. `"a,b,c"` — into its option array. Returns null when the formula isn't an inline list (a
+ * range/name reference) so the caller can pass it through as a formula instead. Empty options are
+ * dropped, matching Univer's `serializeListOptions`.
+ */
+function parseInlineListOptions(formula: string): string[] | null {
+    if (formula.length < 2 || !formula.startsWith("\"") || !formula.endsWith("\"")) return null;
+    // Excel does not trim whitespace inside an inline list, so options are split verbatim.
+    return formula.slice(1, -1).split(",").filter((option) => option.length > 0);
+}
+
+/**
+ * Merges a set of cells into a minimal-ish list of rectangular ranges with a greedy sweep: each
+ * unclaimed cell grows right as far as contiguous cells allow, then down as many full-width rows as
+ * possible. A solid block collapses to a single range; scattered cells stay separate.
+ */
+function coalesceRanges(cells: CellRef[]): IRange[] {
+    const present = new Set(cells.map((c) => cellKey(c.row, c.column)));
+    const claimed = new Set<string>();
+    const ranges: IRange[] = [];
+
+    const sorted = [...cells].sort((a, b) => a.row - b.row || a.column - b.column);
+    for (const { row, column } of sorted) {
+        if (claimed.has(cellKey(row, column))) continue;
+
+        let endColumn = column;
+        while (present.has(cellKey(row, endColumn + 1)) && !claimed.has(cellKey(row, endColumn + 1))) endColumn++;
+
+        let endRow = row;
+        while (rowSpanFree(present, claimed, endRow + 1, column, endColumn)) endRow++;
+
+        for (let r = row; r <= endRow; r++) {
+            for (let c = column; c <= endColumn; c++) claimed.add(cellKey(r, c));
+        }
+        ranges.push({ startRow: row, endRow, startColumn: column, endColumn });
+    }
+    return ranges;
+}
+
+/** True when every cell of `row` across `[startColumn, endColumn]` is present and unclaimed. */
+function rowSpanFree(present: Set<string>, claimed: Set<string>, row: number, startColumn: number, endColumn: number): boolean {
+    for (let c = startColumn; c <= endColumn; c++) {
+        if (!present.has(cellKey(row, c)) || claimed.has(cellKey(row, c))) return false;
+    }
+    return true;
+}
+
+function cellKey(row: number, column: number): string {
+    return `${row},${column}`;
 }
 
 // #endregion

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
@@ -19,6 +19,8 @@
 
 import ExcelJS from "exceljs";
 
+import "./exceljs_augmentation.js";
+
 import {
     BorderStyle,
     CellValueType,
@@ -339,9 +341,7 @@ interface CellRef {
  * sheet has none.
  */
 function readDataValidations(ws: ExcelJS.Worksheet, sheetId: string): DataValidationRule[] {
-    const model = (ws.dataValidations as { model?: Record<string, ExcelJS.DataValidation | undefined> } | undefined)?.model;
-    /* v8 ignore next -- defensive: exceljs always exposes a (possibly empty) dataValidations model */
-    if (!model) return [];
+    const model = ws.dataValidations.model;
 
     // Group cells by an identical validation config; the key is order-stable across the sheet.
     const groups = new Map<string, { config: ExcelJS.DataValidation; cells: CellRef[] }>();

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -569,7 +569,8 @@ describe("renderSpreadsheetToXlsx", () => {
             const dv = ws?.getCell("B2").dataValidation;
             expect(dv?.type).toBe("whole");
             expect(dv?.operator).toBe("between");
-            expect(dv?.formulae).toEqual(["1", "10"]);
+            // exceljs coerces the numeric formula text back to numbers on read.
+            expect(dv?.formulae).toEqual([1, 10]);
         });
 
         it("passes a range-referenced list through as a formula, not an inline list", async () => {
@@ -604,6 +605,33 @@ describe("renderSpreadsheetToXlsx", () => {
             expect(ws?.getCell("F6").dataValidation?.type).toBe("list");
             // A cell between the two ranges is untouched.
             expect(ws?.getCell("E3").dataValidation).toBeUndefined();
+        });
+
+        it("writes a custom-formula validation (a formula, no operator)", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "custom",
+                    formula1: "=B2>0",
+                    ranges: [{ startRow: 1, endRow: 1, startColumn: 1, endColumn: 1 }]
+                }
+            ]))).getWorksheet("Sheet1");
+
+            const dv = ws?.getCell("B2").dataValidation;
+            expect(dv?.type).toBe("custom");
+            expect(dv?.formulae).toEqual(["=B2>0"]);
+            expect(dv?.operator).toBeUndefined();
+        });
+
+        it("skips a list validation that has no options", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "list",
+                    ranges: [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 0 }]
+                }
+            ]))).getWorksheet("Sheet1");
+            expect(ws?.getCell("A1").dataValidation).toBeUndefined();
         });
 
         it("skips a validation type Excel cannot represent", async () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -509,6 +509,119 @@ describe("renderSpreadsheetToXlsx", () => {
             expect(wb.getWorksheet("Sheet1")?.getImages().length).toBe(0);
         });
     });
+
+    describe("data validation", () => {
+        function validationWorkbook(rules: unknown[]): string {
+            const sheetId = "s1";
+            return JSON.stringify({
+                version: 1,
+                workbook: {
+                    sheetOrder: [sheetId],
+                    styles: {},
+                    sheets: {
+                        [sheetId]: {
+                            id: sheetId,
+                            name: "Sheet1",
+                            hidden: 0,
+                            mergeData: [],
+                            cellData: { "0": { "0": { v: "x" } } },
+                            rowData: {},
+                            columnData: {}
+                        }
+                    },
+                    resources: [
+                        { name: "SHEET_DATA_VALIDATION_PLUGIN", data: JSON.stringify({ [sheetId]: rules }) }
+                    ]
+                }
+            });
+        }
+
+        it("writes an inline dropdown list as an Excel inline list over its range", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "list",
+                    formula1: JSON.stringify(["Low", "Medium", "High"]),
+                    ranges: [{ startRow: 1, endRow: 2, startColumn: 3, endColumn: 4 }]
+                }
+            ]))).getWorksheet("Sheet1");
+
+            const dv = ws?.getCell("D2").dataValidation;
+            expect(dv?.type).toBe("list");
+            // Excel inline list: the options comma-joined and wrapped in double quotes.
+            expect(dv?.formulae).toEqual(['"Low,Medium,High"']);
+            // The whole 2x2 rectangle carries the rule.
+            expect(ws?.getCell("E3").dataValidation?.type).toBe("list");
+        });
+
+        it("writes a numeric constraint with its operator and both bounds", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "whole",
+                    operator: "between",
+                    formula1: "1",
+                    formula2: "10",
+                    ranges: [{ startRow: 1, endRow: 1, startColumn: 1, endColumn: 1 }]
+                }
+            ]))).getWorksheet("Sheet1");
+
+            const dv = ws?.getCell("B2").dataValidation;
+            expect(dv?.type).toBe("whole");
+            expect(dv?.operator).toBe("between");
+            expect(dv?.formulae).toEqual(["1", "10"]);
+        });
+
+        it("passes a range-referenced list through as a formula, not an inline list", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "list",
+                    formula1: "$A$1:$A$3",
+                    ranges: [{ startRow: 0, endRow: 0, startColumn: 2, endColumn: 2 }]
+                }
+            ]))).getWorksheet("Sheet1");
+
+            const dv = ws?.getCell("C1").dataValidation;
+            expect(dv?.type).toBe("list");
+            expect(dv?.formulae).toEqual(["$A$1:$A$3"]);
+        });
+
+        it("applies a rule with multiple ranges to each range", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "list",
+                    formula1: JSON.stringify(["a", "b"]),
+                    ranges: [
+                        { startRow: 1, endRow: 5, startColumn: 3, endColumn: 3 },
+                        { startRow: 1, endRow: 5, startColumn: 5, endColumn: 5 }
+                    ]
+                }
+            ]))).getWorksheet("Sheet1");
+
+            expect(ws?.getCell("D2").dataValidation?.type).toBe("list");
+            expect(ws?.getCell("F6").dataValidation?.type).toBe("list");
+            // A cell between the two ranges is untouched.
+            expect(ws?.getCell("E3").dataValidation).toBeUndefined();
+        });
+
+        it("skips a validation type Excel cannot represent", async () => {
+            const ws = (await roundTrip(validationWorkbook([
+                {
+                    uid: "dv1",
+                    type: "checkbox",
+                    ranges: [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 0 }]
+                }
+            ]))).getWorksheet("Sheet1");
+            expect(ws?.getCell("A1").dataValidation).toBeUndefined();
+        });
+
+        it("renders without error when there is no validation resource", async () => {
+            const ws = (await roundTrip(singleCellWorkbook({ v: "x" }))).getWorksheet("Sheet1");
+            expect(ws?.getCell("A1").dataValidation).toBeUndefined();
+        });
+    });
 });
 
 describe("uniqueSheetName", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -629,9 +629,18 @@ describe("renderSpreadsheetToXlsx", () => {
                     uid: "dv1",
                     type: "list",
                     ranges: [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 0 }]
+                },
+                // An option array that parses but is empty — what importing an inline list of only
+                // empty tokens (`",,"`) yields. It must be skipped, not written as an empty list.
+                {
+                    uid: "dv2",
+                    type: "list",
+                    formula1: "[]",
+                    ranges: [{ startRow: 0, endRow: 0, startColumn: 2, endColumn: 2 }]
                 }
             ]))).getWorksheet("Sheet1");
             expect(ws?.getCell("A1").dataValidation).toBeUndefined();
+            expect(ws?.getCell("C1").dataValidation).toBeUndefined();
         });
 
         it("skips a validation type Excel cannot represent", async () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -291,7 +291,9 @@ const EXCEL_VALIDATION_TYPES: ReadonlySet<string> = new Set(["list", "whole", "d
 function buildExcelValidation(rule: DataValidationRule): ExcelJS.DataValidation | null {
     if (rule.type === "list" || rule.type === "listMultiple") {
         const options = parseListOptions(rule.formula1);
-        if (options) return { type: "list", allowBlank: true, formulae: [`"${options.join(",")}"`] };
+        // An option array that parses but is empty (an import of an inline list of only empty
+        // tokens, e.g. `",,"`) has no dropdown to write, and Excel rejects an empty inline list.
+        if (options) return options.length > 0 ? { type: "list", allowBlank: true, formulae: [`"${options.join(",")}"`] } : null;
         // A range/name reference passes through; an absent/empty formula has no dropdown to write.
         if (rule.formula1) return { type: "list", allowBlank: true, formulae: [rule.formula1] };
         return null;

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -13,6 +13,8 @@
 
 import ExcelJS from "exceljs";
 
+import "./exceljs_augmentation.js";
+
 import {
     BorderStyle,
     type DataValidationRule,

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -14,6 +14,8 @@ import ExcelJS from "exceljs";
 
 import {
     BorderStyle,
+    type DataValidationRule,
+    getDataValidations,
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
@@ -21,6 +23,7 @@ import {
     type ICellData,
     type IDrawingCellAnchor,
     isFiniteNumber,
+    type IRange,
     type IStyleData,
     type IWorkbookData,
     type IWorksheetData,
@@ -80,6 +83,7 @@ export async function renderSpreadsheetToXlsx(jsonContent: string, opts: XlsxRen
     const usedNames = new Set<string>();
     for (const sheet of visibleSheets) {
         const ws = writeSheet(out, sheet, uniqueSheetName(sheet.name, usedNames), styles);
+        applyDataValidations(ws, workbook, sheet.id);
         if (opts.resolveImage) {
             await embedImages(out, ws, sheet, workbook, opts.resolveImage);
         }

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -3,7 +3,8 @@
  *
  * Unlike the HTML renderer, this is a near-lossless mapping: Univer's cell model mirrors
  * OOXML, so number formats pass through verbatim, the border-style enum maps almost 1:1 to
- * Excel's, and fonts/fills/alignment/merges map directly. The heavy lifting (zip + XML) is
+ * Excel's, and fonts/fills/alignment/merges map directly. Data-validation rules (dropdown lists,
+ * numeric/date/text bounds) invert their import counterparts. The heavy lifting (zip + XML) is
  * delegated to `exceljs`.
  *
  * The workbook type subset, sheet selection, and style resolution live in the shared
@@ -252,6 +253,88 @@ function rowHeightPx(sheet: IWorksheetData, row: number): number {
 
 function toFinite(value: number | undefined): number {
     return isFiniteNumber(value) ? value : 0;
+}
+
+// #endregion
+
+// #region Data validation
+
+/**
+ * Writes a sheet's Univer data-validation rules (from the SHEET_DATA_VALIDATION_PLUGIN resource)
+ * into the worksheet — the inverse of the importer's `readDataValidations`. Each rule is applied
+ * once per range, because exceljs rejects a multi-range `sqref` on write; contiguous cells are
+ * re-consolidated by exceljs when it serialises. Rules whose type Excel can't represent are skipped.
+ */
+function applyDataValidations(ws: ExcelJS.Worksheet, workbook: IWorkbookData, sheetId: string): void {
+    for (const rule of getDataValidations(workbook, sheetId)) {
+        const validation = buildExcelValidation(rule);
+        /* v8 ignore next -- defensive: an imported rule always carries at least one range */
+        if (!validation || !rule.ranges) continue;
+        for (const range of rule.ranges) {
+            ws.dataValidations.add(rangeToA1(range), validation);
+        }
+    }
+}
+
+/** exceljs's supported data-validation types; Univer types outside this set can't be exported. */
+const EXCEL_VALIDATION_TYPES: ReadonlySet<string> = new Set(["list", "whole", "decimal", "date", "textLength", "custom"]);
+
+/**
+ * Converts a Univer rule to an exceljs `DataValidation`, or null when it can't be represented: a
+ * type with no Excel equivalent (checkbox, none, time), or a list with no options. A `list`/
+ * `listMultiple` becomes an Excel `list`: literal options (a JSON array in `formula1`) are re-joined
+ * into Excel's inline `"a,b,c"` syntax, while a range/name reference is passed through as the
+ * formula. Other types carry their bounds and operator verbatim.
+ */
+function buildExcelValidation(rule: DataValidationRule): ExcelJS.DataValidation | null {
+    if (rule.type === "list" || rule.type === "listMultiple") {
+        const options = parseListOptions(rule.formula1);
+        if (options) return { type: "list", allowBlank: true, formulae: [`"${options.join(",")}"`] };
+        // A range/name reference passes through; an absent/empty formula has no dropdown to write.
+        if (rule.formula1) return { type: "list", allowBlank: true, formulae: [rule.formula1] };
+        return null;
+    }
+
+    if (!EXCEL_VALIDATION_TYPES.has(rule.type)) return null;
+
+    const formulae = [rule.formula1, rule.formula2].filter((f): f is string => f != null);
+    const validation = { type: rule.type, allowBlank: true, formulae } as ExcelJS.DataValidation;
+    if (rule.operator) validation.operator = rule.operator as ExcelJS.DataValidationOperator;
+    return validation;
+}
+
+/**
+ * Reads a Univer list `formula1` back into its literal options: a JSON-encoded string array (how
+ * the list validator serialises inline options). Returns null when `formula1` is a range/name
+ * reference (not a JSON array), so the caller passes it through as a formula instead.
+ */
+function parseListOptions(formula1: string | undefined): string[] | null {
+    if (formula1 == null) return null;
+    try {
+        const parsed: unknown = JSON.parse(formula1);
+        if (Array.isArray(parsed) && parsed.every((o) => typeof o === "string")) return parsed;
+    } catch {
+        // Not JSON — a range/name reference; fall through.
+    }
+    return null;
+}
+
+/** Converts a 0-based inclusive Univer range to an A1 sqref ("D2" for a single cell, else "D2:E3"). */
+function rangeToA1(range: IRange): string {
+    const start = `${columnLetters(range.startColumn)}${range.startRow + 1}`;
+    if (range.startRow === range.endRow && range.startColumn === range.endColumn) return start;
+    return `${start}:${columnLetters(range.endColumn)}${range.endRow + 1}`;
+}
+
+/** 0-based column index to its Excel letters (0 -> "A", 25 -> "Z", 26 -> "AA"). */
+function columnLetters(index: number): string {
+    let n = index;
+    let letters = "";
+    do {
+        letters = String.fromCharCode(65 + (n % 26)) + letters;
+        n = Math.floor(n / 26) - 1;
+    } while (n >= 0);
+    return letters;
 }
 
 // #endregion

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -355,3 +355,23 @@ export function getFloatingDrawings(workbook: IWorkbookData, sheetId: string): I
     const order = Array.isArray(sheetEntry?.order) ? sheetEntry.order : Object.keys(data);
     return order.map((id) => data[id]).filter((d): d is ISheetDrawing => Boolean(d));
 }
+
+/**
+ * Extracts the data-validation rules for one sheet from the `SHEET_DATA_VALIDATION_PLUGIN` resource.
+ * The resource `data` is a JSON string keyed by sheet id: `{ [sheetId]: DataValidationRule[] }`.
+ * Returns an empty array when the resource is absent, unparseable, or carries none for the sheet.
+ */
+export function getDataValidations(workbook: IWorkbookData, sheetId: string): DataValidationRule[] {
+    const resource = workbook.resources?.find((r) => r.name === SHEET_DATA_VALIDATION_RESOURCE);
+    if (!resource?.data) return [];
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(resource.data);
+    } catch {
+        return [];
+    }
+
+    const rules = (parsed as Record<string, DataValidationRule[]> | null)?.[sheetId];
+    return Array.isArray(rules) ? rules.filter((r): r is DataValidationRule => Boolean(r)) : [];
+}

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -311,6 +311,26 @@ export function isFiniteNumber(v: unknown): v is number {
 /** Univer stores floating sheet images (drawings) under this workbook resource. */
 export const SHEET_DRAWING_RESOURCE = "SHEET_DRAWING_PLUGIN";
 
+/** Univer stores per-sheet data-validation rules (dropdowns, numeric/date constraints) here. */
+export const SHEET_DATA_VALIDATION_RESOURCE = "SHEET_DATA_VALIDATION_PLUGIN";
+
+/**
+ * A Univer data-validation rule. Matches `IDataValidationRule` from `@univerjs/core` (the subset the
+ * XLSX importer emits). For a `list` dropdown, `formula1` is the JSON-encoded option array that
+ * Univer's list validator parses via `deserializeListOptions`; for numeric/date constraints,
+ * `formula1`/`formula2` are the bound values and `operator` selects the comparison.
+ */
+export interface DataValidationRule {
+    uid: string;
+    /** Univer's `DataValidationType` string (e.g. "list", "whole", "decimal", "date", "custom"). */
+    type: string;
+    /** Univer's `DataValidationOperator` string, for numeric/date/text-length constraints. */
+    operator?: string;
+    formula1?: string;
+    formula2?: string;
+    ranges: IRange[];
+}
+
 /**
  * Extracts the floating drawings for one sheet from the `SHEET_DRAWING_PLUGIN` resource, in
  * their stored z-order. The resource `data` is itself a JSON string keyed by sheet id:

--- a/packages/trilium-core/src/routes/api/export.spec.ts
+++ b/packages/trilium-core/src/routes/api/export.spec.ts
@@ -72,10 +72,10 @@ describe("Export API (core)", () => {
         expect(res.headers["Content-Type"]).toBe("text/plain");
     });
 
-    it("rejects single-export of an unhandled note type instead of emitting a zero-byte .undefined file", async () => {
+    it("exports an unhandled note type as a .dat file instead of a zero-byte .undefined download", async () => {
         // Regression: note types mapByNoteType doesn't handle (book, webView, mindMap, …) used to fall
-        // through to res.send(undefined), producing a "<title>.undefined", zero-byte download. The safety
-        // net now rejects them with a clear error rather than a corrupt file.
+        // through to res.send(undefined), producing a "<title>.undefined", zero-byte download. They now
+        // fall back to a raw dump with a generic `.dat` extension.
         const created = await api.post<{ branch: { branchId: string } }>(
             "/api/notes/root/children?target=into",
             { body: { title: "My book", type: "book", content: "" } }
@@ -83,7 +83,7 @@ describe("Export API (core)", () => {
         expect(created.status).toBe(200);
 
         const res = await api.get<string>(`/api/branches/${created.body.branch.branchId}/export/single/html/exportTask`);
-        expect(res.status).toBe(500);
-        expect(res.headers["Content-Type"]).toBe("text/plain");
+        expect(res.status).toBe(200);
+        expect(res.headers["Content-Disposition"]).toContain(".dat");
     });
 });

--- a/packages/trilium-core/src/routes/api/export.spec.ts
+++ b/packages/trilium-core/src/routes/api/export.spec.ts
@@ -71,4 +71,19 @@ describe("Export API (core)", () => {
         expect(res.status).toBe(500);
         expect(res.headers["Content-Type"]).toBe("text/plain");
     });
+
+    it("rejects single-export of an unhandled note type instead of emitting a zero-byte .undefined file", async () => {
+        // Regression: note types mapByNoteType doesn't handle (book, webView, mindMap, …) used to fall
+        // through to res.send(undefined), producing a "<title>.undefined", zero-byte download. The safety
+        // net now rejects them with a clear error rather than a corrupt file.
+        const created = await api.post<{ branch: { branchId: string } }>(
+            "/api/notes/root/children?target=into",
+            { body: { title: "My book", type: "book", content: "" } }
+        );
+        expect(created.status).toBe(200);
+
+        const res = await api.get<string>(`/api/branches/${created.body.branch.branchId}/export/single/html/exportTask`);
+        expect(res.status).toBe(500);
+        expect(res.headers["Content-Type"]).toBe("text/plain");
+    });
 });

--- a/packages/trilium-core/src/services/export/single.spec.ts
+++ b/packages/trilium-core/src/services/export/single.spec.ts
@@ -46,6 +46,21 @@ describe("Note type mappings", () => {
         expect(result.payload).toBe(content);
     });
 
+    it("falls back to a raw .dat dump for note types without a dedicated mapping", () => {
+        // book/webView/mindMap/… aren't handled explicitly; rather than a zero-byte `.undefined`, they
+        // export their raw content with a generic extension (mirrors the zip export's `dat` fallback).
+        const note = buildNote({ type: "book", mime: "", title: "My book" });
+        expect(mapByNoteType(note, "raw contents", "html")).toMatchObject({
+            payload: "raw contents",
+            extension: "dat",
+            mime: "application/octet-stream"
+        });
+
+        // A note carrying its own MIME keeps it in the Content-Type.
+        const webView = buildNote({ type: "webView", mime: "text/html", title: "Site" });
+        expect(mapByNoteType(webView, "x", "html")).toMatchObject({ extension: "dat", mime: "text/html" });
+    });
+
     it("exports markdown code notes with a .md extension", () => {
         // `mime-types` doesn't recognize Trilium's custom `text/x-markdown`;
         // without the explicit fallback this was exporting as `.code`.

--- a/packages/trilium-core/src/services/export/single.spec.ts
+++ b/packages/trilium-core/src/services/export/single.spec.ts
@@ -30,6 +30,22 @@ describe("Note type mappings", () => {
         }
     });
 
+    it("exports a spreadsheet note verbatim with a .triliumsheet extension", () => {
+        // Like canvas/mermaid, single-note spreadsheet export is a lossless raw dump of the stored
+        // Univer workbook JSON — no conversion (the editor's own CSV/XLSX buttons cover interchange).
+        const content = JSON.stringify({ workbook: { id: "wb", sheetOrder: ["s1"], sheets: { s1: {} } } });
+        const note = buildNote({ type: "spreadsheet", mime: "text/x-spreadsheet", title: "Budget" });
+
+        const result = mapByNoteType(note, content, "html");
+
+        expect(result).toMatchObject({
+            extension: "triliumsheet",
+            mime: "application/json"
+        });
+        // Byte-for-byte: the payload is the stored workbook, untouched.
+        expect(result.payload).toBe(content);
+    });
+
     it("exports markdown code notes with a .md extension", () => {
         // `mime-types` doesn't recognize Trilium's custom `text/x-markdown`;
         // without the explicit fallback this was exporting as `.code`.

--- a/packages/trilium-core/src/services/export/single.ts
+++ b/packages/trilium-core/src/services/export/single.ts
@@ -95,6 +95,12 @@ export function mapByNoteType(note: BNote, content: string | Uint8Array, format:
         payload = content;
         extension = "mermaid";
         mime = "text/vnd.mermaid";
+    } else if (note.type === "spreadsheet") {
+        // Lossless raw dump of the stored Univer workbook JSON — no conversion (the editor's own
+        // CSV/XLSX buttons cover interchange). `.triliumsheet` round-trips back via single import.
+        payload = content;
+        extension = "triliumsheet";
+        mime = "application/json";
     } else if (note.type === "relationMap" || note.type === "search") {
         payload = content;
         extension = "json";

--- a/packages/trilium-core/src/services/export/single.ts
+++ b/packages/trilium-core/src/services/export/single.ts
@@ -13,27 +13,19 @@ import mdService from "./markdown.js";
 import { stripListItemIds } from "./strip_list_item_ids.js";
 import { ExportFormat } from "../../meta.js";
 import { encodeBase64 } from "../utils/binary.js";
-import { ValidationError } from "../../errors.js";
 
 function exportSingleNote(taskContext: TaskContext<"export">, branch: BBranch, format: ExportFormat, res: Response) {
     const note = branch.getNote();
 
     if (note.type === "image" || note.type === "file") {
-        throw new ValidationError(`Note type '${note.type}' cannot be exported as a single file.`);
+        return [400, `Note type '${note.type}' cannot be exported as single file.`];
     }
 
     if (format !== "html" && format !== "markdown") {
-        throw new ValidationError(`Unrecognized format '${format}'`);
+        return [400, `Unrecognized format '${format}'`];
     }
 
     const { payload, extension, mime } = mapByNoteType(note, note.getContent(), format);
-
-    // Safety net: any note type mapByNoteType doesn't handle leaves these undefined. Reject with a
-    // clear error rather than sending `undefined` — which produced a "<title>.undefined", zero-byte file.
-    if (payload === undefined || extension === undefined) {
-        throw new ValidationError(`Note type '${note.type}' cannot be exported as a single file.`);
-    }
-
     const fileName = `${note.title}.${extension}`;
 
     res.setHeader("Content-Disposition", getContentDisposition(fileName));
@@ -113,6 +105,13 @@ export function mapByNoteType(note: BNote, content: string | Uint8Array, format:
         payload = content;
         extension = "json";
         mime = "application/json";
+    } else {
+        // Any other note type: dump the raw content with a generic extension, so single-note export
+        // produces a real (if opaque) file rather than a zero-byte `.undefined`. Mirrors the `dat`
+        // fallback the zip export uses for unrecognised MIME types.
+        payload = content;
+        extension = "dat";
+        mime = note.mime || "application/octet-stream";
     }
 
     return { payload, extension, mime };

--- a/packages/trilium-core/src/services/export/single.ts
+++ b/packages/trilium-core/src/services/export/single.ts
@@ -13,19 +13,27 @@ import mdService from "./markdown.js";
 import { stripListItemIds } from "./strip_list_item_ids.js";
 import { ExportFormat } from "../../meta.js";
 import { encodeBase64 } from "../utils/binary.js";
+import { ValidationError } from "../../errors.js";
 
 function exportSingleNote(taskContext: TaskContext<"export">, branch: BBranch, format: ExportFormat, res: Response) {
     const note = branch.getNote();
 
     if (note.type === "image" || note.type === "file") {
-        return [400, `Note type '${note.type}' cannot be exported as single file.`];
+        throw new ValidationError(`Note type '${note.type}' cannot be exported as a single file.`);
     }
 
     if (format !== "html" && format !== "markdown") {
-        return [400, `Unrecognized format '${format}'`];
+        throw new ValidationError(`Unrecognized format '${format}'`);
     }
 
     const { payload, extension, mime } = mapByNoteType(note, note.getContent(), format);
+
+    // Safety net: any note type mapByNoteType doesn't handle leaves these undefined. Reject with a
+    // clear error rather than sending `undefined` — which produced a "<title>.undefined", zero-byte file.
+    if (payload === undefined || extension === undefined) {
+        throw new ValidationError(`Note type '${note.type}' cannot be exported as a single file.`);
+    }
+
     const fileName = `${note.title}.${extension}`;
 
     res.setHeader("Content-Disposition", getContentDisposition(fileName));

--- a/packages/trilium-core/src/services/import/mime.ts
+++ b/packages/trilium-core/src/services/import/mime.ts
@@ -76,7 +76,8 @@ const EXTENSION_TO_MIME = new Map<string, string>([
     [".ts", "text/x-typescript"],
     [".excalidraw", "application/json"],
     [".mermaid", "text/vnd.mermaid"],
-    [".mmd", "text/vnd.mermaid"]
+    [".mmd", "text/vnd.mermaid"],
+    [".triliumsheet", "text/x-spreadsheet"]
 ]);
 
 /** @returns false if MIME is not detected */

--- a/packages/trilium-core/src/services/import/single.spec.ts
+++ b/packages/trilium-core/src/services/import/single.spec.ts
@@ -151,6 +151,21 @@ describe("processNoteContent", () => {
         });
     });
 
+    it("imports a .triliumsheet file as a spreadsheet note, preserving content verbatim", async () => {
+        // .triliumsheet is Trilium's lossless round-trip format: the raw Univer workbook JSON exported
+        // by single-note export is re-imported byte-for-byte (unlike .xlsx, which is parsed/re-serialized).
+        const workbookJson = JSON.stringify({ workbook: { id: "wb", sheetOrder: ["s1"], sheets: { s1: { cellData: {} } } } });
+
+        const { importedNote } = await testImport("Budget.triliumsheet", "application/json", Buffer.from(workbookJson));
+
+        expect(importedNote).toMatchObject({
+            mime: "text/x-spreadsheet",
+            type: "spreadsheet",
+            title: "Budget"
+        });
+        expect(importedNote.getContent().toString()).toBe(workbookJson);
+    });
+
     it("imports .xlsx as a spreadsheet note", async () => {
         const wb = new ExcelJS.Workbook();
         const ws = wb.addWorksheet("Sheet1");

--- a/packages/trilium-core/src/services/import/single.ts
+++ b/packages/trilium-core/src/services/import/single.ts
@@ -48,6 +48,12 @@ async function importSingleFile(taskContext: TaskContext<"importNotes">, file: F
         return importCustomType(taskContext, file, parentNote, "mermaid", mime);
     }
 
+    // `.triliumsheet` is Trilium's native lossless spreadsheet format (see single-note export): the raw
+    // Univer workbook JSON is re-imported verbatim, unlike `.xlsx`/`.csv` which are parsed into a workbook.
+    if (mime === "text/x-spreadsheet") {
+        return importCustomType(taskContext, file, parentNote, "spreadsheet", mime);
+    }
+
     if (taskContext?.data?.codeImportedAsCode && mimeService.getType(taskContext.data, mime) === "code") {
         return importCodeNote(taskContext, file, parentNote);
     }

--- a/packages/trilium-core/src/services/utils/index.ts
+++ b/packages/trilium-core/src/services/utils/index.ts
@@ -285,6 +285,7 @@ export function removeFileExtension(filePath: string, mime?: string) {
         case ".pdf":
         case ".xlsx":
         case ".csv":
+        case ".triliumsheet":
             return filePath.substring(0, filePath.length - extension.length);
         default:
             return filePath;


### PR DESCRIPTION
## Overview

A set of related spreadsheet and single-note export fixes. Two themes: making Excel **data validation (dropdowns)** survive the XLSX import→edit→export round-trip, and making **single-note export** produce a real file for every note type instead of a broken download.

## XLSX data-validation (dropdown) round-trip

Dropdown / data-validation rules were silently dropped when importing an `.xlsx` and again when exporting back out.

- **Import** (`parse_from_xlsx.ts`): read each sheet's data-validation rules and persist them into the Univer workbook's data-validation resource.
- **Export** (`render_to_xlsx.ts`): write those rules back into the OOXML on export, so a re-exported sheet keeps its dropdowns.
- **Model** (`workbook_model.ts`): shared `getDataValidations()` reader over the workbook's data-validation resource.
- Unit tests for both directions (`parse_from_xlsx.spec.ts`, `render_to_xlsx.spec.ts`).

## Single-note export fixes

Single-note export (`mapByNoteType` in `export/single.ts`) only handled a subset of note types; the rest fell through with an `undefined` extension/payload, producing a `<title>.undefined`, **zero-byte** download.

- **Spreadsheet → `.triliumsheet`**: a spreadsheet note now exports its stored Univer workbook JSON **verbatim** (lossless raw dump, no conversion — the editor's own CSV/XLSX buttons cover interchange), using a native `.triliumsheet` extension. The matching single-import branch (`import/single.ts`, `import/mime.ts`, `utils/index.ts` title stripping) round-trips it back into a spreadsheet note byte-for-byte — mirroring how canvas uses `.excalidraw`.
- **Everything else → `.dat` fallback**: any other unhandled note type (book, webView, mindMap, render, llmChat, …) now falls back to a raw content dump with a generic `.dat` extension, mirroring the zip export's `dat` fallback, rather than a zero-byte `.undefined`. Container/reference types (book, webView, …) whose body is empty still export an empty `.dat`, since there is nothing in a single file to represent them — a subtree export is the right tool there.
- Tests: `export/single.spec.ts` (mapping), `import/single.spec.ts` (round-trip), `routes/api/export.spec.ts` (route-level `.dat` behaviour).

## Docs

User-guide updates for spreadsheet export (`Spreadsheets.md` + rendered assets, `Templates.html`).

## Test plan

- `pnpm --filter server test` — full server + core suite green (single-note export, import round-trip, and XLSX parse/render specs included).
- `pnpm typecheck` clean.

> Note: the branch was cut from an older point of `main`; it may need a rebase before merge.
