### PR TITLE
fix(docker): repair the rootless images

### DIFF
--- a/apps/server/Dockerfile.alpine.rootless
+++ b/apps/server/Dockerfile.alpine.rootless
@@ -1,4 +1,8 @@
-FROM node:24.18.0-alpine AS builder
+# Alpine is pinned to 3.23 deliberately: musl 1.2.6 (Alpine 3.24+) issues pwritev2, which hosts
+# with libseccomp < 2.3.3 deny with EPERM instead of ENOSYS. musl only falls back on ENOSYS, so
+# SQLite fails with "disk I/O error" there. Alpine 3.23 ships musl 1.2.5 and is supported until
+# 2027-11-01. See https://github.com/TriliumNext/Trilium/issues/10627
+FROM node:24.18.0-alpine3.23 AS builder
 RUN corepack enable
 
 # Install build tools required to compile native addons (e.g. better-sqlite3) on ARM
@@ -10,7 +14,7 @@ COPY ./docker/package.json ./docker/pnpm-workspace.yaml /usr/src/app/
 # We have to use --no-frozen-lockfile due to CKEditor patches
 RUN pnpm install --no-frozen-lockfile --prod && pnpm rebuild
 
-FROM node:24.18.0-alpine
+FROM node:24.18.0-alpine3.23
 # Create a non-root user with configurable UID/GID
 ARG USER=trilium
 ARG UID=1001
@@ -26,13 +30,17 @@ RUN apk add --no-cache dumb-init && \
     addgroup -g ${GID} ${USER} && \
     adduser -u ${UID} -G ${USER} -s /bin/sh -D -h /home/${USER} ${USER}
 
+# Create the app directory up front so it belongs to the user; WORKDIR alone would create it
+# as root.
+RUN mkdir -p /home/${USER}/app && chown ${USER}:${USER} /home/${USER}/app
 WORKDIR /home/${USER}/app
-COPY ./dist /home/${USER}/app
+# Ownership is set as part of each COPY. A trailing `chown -R` would instead rewrite every file
+# into an extra layer, roughly doubling the image.
+COPY --chown=${USER}:${USER} ./dist /home/${USER}/app
 # Also copy the rootless entrypoint script
-COPY rootless-entrypoint.sh /home/${USER}/app/
+COPY --chown=${USER}:${USER} rootless-entrypoint.sh /home/${USER}/app/
 RUN rm -rf /home/${USER}/app/node_modules/better-sqlite3
-COPY --from=builder /usr/src/app/node_modules/better-sqlite3 /home/${USER}/app/node_modules/better-sqlite3
-RUN chown -R ${USER}:${USER} /home/${USER}
+COPY --from=builder --chown=${USER}:${USER} /usr/src/app/node_modules/better-sqlite3 /home/${USER}/app/node_modules/better-sqlite3
 
 # Configure container
 USER ${USER}
@@ -50,4 +58,4 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # Use the entrypoint script
 CMD [ "bash", "./rootless-entrypoint.sh" ]
 
-HEALTHCHECK --start-period=10s CMD node /home/${USER}/app/docker_healthcheck.js
+HEALTHCHECK --start-period=10s CMD node /home/${USER}/app/docker_healthcheck.cjs

--- a/apps/server/Dockerfile.rootless
+++ b/apps/server/Dockerfile.rootless
@@ -32,13 +32,17 @@ RUN rm -rf \
     groupadd -g ${GID} ${USER} && \
     useradd -u ${UID} -g ${USER} -s /bin/sh -m ${USER}
 
+# Create the app directory up front so it belongs to the user; WORKDIR alone would create it
+# as root.
+RUN mkdir -p /home/${USER}/app && chown ${USER}:${USER} /home/${USER}/app
 WORKDIR /home/${USER}/app
-COPY ./dist /home/${USER}/app
+# Ownership is set as part of each COPY. A trailing `chown -R` would instead rewrite every file
+# into an extra layer, roughly doubling the image.
+COPY --chown=${USER}:${USER} ./dist /home/${USER}/app
 # Also copy the rootless entrypoint script
-COPY rootless-entrypoint.sh /home/${USER}/app/
+COPY --chown=${USER}:${USER} rootless-entrypoint.sh /home/${USER}/app/
 RUN rm -rf /home/${USER}/app/node_modules/better-sqlite3
-COPY --from=builder /usr/src/app/node_modules/better-sqlite3 /home/${USER}/app/node_modules/better-sqlite3
-RUN chown -R ${USER}:${USER} /home/${USER}
+COPY --from=builder --chown=${USER}:${USER} /usr/src/app/node_modules/better-sqlite3 /home/${USER}/app/node_modules/better-sqlite3
 
 # Configure container
 USER ${USER}
@@ -53,4 +57,4 @@ ENV TRILIUM_DATA_DIR=/home/${USER}/trilium-data
 # Use the entrypoint script
 CMD [ "bash", "./rootless-entrypoint.sh" ]
 
