### PR TITLE
feat(pdf): enable pdf.js signatures with synced signature library

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -250,8 +250,7 @@
     "drop_or_browse_multiple": "Drag and drop files here, or click to browse",
     "browse_single": "Tap to choose a file",
     "browse_multiple": "Tap to choose files",
-    "selected_one": "{{count}} file selected",
-    "selected_other": "{{count}} files selected"
+    "remove_file": "Remove file"
   },
   "import_provider": {
     "choose_provider": "Choose a service above to import from."

--- a/apps/client/src/types-pdfjs.d.ts
+++ b/apps/client/src/types-pdfjs.d.ts
@@ -10,6 +10,18 @@ type HistoryData = {
     }[];
 };
 
+/**
+ * A single reusable signature as stored by pdf.js' `SignatureStorage` (`web/signature_storage.js`):
+ * a human-readable description plus the compressed outline data produced by `SignatureExtractor`.
+ */
+type PdfSignatureEntry = {
+    description: string;
+    signatureData: unknown;
+};
+
+/** The pdf.js reusable signature library, keyed by signature UUID. Mirrors `localStorage["pdfjs.signature"]`. */
+type PdfSignatureStore = Record<string, PdfSignatureEntry>;
+
 interface Window {
     /**
      * By default, pdf.js will try to store information about the opened PDFs such as zoom and scroll position in local storage.
@@ -18,6 +30,15 @@ interface Window {
      * The variable must be set early at startup, before pdf.js fully initializes.
      */
     TRILIUM_VIEW_HISTORY_STORE?: HistoryData;
+
+    /**
+     * The reusable signature library used by the pdf.js signature tool. pdf.js keeps this in
+     * per-browser `localStorage`; Trilium instead injects it here (from a synced option) so signatures
+     * follow the user across devices. Reads/writes of `localStorage["pdfjs.signature"]` are intercepted
+     * in the viewer and routed through this global + a `pdfjs-viewer-save-signatures` message.
+     * Must be set early at startup, before pdf.js fully initializes.
+     */
+    TRILIUM_SIGNATURES?: PdfSignatureStore;
 
     /**
      * If set to true, hides the pdf.js viewer default sidebar containing the outline, page navigation, etc.
@@ -54,6 +75,12 @@ interface PdfDocumentBlobResultMessage extends WithContext {
 
 interface PdfSaveViewHistoryMessage extends WithContext {
     type: "pdfjs-viewer-save-view-history";
+    data: string;
+}
+
+interface PdfSaveSignaturesMessage extends WithContext {
+    type: "pdfjs-viewer-save-signatures";
+    /** JSON string of the full signature library, as written by pdf.js to `localStorage["pdfjs.signature"]`. */
     data: string;
 }
 
@@ -127,6 +154,7 @@ interface PdfViewerAnnotationsMessage {
 type PdfMessageEvent = MessageEvent<
     PdfDocumentModifiedMessage
     | PdfSaveViewHistoryMessage
+    | PdfSaveSignaturesMessage
     | PdfViewerTocMessage
     | PdfViewerActiveHeadingMessage
     | PdfViewerPageInfoMessage

--- a/apps/client/src/widgets/dialogs/import/anytype.tsx
+++ b/apps/client/src/widgets/dialogs/import/anytype.tsx
@@ -15,7 +15,7 @@ function AnytypePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     const [shrinkImages, setShrinkImages] = useState(compressImages);
     // `format: "anytype"` routes the upload/native import to the Anytype importer, overriding the .zip
     // extension's default (the generic zip importer).
-    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, doImport } = useProviderImport({ format: "anytype", parentNoteId, shrinkImages, closeDialog });
+    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, onRemove, doImport } = useProviderImport({ format: "anytype", parentNoteId, shrinkImages, closeDialog });
 
     // Keep the latest import handler in a ref so the footer effect depends only on whether a file is
     // selected, never on doImport's identity — otherwise re-pushing the footer on every change would loop
@@ -38,7 +38,7 @@ function AnytypePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
         <Card heading={t("anytype_import.choose_file")}>
             <CardSection>
                 <OptionsRow name="import-file" description={t("anytype_import.description_long")} stacked>
-                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} displayNames={displayNames} accept=".zip" />
+                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} onRemove={onRemove} displayNames={displayNames} accept=".zip" />
                 </OptionsRow>
                 <OptionsRowWithToggle
                     name="shrink-images"

--- a/apps/client/src/widgets/dialogs/import/evernote.tsx
+++ b/apps/client/src/widgets/dialogs/import/evernote.tsx
@@ -16,7 +16,7 @@ function EvernotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderP
     const [shrinkImages, setShrinkImages] = useState(compressImages);
 
     // An Evernote export is one ENEX (.enex) file per notebook, so allow selecting several at once.
-    const onChange = useCallback((fileList: FileList | null) => setFiles(fileList ? Array.from(fileList) : []), []);
+    const onChange = useCallback((fileList: File[] | null) => setFiles(fileList ?? []), []);
 
     const doImport = useCallback(async () => {
         if (!files.length) {

--- a/apps/client/src/widgets/dialogs/import/files.tsx
+++ b/apps/client/src/widgets/dialogs/import/files.tsx
@@ -14,7 +14,7 @@ import type { ImportProvider, ImportProviderPanelProps } from "./types.js";
 
 function FilesPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPanelProps) {
     const [compressImages] = useTriliumOptionBool("compressImages");
-    const [files, setFiles] = useState<FileList | null>(null);
+    const [files, setFiles] = useState<File[] | null>(null);
     // Desktop only: files picked via the native OS dialog, identified by capability tokens (not paths) so
     // they can be imported in place. Mutually exclusive with `files` — picking clears one, the other clears it.
     const [nativeFiles, setNativeFiles] = useState<NativeImportPickedFile[] | null>(null);
@@ -63,7 +63,7 @@ function FilesPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPane
         };
 
         closeDialog();
-        await importService.uploadFiles("notes", parentNoteId, Array.from(files), options).catch(() => {});
+        await importService.uploadFiles("notes", parentNoteId, files, options).catch(() => {});
     }, [files, nativeFiles, safeImport, shrinkImages, textImportedAsText, codeImportedAsCode, spreadsheetImportedAsSpreadsheet, explodeArchives, replaceUnderscoresWithSpaces, parentNoteId, closeDialog]);
 
     // Desktop only: browse via the native OS dialog. The dialog (in the main process) is the sole source of
@@ -80,7 +80,7 @@ function FilesPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPane
 
     // Drag-and-drop (or, off desktop, the in-page picker) goes through the normal upload route; a fresh
     // selection there clears any native pick so the two never coexist.
