### PR TITLE
fix(collapsible): allow multi-paragraph drag-selection in Chromium

### DIFF
--- a/packages/ckeditor5-collapsible/src/collapsible-editing.ts
+++ b/packages/ckeditor5-collapsible/src/collapsible-editing.ts
@@ -87,6 +87,17 @@ export default class CollapsibleEditing extends Plugin {
      */
     private readonly preserveOpenOnNextInsert = new Map<any, boolean>();
     /**
+     * Open/collapsed state per <details> model element. The editing view wraps
+     * the body in a content container via `elementToStructure`, which reconverts
+     * the whole <details> whenever its body blocks change — that rebuilds the
+     * <details> DOM element, which defaults to closed and would silently collapse
+     * a block the user has open while they edit its body. The downcast `view()`
+     * reads this back so the rebuilt <details> keeps its `open` attribute. Only
+     * <details> toggled/opened at least once appear here; untouched ones stay
+     * closed (the loaded-document default). Weak so deleted collapsibles drop out.
+     */
+    private readonly detailsOpenState = new WeakMap<any, boolean>();
+    /**
      * Shared manager for summary hints (screen-corner popup on each <summary>).
      * Each summary owns ONE handle in {@link summaryHints}; visibility is
      * driven by the two booleans on {@link SummaryHintState} (hover, caret)
@@ -212,7 +223,41 @@ export default class CollapsibleEditing extends Plugin {
         // <details>
         conversion.for("upcast").elementToElement({ view: "details", model: "details" });
         conversion.for("dataDowncast").elementToElement({ model: "details", view: detailsView });
-        conversion.for("editingDowncast").elementToElement({ model: "details", view: detailsView });
+        // The editing view wraps the body blocks in a <div class="trilium-collapsible-content">.
+        // Chromium caps a native mouse drag-selection to a single block whenever the blocks are
+        // direct children of a <details> in a contenteditable (its ::details-content slot acts as
+        // a hard selection boundary — keyboard and programmatic selection cross it fine, only the
+        // drag algorithm doesn't). Giving the body a single wrapping container removes that
+        // boundary. This is editing-only: the data downcast above stays flat
+        // (<details><summary>…</summary><blocks>) so the saved HTML signature is unchanged. The
+        // <summary> stays a direct child of <details> (native collapse hides everything else), so
+        // only the non-summary blocks go into the wrapper.
+        conversion.for("editingDowncast").elementToStructure({
+            model: "details",
+            view: (modelElement: any, { writer }: any) => {
+                // Reconversion (triggered whenever the body blocks change) rebuilds this
+                // <details>, which would otherwise default to closed and collapse a block
+                // the user is editing. Re-apply the tracked open state as the `open`
+                // attribute so the renderer itself restores it — a post-render fix-up can't,
+                // because the view's "render" event fires *before* the DOM is reconciled.
+                const attributes: Record<string, string> = { class: "trilium-collapsible" };
+                if (this.detailsOpenState.get(modelElement)) attributes.open = "";
+                const details = writer.createContainerElement("details", attributes);
+                writer.insert(
+                    writer.createPositionAt(details, 0),
+                    writer.createSlot((node: any) => node.is("element", "summary"))
+                );
+                const content = writer.createContainerElement("div", {
+                    class: "trilium-collapsible-content"
+                });
+                writer.insert(
+                    writer.createPositionAt(content, 0),
+                    writer.createSlot((node: any) => !node.is("element", "summary"))
+                );
+                writer.insert(writer.createPositionAt(details, "end"), content);
+                return details;
+            }
+        });
 
         // <summary>
         conversion.for("upcast").elementToElement({ view: "summary", model: "summary" });
@@ -347,12 +392,19 @@ export default class CollapsibleEditing extends Plugin {
 
     /** True if the <details> is currently expanded (or no DOM mapping yet). */
     private isDetailsOpen(model: any): boolean {
+        // Prefer the tracked state: mid-reconversion the rebuilt DOM is momentarily
+        // closed even for a block the user has open, and `detailsOpenState` is the
+        // authoritative memory of that (see its declaration). Fall back to the DOM
+        // for <details> that have never been toggled (never entered the map).
+        const tracked = this.detailsOpenState.get(model);
+        if (tracked !== undefined) return tracked;
         const dom = this.getDom<HTMLDetailsElement>(model);
         return !dom || dom.open;
     }
 
-    /** Toggle the DOM `open` attribute directly (the source of truth in this plugin). */
+    /** Remember the open state (so reconversion can restore it) and reflect it to the DOM. */
     private setDetailsOpen(model: any, open: boolean) {
+        this.detailsOpenState.set(model, open);
         const dom = this.getDom<HTMLDetailsElement>(model);
         if (dom) dom.open = open;
     }
@@ -761,10 +813,13 @@ export default class CollapsibleEditing extends Plugin {
         const arrow = detailsDom.querySelector(":scope > summary > .trilium-collapsible-arrow");
         arrow?.setAttribute("aria-expanded", String(detailsDom.open));
 
-        if (detailsDom.open) return;
-
         const detailsView = editor.editing.view.domConverter.mapDomToView(detailsDom);
         const detailsModel = detailsView ? editor.editing.mapper.toModelElement(detailsView as any) : null;
+        // Record the new state so a later reconversion restores it (the arrow's
+        // click handler flips `detailsDom.open` directly, bypassing setDetailsOpen).
+        if (detailsModel) this.detailsOpenState.set(detailsModel, detailsDom.open);
+
+        if (detailsDom.open) return;
         if (!detailsModel) return;
 
         const summary = detailsModel.getChild(0);
@@ -852,16 +907,15 @@ export default class CollapsibleEditing extends Plugin {
                     return;
                 }
                 for (const node of pendingOpen) {
-                    const dom = this.getDom<HTMLDetailsElement>(node);
-                    if (!dom) continue;
+                    if (!this.getDom<HTMLDetailsElement>(node)) continue;
                     // A move (drag-and-drop) records as remove + insert; restore the
                     // pre-move open state so a collapsed block stays collapsed.
                     // Fresh inserts have no entry here and default to open.
                     if (this.preserveOpenOnNextInsert.has(node)) {
-                        dom.open = this.preserveOpenOnNextInsert.get(node)!;
+                        this.setDetailsOpen(node, this.preserveOpenOnNextInsert.get(node) ?? true);
                         this.preserveOpenOnNextInsert.delete(node);
                     } else {
-                        dom.open = true;
+                        this.setDetailsOpen(node, true);
                     }
                 }
                 pendingOpen.clear();

--- a/packages/ckeditor5-collapsible/tests/conversion.ts
+++ b/packages/ckeditor5-collapsible/tests/conversion.ts
@@ -53,6 +53,48 @@ describe("CollapsibleEditing conversion", () => {
         });
     });
 