-HEALTHCHECK --start-period=10s CMD node /home/${USER}/app/docker_healthcheck.js
+HEALTHCHECK --start-period=10s CMD node /home/${USER}/app/docker_healthcheck.cjs

--- a/docker-compose.rootless.yml
+++ b/docker-compose.rootless.yml
@@ -8,7 +8,7 @@ services:
   trilium:
     # Optionally, replace `latest` with a version tag like `v0.90.3`
     # Using `latest` may cause unintended updates to the container
-    image: triliumnext/notes:rootless
+    image: triliumnext/trilium:rootless
     restart: unless-stopped
     environment:
       - TRILIUM_DATA_DIR=/home/trilium/trilium-data


### PR DESCRIPTION
Groundwork for #5790. The rootless images have never actually worked; this fixes them so they can be published. **It does not publish them** — see below.

## What was broken

**Healthcheck (blocking).** Both rootless Dockerfiles probe `docker_healthcheck.js`, but the build emits `docker_healthcheck.cjs` ([apps/server/scripts/build.ts](https://github.com/TriliumNext/Trilium/blob/main/apps/server/scripts/build.ts)). The non-rootless files were corrected in 9867d1ab9f (May 2025); the fix was never propagated. Every rootless container built since has gone `unhealthy`:

```
Error: Cannot find module '/home/trilium/app/docker_healthcheck.js'
  code: 'MODULE_NOT_FOUND'
```

The app itself runs fine — only the probe fails — which is why it went unnoticed for 14 months. It also blocks publishing outright, since `test_docker` gates on `require-healthy: true`.

**Image size.** A trailing `chown -R ${USER}:${USER} /home/${USER}` rewrote all ~4380 files into an extra layer, roughly doubling each image. Setting ownership on the `COPY` instructions instead:

| | before | after |
|---|---|---|
| `Dockerfile.alpine.rootless` | 985 MB | **618 MB** (−367) |
| `Dockerfile.rootless` | 1.09 GB | **719 MB** (−371) |

Both now match their non-rootless counterparts (618 MB / 723 MB). The app directory is created explicitly beforehand, since `WORKDIR` alone would create it root-owned.

**Alpine base.** Pinned to 3.23, matching #10630, so the rootless variant doesn't ship the #10627 `disk I/O error` regression to anyone building locally.

**Compose file.** `docker-compose.rootless.yml` referenced `triliumnext/notes:rootless` — both the pre-rename organisation and a tag that doesn't exist.

## Verification

Built and run on `linux/amd64`:

| | Debian rootless | Alpine rootless |
|---|---|---|
| healthcheck | ✅ `healthy` in ~10 s (was: `unhealthy` forever) | ✅ `healthy` in ~10 s |
| runs as | `uid=1001(trilium)` | `uid=1001(trilium)` |
| data dir | created, writable, `document.db` + `-shm` present | same |
| base | bullseye 11.11 | alpine 3.23.5 |

**Ownership is byte-for-byte identical to the previous images.** Since dropping `chown -R` was the riskiest change, I compared both builds directly — `find /home/trilium -not -user trilium` returns **0 of 4382** paths (Alpine) and **0 of 4385** (Debian), in both the old and new builds.

## Why this does not enable publishing

#7050 attempted that and was reverted in #7082 because it stopped pushing branch tags on `main`. Reading that diff, it failed for two distinct reasons, both avoidable:

1. **The digest sets were never partitioned.** All digests land in one directory via `merge-multiple: true`, so `$(printf '...@sha256:%s ' *)` globbed *everything*. `ROOTLESS_IMAGES` was byte-identical to the standard set, so each tag's index got both variants for the same platform.
2. **`if: startsWith(github.ref, 'refs/tags/')`** was added to the manifest step, which is precisely what stopped `main` from being tagged.

Fixing that means giving the build matrix a `variant`, naming digest artifacts accordingly, and running the tag loop once per variant — plus a decision on the tag scheme (docs promise both `:rootless` and `:rootless-alpine`, which is two manifests, not one) and on which platforms rootless should cover. That's a separate change with real design choices and a track record of breaking releases, so I've kept it out of this PR. Note the merge job has since been rewritten to use `crane` (2de2709420), so it'll need redoing against the current shape rather than reviving #7050.

Until that lands, these images are still build-it-yourself (`pnpm docker-build-rootless-debian` / `-alpine`) — but they now produce something that actually reports healthy, which #5790's reporters could not get.

## Not addressed

- `Dockerfile.rootless` has no `dumb-init`, so node runs as PID 1 with no reaper; the Alpine variant does. Left alone to avoid adding a dependency in a fix PR.
- Its builder stage sets `WORKDIR /usr/src/app/build` while the manifest is copied to `/usr/src/app/` — works only because pnpm walks up to find the workspace root.
- The docs still advertise `docker pull triliumnext/trilium:rootless`, which 404s until publishing is wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