-    const onFilesChange = useCallback((list: FileList | null) => {
+    const onFilesChange = useCallback((list: File[] | null) => {
         setFiles(list);
         if (list?.length) {
             setNativeFiles(null);
@@ -125,6 +125,11 @@ function FilesPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPane
                         // are read in place. Drag-and-drop still uses the upload route via onChange.
                         onBrowse={utils.isElectron() ? () => void doNativeBrowse() : undefined}
                         onNativeDrop={utils.isElectron() ? onNativeDrop : undefined}
+                        // onChange handles the upload-route files; the native picks are ours to remove.
+                        onRemove={(index) => setNativeFiles((prev) => {
+                            const next = prev?.filter((_, i) => i !== index) ?? null;
+                            return next?.length ? next : null;
+                        })}
                         displayNames={nativeFiles?.map((file) => file.fileName)}
                     />
                 </CardSection>

--- a/apps/client/src/widgets/dialogs/import/keep.tsx
+++ b/apps/client/src/widgets/dialogs/import/keep.tsx
@@ -15,7 +15,7 @@ function KeepPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPanel
     const [shrinkImages, setShrinkImages] = useState(compressImages);
     // `format: "keep"` routes the upload/native import to the Google Keep importer, overriding the .zip
     // extension's default (the generic zip importer).
-    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, doImport } = useProviderImport({ format: "keep", parentNoteId, shrinkImages, closeDialog });
+    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, onRemove, doImport } = useProviderImport({ format: "keep", parentNoteId, shrinkImages, closeDialog });
 
     // Keep the latest import handler in a ref so the footer effect depends only on whether a file is
     // selected, never on doImport's identity — otherwise re-pushing the footer on every change would loop
@@ -38,7 +38,7 @@ function KeepPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPanel
         <Card heading={t("keep_import.choose_file")}>
             <CardSection>
                 <OptionsRow name="import-file" description={t("keep_import.description_long")} stacked>
-                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} displayNames={displayNames} accept=".zip" />
+                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} onRemove={onRemove} displayNames={displayNames} accept=".zip" />
                 </OptionsRow>
                 <OptionsRowWithToggle
                     name="shrink-images"

--- a/apps/client/src/widgets/dialogs/import/notion.tsx
+++ b/apps/client/src/widgets/dialogs/import/notion.tsx
@@ -15,7 +15,7 @@ function NotionPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPan
     const [shrinkImages, setShrinkImages] = useState(compressImages);
     // `format: "notion"` routes the upload/native import to the Notion importer, overriding the .zip
     // extension's default (the generic zip importer).
-    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, doImport } = useProviderImport({ format: "notion", parentNoteId, shrinkImages, closeDialog });
+    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, onRemove, doImport } = useProviderImport({ format: "notion", parentNoteId, shrinkImages, closeDialog });
 
     // Keep the latest import handler in a ref so the footer effect depends only on whether a file is
     // selected, never on doImport's identity — otherwise re-pushing the footer on every change would loop
@@ -38,7 +38,7 @@ function NotionPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPan
         <Card heading={t("notion_import.choose_file")}>
             <CardSection>
                 <OptionsRow name="import-file" description={t("notion_import.description_long")} stacked>
-                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} displayNames={displayNames} accept=".zip" />
+                    <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} onRemove={onRemove} displayNames={displayNames} accept=".zip" />
                 </OptionsRow>
                 <OptionsRowWithToggle
                     name="shrink-images"

--- a/apps/client/src/widgets/dialogs/import/obsidian.tsx
+++ b/apps/client/src/widgets/dialogs/import/obsidian.tsx
@@ -15,7 +15,7 @@ function ObsidianPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderP
     const [shrinkImages, setShrinkImages] = useState(compressImages);
     // `format: "obsidian"` routes the upload/native import to the Obsidian importer, overriding the .zip
     // extension's default (the generic zip importer).
-    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, doImport } = useProviderImport({ format: "obsidian", parentNoteId, shrinkImages, closeDialog });
+    const { hasSelection, displayNames, onChange, onBrowse, onNativeDrop, onRemove, doImport } = useProviderImport({ format: "obsidian", parentNoteId, shrinkImages, closeDialog });
 
     // Keep the latest import handler in a ref so the footer effect depends only on whether a file is
     // selected, never on doImport's identity — otherwise re-pushing the footer on every change would loop
@@ -38,7 +38,7 @@ function ObsidianPanel({ parentNoteId, closeDialog, setFooter }: ImportProviderP
         <Card heading={t("obsidian_import.choose_file")}>
             <CardSection>
                 <p className="import-files-description">{t("obsidian_import.description_long")}</p>
-                <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} displayNames={displayNames} />
+                <FileDropZone onChange={onChange} onBrowse={onBrowse} onNativeDrop={onNativeDrop} onRemove={onRemove} displayNames={displayNames} />
                 <OptionsRowWithToggle
                     name="shrink-images"
                     label={t("import.shrinkImages")}

--- a/apps/client/src/widgets/dialogs/import/useProviderImport.spec.tsx
+++ b/apps/client/src/widgets/dialogs/import/useProviderImport.spec.tsx
@@ -25,11 +25,6 @@ function Probe(args: Args) {
     return null;
 }
 
