### PR TITLE
perf(llm): keep agent subprocesses alive across chat turns

### DIFF
--- a/apps/server/src/services/llm/providers/acp_client.ts
+++ b/apps/server/src/services/llm/providers/acp_client.ts
@@ -51,6 +51,13 @@ export interface AcpClientOptions {
      * When no handler is set, requests are answered with "method not found".
      */
     onAgentRequest?: (method: string, params: unknown) => Promise<unknown> | unknown;
+    /**
+     * Called once when the subprocess dies on its own (crash, kill, agent
+     * exit) — never for a deliberate {@link AcpClient.dispose}. A pooled
+     * client uses this to evict itself so the next turn starts a fresh agent
+     * instead of handing out a corpse.
+     */
+    onExit?: (error: Error) => void;
 }
 
 export class AcpClient {
@@ -80,12 +87,12 @@ export class AcpClient {
         // left to report.
         proc.stdin.on("error", () => {});
 
-        proc.on("error", err => this.failAll(new Error(`Failed to start the ACP agent: ${err.message}`)));
+        proc.on("error", err => this.die(new Error(`Failed to start the ACP agent: ${err.message}`)));
         proc.on("exit", (code, sig) => {
             // A deliberate dispose() kills the subprocess — that exit is expected
             // and must not surface as an error for in-flight (cancelled) requests.
             if (!this.disposed) {
-                this.failAll(new Error(`The ACP agent exited unexpectedly (${sig ?? `code ${code}`}).`));
+                this.die(new Error(`The ACP agent exited unexpectedly (${sig ?? `code ${code}`}).`));
             }
         });
     }
@@ -204,6 +211,23 @@ export class AcpClient {
         } catch (err) {
             const text = err instanceof Error ? err.message : String(err);
             this.send({ jsonrpc: "2.0", id, error: { code: -32603, message: text } });
+        }
+    }
+
+    /** Whether the subprocess is still usable (not disposed, not exited). */
+    get alive(): boolean {
+        return !this.disposed && this.exitError === undefined;
+    }
+
+    /**
+     * The subprocess died on its own. Fails everything in flight, then tells
+     * the owner exactly once so a pooled client can evict itself.
+     */
+    private die(error: Error): void {
+        const alreadyDead = this.exitError !== undefined;
+        this.failAll(error);
+        if (!alreadyDead) {
+            this.options.onExit?.(error);
         }
     }
 

--- a/apps/server/src/services/llm/providers/claude_agent.live.spec.ts
+++ b/apps/server/src/services/llm/providers/claude_agent.live.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Live integration test for the Claude Agent keep-alive: drives the user's real
+ * `claude` CLI and asserts a second turn reuses the warm subprocess instead of
+ * re-paying the spawn.
+ *
+ * Opt-in — it spawns a subprocess, needs `claude /login`, and spends the
+ * subscription's budget, so it never runs in CI:
+ *
+ *     TRILIUM_CLAUDE_LIVE_TEST=1 pnpm --filter server test claude_agent.live
+ */
+
+import type { LlmStreamChunk } from "@triliumnext/commons";
+import { describe, expect, it } from "vitest";
+
+import { ClaudeAgentProvider } from "./claude_agent.js";
+import { resetClaudeSessionPoolForTests } from "./claude_session_pool.js";
+
+const live = process.env.TRILIUM_CLAUDE_LIVE_TEST === "1";
+
+/** The cheapest model on the subscription. */
+const MODEL = "claude-haiku-4-5-20251001";
+
+describe.runIf(live)("ClaudeAgentProvider keep-alive (live CLI)", () => {
+    it("answers a second turn on the warm subprocess, without re-paying the spawn", async () => {
+        const provider = new ClaudeAgentProvider();
+        const chatNoteId = "live-keep-alive";
+        resetClaudeSessionPoolForTests();
+
+        async function turn(messages: { role: "user" | "assistant"; content: string }[]) {
+            const startedAt = Date.now();
+            let firstTokenMs: number | undefined;
+            let text = "";
+            for await (const chunk of provider.chatChunks(messages, { chatNoteId, model: MODEL, enableNoteTools: false })) {
+                const typed = chunk as LlmStreamChunk;
+                if (typed.type === "text") {
+                    firstTokenMs ??= Date.now() - startedAt;
+                    text += typed.content;
+                } else if (typed.type === "error") {
+                    throw new Error(`Live agent turn failed: ${typed.error}`);
+                }
+            }
+            return { firstTokenMs, text };
+        }
+
+        const cold = await turn([{ role: "user", content: "Reply with exactly the word: alpha" }]);
+        const warm = await turn([
+            { role: "user", content: "Reply with exactly the word: alpha" },
+            { role: "assistant", content: cold.text },
+            { role: "user", content: "Reply with exactly the word: beta" }
+        ]);
+
+        console.log(`live keep-alive: cold first token ${cold.firstTokenMs} ms, warm ${warm.firstTokenMs} ms`);
+
+        expect(cold.text.toLowerCase()).toContain("alpha");
+        expect(warm.text.toLowerCase()).toContain("beta");
+        // The warm turn skips the ~1.3 s subprocess spawn. Assert a fraction of
+        // that so the test tracks the behaviour, not this machine's numbers.
+        expect(warm.firstTokenMs).toBeLessThan((cold.firstTokenMs ?? 0) - 500);
+    }, 180_000);
+});

--- a/apps/server/src/services/llm/providers/claude_agent.spec.ts
+++ b/apps/server/src/services/llm/providers/claude_agent.spec.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const queryMock = vi.hoisted(() => vi.fn());
 const errorLogMock = vi.hoisted(() => vi.fn());
+/** Streaming-input-only Query controls the session pool drives. */
+const setModelMock = vi.hoisted(() => vi.fn());
+const closeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
     query: queryMock
@@ -43,28 +46,60 @@ const resolveAttachmentPartMock = vi.hoisted(() => vi.fn());
 vi.mock("./attachment_content.js", () => ({ resolveAttachmentPart: resolveAttachmentPartMock }));
 
 const { buildSeededPrompt, ClaudeAgentProvider, hashTranscript, resetAgentCwdForTests } = await import("./claude_agent.js");
+const { resetClaudeSessionPoolForTests } = await import("./claude_session_pool.js");
+type PushablePrompt = { pending: readonly { message: { role: string; content: unknown[] } }[] };
 
