### PR TITLE
fix(docker): pin Alpine base to 3.23, closes #10627

### DIFF
--- a/apps/server/Dockerfile.alpine
+++ b/apps/server/Dockerfile.alpine
@@ -1,4 +1,8 @@
-FROM node:24.18.0-alpine AS builder
+# Alpine is pinned to 3.23 deliberately: musl 1.2.6 (Alpine 3.24+) issues pwritev2, which hosts
+# with libseccomp < 2.3.3 deny with EPERM instead of ENOSYS. musl only falls back on ENOSYS, so
+# SQLite fails with "disk I/O error" there. Alpine 3.23 ships musl 1.2.5 and is supported until
+# 2027-11-01. See https://github.com/TriliumNext/Trilium/issues/10627
+FROM node:24.18.0-alpine3.23 AS builder
 RUN corepack enable
 
 # Install build tools required to compile native addons (e.g. better-sqlite3) on ARM
@@ -10,7 +14,7 @@ COPY ./docker/package.json ./docker/pnpm-workspace.yaml /usr/src/app/
 # We have to use --no-frozen-lockfile due to CKEditor patches
 RUN pnpm install --no-frozen-lockfile --prod && pnpm rebuild
 
-FROM node:24.18.0-alpine
+FROM node:24.18.0-alpine3.23
 # Install runtime dependencies
 RUN apk add --no-cache su-exec shadow
 


### PR DESCRIPTION
Fixes #10627 — `SqliteError: disk I/O error` on container startup, reported after upgrading v0.103.0 → v0.104.0.

## Root cause

The `linux/amd64` image is Alpine-based. Between the two releases its base moved **Alpine 3.23.4 → 3.24.1**, which bumped **musl 1.2.5 → 1.2.6**. musl 1.2.6 routes SQLite's positional writes through `pwritev2`.

`pwritev2` is absent from the libseccomp syscall table until **2.3.3** (Jan 2018) — I checked `src/arch-x86_64-syscalls.c` at `v2.3.1`, `v2.3.3` and `v2.4.0`. runc resolves Docker's seccomp allowlist by *name* through the host's libseccomp and silently skips names it cannot resolve, so on such a host the `pwritev2` allow-rule is dropped and the syscall falls through to the profile's `defaultAction` — `SCMP_ACT_ERRNO`, **EPERM**.

musl falls back to `pwrite` **only on ENOSYS, never on EPERM**, so SQLite surfaces it as `SQLITE_IOERR_*`.

Two things this explains that the original diagnosis did not:

- **Upgrading Docker does not help.** runc links the *host's* libseccomp, so the daemon version is irrelevant — matching the report of a failure on Docker 26.1.4.
- **`seccomp:unconfined` does help.** With no filter, `pwritev2` reaches the kernel, which on these older kernels genuinely lacks it (added in Linux 4.6) and returns ENOSYS, so musl falls back correctly.

## Fix

Pin the base to `node:24.18.0-alpine3.23` (musl 1.2.5), which does not issue `pwritev2`.

- **No size change** — 618 MB, identical to the unpinned build
- **Keeps Node 24**
- **Supported until 2027-11-01** — longer than the Debian bullseye alternative (2026-08-31)

Renovate preserves the compatibility suffix when bumping Node (it kept `bullseye-slim` and `alpine` across every past bump, including 22 → 24 in 05f3f9627d), so no Renovate rule is needed to hold the pin. The in-file comment records *why* it is pinned, since the eventual risk is the pin going stale rather than regressing.

## Verification

Built on `linux/amd64` and run under a seccomp profile denying `pwritev2`/`preadv2` (and `clone3`) with EPERM, simulating an old-libseccomp host:

| Image | Old-libseccomp sim | Default seccomp |
|---|---|---|
| Alpine 3.24 (current `main`) | ❌ `SQLITE_IOERR_WRITE` | ✅ |
| **Alpine 3.23 (this PR)** | ✅ `Listening on port 8080` | ✅ |
| v0.103.0 (control, musl 1.2.5) | ✅ | ✅ |
| v0.104.0 (control, musl 1.2.6) | ❌ `SQLITE_IOERR_*` | ✅ |

Healthcheck reaches `healthy` (~10 s), so the `require-healthy` gate in `test_docker` is unaffected.

Also confirmed the errno is the deciding factor: denying `pwritev2` with **ENOSYS (38)** instead of **EPERM (1)** lets the *unpinned* Alpine image start normally. That gives affected users a safer workaround than `seccomp:unconfined` — take Docker's default profile and set `"defaultErrnoRet": 38`, which keeps full syscall filtering.

## Scope

This is deliberately the minimal fix. It does not address the separate finding that the published manifest mixes base images per architecture (amd64 = Alpine/musl, arm64 + armv7 = Debian/glibc), nor the ~1.65× performance gap measured between musl and glibc on allocation-heavy SQLite reads. Those are worth a separate discussion.

Note that this pin is a deferral, not a cure: every Alpine from 3.24 on carries musl ≥ 1.2.6, so the same wall returns in Nov 2027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
