### PR TITLE
fix(client): inconsistent first tab spacing

### DIFF
--- a/apps/client/src/stylesheets/theme-next/base.css
+++ b/apps/client/src/stylesheets/theme-next/base.css
@@ -56,7 +56,6 @@
 
     --tab-bar-height: 50px;
     --tab-height: 36px;
-    --tab-first-item-horiz-offset: 0;
     --new-tab-button-size: 24px;
 
     --center-pane-border-radius: 10px;

--- a/apps/client/src/stylesheets/theme-next/shell.css
+++ b/apps/client/src/stylesheets/theme-next/shell.css
@@ -111,7 +111,6 @@ body.background-effects.theme-supports-background-effects #center-pane .note-spl
 /* Matches when the left pane is collapsed */
 #horizontal-main-container.left-pane-hidden {
     --note-split-top-border-radius: 0;
-    --tab-first-item-horiz-offset: 5px;
 }
 
 /* Matches when a status bar panel is open */
@@ -1180,10 +1179,6 @@ body.layout-horizontal div.tab-row-widget div.note-tab div.note-tab-wrapper {
     inset-inline-end: 0;
     height: 3px;
     background-color: var(--workspace-tab-background-color);
-}
-
-body:not([dir=rtl]) .tab-row-widget .note-tab:nth-child(1) {
-    transform: translate3d(var(--tab-first-item-horiz-offset), 0, 0);
 }
 
 :root .tab-row-widget .note-tab .note-tab-icon {

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -18,7 +18,6 @@ const isDesktop = utils.isDesktop();
 
 const TAB_CONTAINER_MIN_WIDTH = 100;
 const TAB_CONTAINER_MAX_WIDTH = 240;
-const TAB_CONTAINER_LEFT_PADDING = 5;
 const SCROLL_BUTTON_WIDTH = 36;
 const NEW_TAB_WIDTH = 36;
 const MIN_FILLER_WIDTH = isDesktop ? 50 : 15;
@@ -534,7 +533,7 @@ export default class TabRowWidget extends BasicWidget {
             this.setScrollButtonVisibility(false);
         }
 
-        const marginWidth = (numberOfTabs - 1) * MARGIN_WIDTH + TAB_CONTAINER_LEFT_PADDING;
+        const marginWidth = (numberOfTabs - 1) * MARGIN_WIDTH;
         const targetWidth = (tabsContainerWidth - marginWidth) / numberOfTabs;
         const clampedTargetWidth = Math.max(TAB_CONTAINER_MIN_WIDTH, Math.min(TAB_CONTAINER_MAX_WIDTH, targetWidth));
         const flooredClampedTargetWidth = Math.floor(clampedTargetWidth);
@@ -560,7 +559,7 @@ export default class TabRowWidget extends BasicWidget {
     getTabPositions() {
         const tabPositions: number[] = [];
 
-        let position = TAB_CONTAINER_LEFT_PADDING;
+        let position = 0;
         this.tabWidths.forEach((width) => {
             tabPositions.push(position);
             position += width + MARGIN_WIDTH;


### PR DESCRIPTION
## Fix uneven tab spacing when left pane is visible

### The bug

The gap between the first and second tab in the tab bar is 5px wider than the gap between any other pair of adjacent tabs. Everything else lines up fine — it's just that first gap that's off.

<img width="1491" height="118" alt="image" src="https://github.com/user-attachments/assets/c50305d3-5b5e-4163-84b1-f35b89f0e3e1" />

### Root cause

The tab bar positions tabs using JavaScript (`tab_row.ts`), which starts the first tab at `TAB_CONTAINER_LEFT_PADDING = 5px` and spaces subsequent tabs with `MARGIN_WIDTH = 5px` between them. So tab 1 goes at 5px, tab 2 at `5px + width + 5px`, etc.

However, `shell.css` has a higher-specificity rule that overrides the first tab's position with a CSS custom property:

```css
body:not([dir=rtl]) .tab-row-widget .note-tab:nth-child(1) {
    transform: translate3d(var(--tab-first-item-horiz-offset), 0, 0);
}
```

The default value of `--tab-first-item-horiz-offset` was `0` (in `base.css`), while the JS started tabs at `5px`. So tab 1 got pulled 5px left of where the JS put it, widening the gap to tab 2 by 5px. 

However, when the left pane is hidden, `--tab-first-item-horiz-offset` is set to 5px, which means there is no inconsistent spacing, but all the tabs are shifted to the left by 5px. IMO this makes no sense. My best guess is that the tabs used to be right next to the left pane so this added some spacing, but now there are the nav buttons instead. 

If this PR gets accepted, I'll follow up with another one to add some spacing to the left of the nav buttons when the left pane is collapsed. 

### Fix

Removed `TAB_CONTAINER_LEFT_PADDING` and `--tab-first-item-horiz-offset` entirely. Those two variables would have to be kept in sync (which themes can't do), and themes can just add padding to `tab-row-widget-scrolling-container` or `tab-row-widget` which doesn't have this syncing problem. 

This could break themes, but the variable isn't set in theme-light.css and the next theme is noted to be subject to change, so IMO this is fine. 