-/** Drain the query prompt into the single user message it streams (multimodal path). */
-async function drainPrompt(prompt: unknown): Promise<{ role: string; content: unknown[] }> {
-    const iterator = (prompt as AsyncIterable<unknown>)?.[Symbol.asyncIterator];
-    if (typeof prompt === "string" || typeof iterator !== "function") {
-        throw new Error("expected a streamed multimodal prompt, got a plain string");
+/**
+ * Every turn now feeds the session's streaming input, so the `prompt` option is
+ * always a Pushable and the turn's own message is what was pushed onto it.
+ */
+function pushedMessages(prompt: unknown): { message: { role: string; content: unknown[] } }[] {
+    const pending = (prompt as PushablePrompt)?.pending;
+    if (!Array.isArray(pending)) {
+        throw new Error("expected the prompt to be a streaming-input Pushable");
     }
-    const messages: { message: { role: string; content: unknown[] } }[] = [];
-    for await (const message of prompt as AsyncIterable<{ message: { role: string; content: unknown[] } }>) {
-        messages.push(message);
-    }
+    return [...pending];
+}
+
+/** The single user message a turn streamed (multimodal path). */
+function drainPrompt(prompt: unknown): { role: string; content: unknown[] } {
+    const messages = pushedMessages(prompt);
     expect(messages).toHaveLength(1);
     return messages[0].message;
 }
 
+/** The plain text a turn pushed, for the non-multimodal path. */
+function promptText(prompt: unknown): string {
+    return drainPrompt(prompt).content
+        .map(block => (block && typeof block === "object" && "text" in block ? String(block.text) : ""))
+        .join("");
+}
+
+/**
+ * One long-lived query stream serving several turns, as a warm session does:
+ * the provider consumes up to each turn's `result` and resumes from there on
+ * the next turn instead of starting a new query.
+ */
+function scriptAgentSession(turns: unknown[][]) {
+    queryMock.mockImplementation(() => makeQuery(turns.flat()));
+}
+
 /** Make query() replay the given SDK messages and record its invocation. */
 function scriptAgent(messages: unknown[]) {
-    queryMock.mockImplementation(() => (async function* () {
+    queryMock.mockImplementation(() => makeQuery(messages));
+}
+
+/**
+ * A stand-in for the SDK's Query: an async generator plus the control methods
+ * that only exist in streaming input mode, which the pool drives.
+ */
+function makeQuery(messages: unknown[]) {
+    const generator = (async function* () {
         for (const message of messages) {
             yield message;
         }
-    })());
+    })();
+    return Object.assign(generator, { setModel: setModelMock, close: closeMock });
 }
 
 async function collect(iterable: AsyncIterable<LlmStreamChunk>): Promise<LlmStreamChunk[]> {
@@ -102,6 +137,12 @@ describe("ClaudeAgentProvider.chatChunks", () => {
         errorLogMock.mockReset();
         createMcpServerMock.mockClear(); // clear calls, keep the instance impl
         resolveAttachmentPartMock.mockReset();
+        // Sessions outlive a turn now, so each test must start from a cold
+        // pool. Reset it *before* clearing the mocks: tearing down a leftover
+        // session calls close() and would otherwise count against this test.
+        resetClaudeSessionPoolForTests();
+        setModelMock.mockClear();
+        closeMock.mockClear();
     });
 
     it("maps stream events, tool calls, results, and usage to chunks in order", async () => {
@@ -198,30 +239,34 @@ describe("ClaudeAgentProvider.chatChunks", () => {
         expect(chunks.filter(c => c.type === "text")).toEqual([]);
     });
 
-    it("starts a fresh session with the plain prompt and resumes it when the transcript matches", async () => {
+    it("keeps one warm session across turns, pushing the next message onto its streaming input", async () => {
         const provider = new ClaudeAgentProvider();
         const config = { chatNoteId: "note-resume" };
 
+        scriptAgentSession([
+            [textDelta("first reply"), successResult("sess-A")],
+            [textDelta("second reply"), successResult("sess-A")]
+        ]);
+
         // Turn 1 — no history, no mapping: plain prompt, no resume.
-        scriptAgent([textDelta("first reply"), successResult("sess-A")]);
         await collect(provider.chatChunks([{ role: "user", content: "first question" }], config));
 
         expect(queryMock).toHaveBeenCalledTimes(1);
-        const firstCall = queryMock.mock.calls[0][0];
-        expect(firstCall.prompt).toBe("first question");
-        expect(firstCall.options.resume).toBeUndefined();
+        const call = queryMock.mock.calls[0][0];
+        expect(call.options.resume).toBeUndefined();
 
-        // Turn 2 — transcript = turn 1 + streamed reply: resume with only the new message.
-        scriptAgent([textDelta("second reply"), successResult("sess-A")]);
-        await collect(provider.chatChunks([
+        // Turn 2 — the transcript still matches, so the live subprocess is
+        // reused: no second query(), just another message on the same input.
+        const second = await collect(provider.chatChunks([
             { role: "user", content: "first question" },
             { role: "assistant", content: "first reply" },
             { role: "user", content: "second question" }
         ], config));
 
-        const secondCall = queryMock.mock.calls[1][0];
-        expect(secondCall.prompt).toBe("second question");
-        expect(secondCall.options.resume).toBe("sess-A");
+        expect(queryMock).toHaveBeenCalledTimes(1);
+        expect(second).toContainEqual({ type: "text", content: "second reply" });
+        const pushed = pushedMessages(call.prompt).map(m => (m.message.content[0] as { text: string }).text);
+        expect(pushed).toEqual(["first question", "second question"]);
     });
 
     it("reseeds a fresh session from the transcript when the history diverged", async () => {
@@ -241,10 +286,10 @@ describe("ClaudeAgentProvider.chatChunks", () => {
 
         const secondCall = queryMock.mock.calls[1][0];
         expect(secondCall.options.resume).toBeUndefined();
-        expect(secondCall.prompt).toContain("<conversation_history>");
-        expect(secondCall.prompt).toContain("User: edited");
-        expect(secondCall.prompt).toContain("Assistant: reply");
-        expect(secondCall.prompt).toContain("follow-up");
+        expect(promptText(secondCall.prompt)).toContain("<conversation_history>");
+        expect(promptText(secondCall.prompt)).toContain("User: edited");
+        expect(promptText(secondCall.prompt)).toContain("Assistant: reply");
+        expect(promptText(secondCall.prompt)).toContain("follow-up");
     });
 
     it("prepends the current-note metadata hint to the user message when contextNoteId is set", async () => {
@@ -257,8 +302,7 @@ describe("ClaudeAgentProvider.chatChunks", () => {
         ));
 
         expect(buildNoteHintMock).toHaveBeenCalledWith("note-abc", false);
-        const prompt = queryMock.mock.calls[0][0].prompt;
-        expect(prompt).toBe("NOTE_META(note-abc)\n\nwhat is this note about?");
+        expect(promptText(queryMock.mock.calls[0][0].prompt)).toBe("NOTE_META(note-abc)\n\nwhat is this note about?");
     });
 
     it("does not prepend a hint when the context note no longer exists", async () => {
@@ -270,28 +314,30 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             { contextNoteId: "gone" }
         ));
 
-        expect(queryMock.mock.calls[0][0].prompt).toBe("hello");
+        expect(promptText(queryMock.mock.calls[0][0].prompt)).toBe("hello");
     });
 
     it("keeps the note hint out of the session hash so a later turn still resumes", async () => {
         const provider = new ClaudeAgentProvider();
         const config = { contextNoteId: "note-abc", chatNoteId: "note-hint-resume" };
 
-        scriptAgent([textDelta("first reply"), successResult("sess-H")]);
+        scriptAgentSession([
+            [textDelta("first reply"), successResult("sess-H")],
+            [textDelta("second reply"), successResult("sess-H")]
+        ]);
         await collect(provider.chatChunks([{ role: "user", content: "q1" }], config));
 
-        // Turn 2: transcript matches turn 1 (unhinted) → resume, and the new
-        // message still carries the freshly-built hint.
-        scriptAgent([textDelta("second reply"), successResult("sess-H")]);
+        // Turn 2: transcript matches turn 1 (unhinted), so the warm session is
+        // reused, and the new message still carries the freshly-built hint.
         await collect(provider.chatChunks([
             { role: "user", content: "q1" },
             { role: "assistant", content: "first reply" },
             { role: "user", content: "q2" }
         ], config));
 
-        const secondCall = queryMock.mock.calls[1][0];
-        expect(secondCall.options.resume).toBe("sess-H");
-        expect(secondCall.prompt).toBe("NOTE_META(note-abc)\n\nq2");
+        expect(queryMock).toHaveBeenCalledTimes(1);
+        const pushed = pushedMessages(queryMock.mock.calls[0][0].prompt);
+        expect((pushed[1].message.content[0] as { text: string }).text).toBe("NOTE_META(note-abc)\n\nq2");
     });
 
     it("sends a supported image as a base64 block via a one-message stream", async () => {
@@ -305,7 +351,7 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             ] }
         ], {}));
 
-        const message = await drainPrompt(queryMock.mock.calls[0][0].prompt);
+        const message = drainPrompt(queryMock.mock.calls[0][0].prompt);
         expect(message.role).toBe("user");
         expect(message.content).toEqual([
             { type: "text", text: "what is this?" },
@@ -321,7 +367,7 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             { role: "user", content: [{ type: "file", attachmentId: "att-2", mime: "application/pdf", filename: "report.pdf" }] }
         ], { contextNoteId: "note-abc" }));
 
-        const message = await drainPrompt(queryMock.mock.calls[0][0].prompt);
+        const message = drainPrompt(queryMock.mock.calls[0][0].prompt);
         expect(message.content).toEqual([
             { type: "text", text: "NOTE_META(note-abc)" },
             { type: "document", title: "report.pdf", source: { type: "base64", media_type: "application/pdf", data: "JVBERg==" } }
@@ -340,9 +386,11 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             ] }
         ], {}));
 
-        const prompt = queryMock.mock.calls[0][0].prompt;
-        expect(typeof prompt).toBe("string");
-        expect(prompt).toBe("read this\n\n<file name=\"d.svg\">\n<svg/>\n</file>");
+        // Degrades to a single text block rather than image/document blocks.
+        const message = drainPrompt(queryMock.mock.calls[0][0].prompt);
+        expect(message.content).toEqual([
+            { type: "text", text: "read this\n\n<file name=\"d.svg\">\n<svg/>\n</file>" }
+        ]);
     });
 
     it("wires Trilium's in-process MCP server instance and disables built-in tools", async () => {
@@ -741,7 +789,7 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             ] }
         ], {}));
 