+    describe("editing downcast", () => {
+        it("wraps the body blocks in a content container, <summary> stays a direct child", () => {
+            editor.setData("<details><summary>Title</summary><p>First</p><p>Second</p></details>");
+            const root = editor.editing.view.getDomRoot();
+            const details = root?.querySelector("details.trilium-collapsible");
+            expect(details).toBeTruthy();
+            // <summary> must stay a direct child so native collapse keeps it visible.
+            expect(details?.querySelector(":scope > summary")).toBeTruthy();
+            // Body blocks live inside the wrapper — not as direct children of <details>,
+            // which is what Chromium's drag-selection cannot span.
+            const content = details?.querySelector(":scope > .trilium-collapsible-content");
+            expect(content).toBeTruthy();
+            expect(details?.querySelectorAll(":scope > p").length).toBe(0);
+            expect(content?.querySelectorAll(":scope > p").length).toBe(2);
+        });
+
+        it("preserves the open state across the reconversion a body-block change triggers", () => {
+            editor.setData("<details><summary>Title</summary><p>First</p></details>");
+            const root = editor.editing.view.getDomRoot();
+            const selector = "details.trilium-collapsible";
+            const detailsBefore = root?.querySelector<HTMLDetailsElement>(selector);
+            // Simulate the user opening the block: flip `open` and fire the native
+            // `toggle` the plugin listens for (the arrow's click handler does the same).
+            if (detailsBefore) {
+                detailsBefore.open = true;
+                detailsBefore.dispatchEvent(new Event("toggle"));
+            }
+
+            // Add a second body paragraph — this changes the <details> children and
+            // makes elementToStructure rebuild its DOM (fresh, hence closed).
+            editor.model.change((writer) => {
+                const details = editor.model.document.getRoot()?.getChild(0);
+                if (details?.is("element", "details")) {
+                    writer.insertElement("paragraph", details, "end");
+                }
+            });
+
+            const detailsAfter = root?.querySelector<HTMLDetailsElement>(selector);
+            expect(detailsAfter?.open).toBe(true);
+        });
+    });
+
     describe("data downcast", () => {
         it("emits the trilium-collapsible class on the rendered <details>", () => {
             editor.setData("<details><summary>Title</summary><p>Body</p></details>");

--- a/packages/ckeditor5-collapsible/theme/collapsible.css
+++ b/packages/ckeditor5-collapsible/theme/collapsible.css
@@ -137,12 +137,20 @@
 
     /* Body-paragraph placeholder ("Content") is registered on the first body
      * block. Hide it whenever the body has more than one block — the hint is
-     * only useful when the body is a single empty <p>. `:has(> :nth-child(3))`
-     * matches a <details> with summary + 2+ body children; `:not(:last-child)`
-     * would only hide the placeholder on non-last paragraphs, leaving the last
-     * one (e.g. the original empty body after Enter-in-summary) still visible. */
-    &:has(> :nth-child(3)) > p.ck-placeholder::before {
+     * only useful when the body is a single empty <p>. The body blocks live in
+     * the editing-only `.trilium-collapsible-content` wrapper, so `:has(> :nth-child(2))`
+     * matches a wrapper with 2+ body children; `:not(:last-child)` would only hide
+     * the placeholder on non-last paragraphs, leaving the last one (e.g. the
+     * original empty body after Enter-in-summary) still visible. */
+    .trilium-collapsible-content:has(> :nth-child(2)) > p.ck-placeholder::before {
         display: none;
+    }
+
+    /* The shared `> *:last-child:not(summary)` rule now lands on the content
+     * wrapper (which has no margin of its own); zero the wrapper's last body
+     * block instead so the collapsible keeps its tight bottom padding. */
+    .trilium-collapsible-content > *:last-child {
+        margin-bottom: 0;
     }
 
     > summary {


### PR DESCRIPTION
## Problem

In the editor, dragging the mouse to select text inside a collapsible block (`<details>`) is capped to a **single paragraph** on Chromium/Electron. Firefox is unaffected.

Root-caused as a Chromium bug: inside a `contenteditable`, native mouse **drag-selection cannot cross the `::details-content` slot boundary** when the body blocks are direct children of `<details>`. Keyboard selection (Shift+↓) and *programmatic* selection cross it fine — only the drag algorithm doesn't, which is why the model/cache never saw a problem. It reproduces on Chromium 150 (well ahead of stable), and no CSS (`user-select`, `::details-content { … }`, `display`, `content-visibility`, …) works around it.

## Fix

Wrap the body blocks in a `<div class="trilium-collapsible-content">` in the **editing view** (`elementToStructure` + slots). A single wrapping container removes the selection boundary. `<summary>` stays a direct child of `<details>` (native collapse must keep it visible), so only the non-summary blocks are wrapped.

- **HTML signature unchanged** — the *data* downcast stays flat `<details><summary>…</summary><p>…</p></details>`. The wrapper exists only in the editing view; nothing new is saved, no migration, existing notes load identically.
- **Open-state preservation** — `elementToStructure` reconverts the `<details>` on every body-block change, which rebuilds it closed and would collapse a block mid-edit. A `WeakMap` of open state (fed by the arrow toggle, `setDetailsOpen`, and auto-open) is read back in the downcast `view()` to re-apply the `open` attribute. A post-render fix-up doesn't work here because CKEditor fires its `render` event *before* the DOM is reconciled — setting the attribute in `view()` lets the renderer apply it correctly.
- CSS: the body-placeholder-hide and last-child-margin rules were retargeted to the wrapper (editing view only; read/share view untouched).

## Validation

- 30/30 package tests pass (28 existing + 2 new: wrapper structure, and open-state survives a body-block change / reconversion). Typecheck + lint clean.
- Verified the actual fix in **real Chromium 150** against the exact DOM the plugin emits: selecting across all body paragraphs works, and dragging from inside the collapsible out across the `<details>` boundary works too.

Note: validated at the unit + isolated-browser level, not a full running-editor build — worth a quick manual smoke test that collapse/expand still feels right while editing a block's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)