-/** Builds a FileList-like the hook can index (it only reads `[0]` and `.length`). */
-function fileListOf(...files: File[]): FileList {
-    return Object.assign(files.slice(), { item: (i: number) => files[i] ?? null }) as unknown as FileList;
-}
-
 describe("useProviderImport", () => {
     let container: HTMLElement;
     let closeDialog: ReturnType<typeof vi.fn>;
@@ -84,7 +79,7 @@ describe("useProviderImport", () => {
         it("marks a selection once a file is chosen via the upload route", async () => {
             await mount();
             const file = new File(["x"], "vault.zip");
-            await act(async () => current().onChange(fileListOf(file)));
+            await act(async () => current().onChange([file]));
             expect(current().hasSelection).toBe(true);
             // The upload route has no display name override — FileDropZone shows the File itself.
             expect(current().displayNames).toBeUndefined();
@@ -92,9 +87,26 @@ describe("useProviderImport", () => {
 
         it("clears the selection when onChange receives no files", async () => {
             await mount();
-            await act(async () => current().onChange(fileListOf(new File(["x"], "vault.zip"))));
+            await act(async () => current().onChange([new File(["x"], "vault.zip")]));
             await act(async () => current().onChange(null));
             expect(current().hasSelection).toBe(false);
+        });
+
+        it("clears either route's selection via onRemove (the drop zone's per-file [X])", async () => {
+            isElectron.mockReturnValue(true);
+            await mount();
+            await act(async () => current().onChange([new File(["x"], "vault.zip")]));
+            await act(async () => current().onRemove());
+            expect(current().hasSelection).toBe(false);
+
+            pickFiles.mockResolvedValueOnce({ status: "selected", files: [{ token: "tok", fileName: "Vault.zip" }] });
+            await act(async () => {
+                current().onBrowse?.();
+            });
+            expect(current().hasSelection).toBe(true);
+            await act(async () => current().onRemove());
+            expect(current().hasSelection).toBe(false);
+            expect(current().displayNames).toBeUndefined();
         });
 
         it("exposes native browse/drop on desktop", async () => {
@@ -110,7 +122,7 @@ describe("useProviderImport", () => {
 
         it("stores the native pick and shows its filename, clearing any upload file", async () => {
             await mount();
-            await act(async () => current().onChange(fileListOf(new File(["x"], "dropped.zip"))));
+            await act(async () => current().onChange([new File(["x"], "dropped.zip")]));
             pickFiles.mockResolvedValueOnce({ status: "selected", files: [{ token: "tok", fileName: "Vault.zip" }] });
 
             await act(async () => {
@@ -174,7 +186,7 @@ describe("useProviderImport", () => {
         it("uploads the chosen file with the provider format and safe-import flags", async () => {
             await mount({ shrinkImages: true });
             const file = new File(["x"], "vault.zip");
-            await act(async () => current().onChange(fileListOf(file)));
+            await act(async () => current().onChange([file]));
             await act(async () => current().doImport());
 
             expect(closeDialog).toHaveBeenCalled();

--- a/apps/client/src/widgets/dialogs/import/useProviderImport.ts
+++ b/apps/client/src/widgets/dialogs/import/useProviderImport.ts
@@ -17,11 +17,13 @@ interface ProviderImport {
     hasSelection: boolean;
     /** Native-pick filename(s) to show in the drop zone; undefined when using the upload route. */
     displayNames?: string[];
-    onChange: (files: FileList | null) => void;
+    onChange: (files: File[] | null) => void;
     /** Desktop-only native browse (reads the zip in place); undefined elsewhere. */
     onBrowse?: () => void;
     /** Desktop-only native drop (reads the dropped zip in place); undefined elsewhere. */
     onNativeDrop?: (files: File[]) => Promise<boolean>;
+    /** Removes the selection — a provider holds a single file, so the index is irrelevant (the drop zone's per-file [X]). */
+    onRemove: () => void;
     doImport: () => Promise<void>;
 }
 
@@ -35,7 +37,7 @@ export default function useProviderImport({ format, parentNoteId, shrinkImages, 
     const [file, setFile] = useState<File | null>(null);
     const [nativeFile, setNativeFile] = useState<NativeImportPickedFile | null>(null);
 
-    const onChange = useCallback((files: FileList | null) => {
+    const onChange = useCallback((files: File[] | null) => {
         setFile(files?.[0] ?? null);
         if (files?.length) {
             setNativeFile(null);
@@ -61,6 +63,11 @@ export default function useProviderImport({ format, parentNoteId, shrinkImages, 
         setFile(null);
         setNativeFile(pick.files[0]);
         return true;
+    }, []);
+
+    const onRemove = useCallback(() => {
+        setFile(null);
+        setNativeFile(null);
     }, []);
 
     const doImport = useCallback(async () => {
@@ -90,6 +97,7 @@ export default function useProviderImport({ format, parentNoteId, shrinkImages, 
         onChange,
         onBrowse: utils.isElectron() ? () => void browse() : undefined,
         onNativeDrop: utils.isElectron() ? nativeDrop : undefined,
+        onRemove,
         doImport
     };
 }

--- a/apps/client/src/widgets/react/FileDropZone.css
+++ b/apps/client/src/widgets/react/FileDropZone.css
@@ -5,7 +5,6 @@
     justify-content: center;
     width: 100%;
     min-height: 8em;
-    padding: 0.5em 1.5em;
     border: 1px solid var(--main-border-color);
     border-radius: 8px;
     background: var(--accented-background-color);
@@ -56,15 +55,10 @@
     width: 100%;
 }
 
-.file-drop-zone-count {
-    color: var(--muted-text-color);
-    font-size: 0.9em;
-}
-
 .file-drop-zone-files {
     list-style: none;
     margin: 0;
-    padding: 0;
+    padding: 1em;
     display: flex;
     flex-direction: column;
     gap: 0.35em;
@@ -85,4 +79,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.file-drop-zone-remove {
+    margin-left: auto;
+    flex-shrink: 0;
 }

--- a/apps/client/src/widgets/react/FileDropZone.spec.tsx
+++ b/apps/client/src/widgets/react/FileDropZone.spec.tsx
@@ -58,6 +58,61 @@ describe("FileDropZone", () => {
         });
     });
 
+    const removeButtons = () => Array.from(container.querySelectorAll<HTMLButtonElement>(".file-drop-zone-files .file-drop-zone-remove"));
+    const click = (button: HTMLButtonElement) => act(async () => {
+        button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    /** Simulates picking `files` through the in-page input. */
+    const pickInternal = (files: File[]) => {
+        const input = container.querySelector("input[type=file]") as HTMLInputElement;
+        Object.defineProperty(input, "files", { value: files, configurable: true });
+        return act(async () => {
+            input.dispatchEvent(new Event("change", { bubbles: true }));
+        });
+    };
+    const mustFind = <T,>(element: T | null | undefined, what: string): T => {
+        if (!element) {
+            throw new Error(`${what} not rendered`);
+        }
+        return element;
+    };
+
+    describe("per-file remove buttons", () => {
+        it("removes one internal file and reports the remaining selection, null once empty", async () => {
+            const onChange = vi.fn();
+            await act(async () => render(<FileDropZone onChange={onChange} multiple />, container));
+            const [fileA, fileB] = [new File(["a"], "a.zip"), new File(["b"], "b.zip")];
+            await pickInternal([fileA, fileB]);
+
+            await click(mustFind(removeButtons()[0], "first remove button"));
+            expect(filenames()).toEqual(["b.zip"]);
+            expect(onChange).toHaveBeenLastCalledWith([fileB]);
+
+            await click(mustFind(removeButtons()[0], "remaining remove button"));
+            expect(filenames()).toEqual([]);
+            expect(onChange).toHaveBeenLastCalledWith(null);
+        });
+
+        it("delegates removal of an external entry to onRemove with its index", async () => {
+            const onChange = vi.fn();
+            const onRemove = vi.fn();
+            const onBrowse = vi.fn();
+            await act(async () => render(
+                <FileDropZone onChange={onChange} onRemove={onRemove} onBrowse={onBrowse} displayNames={["a.zip", "b.zip"]} />,
+                container
+            ));
+            onChange.mockClear(); // drop the mount-time reset call
+
+            await click(mustFind(removeButtons()[1], "second remove button"));
+
+            expect(onRemove).toHaveBeenCalledWith(1);
+            // The external selection is the caller's — onChange only reports the internal one.
+            expect(onChange).not.toHaveBeenCalled();
+            // The click must not bubble to the label and reopen the browse dialog.
+            expect(onBrowse).not.toHaveBeenCalled();
+        });
+    });
+
     describe("onBrowse override", () => {
         it("calls the override and prevents the in-page file input from opening", async () => {
             const onBrowse = vi.fn();

--- a/apps/client/src/widgets/react/FileDropZone.tsx
+++ b/apps/client/src/widgets/react/FileDropZone.tsx
@@ -4,10 +4,12 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import { t } from "../../services/i18n";
 import { isMobile } from "../../services/utils";
+import ActionButton from "./ActionButton";
 
 export interface FileDropZoneProps {
     name?: string;
-    onChange: (files: FileList | null) => void;
+    /** Reports the current selection after every change (picking, dropping, per-file removal, clearing); `null` when empty. */
+    onChange: (files: File[] | null) => void;
     multiple?: boolean;
     /** Optional `accept` attribute forwarded to the underlying file input (e.g. `".zip"`). */
     accept?: string;
@@ -26,14 +28,21 @@ export interface FileDropZoneProps {
      * `true` if handled — the upload `onChange` is then skipped; return `false` to fall back to upload.
      */
     onNativeDrop?: (files: File[]) => Promise<boolean>;
+    /**
+     * Called when the user removes an *external* entry (`displayNames[index]`) via its per-file [X].
+     * Internal selections are trimmed by the zone itself and reported through `onChange`; callers
+     * passing `displayNames` must pass this too.
+     */
+    onRemove?: (index: number) => void;
 }
 
 /**
  * A styled drop region for selecting files: drag-and-drop onto it or click it to open the native file
- * picker. Selected files are listed inside. Drop-in replacement for {@link FormFileUpload} — same
- * `onChange(files)` / `multiple` contract.
+ * picker. Selected files are listed inside, each removable via its own [X]. Covers the same role as
+ * {@link FormFileUpload}, but reports the selection as a `File[]` (so per-file removal can be
+ * expressed) rather than the input's raw `FileList`.
  */
-export default function FileDropZone({ name, onChange, multiple, accept, onBrowse, displayNames, onNativeDrop }: FileDropZoneProps) {
+export default function FileDropZone({ name, onChange, multiple, accept, onBrowse, displayNames, onNativeDrop, onRemove }: FileDropZoneProps) {
     const inputRef = useRef<HTMLInputElement>(null);
     const [files, setFiles] = useState<File[]>([]);
     const [dragging, setDragging] = useState(false);
@@ -54,7 +63,7 @@ export default function FileDropZone({ name, onChange, multiple, accept, onBrows
     const update = useCallback((list: FileList | null) => {
         const selected = list && list.length ? (multiple ? Array.from(list) : [list[0]]) : [];
         setFiles(selected);
-        onChange(selected.length ? list : null);
+        onChange(selected.length ? selected : null);
     }, [multiple, onChange]);
 
     const onDragEnter = useCallback((e: DragEvent) => {
@@ -86,6 +95,24 @@ export default function FileDropZone({ name, onChange, multiple, accept, onBrows
         update(dropped);
     }, [update, onNativeDrop]);
 
+    // Removes a single entry. An external (native) selection belongs to the caller, so its entries go
+    // through onRemove; internal ones are trimmed here and reported via onChange. The input's value is
+    // dropped so its stale FileList can't resurface and re-picking the same file still fires a change event.
+    const removeAt = useCallback((e: MouseEvent, index: number) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (displayNames?.length) {
+            onRemove?.(index);
+            return;
+        }
+        if (inputRef.current) {
+            inputRef.current.value = "";
+        }
+        const remaining = files.filter((_, i) => i !== index);
+        setFiles(remaining);
+        onChange(remaining.length ? remaining : null);
+    }, [displayNames, files, onChange, onRemove]);
+
     // An external (native) selection takes precedence over whatever the in-page input/drop produced.
     const selectedNames = displayNames?.length ? displayNames : files.map((file) => file.name);
 
@@ -111,10 +138,19 @@ export default function FileDropZone({ name, onChange, multiple, accept, onBrows
             />
             {selectedNames.length ? (
                 <div className="file-drop-zone-selection">
-                    {selectedNames.length > 1 && <div className="file-drop-zone-count">{t("file_upload.selected", { count: selectedNames.length })}</div>}
                     <ul className="file-drop-zone-files">
                         {selectedNames.map((fileName, index) => (
-                            <li key={index}><span className="bx bx-file-blank" /> <span className="file-drop-zone-filename">{fileName}</span></li>
+                            <li key={index}>
+                                <span className="bx bx-file-blank" />
+                                <span className="file-drop-zone-filename">{fileName}</span>
+                                <ActionButton
+                                    className="file-drop-zone-remove"
+                                    icon="bx bx-x"
+                                    text={t("file_upload.remove_file")}
+                                    tooltipClass="tooltip-top"
+                                    onClick={(e) => removeAt(e, index)}
+                                />
+                            </li>
                         ))}
                     </ul>
                 </div>

--- a/apps/client/src/widgets/type_widgets/file/Pdf.tsx
+++ b/apps/client/src/widgets/type_widgets/file/Pdf.tsx
@@ -5,6 +5,7 @@ import type NoteContext from "../../../components/note_context";
 import FBlob from "../../../entities/fblob";
 import FNote from "../../../entities/fnote";
 import open from "../../../services/open";
+import options from "../../../services/options";
 import { useViewModeConfig } from "../../collections/NoteList";
 import { useBlobEditorSpacedUpdate, useEffectiveReadOnly, useTriliumEvent } from "../../react/hooks";
 import PdfViewer from "./PdfViewer";
@@ -67,6 +68,14 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
             if (event.data.type === "pdfjs-viewer-save-view-history" && event.data?.data) {
                 if (event.data.noteId === note.noteId && event.data.ntxId === noteContext.ntxId) {
                     historyConfig?.storeFn(JSON.parse(event.data.data));
+                }
+            }
+
+            if (event.data.type === "pdfjs-viewer-save-signatures" && event.data?.data) {
+                // The signature library is global (not per-note), but scope the write to this
+                // viewer instance so multiple open PDFs don't each re-save the same payload.
+                if (event.data.noteId === note.noteId && event.data.ntxId === noteContext.ntxId) {
+                    options.save("pdfSignatures", event.data.data);
                 }
             }
 
@@ -223,6 +232,7 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
                 const win = iframeRef.current?.contentWindow;
                 if (win) {
                     win.TRILIUM_VIEW_HISTORY_STORE = historyConfig.config;
+                    win.TRILIUM_SIGNATURES = options.getJson("pdfSignatures") ?? {};
                     win.TRILIUM_NOTE_ID = note.noteId;
                     win.TRILIUM_NTX_ID = noteContext.ntxId;
                 }

--- a/apps/client/src/widgets/type_widgets/file/Pdf.tsx
+++ b/apps/client/src/widgets/type_widgets/file/Pdf.tsx
@@ -71,7 +71,7 @@ export default function PdfPreview({ note, blob, componentId, noteContext }: {
                 }
             }
 
-            if (event.data.type === "pdfjs-viewer-save-signatures" && event.data?.data) {
+            if (event.data?.type === "pdfjs-viewer-save-signatures" && event.data?.data) {
                 // The signature library is global (not per-note), but scope the write to this
                 // viewer instance so multiple open PDFs don't each re-save the same payload.
                 if (event.data.noteId === note.noteId && event.data.ntxId === noteContext.ntxId) {

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/PDFs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/PDFs.html
@@ -21,6 +21,9 @@
   <li>Integrates with the sidebar in the&nbsp;<a class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>,
     by displaying the list of pages with thumbnails, table of contents and
     a listing of the annotations.</li>
+  <li>Basic support for signatures (the hand-drawn ones, not proper digital
+    signatures), similar to annotations. Signatures are stored and can be reused
+    across multiple documents (up to 5).</li>
 </ul>
 <h2>Storing last position and settings</h2>
 <p>For every PDF, Trilium will remember the following information:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Markdown.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Markdown.html
@@ -32,11 +32,16 @@
 <p>The following features are supported by Trilium's Markdown format and
   will show up in the preview pane:</p>
 <ul>
-  <li>All standard and GitHub-flavored syntax (basic formatting, tables, blockquotes).</li>
-  <li>Basic HTML is also supported (e.g. collapsible blocks using <code spellcheck="false">&lt;details&gt;</code> and
-    <code
-    spellcheck="false">&lt;summary&gt;</code>).</li>
-  <li>Code blocks with syntax highlight.
+  <li>
+    <p>All standard and GitHub-flavored syntax (basic formatting, tables, blockquotes).</p>
+  </li>
+  <li>
+    <p>Basic HTML is also supported (e.g. collapsible blocks using <code spellcheck="false">&lt;details&gt;</code> and
+      <code
+      spellcheck="false">&lt;summary&gt;</code>).</p>
+  </li>
+  <li>
+    <p>Code blocks with syntax highlight.</p>
     <ul>
       <li>The language must be specified for syntax highlight to be applied (e.g.
         <code
@@ -46,13 +51,19 @@
         href="#root/_help_4TIF1oA4VQRO">Options</a>.</li>
     </ul>
   </li>
-  <li><a class="reference-link" href="#root/_help_NwBbFdNZ9h7O">Block quotes &amp; admonitions</a>
+  <li>
+    <p><a class="reference-link" href="#root/_help_NwBbFdNZ9h7O">Block quotes &amp; admonitions</a>
+    </p>
   </li>
-  <li><a class="reference-link" href="#root/_help_YfYAtQBcfo5V">Math Equations</a>&nbsp;(both
-    inline and block)</li>
-  <li><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;using
-    <code
-    spellcheck="false">```mermaid</code>
+  <li>
+    <p><a class="reference-link" href="#root/_help_YfYAtQBcfo5V">Math Equations</a>&nbsp;(both
+      inline and block)</p>
+  </li>
+  <li>
+    <p><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;using
+      <code
+      spellcheck="false">```mermaid</code>
+    </p>
   </li>
   <li>
     <p><a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>&nbsp;(no
@@ -105,9 +116,9 @@
   <li>Use the <em>Add link</em> dialog by pressing <kbd>Ctrl</kbd>+<kbd>L</kbd> or
     typing the <code spellcheck="false">/link</code> command.</li>
 </ul>
-<p><a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/_help_UmgZAfcltxkS">Link Previews</a>&nbsp;are
+<p><a class="reference-link" href="#root/_help_UmgZAfcltxkS">Link Previews</a>&nbsp;are
   also rendered, but there is no mechanism to insert them automatically as
-  of now, they have to be copied from a&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/_help_iPIMuisry3hd">Text</a>&nbsp;note
+  of now, they have to be copied from a&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note
   instead.</p>
 <h3>Keyboard shortcuts</h3>
 <p>The Markdown notes share some of the keyboard shortcuts from&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Link Previews.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Link Previews.html
@@ -4,7 +4,7 @@
 <p>A link preview can be displayed in one of three modes:</p>
 <ul>
   <li><strong>Inline</strong> — a link showing the site's favicon and page title
-    (quite similar to&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/QEAPj01N5f7w/_help_hrZ1D00cLbal">Internal (reference) links</a>).
+    (quite similar to&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>).
     Use this when you want the link to flow with the surrounding paragraph.</li>
   <li><strong>Card</strong> — a block-level preview with thumbnail, title, description,
     and site name. Use this when the link is the focus of a paragraph.</li>
@@ -17,58 +17,55 @@
     </ul>
   </li>
 </ul>
-<figure class="table" style="width:100%;">
-  <table class="ck-table-resized">
-    <colgroup>
-      <col style="width:21.85%;">
-        <col style="width:38.84%;">
-          <col style="width:39.31%;">
-    </colgroup>
-    <tbody>
-      <tr>
-        <td>
-          <figure class="image image_resized" style="width:100%;">
-            <img style="aspect-ratio:251/42;" src="Link Previews_image.png"
-            width="251" height="42">
-            <figcaption><em>Inline</em> link preview</figcaption>
-          </figure>
-        </td>
-        <td>
-          <figure class="image image_resized" style="width:100%;">
-            <img style="aspect-ratio:1217/196;" src="2_Link Previews_image.png"
-            width="1217" height="196">
-            <figcaption><em>Card</em> link preview</figcaption>
-          </figure>
-        </td>
-        <td>
-          <figure class="image image_resized" style="width:100%;">
-            <img style="aspect-ratio:994/563;" src="1_Link Previews_image.png"
-            width="994" height="563">
-            <figcaption><em>Embed</em> link preview</figcaption>
-          </figure>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</figure>
+<table class="ck-table-resized">
+  <colgroup>
+    <col style="width:21.85%;">
+      <col style="width:38.84%;">
+        <col style="width:39.31%;">
+  </colgroup>
+  <tbody>
+    <tr>
+      <td>
+        <figure class="image image_resized" style="width:100%;">
+          <img style="aspect-ratio:251/42;" src="Link Previews_image.png"
+          width="251" height="42">
+          <figcaption><em>Inline</em> link preview</figcaption>
+        </figure>
+      </td>
+      <td>
+        <figure class="image image_resized" style="width:100%;">
+          <img style="aspect-ratio:1217/196;" src="2_Link Previews_image.png"
+          width="1217" height="196">
+          <figcaption><em>Card</em> link preview</figcaption>
+        </figure>
+      </td>
+      <td>
+        <figure class="image image_resized" style="width:100%;">
+          <img style="aspect-ratio:994/563;" src="1_Link Previews_image.png"
+          width="994" height="563">
+          <figcaption><em>Embed</em> link preview</figcaption>
+        </figure>
+      </td>
+    </tr>
+  </tbody>
+</table>
 <h2>Inserting a link preview</h2>
 <p>There are two ways to create one:</p>
 <h3>1. By pasting a URL</h3>
 <p>A link preview is automatically created:</p>
 <ul>
-  <li>By pasting the URL and pressing <kbd spellcheck="false">Space</kbd>. This
-    will create an <em>inline</em> link preview.</li>
-  <li>When at the start of a new paragraph, pressing <kbd spellcheck="false">Enter</kbd> will
-    create a <em>card</em> or an <em>embed</em> for YouTube URLs.</li>
+  <li>By pasting the URL and pressing <kbd>Space</kbd>. This will create an <em>inline</em> link
+    preview.</li>
+  <li>When at the start of a new paragraph, pressing <kbd>Enter</kbd> will create
+    a <em>card</em> or an <em>embed</em> for YouTube URLs.</li>
 </ul>
-<p>To undo an automatic link preview, press <kbd spellcheck="false">Ctrl</kbd>+
-  <kbd
-  spellcheck="false">Z</kbd>immediately afterwards which keeps it as a plain link instead.
-    Alternatively, once a link preview was created, click on the link and select <em>Plain link</em> from
-    the link preview toolbar.</p>
+<p>To undo an automatic link preview, press <kbd>Ctrl</kbd>+<kbd>Z</kbd> immediately
+  afterwards which keeps it as a plain link instead. Alternatively, once
+  a link preview was created, click on the link and select <em>Plain link</em> from
+  the link preview toolbar.</p>
 <p>This automatic conversion can be disabled by going to&nbsp;<a class="reference-link"
-  href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/Vc8PjrjAGuOp/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Text Notes</em> and
-  unchecking <em>Autogenerate link previews</em> from the <em>Features</em> section.</p>
+  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Text Notes</em> and unchecking <em>Autogenerate link previews</em> from
+  the <em>Features</em> section.</p>
 <p>If the link is not accessible to the Trilium server (or the network request
   fails for any other reason), it will not be converted to a link preview.</p>
 <aside
@@ -117,7 +114,7 @@ class="admonition note">
     refreshed. If the linked page later changes its title or thumbnail, you'll
     need to re-insert the link to pick up the new values. To refresh a link,
     simply create it again.</p>
-  <p>When accessing a&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/Otzi9La2YAUX/_help_WOcw2SLH6tbX">Server Installation</a>,
+  <p>When accessing a&nbsp;<a class="reference-link" href="#root/_help_WOcw2SLH6tbX">Server Installation</a>,
     the data is fetched from the remote URL by the server and not the client.</p>
   <h2>Known limitations</h2>
   <ul>

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -10220,6 +10220,27 @@
                                     "mime": "text/html",
                                     "attributes": [
                                         {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "hrZ1D00cLbal",
+                                            "isInheritable": false,
+                                            "position": 10
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "4TIF1oA4VQRO",
+                                            "isInheritable": false,
+                                            "position": 20
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "WOcw2SLH6tbX",
+                                            "isInheritable": false,
+                                            "position": 30
+                                        },
+                                        {
                                             "type": "label",
                                             "name": "iconClass",
                                             "value": "bx bx-link-external",
@@ -10232,27 +10253,6 @@
                                             "value": "link-previews",
                                             "isInheritable": false,
                                             "position": 40
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "hrZ1D00cLbal",
-                                            "isInheritable": false,
-                                            "position": 50
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "4TIF1oA4VQRO",
-                                            "isInheritable": false,
-                                            "position": 60
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "WOcw2SLH6tbX",
-                                            "isInheritable": false,
-                                            "position": 70
                                         }
                                     ],
                                     "format": "markdown",
@@ -12882,51 +12882,58 @@
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "0vhv7lsOLy82",
+                                    "value": "UmgZAfcltxkS",
                                     "isInheritable": false,
                                     "position": 130
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "BFvAtE74rbP6",
+                                    "value": "0vhv7lsOLy82",
                                     "isInheritable": false,
                                     "position": 140
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "RnaPdbciOfeq",
+                                    "value": "BFvAtE74rbP6",
                                     "isInheritable": false,
                                     "position": 150
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "IjZS7iK5EXtb",
+                                    "value": "RnaPdbciOfeq",
                                     "isInheritable": false,
                                     "position": 160
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "R9pX4DGra2Vt",
+                                    "value": "IjZS7iK5EXtb",
                                     "isInheritable": false,
                                     "position": 170
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "wy8So3yZZlH9",
+                                    "value": "R9pX4DGra2Vt",
                                     "isInheritable": false,
                                     "position": 180
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "oPVyFC7WL2Lp",
+                                    "value": "wy8So3yZZlH9",
                                     "isInheritable": false,
                                     "position": 190
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "oPVyFC7WL2Lp",
+                                    "isInheritable": false,
+                                    "position": 200
                                 },
                                 {
                                     "type": "label",
@@ -12941,13 +12948,6 @@
                                     "value": "markdown",
                                     "isInheritable": false,
                                     "position": 40
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "UmgZAfcltxkS",
-                                    "isInheritable": false,
-                                    "position": 210
                                 }
                             ],
                             "format": "markdown",

--- a/docs/User Guide/User Guide/Note Types/File/PDFs.md
+++ b/docs/User Guide/User Guide/Note Types/File/PDFs.md
@@ -13,6 +13,7 @@ Since v0.102.0, PDFs will be rendered using Trilium's built-in PDF viewer, which
 *   Can be printed or downloaded.
 *   Can be saved as a [template](../../Advanced%20Usage/Templates.md) and the content of the PDF will be copied over to the new note. This is especially useful in combination with annotations or filled forms.
 *   Integrates with the sidebar in the <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/New%20Layout.md">New Layout</a>, by displaying the list of pages with thumbnails, table of contents and a listing of the annotations.
+*   Basic support for signatures (the hand-drawn ones, not proper digital signatures), similar to annotations. Signatures are stored and can be reused across multiple documents (up to 5).
 
 ## Storing last position and settings
 

--- a/docs/User Guide/User Guide/Note Types/Markdown.md
+++ b/docs/User Guide/User Guide/Note Types/Markdown.md
@@ -27,6 +27,7 @@ The following features are supported by Trilium's Markdown format and will show 
 *   All standard and GitHub-flavored syntax (basic formatting, tables, blockquotes).
 *   Basic HTML is also supported (e.g. collapsible blocks using `<details>` and `<summary>`).
 *   Code blocks with syntax highlight.
+    
     *   The language must be specified for syntax highlight to be applied (e.g. ` ```js `).
     *   Code blocks will respect the text wrapping from the <a class="reference-link" href="Text.md">Text</a> section in <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Options.md">Options</a>.
 *   <a class="reference-link" href="Text/Block%20quotes%20%26%20admonitions.md">Block quotes &amp; admonitions</a>

--- a/docs/User Guide/User Guide/Note Types/Text/Link Previews.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Link Previews.md
@@ -34,10 +34,10 @@ There are two ways to create one:
 
 A link preview is automatically created:
 
-*   By pasting the URL and pressing <kbd spellcheck="false">Space</kbd>. This will create an _inline_ link preview.
-*   When at the start of a new paragraph, pressing <kbd spellcheck="false">Enter</kbd> will create a _card_ or an _embed_ for YouTube URLs.
+*   By pasting the URL and pressing <kbd>Space</kbd>. This will create an _inline_ link preview.
+*   When at the start of a new paragraph, pressing <kbd>Enter</kbd> will create a _card_ or an _embed_ for YouTube URLs.
 
-To undo an automatic link preview, press <kbd spellcheck="false">Ctrl</kbd>+<kbd spellcheck="false">Z</kbd> immediately afterwards which keeps it as a plain link instead. Alternatively, once a link preview was created, click on the link and select _Plain link_ from the link preview toolbar.
+To undo an automatic link preview, press <kbd>Ctrl</kbd>+<kbd>Z</kbd> immediately afterwards which keeps it as a plain link instead. Alternatively, once a link preview was created, click on the link and select _Plain link_ from the link preview toolbar.
 
 This automatic conversion can be disabled by going to <a class="reference-link" href="../../Basic%20Concepts%20and%20Features/UI%20Elements/Options.md">Options</a> → _Text Notes_ and unchecking _Autogenerate link previews_ from the _Features_ section.
 

--- a/packages/commons/src/lib/options_interface.ts
+++ b/packages/commons/src/lib/options_interface.ts
@@ -194,6 +194,14 @@ export interface OptionDefinitions extends KeyboardShortcutsOptions<KeyboardActi
     backgroundEffects: boolean;
     newLayout: boolean;
 
+    // PDF settings
+    /**
+     * The pdf.js reusable signature library, stored as a JSON string keyed by signature UUID
+     * (`{ [uuid]: { description, signatureData } }`). Persisted here — instead of pdf.js' default
+     * per-browser `localStorage` — so saved signatures sync across devices.
+     */
+    pdfSignatures: string;
+
     // Search settings
     /** Whether fuzzy matching is enabled in search (matches similar words when exact matches are insufficient). */
     searchEnableFuzzyMatching: boolean;

--- a/packages/pdfjs-viewer/src/custom.ts
+++ b/packages/pdfjs-viewer/src/custom.ts
@@ -91,6 +91,7 @@ function configurePdfViewerOptions() {
             window.PDFViewerApplicationOptions.set("disablePreferences", true);
             window.PDFViewerApplicationOptions.set("enableHighlightFloatingButton", true);
             window.PDFViewerApplicationOptions.set("enableComment", true);
+            window.PDFViewerApplicationOptions.set("enableSignatureEditor", true);
             if (locale) {
                 window.PDFViewerApplicationOptions.set("localeProperties", { lang: locale });
             }

--- a/packages/pdfjs-viewer/src/persistence.spec.ts
+++ b/packages/pdfjs-viewer/src/persistence.spec.ts
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import interceptPersistence from "./persistence";
+
+const SIGNATURE_KEY = "pdfjs.signature";
+const ENTRY = { description: "Mine", signatureData: "data-1" };
+
+/**
+ * Captured before {@link interceptPersistence} monkey-patches `Storage.prototype`, so tests can
+ * both restore the pristine methods afterwards and peek at the *real* backing store to prove that
+ * intercepted keys never leak into it.
+ */
+let realGetItem: Storage["getItem"];
+let realSetItem: Storage["setItem"];
+let postMessageSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+    localStorage.clear();
+    realGetItem = Storage.prototype.getItem;
+    realSetItem = Storage.prototype.setItem;
+
+    window.TRILIUM_NOTE_ID = "note-1";
+    window.TRILIUM_NTX_ID = "ntx-1";
+    delete window.TRILIUM_SIGNATURES;
+    delete window.TRILIUM_VIEW_HISTORY_STORE;
+
+    // happy-dom has no real parent frame (window.parent === window); spy so we can assert the
+    // payload synchronously instead of racing the async message event.
+    postMessageSpy = vi.spyOn(window.parent, "postMessage").mockImplementation(() => {});
+});
+
+afterEach(() => {
+    Storage.prototype.getItem = realGetItem;
+    Storage.prototype.setItem = realSetItem;
+    vi.restoreAllMocks();
+    localStorage.clear();
+});
+
+/** Reads the real backing store, bypassing the interception patch installed on the prototype. */
+function readRealStore(key: string) {
+    return realGetItem.call(localStorage, key);
+}
+
+describe("signature-library interception", () => {
+    it("serves the injected library and never touches real localStorage on read", () => {
+        interceptPersistence();
+
+        // Nothing injected yet -> pdf.js sees an empty library, not `null`.
+        expect(localStorage.getItem(SIGNATURE_KEY)).toBe("{}");
+
+        window.TRILIUM_SIGNATURES = { abc: ENTRY };
+        expect(JSON.parse(localStorage.getItem(SIGNATURE_KEY) ?? "null")).toEqual({ abc: ENTRY });
+
+        // The library lives only in the injected global; the real store is never populated.
+        expect(readRealStore(SIGNATURE_KEY)).toBeNull();
+    });
+
+    it("forwards writes to the parent, mirrors the global, and keeps them local-free", () => {
+        interceptPersistence();
+
+        const payload = JSON.stringify({ abc: ENTRY });
+        localStorage.setItem(SIGNATURE_KEY, payload);
+
+        expect(postMessageSpy).toHaveBeenCalledWith(
+            {
+                type: "pdfjs-viewer-save-signatures",
+                data: payload,
+                ntxId: "ntx-1",
+                noteId: "note-1"
+            },
+            window.location.origin
+        );
+        // The in-session global is updated so a subsequent read stays consistent...
+        expect(window.TRILIUM_SIGNATURES).toEqual({ abc: ENTRY });
+        // ...but nothing is persisted to the browser's own localStorage.
+        expect(readRealStore(SIGNATURE_KEY)).toBeNull();
+    });
+
+    it("leaves unrelated keys and the view-history channel working", () => {
+        interceptPersistence();
+
+        // Unrelated keys pass straight through to the real store.
+        localStorage.setItem("some-other-key", "value");
+        expect(readRealStore("some-other-key")).toBe("value");
+
+        // The pre-existing view-history interception is unaffected by the signature handling.
+        window.TRILIUM_VIEW_HISTORY_STORE = { files: [] };
+        expect(JSON.parse(localStorage.getItem("pdfjs.history") ?? "null")).toEqual({ files: [] });
+        expect(readRealStore("pdfjs.history")).toBeNull();
+    });
+});
+
+describe("real pdf.js SignatureStorage against the interception", () => {
+    const { SignatureStorage } = loadRealSignatureStorage();
+    const NEW_ENTRY = { description: "New one", signatureData: "sig-new" };
+
+    function newStorage() {
+        // signal=null skips the cross-tab `storage` listener; a minimal eventBus is enough.
+        return new SignatureStorage({ dispatch: vi.fn() }, null);
+    }
+
+    it("uses the exact localStorage key our interception assumes", () => {
+        // Guards the key name persistence.ts hard-codes; a pdf.js rename fails here.
+        expect(SignatureStorage.EXPECTED_KEY).toBe(SIGNATURE_KEY);
+    });
+
+    it("reads the injected library through the patched storage", async () => {
+        window.TRILIUM_SIGNATURES = { seed: { description: "Seed", signatureData: "sig-seed" } };
+        interceptPersistence();
+
+        const signatures = await newStorage().getAll();
+        expect(signatures.get("seed")).toEqual({ description: "Seed", signatureData: "sig-seed" });
+        expect(signatures.size).toBe(1);
+    });
+
+    it("routes a created signature to the parent without persisting locally", async () => {
+        window.TRILIUM_SIGNATURES = {};
+        interceptPersistence();
+
+        const storage = newStorage();
+        const uuid = await storage.create(NEW_ENTRY);
+        expect(uuid).toBeTruthy();
+
+        // pdf.js serialized and "saved" the new entry -> our interception caught and forwarded it.
+        expect(postMessageSpy).toHaveBeenCalledTimes(1);
+        const [ message ] = postMessageSpy.mock.calls[0];
+        expect(message).toMatchObject({
+            type: "pdfjs-viewer-save-signatures",
+            noteId: "note-1",
+            ntxId: "ntx-1"
+        });
+        expect(JSON.parse((message as { data: string }).data)).toEqual({ [uuid]: NEW_ENTRY });
+
+        // The library reflects the addition in-session, but the browser store stays empty.
+        expect(window.TRILIUM_SIGNATURES?.[uuid]).toEqual(NEW_ENTRY);
+        expect(readRealStore(SIGNATURE_KEY)).toBeNull();
+
+        // A fresh storage (fresh cache) still sees it, proving the read path round-trips.
+        expect((await newStorage().getAll()).get(uuid)).toEqual(NEW_ENTRY);
+    });
+});
+
+/**
+ * Extracts the real `SignatureStorage` class from the vendored pdf.js viewer bundle and evaluates
+ * it with its two module-private dependencies injected. pdf.js does not export this class (it lives
+ * inside the self-executing `viewer.mjs` app bundle), so this is the only way to drive pdf.js' own
+ * storage code — rather than a re-implementation — against our interception. If pdf.js refactors
+ * the class beyond recognition the extraction throws, the correct signal to revisit the wiring.
+ */
+function loadRealSignatureStorage(): { SignatureStorage: any } {
+    // happy-dom rewrites `import.meta.url` to an http:// origin, so resolve the bundle from the
+    // working directory instead — walking up to tolerate package-dir and monorepo-root runs.
+    const bundle = readFileSync(resolveViewerBundle(), "utf8");
+
+    const keyMatch = bundle.match(/KEY_STORAGE\s*=\s*"([^"]+)"/);
+    if (!keyMatch) {
+        throw new Error("Could not locate KEY_STORAGE in the vendored pdf.js viewer bundle");
+    }
+    const key = keyMatch[1];
+
+    const start = bundle.indexOf("class SignatureStorage");
+    if (start < 0) {
+        throw new Error("Could not locate SignatureStorage in the vendored pdf.js viewer bundle");
+    }
+    const classSource = bundle.slice(start, matchingBraceEnd(bundle, start));
+
+    let counter = 0;
+    const getUuid = () => `uuid-${++counter}`;
+
+    const body = `${classSource}\nreturn SignatureStorage;`;
+    const factory = new Function("KEY_STORAGE", "getUuid", body);
+    const SignatureStorage = factory(key, getUuid);
+    // Expose the key pdf.js actually uses so the contract test can assert on it.
+    SignatureStorage.EXPECTED_KEY = key;
+    return { SignatureStorage };
+}
+
+/** Finds `viewer/viewer.mjs` by walking up from the working directory (or its package root). */
+function resolveViewerBundle(): string {
+    const relative = join("viewer", "viewer.mjs");
+    let dir = process.cwd();
+    for (;;) {
+        const candidates = [ join(dir, relative), join(dir, "packages", "pdfjs-viewer", relative) ];
+        for (const candidate of candidates) {
+            if (existsSync(candidate)) {
+                return candidate;
+            }
+        }
+        const parent = dirname(dir);
+        if (parent === dir) {
+            throw new Error("Could not locate the pdf.js viewer bundle (viewer/viewer.mjs)");
+        }
+        dir = parent;
+    }
+}
+
+/** Returns the index just past the `}` that closes the first `{` at or after `from`. */
+function matchingBraceEnd(source: string, from: number): number {
+    let depth = 0;
+    let seenBrace = false;
+    for (let i = from; i < source.length; i++) {
+        const char = source[i];
+        if (char === "{") {
+            depth++;
+            seenBrace = true;
+        } else if (char === "}") {
+            depth--;
+            if (seenBrace && depth === 0) {
+                return i + 1;
+            }
+        }
+    }
+    throw new Error("Unbalanced braces while extracting class from the pdf.js viewer bundle");
+}

--- a/packages/pdfjs-viewer/src/persistence.spec.ts
+++ b/packages/pdfjs-viewer/src/persistence.spec.ts
@@ -80,6 +80,18 @@ describe("signature-library interception", () => {
         expect(readRealStore(SIGNATURE_KEY)).toBeNull();
     });
 
+    it("aborts on a malformed payload instead of forwarding broken JSON", () => {
+        window.TRILIUM_SIGNATURES = { abc: ENTRY };
+        interceptPersistence();
+
+        // A non-JSON value must not be forwarded — persisting it would make the parent's getJson
+        // fall back to {} and wipe every saved signature. The prior library stays untouched.
+        localStorage.setItem(SIGNATURE_KEY, "not json{");
+
+        expect(postMessageSpy).not.toHaveBeenCalled();
+        expect(window.TRILIUM_SIGNATURES).toEqual({ abc: ENTRY });
+    });
+
     it("leaves unrelated keys and the view-history channel working", () => {
         interceptPersistence();
 

--- a/packages/pdfjs-viewer/src/persistence.ts
+++ b/packages/pdfjs-viewer/src/persistence.ts
@@ -62,7 +62,7 @@ function saveHistory(value: string) {
 }
 
 /**
- * Persists the reusable signature library. pdf.js writes the full library to `localStorage` on every
+ * Persists the reusable signature library. pdf.js writes the library to `localStorage` on every
  * add/remove; we mirror it into the injected `TRILIUM_SIGNATURES` global (so in-session reads stay
  * consistent) and forward it to the parent, which stores it in the synced `pdfSignatures` option.
  * These are discrete user actions, so — unlike view history — no debounce is needed.
@@ -71,7 +71,10 @@ function saveSignatures(value: string) {
     try {
         window.TRILIUM_SIGNATURES = JSON.parse(value);
     } catch {
-        // Malformed payload should never reach here; keep the previous in-memory copy if it does.
+        // Malformed payload should never reach here (pdf.js always serializes valid JSON). If it
+        // somehow does, abort rather than forward it — persisting broken JSON into the synced
+        // option would make `getJson` fall back to `{}` and silently wipe every saved signature.
+        return;
     }
 
     window.parent.postMessage({

--- a/packages/pdfjs-viewer/src/persistence.ts
+++ b/packages/pdfjs-viewer/src/persistence.ts
@@ -1,3 +1,6 @@
+/** pdf.js' localStorage key for the reusable signature library (`web/signature_storage.js`). */
+const SIGNATURE_STORAGE_KEY = "pdfjs.signature";
+
 export default function interceptViewHistory(customOptions?: object) {
     // We need to monkey-patch the localStorage used by PDF.js to store view history.
     // Other attempts to intercept the history saving/loading (like overriding methods on PDFViewerApplication) have failed.
@@ -5,6 +8,11 @@ export default function interceptViewHistory(customOptions?: object) {
     Storage.prototype.setItem = function (key: string, value: string) {
         if (key === "pdfjs.history") {
             saveHistory(value);
+            return;
+        }
+
+        if (key === SIGNATURE_STORAGE_KEY) {
+            saveSignatures(value);
             return;
         }
 
@@ -19,6 +27,10 @@ export default function interceptViewHistory(customOptions?: object) {
 
         if (key === "pdfjs.history") {
             return JSON.stringify(window.TRILIUM_VIEW_HISTORY_STORE || {});
+        }
+
+        if (key === SIGNATURE_STORAGE_KEY) {
+            return JSON.stringify(window.TRILIUM_SIGNATURES || {});
         }
 
         return originalGetItem.call(this, key);
@@ -47,4 +59,25 @@ function saveHistory(value: string) {
         } satisfies PdfSaveViewHistoryMessage, window.location.origin);
         saveTimeout = null;
     }, 2_000);
+}
+
+/**
+ * Persists the reusable signature library. pdf.js writes the full library to `localStorage` on every
+ * add/remove; we mirror it into the injected `TRILIUM_SIGNATURES` global (so in-session reads stay
+ * consistent) and forward it to the parent, which stores it in the synced `pdfSignatures` option.
+ * These are discrete user actions, so — unlike view history — no debounce is needed.
+ */
+function saveSignatures(value: string) {
+    try {
+        window.TRILIUM_SIGNATURES = JSON.parse(value);
+    } catch {
+        // Malformed payload should never reach here; keep the previous in-memory copy if it does.
+    }
+
+    window.parent.postMessage({
+        type: "pdfjs-viewer-save-signatures",
+        data: value,
+        ntxId: window.TRILIUM_NTX_ID,
+        noteId: window.TRILIUM_NOTE_ID
+    } satisfies PdfSaveSignaturesMessage, window.location.origin);
 }

--- a/packages/trilium-core/src/routes/api/options.ts
+++ b/packages/trilium-core/src/routes/api/options.ts
@@ -43,6 +43,7 @@ const ALLOWED_OPTIONS = new Set<OptionNames>([
     "codeNoteThemeDark",
     "codeNoteTabWidth",
     "codeNoteIndentWithTabs",
+    "pdfSignatures",
     "syncServerHost",
     "syncServerTimeout",
     "syncServerTimeoutTimeScale",

--- a/packages/trilium-core/src/services/options_init.ts
+++ b/packages/trilium-core/src/services/options_init.ts
@@ -216,6 +216,9 @@ const defaultOptions: DefaultOption[] = [
     { name: "smoothScrollEnabled", value: "true", isSynced: false },
     { name: "newLayout", value: "true", isSynced: true },
 
+    // PDF
+    { name: "pdfSignatures", value: "{}", isSynced: true },
+
     // Internationalization
     { name: "locale", value: "en", isSynced: true },
     { name: "formattingLocale", value: "", isSynced: true }, // no value means auto-detect


### PR DESCRIPTION
## Summary

Enables the pdf.js **signature** annotation tool in the embedded PDF viewer, and makes the reusable signature library **sync across devices** instead of living in per-browser `localStorage`.

The feature already ships in the vendored `pdfjs-dist` build (toolbar button, add/edit dialogs, localization) but is off by default — enabling it is a one-line viewer option. The larger part of this PR is redirecting where saved signatures are stored.

> **Note:** these are *drawn* signature stamps (ink/image annotations), not cryptographic digital signatures. pdf.js does not validate digital signatures ([mozilla/pdf.js#13351](https://github.com/mozilla/pdf.js/issues/13351)).

## What changed

**Enable the tool** — set `enableSignatureEditor` in `configurePdfViewerOptions()`. The signed document itself already persists through the existing `saveDocument()` → `annotationStorage` path (it becomes note content), so no extra wiring is needed for that.

**Sync the reusable signature library** — pdf.js keeps the "saved signatures you pick from when signing" in `localStorage["pdfjs.signature"]`, so they never follow the user across devices. This PR routes that storage through Trilium's synced options:

- New synced `pdfSignatures` option (JSON map of saved signatures), defaulted to `"{}"` and whitelisted for client writes.
- In the viewer, the existing `Storage.prototype` interception (already used for view history) now also serves the `pdfjs.signature` key from an injected `TRILIUM_SIGNATURES` global and forwards writes to the parent via a `pdfjs-viewer-save-signatures` message. Overriding `PDFViewerApplication` methods directly does not work (see the note in `persistence.ts`), hence the storage-level interception.
- `Pdf.tsx` injects the library from the option at load and persists the option when the viewer reports a change.

## Tests

Viewer-side tests in `packages/pdfjs-viewer/src/persistence.spec.ts` (happy-dom):

- Direct tests of `interceptPersistence()`: the `pdfjs.signature` key is served from `TRILIUM_SIGNATURES`, writes are forwarded to the parent (and mirrored to the global) without touching real `localStorage`, and unrelated keys + the view-history channel still work.
- An integration test that extracts pdf.js' own (unexported) `SignatureStorage` class from the vendored `viewer.mjs` bundle and drives its `getAll()`/`create()` against our interception — so a pdf.js upgrade that renames the storage key or changes the serialization shape fails loudly.

`pnpm typecheck` (full repo), the new spec suite (19 tests in the package), and the `options_init` server spec all pass.

## Known limitations

- The **5-signature cap** is hardcoded in pdf.js' `SignatureManager`; syncing doesn't change it.
- The `pdfSignatures` option is **last-write-wins**, so two devices saving a signature simultaneously could drop one. Acceptable for a rarely-mutated list; a merge-on-write could harden it later.
- No end-to-end app run yet — the tests prove the storage-wiring contract, not the full visual sign-and-sync flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)