-        const message = await drainPrompt(queryMock.mock.calls[0][0].prompt);
+        const message = drainPrompt(queryMock.mock.calls[0][0].prompt);
         expect(message.content).toEqual([
             { type: "image", source: { type: "base64", media_type: "image/png", data: "AQ==" } },
             { type: "text", text: "[attached image]" },
@@ -756,7 +804,7 @@ describe("ClaudeAgentProvider.chatChunks", () => {
         await collect(provider.chatChunks([
             { role: "user", content: [{ type: "text", text: "line one" }, { type: "text", text: "line two" }] }
         ], {}));
-        expect(queryMock.mock.calls[0][0].prompt).toBe("line one\nline two");
+        expect(promptText(queryMock.mock.calls[0][0].prompt)).toBe("line one\nline two");
     });
 
     it("creates the isolating .git marker only when it is absent", async () => {
@@ -780,6 +828,69 @@ describe("ClaudeAgentProvider.chatChunks", () => {
         expect(fs.statSync(path.join(agentDir, ".git", "HEAD")).mtimeMs).toBe(headBefore);
     });
 
+    it("switches models on the live session instead of respawning it", async () => {
+        const provider = new ClaudeAgentProvider();
+        const config = { chatNoteId: "note-model" };
+        scriptAgentSession([
+            [textDelta("a"), successResult("sess-M")],
+            [textDelta("b"), successResult("sess-M")]
+        ]);
+
+        await collect(provider.chatChunks([{ role: "user", content: "q1" }], { ...config, model: "claude-sonnet-5" }));
+        await collect(provider.chatChunks([
+            { role: "user", content: "q1" },
+            { role: "assistant", content: "a" },
+            { role: "user", content: "q2" }
+        ], { ...config, model: "claude-haiku-4-5-20251001" }));
+
+        // setModel is a streaming-input-only control: it is why a model change
+        // costs ~0 ms instead of a cold start.
+        expect(queryMock).toHaveBeenCalledTimes(1);
+        expect(setModelMock).toHaveBeenCalledExactlyOnceWith("claude-haiku-4-5-20251001");
+    });
+
+    it("starts a new session when an option fixed at construction changes", async () => {
+        const provider = new ClaudeAgentProvider();
+        const config = { chatNoteId: "note-fixed" };
+        scriptAgent([textDelta("a"), successResult("sess-F")]);
+        await collect(provider.chatChunks([{ role: "user", content: "q1" }], { ...config, enableNoteTools: true }));
+
+        // Note tools are wired into query()'s options and can't be changed on a
+        // live session, so this must build a new one (and retire the old).
+        scriptAgent([textDelta("b"), successResult("sess-F2")]);
+        await collect(provider.chatChunks([
+            { role: "user", content: "q1" },
+            { role: "assistant", content: "a" },
+            { role: "user", content: "q2" }
+        ], { ...config, enableNoteTools: false }));
+
+        expect(queryMock).toHaveBeenCalledTimes(2);
+        expect(closeMock).toHaveBeenCalled();
+    });
+
+    it("closes the session after an aborted turn rather than reusing a half-finished one", async () => {
+        const controller = new AbortController();
+        const provider = new ClaudeAgentProvider();
+        const config = { chatNoteId: "note-abort" };
+
+        // The turn is cancelled mid-stream, so the session's real state is
+        // unknown — it must not be handed to the next turn.
+        queryMock.mockImplementation(() => makeQuery([textDelta("partial"), successResult("sess-X")]));
+        const chunks = await collect(provider.chatChunks(
+            [{ role: "user", content: "q" }],
+            config,
+            (controller.abort(), controller.signal)
+        ));
+
+        expect(chunks).toEqual([]);
+        expect(closeMock).not.toHaveBeenCalled(); // nothing was started to close
+
+        // A later turn starts a fresh session rather than resuming.
+        scriptAgent([textDelta("ok"), successResult("sess-Y")]);
+        await collect(provider.chatChunks([{ role: "user", content: "q" }], config));
+        expect(queryMock).toHaveBeenCalledTimes(1);
+    });
+
     it("evicts the oldest chat-note mapping once the session cap is exceeded", async () => {
         const provider = new ClaudeAgentProvider();
 
@@ -791,6 +902,11 @@ describe("ClaudeAgentProvider.chatChunks", () => {
             scriptAgent([textDelta("r"), successResult(`sess-${i}`)]);
             await collect(provider.chatChunks([{ role: "user", content: "q" }], { chatNoteId: `filler-${i}` }));
         }
+
+        // This test is about the chat-note → session-id map, not the warm
+        // subprocess pool; drop the warm sessions so both follow-ups have to
+        // start a query and reveal what they would resume.
+        resetClaudeSessionPoolForTests();
 
         // Despite a perfectly matching transcript, the victim can no longer resume.
         scriptAgent([successResult()]);

--- a/apps/server/src/services/llm/providers/claude_agent.ts
+++ b/apps/server/src/services/llm/providers/claude_agent.ts
@@ -35,6 +35,14 @@ import type { LlmProvider, LlmProviderConfig, ModelInfo, ModelPricing, StreamRes
 import { resolveAttachmentPart } from "./attachment_content.js";
 import { buildModelList } from "./base_provider.js";
 import { resolveClaudeBinaryPath } from "./claude_binary.js";
+import {
+    type ClaudeSession,
+    closeSession,
+    Pushable,
+    releaseSession,
+    rememberSession as rememberWarmSession,
+    takeWarmSession
+} from "./claude_session_pool.js";
 import { buildNoteHint } from "./note_hint.js";
 import { buildSystemPrompt } from "./system_prompt.js";
 import { attachmentPlaceholder, buildHistoryReplay, flattenContent, hashTranscript } from "./transcript.js";
@@ -229,6 +237,8 @@ export class ClaudeAgentProvider implements LlmProvider {
         const modelDisplayName = AVAILABLE_MODELS.find(m => m.id === model)?.name ?? model;
         let sessionId: string | undefined;
         let assistantText = "";
+        /** The session this turn is driving, released (not closed) at the end. */
+        let held: ClaudeSession | undefined;
         // tool_use id → name, for labelling results; also serves as the guard
         // that only results belonging to *this* turn's tool calls are emitted.
         const toolNamesById = new Map<string, string>();
@@ -236,21 +246,76 @@ export class ClaudeAgentProvider implements LlmProvider {
         const toolIdsByBlockIndex = new Map<number, string>();
 
         try {
-            const response = query({
-                prompt,
-                options: {
-                    ...await this.buildBaseOptions(config),
-                    systemPrompt: this.composeSystemPrompt(messages, config),
-                    model,
-                    resume,
-                    includePartialMessages: true,
-                    maxTurns: MAX_TURNS,
-                    abortController
-                }
+            const systemPrompt = this.composeSystemPrompt(messages, config);
+            // Options the SDK fixes at query() construction: a change to any of
+            // them can't be applied to a live session, so it forces a new one.
+            // `model` is deliberately absent — setModel() handles it in place.
+            const fingerprint = JSON.stringify({
+                systemPrompt,
+                noteTools: areNoteToolsAvailable(config),
+                thinking: config.enableExtendedThinking !== false
             });
 
-            for await (const message of response) {
+            // Only reuse a warm session when the transcript still matches what
+            // it last saw (`resume`), so an edited history reseeds as before.
+            const warm = config.chatNoteId && resume
+                ? takeWarmSession(config.chatNoteId, fingerprint)
+                : undefined;
+            let session = warm?.sessionId === resume ? warm : undefined;
+            if (warm && !session) {
+                // Right chat, wrong conversation — retire it rather than reply
+                // into the wrong session.
+                closeSession(config.chatNoteId ?? "", warm);
+            }
+
+            if (session) {
+                if (model && session.model !== model) {
+                    // Streaming input mode only; ~0 ms in practice.
+                    await session.query.setModel(model);
+                    session.model = model;
+                }
+            } else {
+                const input = new Pushable<SDKUserMessage>();
+                session = {
+                    query: query({
+                        prompt: input,
+                        options: {
+                            ...await this.buildBaseOptions(config),
+                            systemPrompt,
+                            model,
+                            resume,
+                            includePartialMessages: true,
+                            maxTurns: MAX_TURNS,
+                            abortController
+                        }
+                    }),
+                    input,
+                    fingerprint,
+                    closed: false,
+                    busy: true,
+                    model
+                };
+                if (config.chatNoteId) {
+                    rememberWarmSession(config.chatNoteId, session);
+                }
+            }
+            const active = session;
+            held = active;
+            await pushUserTurn(active.input, prompt);
+
+            // Manual iteration on purpose: `for await (…) { break }` calls
+            // iterator.return(), which closes the query and kills the process
+            // this whole pool exists to keep warm.
+            let turnComplete = false;
+            for (;;) {
+                const next = await active.query.next();
+                if (next.done) {
+                    active.closed = true;
+                    break;
+                }
+                const message = next.value;
                 sessionId = takeSessionId(message) ?? sessionId;
+                active.sessionId = sessionId ?? active.sessionId;
 
                 switch (message.type) {
                     case "stream_event": {
@@ -355,6 +420,9 @@ export class ClaudeAgentProvider implements LlmProvider {
                                 model: modelDisplayName
                             }
                         };
+                        // The turn is over, but the session stays open for the
+                        // next one — this is what keeps the process warm.
+                        turnComplete = true;
                         break;
                     }
 
@@ -376,6 +444,10 @@ export class ClaudeAgentProvider implements LlmProvider {
                     default:
                         break;
                 }
+
+                if (turnComplete) {
+                    break;
+                }
             }
 
             if (config.chatNoteId && sessionId) {
@@ -393,7 +465,21 @@ export class ClaudeAgentProvider implements LlmProvider {
             yield { type: "error", error: describeAgentError(error) };
         } finally {
             signal?.removeEventListener("abort", onAbort);
-            abortController.abort();
+            const reusable = held && config.chatNoteId && !held.closed && !signal?.aborted;
+            if (reusable && held && config.chatNoteId) {
+                // Keep the subprocess warm; the pool reaps it when idle.
+                releaseSession(config.chatNoteId, held);
+            } else {
+                // A cancelled turn stops mid-stream, so the session's real
+                // state is unknown and the SDK may be wedged mid-`next()`
+                // (interrupt() is not guaranteed to make it yield). Killing the
+                // process is the one reliable way out: the next turn simply
+                // pays a cold start rather than inheriting a broken session.
+                if (held) {
+                    closeSession(config.chatNoteId ?? "", held);
+                }
+                abortController.abort();
+            }
         }
     }
 
@@ -613,6 +699,26 @@ function buildContentBlocks(content: LlmMessagePart[], prefix: string): ContentB
 /** One-shot streaming-input prompt: a single user message, then end of input. */
 async function* streamSingleUserMessage(content: ContentBlockParam[]): AsyncIterable<SDKUserMessage> {
     yield { type: "user", message: { role: "user", content }, parent_tool_use_id: null };
+}
+
+/**
+ * Feed one user turn into a live session's streaming input. Accepts both prompt
+ * forms {@link buildPrompt} produces: a plain string, or the one-message stream
+ * used for natively-consumable attachments (drained here, since a pooled
+ * session's input is the only stream the SDK is reading).
+ */
+async function pushUserTurn(input: Pushable<SDKUserMessage>, prompt: string | AsyncIterable<SDKUserMessage>): Promise<void> {
+    if (typeof prompt !== "string") {
+        for await (const message of prompt) {
+            input.push(message);
+        }
+        return;
+    }
+    input.push({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: prompt }] },
+        parent_tool_use_id: null
+    });
 }
 
 /** Strip the MCP prefix so the client shows "search_notes", not "mcp__trilium__search_notes". */

--- a/apps/server/src/services/llm/providers/claude_session_pool.ts
+++ b/apps/server/src/services/llm/providers/claude_session_pool.ts
@@ -1,0 +1,206 @@
+/**
+ * Keeps one Claude Code subprocess alive per chat, across turns.
+ *
+ * The SDK's default `query({ prompt: "text" })` binds the subprocess to the
+ * returned iterator: it spawns on call and dies when iteration ends, so every
+ * turn re-pays the spawn. Measured on Windows that is ~2.0 s to the first
+ * token cold versus ~0.8 s once the process is warm.
+ *
+ * The alternative the SDK offers is *streaming input mode*: pass an
+ * `AsyncIterable<SDKUserMessage>` as the prompt and the process stays alive
+ * consuming messages as they are pushed. That is also the only mode in which
+ * the `Query` control methods (`setModel`, `interrupt`) work — which is what
+ * lets a mid-chat model switch happen without a respawn (measured: ~0 ms).
+ *
+ * Turns within a chat are strictly sequential (one user waiting on one reply),
+ * so a turn can simply drive `query.next()` until its `result` message and
+ * stop — no persistent consumer or turn queue is needed. Iteration must be
+ * manual: `for await (…) { break }` calls `iterator.return()`, which would
+ * close the query and defeat the whole point.
+ *
+ * Sessions are keyed by chat note, reaped after {@link IDLE_TIMEOUT_MS}, and
+ * rebuilt whenever an option that is fixed at construction changes.
+ */
+
+import type { Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { getLog } from "@triliumnext/core";
+
+/**
+ * How long an unused session's subprocess is kept warm. Unlike the Copilot
+ * pool this is one process *per chat*, so the reaper bounds real memory, not
+ * just tidiness.
+ */
+export const IDLE_TIMEOUT_MS = 5 * 60_000;
+
+/** Sessions kept warm; bounded so many open chats can't exhaust the host. */
+export const MAX_WARM_SESSIONS = 8;
+
+/**
+ * Bridges push-based turns to the pull-based `AsyncIterable` the SDK wants.
+ * Pushing after {@link end} is a no-op rather than a hang: a message enqueued
+ * onto a dead stream would otherwise wait on a promise nobody settles.
+ */
+export class Pushable<T> implements AsyncIterable<T> {
+    private readonly queue: T[] = [];
+    private readonly resolvers: ((result: IteratorResult<T>) => void)[] = [];
+    private done = false;
+
+    push(item: T): void {
+        if (this.done) {
+            return;
+        }
+        const resolve = this.resolvers.shift();
+        if (resolve) {
+            resolve({ value: item, done: false });
+        } else {
+            this.queue.push(item);
+        }
+    }
+
+    /** Messages pushed but not yet consumed — for assertions in tests. */
+    get pending(): readonly T[] {
+        return this.queue;
+    }
+
+    end(): void {
+        this.done = true;
+        let resolve = this.resolvers.shift();
+        while (resolve) {
+            resolve({ value: undefined as never, done: true });
+            resolve = this.resolvers.shift();
+        }
+    }
+
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+        return {
+            next: (): Promise<IteratorResult<T>> => {
+                if (this.queue.length > 0) {
+                    return Promise.resolve({ value: this.queue.shift() as T, done: false });
+                }
+                if (this.done) {
+                    return Promise.resolve({ value: undefined as never, done: true });
+                }
+                return new Promise<IteratorResult<T>>(resolve => this.resolvers.push(resolve));
+            }
+        };
+    }
+}
+
+export interface ClaudeSession {
+    readonly query: Query;
+    readonly input: Pushable<SDKUserMessage>;
+    /**
+     * Options that cannot be changed after `query()` starts (system prompt,
+     * note tools, thinking, resume target). A mismatch forces a new session.
+     */
+    readonly fingerprint: string;
+    /** The agent session id, learned from the first message that carries one. */
+    sessionId?: string;
+    /** Set once the stream ends; pushing onto a closed session would hang. */
+    closed: boolean;
+    /** A turn is currently driving `query.next()`. */
+    busy: boolean;
+    /** Last model asked for via `setModel`, so it is only re-sent on change. */
+    model?: string;
+    idleTimer?: NodeJS.Timeout;
+}
+
+const sessionsByChatNote = new Map<string, ClaudeSession>();
+
+/**
+ * The warm session for a chat, or undefined when the caller must build one.
+ * A session that is closed, busy, or built with different construction-time
+ * options is dropped here so the caller starts fresh.
+ */
+export function takeWarmSession(chatNoteId: string, fingerprint: string): ClaudeSession | undefined {
+    const session = sessionsByChatNote.get(chatNoteId);
+    if (!session) {
+        return undefined;
+    }
+    if (session.closed || session.busy || session.fingerprint !== fingerprint) {
+        // Busy means a previous turn is still streaming — rather than queue
+        // behind it, the caller gets a fresh session and this one is retired.
+        closeSession(chatNoteId, session);
+        return undefined;
+    }
+    cancelIdleTimer(session);
+    session.busy = true;
+    return session;
+}
+
+/** Register a freshly built session as this chat's warm one. */
+export function rememberSession(chatNoteId: string, session: ClaudeSession): void {
+    const previous = sessionsByChatNote.get(chatNoteId);
+    if (previous && previous !== session) {
+        closeSession(chatNoteId, previous);
+    }
+    session.busy = true;
+    sessionsByChatNote.delete(chatNoteId);
+    sessionsByChatNote.set(chatNoteId, session);
+    evictOldest();
+}
+
+/** Hand a session back after a turn; it is reaped once idle for long enough. */
+export function releaseSession(chatNoteId: string, session: ClaudeSession): void {
+    session.busy = false;
+    if (session.closed) {
+        sessionsByChatNote.delete(chatNoteId);
+        return;
+    }
+    cancelIdleTimer(session);
+    session.idleTimer = setTimeout(() => {
+        session.idleTimer = undefined;
+        if (!session.busy) {
+            getLog().info(`Claude Agent provider: reaping the idle agent process for chat ${chatNoteId}.`);
+            closeSession(chatNoteId, session);
+        }
+    }, IDLE_TIMEOUT_MS);
+    // Don't hold the event loop open just to reap an idle subprocess.
+    session.idleTimer.unref?.();
+}
+
+/** End the stream and terminate the subprocess. Safe to call more than once. */
+export function closeSession(chatNoteId: string, session: ClaudeSession): void {
+    cancelIdleTimer(session);
+    if (sessionsByChatNote.get(chatNoteId) === session) {
+        sessionsByChatNote.delete(chatNoteId);
+    }
+    if (session.closed) {
+        return;
+    }
+    session.closed = true;
+    try {
+        session.input.end();
+        session.query.close();
+    } catch (err) {
+        getLog().info(`Claude Agent provider: error closing the agent session (${err instanceof Error ? err.message : String(err)}).`);
+    }
+}
+
+function evictOldest(): void {
+    while (sessionsByChatNote.size > MAX_WARM_SESSIONS) {
+        const [oldestId, oldest] = [...sessionsByChatNote.entries()][0];
+        // Never evict a session mid-turn; stop at the first busy one so a
+        // pathological all-busy map degrades to "no eviction" instead of
+        // killing a live reply.
+        if (oldest.busy) {
+            break;
+        }
+        closeSession(oldestId, oldest);
+    }
+}
+
+function cancelIdleTimer(session: ClaudeSession): void {
+    if (session.idleTimer) {
+        clearTimeout(session.idleTimer);
+        session.idleTimer = undefined;
+    }
+}
+
+/** For tests: close every warm session and forget the map. */
+export function resetClaudeSessionPoolForTests(): void {
+    for (const [chatNoteId, session] of [...sessionsByChatNote.entries()]) {
+        closeSession(chatNoteId, session);
+    }
+    sessionsByChatNote.clear();
+}

--- a/apps/server/src/services/llm/providers/copilot_agent.live.spec.ts
+++ b/apps/server/src/services/llm/providers/copilot_agent.live.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Live integration test for the Copilot Agent keep-alive: drives the user's
+ * real `copilot` CLI and asserts that a second turn skips the spawn and the
+ * session handshake the first one paid for.
+ *
+ * Opt-in — it spawns a subprocess, needs `copilot login`, and spends the
+ * subscription's premium-request budget, so it never runs in CI:
+ *
+ *     TRILIUM_COPILOT_LIVE_TEST=1 pnpm --filter server test copilot_agent.live
+ */
+
+import type { LlmStreamChunk } from "@triliumnext/commons";
+import { describe, expect, it, vi } from "vitest";
+
+import { AcpClient } from "./acp_client.js";
+import { CopilotAgentProvider } from "./copilot_agent.js";
+import { resetCopilotClientPoolForTests } from "./copilot_client_pool.js";
+
+const live = process.env.TRILIUM_COPILOT_LIVE_TEST === "1";
+
+/** The cheapest model on the subscription (0x premium multiplier). */
+const MODEL = "gpt-5-mini";
+
+describe.runIf(live)("CopilotAgentProvider keep-alive (live CLI)", () => {
+    it("answers a second turn without re-paying the spawn and session handshake", async () => {
+        const provider = new CopilotAgentProvider();
+        const chatNoteId = "live-keep-alive";
+        resetCopilotClientPoolForTests();
+
+        // Record the ACP methods each turn issues, so the assertions describe
+        // the protocol traffic rather than inferring it from wall-clock time.
+        let methods: string[] = [];
+        const originalRequest = AcpClient.prototype.request;
+        vi.spyOn(AcpClient.prototype, "request").mockImplementation(function (this: AcpClient, method: string, params: unknown, timeoutMs?: number) {
+            methods.push(method);
+            return originalRequest.call(this, method, params, timeoutMs);
+        } as never);
+
+        async function turn(messages: { role: "user" | "assistant"; content: string }[]) {
+            methods = [];
+            const startedAt = Date.now();
+            let firstTokenMs: number | undefined;
+            let text = "";
+            for await (const chunk of provider.chatChunks(messages, { chatNoteId, model: MODEL, enableNoteTools: false })) {
+                const typed = chunk as LlmStreamChunk;
+                if (typed.type === "text") {
+                    firstTokenMs ??= Date.now() - startedAt;
+                    text += typed.content;
+                } else if (typed.type === "error") {
+                    throw new Error(`Live agent turn failed: ${typed.error}`);
+                }
+            }
+            return { firstTokenMs, text, methods: [...methods] };
+        }
+
+        const cold = await turn([{ role: "user", content: "Reply with exactly the word: alpha" }]);
+        const warm = await turn([
+            { role: "user", content: "Reply with exactly the word: alpha" },
+            { role: "assistant", content: cold.text },
+            { role: "user", content: "Reply with exactly the word: beta" }
+        ]);
+
+        console.log(
+            `live keep-alive: cold ${cold.firstTokenMs} ms [${cold.methods.join(", ")}]`
+            + ` | warm ${warm.firstTokenMs} ms [${warm.methods.join(", ")}]`
+            + ` | cold reply ${JSON.stringify(cold.text)} | warm reply ${JSON.stringify(warm.text)}`
+        );
+
+        expect(cold.text.toLowerCase()).toContain("alpha");
+        expect(warm.text.toLowerCase()).toContain("beta");
+        // The warm turn talks to a session that is already loaded.
+        expect(warm.methods).toEqual(["session/set_model", "session/prompt"]);
+        // The warm turn skips the spawn (~0.8 s) plus the cold session/new
+        // (~2.4 s). Assert a conservative fraction of that so the test tracks
+        // the behaviour rather than this machine's exact numbers.
+        expect(warm.firstTokenMs).toBeLessThan((cold.firstTokenMs ?? 0) - 1000);
+    }, 180_000);
+});

--- a/apps/server/src/services/llm/providers/copilot_agent.spec.ts
+++ b/apps/server/src/services/llm/providers/copilot_agent.spec.ts
@@ -44,6 +44,7 @@ vi.mock("./attachment_content.js", () => ({ resolveAttachmentPart: resolveAttach
 class FakeAcpClient {
     onNotification: (method: string, params: unknown) => void;
     onAgentRequest?: (method: string, params: unknown) => unknown;
+    onExit?: (error: Error) => void;
     requests: { method: string; params: unknown }[] = [];
     notifications: { method: string; params: unknown }[] = [];
     disposed = false;
@@ -57,12 +58,13 @@ class FakeAcpClient {
     /** Id handed out by the next `session/new` (the real CLI never reuses one). */
     static newSessionId = "sess-1";
 
-    constructor(opts: { onNotification: (m: string, p: unknown) => void; onAgentRequest?: (m: string, p: unknown) => unknown }) {
+    constructor(opts: { onNotification: (m: string, p: unknown) => void; onAgentRequest?: (m: string, p: unknown) => unknown; onExit?: (e: Error) => void }) {
         this.onNotification = opts.onNotification;
         this.onAgentRequest = opts.onAgentRequest;
+        this.onExit = opts.onExit;
     }
 
-    static start(_binary: string, opts: { args?: string[]; onNotification: (m: string, p: unknown) => void; onAgentRequest?: (m: string, p: unknown) => unknown }) {
+    static start(_binary: string, opts: { args?: string[]; onNotification: (m: string, p: unknown) => void; onAgentRequest?: (m: string, p: unknown) => unknown; onExit?: (e: Error) => void }) {
         FakeAcpClient.current = new FakeAcpClient(opts);
         return FakeAcpClient.current;
     }
@@ -99,6 +101,25 @@ class FakeAcpClient {
         this.disposed = true;
     }
 
+    /** Mirrors the real client: the pool only reuses a live subprocess. */
+    get alive(): boolean {
+        return !this.disposed;
+    }
+
+    /** Simulate the subprocess dying on its own, as the real client reports it. */
+    die(message = "The ACP agent exited unexpectedly (SIGKILL)."): void {
+        this.disposed = true;
+        this.onExit?.(new Error(message));
+    }
+
+    /**
+     * Forget the requests recorded so far. The client outlives a turn now, so
+     * a test that spans several turns clears between them to assert on one.
+     */
+    clearRequests(): void {
+        this.requests = [];
+    }
+
     /** Fire a session/update notification as the agent would. */
     update(update: Record<string, unknown>, sessionId = "sess-1"): void {
         this.onNotification("session/update", { sessionId, update });
@@ -114,6 +135,7 @@ class FakeAcpError extends Error {
 vi.mock("./acp_client.js", () => ({ AcpClient: FakeAcpClient, AcpError: FakeAcpError }));
 
 const { buildPromptBlocks, CopilotAgentProvider, createUpdateCollector, decidePermission, resetAgentCwdForTests } = await import("./copilot_agent.js");
+const { IDLE_TIMEOUT_MS, resetCopilotClientPoolForTests } = await import("./copilot_client_pool.js");
 
 async function collect(iterable: AsyncIterable<LlmStreamChunk>): Promise<LlmStreamChunk[]> {
     const chunks: LlmStreamChunk[] = [];
@@ -131,6 +153,9 @@ function resetFakes() {
     infoLogMock.mockReset();
     resolveAttachmentPartMock.mockReset();
     resetAgentCwdForTests();
+    // The agent process is shared and outlives a turn now, so each test must
+    // start from a cold pool or it would reuse the previous test's client.
+    resetCopilotClientPoolForTests();
     mcpEndpointMock.mockClear();
     FakeAcpClient.current = undefined;
     FakeAcpClient.initializeError = undefined;
@@ -176,7 +201,8 @@ describe("CopilotAgentProvider.chatChunks", () => {
             { type: "tool_result", toolCallId: "t1", toolName: "search_notes", result: "3 results", isError: false },
             { type: "done" }
         ]);
-        expect(FakeAcpClient.current?.disposed).toBe(true);
+        // The agent process is kept warm for the next turn.
+        expect(FakeAcpClient.current?.disposed).toBe(false);
     });
 
     it("wires the loopback MCP server into session/new when note tools are enabled", async () => {
@@ -242,7 +268,9 @@ describe("CopilotAgentProvider.chatChunks", () => {
         const chunks = await collect(provider.chatChunks([userMessage("hi")], {}));
 
         expect(chunks).toEqual([{ type: "error", error: expect.stringContaining("copilot login") }]);
-        expect(FakeAcpClient.current?.disposed).toBe(true);
+        // A failed session is not a failed process: the client stays pooled so
+        // the next turn (e.g. after `copilot login`) doesn't pay a respawn.
+        expect(FakeAcpClient.current?.disposed).toBe(false);
     });
 
     it("rejects a transcript whose last message is not from the user", async () => {
@@ -291,7 +319,8 @@ describe("CopilotAgentProvider.chatChunks", () => {
 
         expect(chunks).toEqual([{ type: "text", content: "partial" }, { type: "done" }]);
         expect(FakeAcpClient.current?.notifications).toContainEqual({ method: "session/cancel", params: { sessionId: "sess-1" } });
-        expect(FakeAcpClient.current?.disposed).toBe(true);
+        // Cancelling one chat must not kill the process every other chat shares.
+        expect(FakeAcpClient.current?.disposed).toBe(false);
 
         // The aborted session's real history is unknown, so the next turn must
         // reseed rather than resume it — even though the transcript lines up.
@@ -352,7 +381,7 @@ describe("CopilotAgentProvider.chatChunks", () => {
         expect(blocks.at(-1)).toEqual({ type: "text", text: "[attached file: doc.pdf]" });
     });
 
-    it("resumes a mapped session, suppressing the load replay, and reseeds once the transcript diverges", async () => {
+    it("prompts a still-loaded session directly, and reseeds once the transcript diverges", async () => {
         const provider = new CopilotAgentProvider();
         FakeAcpClient.promptScript = async client => {
             client.update({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "answer" } });
@@ -360,17 +389,17 @@ describe("CopilotAgentProvider.chatChunks", () => {
         };
         await collect(provider.chatChunks([userMessage("hi")], { chatNoteId: "chat-resume" }));
 
-        // Same transcript → session/load instead of a fresh session/new, and no
-        // system instructions or history replay in the prompt.
+        // Same transcript and the session is still loaded in the pooled agent,
+        // so the turn is a bare session/prompt: no session/new (the ~2.4 s cost
+        // this whole feature exists to avoid) and no session/load either.
+        FakeAcpClient.current?.clearRequests();
         FakeAcpClient.promptScript = async () => ({ stopReason: "end_turn" });
         const resumed = await collect(provider.chatChunks(
             [userMessage("hi"), assistantMessage("answer"), userMessage("more")],
             { chatNoteId: "chat-resume" }
         ));
 
-        const load = FakeAcpClient.current?.requests.find(r => r.method === "session/load");
-        expect(load?.params).toMatchObject({ sessionId: "sess-1", cwd: AGENT_CWD });
-        expect(FakeAcpClient.current?.requests.some(r => r.method === "session/new")).toBe(false);
+        expect(FakeAcpClient.current?.requests.map(r => r.method)).toEqual(["session/prompt"]);
         expect(resumed).toEqual([{ type: "done" }]);
         const prompt = FakeAcpClient.current?.requests.find(r => r.method === "session/prompt");
         const blocks = (prompt?.params as { prompt: { type: string; text: string }[] }).prompt;
@@ -378,6 +407,7 @@ describe("CopilotAgentProvider.chatChunks", () => {
 
         // An edited history no longer hashes to the mapped session, so the next
         // turn must reseed rather than resume.
+        FakeAcpClient.current?.clearRequests();
         await collect(provider.chatChunks(
             [userMessage("rewritten"), assistantMessage("answer"), userMessage("more")],
             { chatNoteId: "chat-resume" }
@@ -386,10 +416,13 @@ describe("CopilotAgentProvider.chatChunks", () => {
         expect(FakeAcpClient.current?.requests.some(r => r.method === "session/new")).toBe(true);
     });
 
-    it("reseeds a fresh session when session/load fails", async () => {
+    it("reseeds a fresh session when session/load fails after the agent process died", async () => {
         const provider = new CopilotAgentProvider();
         await collect(provider.chatChunks([userMessage("hi")], { chatNoteId: "chat-load-fail" }));
 
+        // The session only exists inside the process that made it; once that is
+        // gone the next turn has to load it back from disk.
+        FakeAcpClient.current?.die();
         FakeAcpClient.sessionLoadError = new Error("unknown session");
         FakeAcpClient.newSessionId = "sess-2";
         const chunks = await collect(provider.chatChunks(
@@ -496,11 +529,114 @@ describe("CopilotAgentProvider.chatChunks", () => {
         }
 
         const followUp = [userMessage("hi"), assistantMessage(""), userMessage("more")];
+        // "lru-0" was evicted, so its follow-up has no session to resume.
+        FakeAcpClient.current?.clearRequests();
         await collect(provider.chatChunks(followUp, { chatNoteId: "lru-0" }));
-        expect(FakeAcpClient.current?.requests.some(r => r.method === "session/load")).toBe(false);
+        expect(FakeAcpClient.current?.requests.some(r => r.method === "session/new")).toBe(true);
 
+        // "lru-200" is still mapped and still loaded, so it prompts directly.
+        FakeAcpClient.current?.clearRequests();
         await collect(provider.chatChunks(followUp, { chatNoteId: "lru-200" }));
-        expect(FakeAcpClient.current?.requests.some(r => r.method === "session/load")).toBe(true);
+        expect(FakeAcpClient.current?.requests.map(r => r.method)).toEqual(["session/prompt"]);
+    });
+});
+
+describe("CopilotAgentProvider keep-alive", () => {
+    beforeEach(resetFakes);
+
+    it("reuses one agent process across turns and chats, spawning and initializing only once", async () => {
+        // spyOn returns the existing spy when one is already installed, so the
+        // count has to be cleared or it carries over from an earlier test.
+        const startSpy = vi.spyOn(FakeAcpClient, "start").mockClear();
+        const provider = new CopilotAgentProvider();
+
+        await collect(provider.chatChunks([userMessage("hi")], { chatNoteId: "chat-a" }));
+        const first = FakeAcpClient.current;
+        FakeAcpClient.newSessionId = "sess-b";
+        await collect(provider.chatChunks([userMessage("hi")], { chatNoteId: "chat-b" }));
+
+        // Same process, one handshake, one session per chat — ACP multiplexes.
+        expect(FakeAcpClient.current).toBe(first);
+        expect(startSpy).toHaveBeenCalledTimes(1);
+        const methods = FakeAcpClient.current?.requests.map(r => r.method) ?? [];
+        expect(methods.filter(m => m === "initialize")).toHaveLength(1);
+        expect(methods.filter(m => m === "session/new")).toHaveLength(2);
+    });
+
+    it("shares a single spawn between turns that start concurrently", async () => {
+        const startSpy = vi.spyOn(FakeAcpClient, "start").mockClear();
+        FakeAcpClient.promptScript = async () => {
+            await new Promise(resolve => setTimeout(resolve, 5));
+            return { stopReason: "end_turn" };
+        };
+        const provider = new CopilotAgentProvider();
+
+        await Promise.all([
+            collect(provider.chatChunks([userMessage("one")], { chatNoteId: "chat-1" })),
+            collect(provider.chatChunks([userMessage("two")], { chatNoteId: "chat-2" }))
+        ]);
+
+        expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps each turn's updates to its own session", async () => {
+        FakeAcpClient.promptScript = async client => {
+            client.update({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "mine" } }, "sess-1");
+            // Another chat's traffic on the shared connection must not leak in.
+            client.update({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "theirs" } }, "sess-other");
+            return { stopReason: "end_turn" };
+        };
+
+        const chunks = await collect(new CopilotAgentProvider().chatChunks([userMessage("hi")], {}));
+
+        expect(chunks).toEqual([{ type: "text", content: "mine" }, { type: "done" }]);
+    });
+
+    it("starts a replacement process transparently after the pooled one dies", async () => {
+        const provider = new CopilotAgentProvider();
+        await collect(provider.chatChunks([userMessage("hi")], {}));
+
+        FakeAcpClient.current?.die();
+        const dead = FakeAcpClient.current;
+        const chunks = await collect(provider.chatChunks([userMessage("hi again")], {}));
+
+        expect(FakeAcpClient.current).not.toBe(dead);
+        expect(FakeAcpClient.current?.requests.map(r => r.method))
+            .toEqual(["initialize", "session/new", "session/prompt"]);
+        expect(chunks).toEqual([{ type: "done" }]);
+    });
+
+    it("starts a new session when the note-tools toggle flips, since MCP servers are fixed at session/new", async () => {
+        const provider = new CopilotAgentProvider();
+        const transcript = [userMessage("hi")];
+        await collect(provider.chatChunks(transcript, { chatNoteId: "chat-tools", enableNoteTools: true }));
+
+        // Same transcript, so it would otherwise resume the live session.
+        FakeAcpClient.current?.clearRequests();
+        FakeAcpClient.newSessionId = "sess-2";
+        await collect(provider.chatChunks(
+            [...transcript, assistantMessage(""), userMessage("more")],
+            { chatNoteId: "chat-tools", enableNoteTools: false }
+        ));
+
+        const sessionNew = FakeAcpClient.current?.requests.find(r => r.method === "session/new");
+        expect(sessionNew?.params).toMatchObject({ mcpServers: [] });
+    });
+
+    it("reaps the idle process once no turn has used it for the timeout", async () => {
+        vi.useFakeTimers();
+        try {
+            await collect(new CopilotAgentProvider().chatChunks([userMessage("hi")], {}));
+            const client = FakeAcpClient.current;
+            expect(client?.disposed).toBe(false);
+
+            vi.advanceTimersByTime(IDLE_TIMEOUT_MS + 1);
+
+            expect(client?.disposed).toBe(true);
+            expect(infoLogMock).toHaveBeenCalledWith(expect.stringContaining("reaping the idle agent process"));
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });
 
@@ -525,7 +661,7 @@ describe("CopilotAgentProvider.generateTitle", () => {
             .toMatchObject({ modelId: "gpt-5-mini" });
         expect(FakeAcpClient.current?.requests.find(r => r.method === "session/new")?.params)
             .toMatchObject({ mcpServers: [] });
-        expect(FakeAcpClient.current?.disposed).toBe(true);
+        expect(FakeAcpClient.current?.disposed).toBe(false);
     });
 
     it("still produces a title when the cheap model cannot be selected", async () => {
@@ -543,7 +679,7 @@ describe("CopilotAgentProvider.generateTitle", () => {
 
         expect(await new CopilotAgentProvider().generateTitle("hi")).toBe("");
         expect(errorLogMock).toHaveBeenCalledWith(expect.stringContaining("Failed to start the GitHub Copilot CLI"));
-        expect(FakeAcpClient.current?.disposed).toBe(true);
+        expect(FakeAcpClient.current?.disposed).toBe(false);
     });
 });
 

--- a/apps/server/src/services/llm/providers/copilot_agent.ts
+++ b/apps/server/src/services/llm/providers/copilot_agent.ts
@@ -28,9 +28,18 @@ import path from "path";
 
 import dataDirs from "../../data_dir.js";
 import type { LlmProvider, LlmProviderConfig, ModelInfo, ModelPricing, StreamResult } from "../types.js";
-import { AcpClient, AcpError } from "./acp_client.js";
+import { AcpError } from "./acp_client.js";
 import { resolveAttachmentPart } from "./attachment_content.js";
 import { needsShell, resolveCopilotBinaryPath } from "./copilot_binary.js";
+import {
+    acquireClient,
+    addSessionListener,
+    type ClientLease,
+    INIT_TIMEOUT_MS,
+    releaseClient,
+    removeSessionListener,
+    setAgentRequestHandler
+} from "./copilot_client_pool.js";
 import { getCopilotMcpEndpointUrl } from "./copilot_mcp_endpoint.js";
 import { buildNoteHint } from "./note_hint.js";
 import { buildSystemPrompt } from "./system_prompt.js";
@@ -58,29 +67,6 @@ const AVAILABLE_MODELS: ModelInfo[] = [
 /** Free-tier model used for the cheap title turn. */
 const TITLE_MODEL = "gpt-5-mini";
 
-/**
- * CLI arguments passed alongside `--acp`. These form the *primary* security
- * boundary; the permission callback (see {@link decidePermission}) is a
- * fail-closed backstop.
- *   - `--allow-tool=trilium` auto-approves every tool from our "trilium" MCP
- *     server, so note tools run without a permission round-trip (and without
- *     relying on us recognizing them — the CLI presents MCP tool calls with
- *     opaque IDs and human-friendly titles that don't embed the server name).
- *   - `--deny-tool` on each built-in file/shell/network tool guarantees they
- *     can never run even if a future CLI build changed the permission-prompt
- *     defaults. The agent's only capability surface is Trilium's note tools.
- *   - `--no-custom-instructions` keeps any AGENTS.md/copilot-instructions.md in
- *     an enclosing directory out of the notes chat.
- *   - `--no-auto-update` keeps the pinned binary from mutating under us.
- */
-const COPILOT_ACP_ARGS = [
-    "--allow-tool=trilium",
-    ...["shell", "powershell", "write", "edit", "create", "view", "glob", "grep", "task", "web_fetch"].map(t => `--deny-tool=${t}`),
-    "--no-custom-instructions",
-    "--no-auto-update"
-];
-
-const INIT_TIMEOUT_MS = 30_000;
 const SESSION_TIMEOUT_MS = 120_000;
 /** Upper bound for a whole prompt turn (agentic loops included). */
 const PROMPT_TIMEOUT_MS = 15 * 60_000;
@@ -92,6 +78,18 @@ interface SessionEntry {
     sessionId: string;
     /** Hash of the transcript as it stood when the session last responded. */
     transcriptHash: string;
+    /**
+     * The pooled agent process the session was created on. A session only
+     * exists inside the process that created it, so a mismatch means the
+     * session must be re-loaded from disk rather than prompted directly.
+     */
+    generation: number;
+    /**
+     * Whether the session was created with the note-tools MCP server attached.
+     * MCP servers are fixed at `session/new`, so flipping the chat's note
+     * access forces a new session rather than a resume.
+     */
+    noteToolsEnabled: boolean;
 }
 
 /**
@@ -188,47 +186,69 @@ export class CopilotAgentProvider implements LlmProvider {
         };
 
         const collector = createUpdateCollector(emit);
-        let client: AcpClient | undefined;
-        let sessionId: string | undefined;
+        let lease: ClientLease | undefined;
+        let listeningTo: string | undefined;
         let assistantText = "";
 
         try {
-            client = await this.startClient(collector.onNotification);
+            // Held in a const too: `lease` is captured by the cleanup below, so
+            // narrowing it to non-undefined here wouldn't survive.
+            const acquired = await acquireSharedClient();
+            lease = acquired;
+            const client = acquired.client;
 
-            const mcpServers = noteToolsEnabled ? await buildMcpServersConfig() : [];
+            // MCP servers are fixed at session/new, so a flipped note-tools
+            // toggle can't reuse the mapped session at all — neither by
+            // prompting it nor by loading it back with a different config.
+            const resumable = resume !== undefined && stored?.noteToolsEnabled === noteToolsEnabled
+                ? resume
+                : undefined;
+            // The fast path: the session is still loaded in this very agent
+            // process, so the turn skips session/new (and the ~2.4 s auth and
+            // model-list refresh the first one pays) and prompts it directly.
+            const isLive = resumable !== undefined && stored?.generation === acquired.generation;
 
-            // Resume the existing session only when the transcript still
-            // matches what it last saw; any divergence (edited history, lost
-            // mapping, server restart) reseeds a fresh session. session/load
-            // replays the session's history as notifications — the collector
-            // suppresses everything until the load completes.
-            if (resume) {
-                collector.muted = true;
+            // Resolved through a local the closures below don't capture, so it
+            // still narrows to a definite string once every branch has run.
+            let resolved: string | undefined;
+            if (isLive) {
+                resolved = resumable;
+            } else if (resumable !== undefined) {
+                // The session outlived its process (reaped, crashed, or the
+                // server restarted). session/load replays its history from
+                // disk; no listener is registered yet, so that replay is
+                // dropped rather than streamed to the user as a fresh reply.
+                const mcpServers = noteToolsEnabled ? await buildMcpServersConfig() : [];
                 try {
-                    await client.request("session/load", { sessionId: resume, cwd: getAgentCwd(), mcpServers }, SESSION_TIMEOUT_MS);
-                    sessionId = resume;
+                    await client.request("session/load", { sessionId: resumable, cwd: getAgentCwd(), mcpServers }, SESSION_TIMEOUT_MS);
+                    resolved = resumable;
                 } catch (err) {
                     getLog().info(`Copilot Agent provider: session/load failed (${describeError(err)}); reseeding a fresh session.`);
-                } finally {
-                    collector.muted = false;
                 }
             }
 
-            if (!sessionId) {
+            if (!resolved) {
+                const mcpServers = noteToolsEnabled ? await buildMcpServersConfig() : [];
                 const created = await client.request<{ sessionId: string }>(
                     "session/new",
                     { cwd: getAgentCwd(), mcpServers },
                     SESSION_TIMEOUT_MS
                 );
-                sessionId = created.sessionId;
+                resolved = created.sessionId;
             }
-            collector.sessionId = sessionId;
+            const activeSession = resolved;
+            collector.sessionId = activeSession;
+            // Subscribe only now: everything above is setup whose notifications
+            // (session/load's replay, session/new's config announcements) must
+            // not reach the chat.
+            listeningTo = activeSession;
+            addSessionListener(activeSession, params => collector.onNotification("session/update", params));
 
             if (model !== "auto") {
                 // Model selection is an optional ACP capability — degrade to the
                 // agent's default rather than failing the turn.
                 try {
-                    await client.request("session/set_model", { sessionId, modelId: model }, INIT_TIMEOUT_MS);
+                    await client.request("session/set_model", { sessionId: activeSession, modelId: model }, INIT_TIMEOUT_MS);
                 } catch (err) {
                     getLog().error(`Copilot Agent provider: failed to select model "${model}" (${describeError(err)}); continuing with the agent's default.`);
                 }
@@ -238,7 +258,7 @@ export class CopilotAgentProvider implements LlmProvider {
             // instructions and replayed transcript when the session is fresh,
             // then the volatile current-note metadata hint (kept out of the
             // transcript hash so a later turn can still resume).
-            const isFreshSession = sessionId !== resume;
+            const isFreshSession = activeSession !== resumable;
             const hasAttachments = Array.isArray(lastMessage.content) && lastMessage.content.some(p => p.type !== "text");
             const noteHint = config.contextNoteId ? buildNoteHint(config.contextNoteId, hasAttachments) : null;
             const prefix = [
@@ -248,9 +268,10 @@ export class CopilotAgentProvider implements LlmProvider {
             ].filter((s): s is string => Boolean(s)).join("\n\n");
 
             const onAbort = () => {
-                if (sessionId) {
-                    client?.notify("session/cancel", { sessionId });
-                }
+                // Cancel the turn in-band. The client is shared with every
+                // other chat now, so disposing it here would kill their turns
+                // too — reaping is the pool's job alone.
+                client.notify("session/cancel", { sessionId: activeSession });
                 // Wake the drain loop below: an agent slow to honour the cancel
                 // (or ignoring it) would otherwise keep this generator — and its
                 // subprocess — suspended until PROMPT_TIMEOUT_MS elapses.
@@ -261,7 +282,7 @@ export class CopilotAgentProvider implements LlmProvider {
             try {
                 const promptPromise = client.request<{ stopReason?: string }>(
                     "session/prompt",
-                    { sessionId, prompt: buildPromptBlocks(lastMessage.content, prefix) },
+                    { sessionId: activeSession, prompt: buildPromptBlocks(lastMessage.content, prefix) },
                     PROMPT_TIMEOUT_MS
                 );
 
@@ -308,13 +329,15 @@ export class CopilotAgentProvider implements LlmProvider {
             // session's real history is unknown — recording a hash here would
             // let a later turn resume a session that diverged from the
             // transcript. Forgetting it just reseeds a fresh one.
-            if (config.chatNoteId && sessionId && !signal?.aborted) {
+            if (config.chatNoteId && !signal?.aborted) {
                 rememberSession(config.chatNoteId, {
-                    sessionId,
+                    sessionId: activeSession,
                     transcriptHash: hashTranscript([
                         ...conversation,
                         { role: "assistant", content: assistantText }
-                    ])
+                    ]),
+                    generation: acquired.generation,
+                    noteToolsEnabled
                 });
             }
 
@@ -322,29 +345,39 @@ export class CopilotAgentProvider implements LlmProvider {
         } catch (error) {
             yield { type: "error", error: describeCopilotError(error) };
         } finally {
-            client?.dispose();
+            // Stop listening, then hand the client back. The subprocess stays
+            // warm for the next turn; the pool reaps it once nothing is using
+            // it (see copilot_client_pool.ts).
+            if (listeningTo) {
+                removeSessionListener(listeningTo);
+            }
+            if (lease) {
+                releaseClient();
+            }
         }
     }
 
     async generateTitle(firstMessage: string): Promise<string> {
-        let client: AcpClient | undefined;
+        let lease: ClientLease | undefined;
+        let listeningTo: string | undefined;
         try {
             let title = "";
-            client = await this.startClient((method, params) => {
-                if (method !== "session/update") {
-                    return;
-                }
-                const update = (params as AcpSessionUpdate).update;
-                if (update?.sessionUpdate === "agent_message_chunk" && update.content && "text" in update.content && update.content.type === "text") {
-                    title += update.content.text;
-                }
-            });
+            const acquired = await acquireSharedClient();
+            lease = acquired;
+            const client = acquired.client;
 
             const { sessionId } = await client.request<{ sessionId: string }>(
                 "session/new",
                 { cwd: getAgentCwd(), mcpServers: [] },
                 SESSION_TIMEOUT_MS
             );
+            listeningTo = sessionId;
+            addSessionListener(sessionId, params => {
+                const update = (params as AcpSessionUpdate).update;
+                if (update?.sessionUpdate === "agent_message_chunk" && update.content && "text" in update.content && update.content.type === "text") {
+                    title += update.content.text;
+                }
+            });
             try {
                 await client.request("session/set_model", { sessionId, modelId: TITLE_MODEL }, INIT_TIMEOUT_MS);
             } catch {
@@ -366,37 +399,13 @@ export class CopilotAgentProvider implements LlmProvider {
             getLog().error(`Copilot Agent title generation failed: ${describeCopilotError(error)}`);
             return "";
         } finally {
-            client?.dispose();
+            if (listeningTo) {
+                removeSessionListener(listeningTo);
+            }
+            if (lease) {
+                releaseClient();
+            }
         }
-    }
-
-    /** Spawn `copilot --acp` and run the ACP initialize handshake. */
-    private async startClient(onNotification: (method: string, params: unknown) => void): Promise<AcpClient> {
-        const binary = await resolveCopilotBinaryPath();
-        const client = AcpClient.start(binary, {
-            cwd: getAgentCwd(),
-            shell: needsShell(binary),
-            args: COPILOT_ACP_ARGS,
-            onNotification,
-            onAgentRequest: handleAgentRequest
-        });
-        try {
-            await client.request(
-                "initialize",
-                {
-                    protocolVersion: 1,
-                    clientInfo: { name: "trilium-notes", version: "1.0" },
-                    // No fs capabilities: the agent must never touch the host
-                    // filesystem — notes are its only data surface.
-                    clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } }
-                },
-                INIT_TIMEOUT_MS
-            );
-        } catch (err) {
-            client.dispose();
-            throw err;
-        }
-        return client;
     }
 
     /**
@@ -410,6 +419,17 @@ export class CopilotAgentProvider implements LlmProvider {
         /* v8 ignore next */
         return buildSystemPrompt(messages, config) ?? "";
     }
+}
+
+/**
+ * Borrow the shared agent process for one turn, resolving the user's binary on
+ * first use. The permission policy is installed from here rather than owned by
+ * the pool, so the security decision stays beside the CLI flags that back it.
+ */
+async function acquireSharedClient(): Promise<ClientLease> {
+    setAgentRequestHandler(handleAgentRequest);
+    const binary = await resolveCopilotBinaryPath();
+    return acquireClient(binary, getAgentCwd(), needsShell(binary));
 }
 
 /** The MCP server list for `session/new`/`session/load`, pointing at the private loopback endpoint. */

--- a/apps/server/src/services/llm/providers/copilot_client_pool.ts
+++ b/apps/server/src/services/llm/providers/copilot_client_pool.ts
@@ -1,0 +1,237 @@
+/**
+ * Keeps a single `copilot --acp` subprocess alive across chat turns.
+ *
+ * Spawning the CLI and creating a session is expensive — measured on Windows,
+ * a cold turn pays ~785 ms to spawn and run `initialize` plus ~2.4 s for the
+ * first `session/new` (it refreshes auth and fetches the model list), so the
+ * agent only starts generating ~3.2 s after the user hits send. None of that
+ * is model latency, and all of it repeats on every message when the client is
+ * disposed at the end of each turn.
+ *
+ * ACP is designed for exactly this: one connection hosts many sessions, each
+ * addressed by `sessionId`, and prompting is a method call on a session that
+ * already exists. So the client is shared process-wide rather than pooled per
+ * chat — a warm turn skips the spawn, the handshake *and* session creation
+ * entirely.
+ *
+ * Lifetime: started on demand, reference-counted for the duration of each
+ * turn, and reaped after {@link IDLE_TIMEOUT_MS} with no active turns so an
+ * idle Trilium isn't holding an agent subprocess open forever. A client that
+ * dies on its own evicts itself, so the next turn transparently starts a new
+ * one.
+ */
+
+import { getLog } from "@triliumnext/core";
+
+import { AcpClient } from "./acp_client.js";
+
+/**
+ * CLI arguments passed alongside `--acp`. These form the *primary* security
+ * boundary; the permission callback is a fail-closed backstop.
+ *   - `--allow-tool=trilium` auto-approves every tool from our "trilium" MCP
+ *     server, so note tools run without a permission round-trip (and without
+ *     relying on us recognizing them — the CLI presents MCP tool calls with
+ *     opaque IDs and human-friendly titles that don't embed the server name).
+ *   - `--deny-tool` on each built-in file/shell/network tool guarantees they
+ *     can never run even if a future CLI build changed the permission-prompt
+ *     defaults. The agent's only capability surface is Trilium's note tools.
+ *   - `--no-custom-instructions` keeps any AGENTS.md/copilot-instructions.md in
+ *     an enclosing directory out of the notes chat.
+ *   - `--no-auto-update` keeps the pinned binary from mutating under us.
+ */
+export const COPILOT_ACP_ARGS = [
+    "--allow-tool=trilium",
+    ...["shell", "powershell", "write", "edit", "create", "view", "glob", "grep", "task", "web_fetch"].map(t => `--deny-tool=${t}`),
+    "--no-custom-instructions",
+    "--no-auto-update"
+];
+
+export const INIT_TIMEOUT_MS = 30_000;
+
+/**
+ * How long a client with no active turns is kept warm. Long enough to cover
+ * a user reading a reply and following up, short enough that a Trilium left
+ * open overnight isn't holding a subprocess.
+ */
+export const IDLE_TIMEOUT_MS = 5 * 60_000;
+
+/** Routes `session/update` notifications to the turn that owns that session. */
+type SessionListener = (params: unknown) => void;
+
+export interface ClientLease {
+    readonly client: AcpClient;
+    /**
+     * Identifies the subprocess this lease belongs to. A session id is only
+     * meaningful on the generation that created it — after a reap or a crash
+     * the agent has no such session loaded, so callers must compare before
+     * prompting an existing session.
+     */
+    readonly generation: number;
+}
+
+interface PooledClient {
+    client: AcpClient;
+    generation: number;
+    listeners: Map<string, SessionListener>;
+}
+
+let pooled: PooledClient | undefined;
+/** In-flight start, so concurrent first turns share one spawn. */
+let starting: Promise<PooledClient> | undefined;
+let generationCounter = 0;
+let activeTurns = 0;
+let idleTimer: NodeJS.Timeout | undefined;
+
+/**
+ * Borrow the shared client for one turn, starting it if necessary. Every
+ * successful call must be paired with {@link releaseClient} — the reference
+ * count is what keeps a turn's subprocess from being reaped underneath it.
+ */
+export async function acquireClient(binaryPath: string, cwd: string, shell: boolean): Promise<ClientLease> {
+    // Count the turn before any await: an idle reap must not slip in between
+    // the client being handed out and the caller starting to use it.
+    activeTurns++;
+    cancelIdleTimer();
+    try {
+        const entry = await startOrReuse(binaryPath, cwd, shell);
+        return { client: entry.client, generation: entry.generation };
+    } catch (err) {
+        releaseClient();
+        throw err;
+    }
+}
+
+/** Return a lease. The client is reaped once every turn has released it. */
+export function releaseClient(): void {
+    activeTurns = Math.max(0, activeTurns - 1);
+    if (activeTurns === 0 && pooled) {
+        armIdleTimer();
+    }
+}
+
+/**
+ * Subscribe to a session's `session/update` notifications for the duration of
+ * a turn. Updates for sessions nobody is listening to are dropped, which is
+ * what keeps a shared connection from leaking one chat's output into another.
+ */
+export function addSessionListener(sessionId: string, listener: SessionListener): void {
+    pooled?.listeners.set(sessionId, listener);
+}
+
+export function removeSessionListener(sessionId: string): void {
+    pooled?.listeners.delete(sessionId);
+}
+
+async function startOrReuse(binaryPath: string, cwd: string, shell: boolean): Promise<PooledClient> {
+    if (pooled?.client.alive) {
+        return pooled;
+    }
+    // A dead client that never fired onExit (or fired it after we read it).
+    pooled = undefined;
+
+    if (!starting) {
+        starting = start(binaryPath, cwd, shell).finally(() => {
+            starting = undefined;
+        });
+    }
+    return starting;
+}
+
+async function start(binaryPath: string, cwd: string, shell: boolean): Promise<PooledClient> {
+    const generation = ++generationCounter;
+    const listeners = new Map<string, SessionListener>();
+
+    const client = AcpClient.start(binaryPath, {
+        cwd,
+        shell,
+        args: COPILOT_ACP_ARGS,
+        onNotification: (method, params) => {
+            if (method !== "session/update") {
+                return;
+            }
+            const sessionId = (params as { sessionId?: string }).sessionId;
+            if (sessionId) {
+                listeners.get(sessionId)?.(params);
+            }
+        },
+        onAgentRequest: (method, params) => agentRequestHandler(method, params),
+        onExit: error => {
+            // Only evict ourselves: a later generation may already be running.
+            if (pooled?.generation === generation) {
+                pooled = undefined;
+            }
+            listeners.clear();
+            getLog().info(`Copilot Agent provider: agent process #${generation} ended (${error.message}); the next turn will start a new one.`);
+        }
+    });
+
+    try {
+        await client.request(
+            "initialize",
+            {
+                protocolVersion: 1,
+                clientInfo: { name: "trilium-notes", version: "1.0" },
+                // No fs capabilities: the agent must never touch the host
+                // filesystem — notes are its only data surface.
+                clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } }
+            },
+            INIT_TIMEOUT_MS
+        );
+    } catch (err) {
+        client.dispose();
+        throw err;
+    }
+
+    const entry: PooledClient = { client, generation, listeners };
+    pooled = entry;
+    return entry;
+}
+
+/**
+ * The agent→client request handler, installed by the provider. Kept as a
+ * hook so the permission policy stays with the provider that defines it,
+ * while the pool owns the connection.
+ */
+let agentRequestHandler: (method: string, params: unknown) => unknown = () => {
+    throw new Error("No agent request handler installed.");
+};
+
+export function setAgentRequestHandler(handler: (method: string, params: unknown) => unknown): void {
+    agentRequestHandler = handler;
+}
+
+function armIdleTimer(): void {
+    cancelIdleTimer();
+    idleTimer = setTimeout(() => {
+        idleTimer = undefined;
+        if (activeTurns === 0 && pooled) {
+            getLog().info(`Copilot Agent provider: reaping the idle agent process after ${Math.round(IDLE_TIMEOUT_MS / 1000)} s.`);
+            disposePooled();
+        }
+    }, IDLE_TIMEOUT_MS);
+    // Don't hold the event loop open just to reap an idle subprocess.
+    idleTimer.unref?.();
+}
+
+function cancelIdleTimer(): void {
+    if (idleTimer) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+    }
+}
+
+function disposePooled(): void {
+    const entry = pooled;
+    pooled = undefined;
+    entry?.listeners.clear();
+    entry?.client.dispose();
+}
+
+/** For tests: drop the shared client and all bookkeeping. */
+export function resetCopilotClientPoolForTests(): void {
+    cancelIdleTimer();
+    disposePooled();
+    starting = undefined;
+    activeTurns = 0;
+    generationCounter = 0;
+}


### PR DESCRIPTION
Both agent providers spawned a CLI subprocess, ran a handshake, and threw it all away on **every** chat turn. This keeps the process warm between turns, cutting seconds of pure overhead off each message — none of it model latency.

Measured on Windows against the real CLIs (times to first token):

| provider | before | after | saved |
|---|---|---|---|
| Copilot | 6912 ms | 3078 ms | **3.8 s (55%)** |
| Claude  | 2265 ms |  866 ms | **1.4 s (62%)** |

Two commits, one per provider — they solve the same problem but the mechanisms have nothing in common.

## Copilot: one shared client, many sessions

ACP is built for this — one connection hosts many sessions addressed by `sessionId`, and prompting is a call on a session that already exists. The client is now shared process-wide and reaped after 5 minutes idle. The protocol trace tells the story:

```
cold  [initialize, session/new, session/set_model, session/prompt]
warm  [session/set_model, session/prompt]
```

The `session/new` alone was ~2.4 s: it refreshes auth and fetches the model list.

Consequences worth reviewing:

- **Cancellation is now in-band.** The client is shared, so disposing it on abort would kill every other chat's turn.
- **Session mappings record the process generation.** A session lives inside its process, so after a reap or crash the mapping is stale and the turn falls back to `session/load`. Prompting a live session directly is what makes the warm path cheap — `session/load` on an already-loaded session is rejected by the CLI (`"already loaded"`).
- **Flipping note access starts a new session**: MCP servers are fixed at `session/new`.
- `AcpClient` gained an `onExit` hook so a dead subprocess evicts itself.

## Claude: streaming input mode

`query({ prompt: "text" })` binds the subprocess to the returned iterator, so it dies when iteration ends. Passing an `AsyncIterable` instead keeps one subprocess per chat. That is also the only mode in which the `Query` control methods work — which makes a mid-chat model switch a **~0 ms `setModel()`** instead of a cold start.

Iteration is deliberately manual (`query.next()` in a loop, stopping at the turn's `result`) rather than `for await … break`: breaking out of a for-await calls `iterator.return()`, which closes the query and kills the process this exists to keep warm.

The design follows [zed's claude-code-acp adapter](https://github.com/zed-industries/claude-agent-acp), which solves the same problem — minus its persistent-consumer and turn-deferred machinery, which exists to interleave queued and autonomous turns. A Trilium chat is strictly one turn at a time.

Decisions worth reviewing:

- Options fixed at `query()` construction (system prompt, note tools, thinking) are **fingerprinted**; a change retires the session.
- **An aborted turn closes the session** rather than pooling it: it stops mid-stream, so the state is unknown and the SDK can wedge mid-`next()` (`interrupt()` is not guaranteed to yield — [claude-agent-acp#680](https://github.com/zed-industries/claude-agent-acp/issues/680)). The next turn pays a cold start.
- `Pushable.push` after `end()` is a **no-op, not a hang** — enqueueing onto a dead stream would otherwise wait on a promise nobody settles ([claude-agent-acp#338](https://github.com/zed-industries/claude-agent-acp/issues/338)).
- One subprocess **per chat** here (vs. one shared for Copilot), so the idle reaper and the warm-session cap bound real memory.

## Testing

359 server LLM tests pass. New unit coverage: process reuse across turns and chats, a shared spawn for concurrent turns, per-session update routing, crash recovery, config-change reseeds, cancellation, and the idle reap.

Two **opt-in** live integration tests drive the real CLIs and assert the latency drop — skipped by default since they spend subscription budget:

```
TRILIUM_COPILOT_LIVE_TEST=1 pnpm --filter server test copilot_agent.live
TRILIUM_CLAUDE_LIVE_TEST=1  pnpm --filter server test claude_agent.live
```

## Notes for the reviewer

- Targets `worktree-copilot-agent-provider`, not `main` — the Copilot provider isn't in `main` yet, so this stacks on that branch.
- Draft, since it can't land before its base does.
- The behaviour change that touches the most existing tests is the resume path: within one live process, a resume is now a bare `session/prompt` rather than `session/load`. Those assertions were updated, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)