### PR TITLE
OneNote import: figures/captions, table widths & shading, theme-adaptive ink, and import-order fix

### DIFF
--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -273,6 +273,8 @@
     "select_sections": "Select the sections to import",
     "select_sections_hint": "OneNote doesn't include the original ordering in the import data, so sections and groups are sorted by creation date and may not match how they appear in OneNote.",
     "import": "Import selected",
+    "import_count_one": "Import {{count}} section",
+    "import_count_other": "Import {{count}} sections",
     "attach_source": "Attach original HTML (debug)",
     "attach_source_hint": "Saves each page's unmodified OneNote HTML as an attachment on the imported note, for comparing against the converted result."
   },

--- a/apps/client/src/widgets/dialogs/import/import_dialog.css
+++ b/apps/client/src/widgets/dialogs/import/import_dialog.css
@@ -89,31 +89,16 @@
     }
 
     .onenote-notebooks {
-        display: flex;
-        flex-direction: column;
-        gap: 1em;
         max-height: 45vh;
         overflow-y: auto;
-    }
 
-    .onenote-notebook {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25em;
-    }
+        /* Notebooks are the tree's roots; set them apart like the headings they replaced. */
+        > .checkbox-tree {
+            gap: 0.5em;
+        }
 
-    .onenote-section-group {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25em;
-        padding-left: 1.25em;
-        border-left: 1px solid var(--main-border-color);
-        margin-left: 0.25em;
-    }
-
-    .onenote-section-group-title {
-        color: var(--muted-text-color);
-        font-size: 0.9em;
-        font-weight: bold;
+        > .checkbox-tree > .checkbox-tree-container > .checkbox-tree-row .form-check-label {
+            font-weight: bold;
+        }
     }
 }

--- a/apps/client/src/widgets/dialogs/import/onenote.tsx
+++ b/apps/client/src/widgets/dialogs/import/onenote.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 
 import { t } from "../../../services/i18n.js";
 import onenoteImport, { buildSectionSelections, type OneNoteAccount, type OneNoteContainer, type OneNoteDeviceLogin, type OneNoteNotebook, orderedChildren } from "../../../services/onenote_import.js";
@@ -6,7 +6,7 @@ import toast from "../../../services/toast.js";
 import { isElectron, randomString } from "../../../services/utils.js";
 import Button from "../../react/Button.js";
 import { Card, CardSection } from "../../react/Card.js";
-import FormCheckbox from "../../react/FormCheckbox.js";
+import CheckboxTree, { type CheckboxTreeNode } from "../../react/CheckboxTree.js";
 import { useTriliumOptionBool } from "../../react/hooks.js";
 import LoadingSpinner from "../../react/LoadingSpinner.js";
 import NoItems from "../../react/NoItems.js";
@@ -156,17 +156,11 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
         setPhase("disconnected");
     }, [stopPolling]);
 
-    const toggleSection = useCallback((id: string, checked: boolean) => {
-        setSelectedIds((prev) => {
-            const next = new Set(prev);
-            if (checked) {
-                next.add(id);
-            } else {
-                next.delete(id);
-            }
-            return next;
-        });
-    }, []);
+    const treeNodes = useMemo(() => notebooks.map((notebook): CheckboxTreeNode => ({
+        id: notebook.id,
+        label: notebook.title,
+        children: buildTreeNodes(notebook)
+    })), [notebooks]);
 
     const doImport = useCallback(async () => {
         const sections = buildSectionSelections(notebooks, selectedIds);
@@ -193,18 +187,19 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     doImportRef.current = doImport;
 
     // Surface the import button in the dialog's pinned footer once notebooks are loaded; the other
-    // phases set it to null so the connect screens show no footer.
-    const importDisabled = selectedIds.size === 0;
+    // phases set it to null so the connect screens show no footer. The button carries the selection
+    // count as feedback that a bulk (notebook/group) toggle selected what the user expected.
+    const selectedCount = selectedIds.size;
     useEffect(() => {
         setFooter(phase !== "ready" ? null : (
             <Button
-                text={t("onenote_import.import")}
+                text={selectedCount > 0 ? t("onenote_import.import_count", { count: selectedCount }) : t("onenote_import.import")}
                 kind="primary"
-                disabled={importDisabled}
+                disabled={selectedCount === 0}
                 onClick={() => void doImportRef.current()}
             />
         ));
-    }, [phase, importDisabled, setFooter]);
+    }, [phase, selectedCount, setFooter]);
 
     if (phase === "checking") {
         return (
@@ -260,12 +255,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
                         <>
                             <OptionsRow name="onenote-sections" label={t("onenote_import.select_sections")} description={t("onenote_import.select_sections_hint")} stacked>
                                 <div className="onenote-notebooks">
-                                    {notebooks.map((notebook) => (
-                                        <div className="onenote-notebook" key={notebook.id}>
-                                            <strong>{notebook.title}</strong>
-                                            <SectionTree container={notebook} selectedIds={selectedIds} onToggle={toggleSection} />
-                                        </div>
-                                    ))}
+                                    <CheckboxTree nodes={treeNodes} selectedIds={selectedIds} onChange={setSelectedIds} />
                                 </div>
                             </OptionsRow>
                             <OptionsRowWithToggle
@@ -290,34 +280,14 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     );
 }
 
-/** Renders a notebook's (or section group's) sections as checkboxes and recurses into nested section
- *  groups. Sections and groups are interleaved in creation-date order so the picker mirrors the OneNote
- *  left rail (which the API can't reproduce exactly — see the order caveat above the list). */
-function SectionTree({ container, selectedIds, onToggle }: {
-    container: OneNoteContainer;
-    selectedIds: Set<string>;
-    onToggle: (id: string, checked: boolean) => void;
-}) {
-    return (
-        <>
-            {orderedChildren(container).map((child) => (child.type === "section"
-                ? (
-                    <FormCheckbox
-                        key={child.section.id}
-                        name={`onenote-section-${child.section.id}`}
-                        label={child.section.title}
-                        currentValue={selectedIds.has(child.section.id)}
-                        onChange={(checked) => onToggle(child.section.id, checked)}
-                    />
-                )
-                : (
-                    <div className="onenote-section-group" key={child.group.id}>
-                        <span className="onenote-section-group-title">{child.group.title}</span>
-                        <SectionTree container={child.group} selectedIds={selectedIds} onToggle={onToggle} />
-                    </div>
-                )))}
-        </>
-    );
+/** Maps a notebook's (or section group's) children onto picker tree nodes: sections become leaves,
+ *  section groups become (recursed) containers. Sections and groups are interleaved in creation-date
+ *  order so the picker mirrors the OneNote left rail (which the API can't reproduce exactly — see the
+ *  order caveat above the list). */
+function buildTreeNodes(container: OneNoteContainer): CheckboxTreeNode[] {
+    return orderedChildren(container).map((child) => (child.type === "section"
+        ? { id: child.section.id, label: child.section.title }
+        : { id: child.group.id, label: child.group.title, children: buildTreeNodes(child.group) }));
 }
 
 const provider: ImportProvider = {

--- a/apps/client/src/widgets/react/CheckboxTree.css
+++ b/apps/client/src/widgets/react/CheckboxTree.css
@@ -1,0 +1,68 @@
+ul.checkbox-tree,
+.checkbox-tree ul.checkbox-tree-level {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+}
+
+.checkbox-tree {
+    /* Nested levels indent past the parent's caret and pick up a guide line. */
+    .checkbox-tree-container > .checkbox-tree-level {
+        margin-top: 0.25em;
+        margin-inline-start: 0.6em;
+        padding-inline-start: 1em;
+        border-inline-start: 1px solid var(--main-border-color);
+    }
+
+    .checkbox-tree-row {
+        display: flex;
+        align-items: center;
+        gap: 0.25em;
+
+        .form-checkbox {
+            min-width: 0;
+        }
+    }
+
+    .checkbox-tree-caret {
+        flex-shrink: 0;
+        width: 1.5em;
+        /* Center the icon glyph itself: without this the button lays the oversized icon out on the
+           text baseline, leaving the chevron visibly high against the checkbox row. */
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        align-self: center;
+        line-height: 1;
+        padding: 0;
+        border: none;
+        background: none;
+        color: var(--main-text-color);
+        cursor: pointer;
+
+        .arrow {
+            font-size: 1.2em;
+            line-height: 1;
+            transition: transform 150ms ease-in;
+
+            &.expanded {
+                transform: rotate(90deg);
+            }
+        }
+    }
+
+    /* Leaves have no caret; keep their checkboxes aligned with sibling containers'. */
+    .checkbox-tree-leaf {
+        padding-inline-start: calc(1.5em + 0.25em);
+    }
+
+    .checkbox-tree-count {
+        flex-shrink: 0;
+        color: var(--muted-text-color);
+        border: 1px solid var(--main-border-color);
+        font-weight: normal;
+    }
+}

--- a/apps/client/src/widgets/react/CheckboxTree.spec.tsx
+++ b/apps/client/src/widgets/react/CheckboxTree.spec.tsx
@@ -1,0 +1,165 @@
+import { render } from "preact";
+import { useState } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import CheckboxTree, { type CheckboxTreeNode } from "./CheckboxTree";
+
+/**
+ * Work ─┬─ Meetings           (leaf)
+ *       ├─ Projects           (leaf)
+ *       └─ Archive  ─┬─ Old plans   (leaf)
+ *                    └─ Newer plans (leaf)
+ * Empty notebook     (container without any descendant leaves)
+ */
+const NODES: CheckboxTreeNode[] = [
+    {
+        id: "work",
+        label: "Work",
+        children: [
+            { id: "meetings", label: "Meetings" },
+            { id: "projects", label: "Projects" },
+            {
+                id: "archive",
+                label: "Archive",
+                children: [
+                    { id: "plansOld", label: "Old plans" },
+                    { id: "plansNew", label: "Newer plans" }
+                ]
+            }
+        ]
+    },
+    { id: "empty", label: "Empty notebook", children: [] }
+];
+
+let container: HTMLDivElement | undefined;
+
+function mount(vnode: Parameters<typeof render>[0]) {
+    const target = document.createElement("div");
+    container = target;
+    document.body.appendChild(target);
+    void act(() => render(vnode, target));
+    return target;
+}
+
+afterEach(() => {
+    if (container) {
+        render(null, container);
+        container.remove();
+        container = undefined;
+    }
+});
+
+/** Clicks inside act() so Preact flushes the resulting re-render before assertions run. */
+function click(el: HTMLElement | null | undefined) {
+    expect(el, "click target").not.toBeNull();
+    void act(() => el?.click());
+}
+
+function checkboxFor(root: HTMLElement, id: string): HTMLInputElement {
+    const input = root.querySelector<HTMLInputElement>(`input[id^="checkbox-tree-${id}"]`);
+    if (!input) {
+        throw new Error(`no checkbox for ${id}`);
+    }
+    return input;
+}
+
+/** Renders the tree with its selection state held in a component, the way callers use it. */
+function Harness({ initialSelection = [], onChange }: { initialSelection?: string[]; onChange?: (next: Set<string>) => void }) {
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set(initialSelection));
+    return (
+        <CheckboxTree
+            nodes={NODES}
+            selectedIds={selectedIds}
+            onChange={(next) => {
+                setSelectedIds(next);
+                onChange?.(next);
+            }}
+        />
+    );
+}
+
+describe("CheckboxTree", () => {
+    it("derives container states from selected leaves: unchecked → indeterminate → checked", () => {
+        const root = mount(<Harness />);
+        const work = () => checkboxFor(root, "work");
+
+        expect(work().checked).toBe(false);
+        expect(work().indeterminate).toBe(false);
+
+        click(checkboxFor(root, "meetings"));
+        expect(work().checked).toBe(false);
+        expect(work().indeterminate).toBe(true);
+
+        // Selecting a partially selected container selects the remainder, everywhere beneath it.
+        click(work());
+        expect(work().checked).toBe(true);
+        expect(work().indeterminate).toBe(false);
+        expect(checkboxFor(root, "archive").checked).toBe(true);
+        expect(checkboxFor(root, "projects").checked).toBe(true);
+    });
+
+    it("toggles all descendant leaves through a container and reports the full selection", () => {
+        const onChange = vi.fn();
+        const root = mount(<Harness onChange={onChange} />);
+
+        click(checkboxFor(root, "work"));
+        expect(onChange).toHaveBeenLastCalledWith(new Set(["meetings", "projects", "plansOld", "plansNew"]));
+
+        // A fully selected container deselects everything beneath it.
+        click(checkboxFor(root, "work"));
+        expect(onChange).toHaveBeenLastCalledWith(new Set());
+    });
+
+    it("keeps leaf toggling independent and unchecks the container when its last leaf is dropped", () => {
+        const onChange = vi.fn();
+        const root = mount(<Harness initialSelection={["meetings"]} onChange={onChange} />);
+
+        click(checkboxFor(root, "projects"));
+        expect(onChange).toHaveBeenLastCalledWith(new Set(["meetings", "projects"]));
+
+        click(checkboxFor(root, "meetings"));
+        click(checkboxFor(root, "projects"));
+        expect(onChange).toHaveBeenLastCalledWith(new Set());
+        expect(checkboxFor(root, "work").indeterminate).toBe(false);
+    });
+
+    it("disables containers without descendant leaves and gives them no caret", () => {
+        const root = mount(<Harness />);
+        const empty = checkboxFor(root, "empty");
+
+        expect(empty.disabled).toBe(true);
+        const emptyRow = empty.closest(".checkbox-tree-row");
+        expect(emptyRow?.querySelector("button.checkbox-tree-caret")).toBeNull();
+    });
+
+    it("expands roots by default, collapses deeper containers behind a caret with a count badge", () => {
+        const root = mount(<Harness initialSelection={["plansOld"]} />);
+
+        // Root level is expanded (its leaves are rendered), the nested group is not.
+        expect(root.querySelector(`input[id^="checkbox-tree-meetings"]`)).not.toBeNull();
+        expect(root.querySelector(`input[id^="checkbox-tree-plansOld"]`)).toBeNull();
+
+        // The collapsed group still surfaces its hidden selection as "selected / total".
+        const archiveRow = checkboxFor(root, "archive").closest(".checkbox-tree-row");
+        expect(archiveRow?.querySelector(".checkbox-tree-count")?.textContent).toBe("1 / 2");
+        expect(checkboxFor(root, "archive").indeterminate).toBe(true);
+
+        // Expanding reveals the leaves and hides the badge; collapsing restores it.
+        const caret = archiveRow?.querySelector<HTMLButtonElement>("button.checkbox-tree-caret");
+        expect(caret?.getAttribute("aria-expanded")).toBe("false");
+        click(caret);
+        expect(caret?.getAttribute("aria-expanded")).toBe("true");
+        expect(root.querySelector(`input[id^="checkbox-tree-plansOld"]`)).not.toBeNull();
+        expect(root.querySelector(".checkbox-tree-count")).toBeNull();
+        click(caret);
+        expect(root.querySelector(`input[id^="checkbox-tree-plansOld"]`)).toBeNull();
+        expect(root.querySelector(".checkbox-tree-count")?.textContent).toBe("1 / 2");
+    });
+
+    it("shows plain totals on collapsed containers without any selection", () => {
+        const root = mount(<Harness />);
+        const archiveRow = checkboxFor(root, "archive").closest(".checkbox-tree-row");
+        expect(archiveRow?.querySelector(".checkbox-tree-count")?.textContent).toBe("2");
+    });
+});

--- a/apps/client/src/widgets/react/CheckboxTree.tsx
+++ b/apps/client/src/widgets/react/CheckboxTree.tsx
@@ -1,0 +1,154 @@
+import "./CheckboxTree.css";
+
+import clsx from "clsx";
+import { useMemo, useState } from "preact/hooks";
+
+import SimpleBadge from "./Badge";
+import FormCheckbox from "./FormCheckbox";
+import Icon from "./Icon";
+
+export interface CheckboxTreeNode {
+    id: string;
+    label: string;
+    /** Present (possibly empty) on container nodes; absent on selectable leaves. */
+    children?: CheckboxTreeNode[];
+}
+
+interface CheckboxTreeProps {
+    nodes: CheckboxTreeNode[];
+    /** Selected leaf ids — the single source of truth; container checkbox states are derived from it. */
+    selectedIds: Set<string>;
+    onChange(next: Set<string>): void;
+    /** Containers shallower than this many levels start expanded. Defaults to 1 (root containers only). */
+    defaultExpandedDepth?: number;
+}
+
+/**
+ * A tree of checkboxes for picking a subset of leaves out of a hierarchy. Leaves toggle themselves;
+ * containers show a tri-state checkbox (checked / indeterminate / unchecked) derived from their
+ * descendant leaves and toggle all of them at once. Containers can be collapsed, in which case a
+ * badge keeps the selection visible as "selected / total" leaf counts.
+ *
+ * Selection is controlled: the caller owns the set of selected leaf ids and receives the whole next
+ * set on every change. Node ids must be unique across the entire tree.
+ */
+export default function CheckboxTree({ nodes, selectedIds, onChange, defaultExpandedDepth = 1 }: CheckboxTreeProps) {
+    const leafIdsByContainer = useMemo(() => {
+        const map = new Map<string, string[]>();
+        collectLeafIds(nodes, map);
+        return map;
+    }, [nodes]);
+
+    // Expansion is tracked as per-node overrides on top of the depth-based default rather than as a
+    // set of expanded ids, so nodes arriving after mount (async loads) still get the default.
+    const [expandOverrides, setExpandOverrides] = useState<ReadonlyMap<string, boolean>>(new Map());
+
+    const toggleExpanded = (id: string, expandedByDefault: boolean) => {
+        setExpandOverrides((prev) => {
+            const next = new Map(prev);
+            next.set(id, !(prev.get(id) ?? expandedByDefault));
+            return next;
+        });
+    };
+
+    const toggleLeaf = (id: string, checked: boolean) => {
+        const next = new Set(selectedIds);
+        if (checked) {
+            next.add(id);
+        } else {
+            next.delete(id);
+        }
+        onChange(next);
+    };
+
+    // A partially selected container selects the remainder (the file-picker convention);
+    // only a fully selected one deselects.
+    const toggleContainer = (leafIds: string[], allSelected: boolean) => {
+        const next = new Set(selectedIds);
+        for (const id of leafIds) {
+            if (allSelected) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+        }
+        onChange(next);
+    };
+
+    const renderLevel = (levelNodes: CheckboxTreeNode[], depth: number) => (
+        <ul className={clsx("checkbox-tree-level", { "checkbox-tree": depth === 0 })}>
+            {levelNodes.map((node) => {
+                if (!node.children) {
+                    return (
+                        <li key={node.id} className="checkbox-tree-leaf">
+                            <FormCheckbox
+                                name={`checkbox-tree-${node.id}`}
+                                label={node.label}
+                                currentValue={selectedIds.has(node.id)}
+                                onChange={(checked) => toggleLeaf(node.id, checked)}
+                            />
+                        </li>
+                    );
+                }
+
+                const leafIds = leafIdsByContainer.get(node.id) ?? [];
+                const selectedCount = leafIds.reduce((count, id) => count + (selectedIds.has(id) ? 1 : 0), 0);
+                const allSelected = leafIds.length > 0 && selectedCount === leafIds.length;
+                const expandedByDefault = depth < defaultExpandedDepth;
+                const expanded = node.children.length > 0 && (expandOverrides.get(node.id) ?? expandedByDefault);
+
+                return (
+                    <li key={node.id} className="checkbox-tree-container">
+                        <div className="checkbox-tree-row">
+                            {node.children.length > 0
+                                ? (
+                                    <button
+                                        type="button"
+                                        className="checkbox-tree-caret tn-low-profile"
+                                        aria-expanded={expanded}
+                                        aria-label={node.label}
+                                        onClick={() => toggleExpanded(node.id, expandedByDefault)}
+                                    >
+                                        <Icon className={clsx("arrow", { expanded })} icon="bx bx-chevron-right" />
+                                    </button>
+                                )
+                                : <span className="checkbox-tree-caret" />}
+                            <FormCheckbox
+                                name={`checkbox-tree-${node.id}`}
+                                label={node.label}
+                                currentValue={allSelected}
+                                indeterminate={selectedCount > 0 && !allSelected}
+                                disabled={leafIds.length === 0}
+                                onChange={() => toggleContainer(leafIds, allSelected)}
+                            />
+                            {!expanded && leafIds.length > 0 && (
+                                <SimpleBadge
+                                    className="checkbox-tree-count"
+                                    title={selectedCount > 0 ? `${selectedCount} / ${leafIds.length}` : `${leafIds.length}`}
+                                />
+                            )}
+                        </div>
+                        {expanded && renderLevel(node.children, depth + 1)}
+                    </li>
+                );
+            })}
+        </ul>
+    );
+
+    return renderLevel(nodes, 0);
+}
+
+/** Fills `map` with each container's transitive leaf ids and returns the ids for the given level. */
+function collectLeafIds(nodes: CheckboxTreeNode[], map: Map<string, string[]>): string[] {
+    const leafIds: string[] = [];
+    for (const node of nodes) {
+        if (node.children) {
+            const childLeafIds = collectLeafIds(node.children, map);
+            map.set(node.id, childLeafIds);
+            leafIds.push(...childLeafIds);
+        } else {
+            leafIds.push(node.id);
+        }
+    }
+    return leafIds;
+}

--- a/apps/client/src/widgets/react/FormCheckbox.tsx
+++ b/apps/client/src/widgets/react/FormCheckbox.tsx
@@ -13,14 +13,26 @@ interface FormCheckboxProps {
      */
     hint?: string;
     currentValue: boolean;
+    /**
+     * Shows the native mixed state (a dash), e.g. for a parent whose children are partially selected.
+     * `indeterminate` is a DOM property only (there is no HTML attribute), so it is applied via a ref.
+     */
+    indeterminate?: boolean;
     disabled?: boolean;
     onChange(newValue: boolean): void;
     containerStyle?: CSSProperties;
 }
 
-export default function FormCheckbox({ name, disabled, label, currentValue, onChange, hint, containerStyle }: FormCheckboxProps) {
+export default function FormCheckbox({ name, disabled, label, currentValue, indeterminate, onChange, hint, containerStyle }: FormCheckboxProps) {
     const labelRef = useRef<HTMLLabelElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
     const id = useUniqueName(name);
+
+    useEffect(() => {
+        if (inputRef.current) {
+            inputRef.current.indeterminate = indeterminate ?? false;
+        }
+    }, [indeterminate]);
 
     useEffect(() => {
         if (!hint || !labelRef.current) return;
@@ -54,6 +66,7 @@ export default function FormCheckbox({ name, disabled, label, currentValue, onCh
             >
                 <input
                     id={id}
+                    ref={inputRef}
                     className="form-check-input"
                     type="checkbox"
                     name={id}

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI.html
@@ -7,9 +7,9 @@
   you pick also decides where your notes travel: a cloud API billed per use,
   a subscription you already pay for, or a model running on your own hardware,
   in which case nothing leaves the machine. See&nbsp;<a class="reference-link"
-  href="#root/pOsGYCXsbNQG/GBBMSlVSOIGP/_help_bkPZAMT7d2sR">Providers</a>&nbsp;for
-  what each involves, and&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/GBBMSlVSOIGP/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for
-  exactly what gets sent.</p>
+  href="#root/_help_bkPZAMT7d2sR">Providers</a>&nbsp;for what each involves, and&nbsp;
+  <a
+  class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for exactly what gets sent.</p>
 <p>Once enabled, the assistant is available both as a panel in the right
   sidebar and as a dedicated note type. It can read and modify notes through
   tools, which you can switch off per conversation if you would rather it
@@ -56,7 +56,7 @@
       <li>Currently only Claude Code is supported.</li>
     </ul>
   </li>
-  <li class="ck-list-marker-bold"><strong>Local or self-hosted LLM solutions</strong>
+  <li><strong>Local or self-hosted LLM solutions</strong>
     <ul>
       <li>Ollama</li>
       <li>LM Studio.</li>
@@ -67,9 +67,9 @@
     local or hosted (e.g. OpenRouter, Groq, Mistral).</li>
 </ul>
 <p>For more information about each provider, see&nbsp;<a class="reference-link"
-  href="#root/GBBMSlVSOIGP/_help_bkPZAMT7d2sR">Providers</a>. See the dedicated&nbsp;
-  <a
-  class="reference-link" href="#root/pOsGYCXsbNQG/GBBMSlVSOIGP/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;to better understand what data is sent to providers.</p>
+  href="#root/_help_bkPZAMT7d2sR">Providers</a>. See the dedicated&nbsp;<a class="reference-link"
+  href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;to better understand what data
+  is sent to providers.</p>
 <h2>Enabling the AI integration</h2>
 <p>To enable the AI integration, simply go to&nbsp;<a class="reference-link"
   href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>AI / LLM</em> and press

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Privacy.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Privacy.html
@@ -9,8 +9,8 @@
   <table>
     <thead>
       <tr>
-        <th scope="col">Provider type</th>
-        <th scope="col">Destination</th>
+        <th>Provider type</th>
+        <th>Destination</th>
       </tr>
     </thead>
     <tbody>
@@ -38,14 +38,14 @@
   by you, before anything is sent.</p>
 <h2>What is actually sent</h2>
 <ul>
-  <li class="ck-list-marker-bold"><strong>Always, with every message</strong>
+  <li><strong>Always, with every message</strong>
     <ul>
       <li>The conversation itself: your messages and the assistant's replies, including
         earlier turns</li>
       <li>Trilium's system prompt describing how to format answers and use tools.</li>
     </ul>
   </li>
-  <li class="ck-list-marker-bold"><strong>The current note, only when note context is enabled.</strong>
+  <li><strong>The current note, only when note context is enabled.</strong>
     <ul>
       <li>In the sidebar chat this is the file icon at the bottom; the dedicated
         chat note type never sends a current note.</li>
@@ -56,7 +56,7 @@
         the model must call a tool to read further.</li>
     </ul>
   </li>
-  <li class="ck-list-marker-bold"><strong>Any note the model asks for, when note access is enabled.</strong>
+  <li><strong>Any note the model asks for, when note access is enabled.</strong>
     <ul>
       <li>Tools let the model search your tree and read notes, attributes and attachments
         beyond the current one.</li>
@@ -71,8 +71,8 @@
     search terms reach the provider's own search infrastructure.</li>
 </ul>
 <h2>Protected notes</h2>
-<p>While your <a href="#root/pOsGYCXsbNQG/gh7bpGYxajRS/BFs8mudNFgCS/_help_bwg0e8ewQMak">protected session</a> is
-  locked, protected notes send neither title nor content. <strong>While it is unlocked they are treated like any other note</strong> —
+<p>While your <a href="#root/_help_bwg0e8ewQMak">protected session</a> is locked,
+  protected notes send neither title nor content. <strong>While it is unlocked they are treated like any other note</strong> —
   a note the model reads through a tool is sent to the provider in full.
   If you keep sensitive material in protected notes, be aware that unlocking
   them removes that boundary for the duration of the session.</p>
@@ -100,7 +100,7 @@
 <p>Your API key is stored in your database, sent only to the provider it
   belongs to, and is write-only through the options API so that a malevolent&nbsp;
   <a
-  class="reference-link" href="#root/pOsGYCXsbNQG/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;cannot access it. If you have backend or SQL console
+  class="reference-link" href="#root/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;cannot access it. If you have backend or SQL console
     access enabled, a malevolent script <strong>could potentially exfiltrate your API keys</strong>.</p>
 <p>The built-in MCP server has no authentication and exposes the same note
   tools to any application on your machine that can reach it. It is off by

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
@@ -22,7 +22,7 @@
     for a different cloud provider, make sure to discuss it over <a href="https://github.com/orgs/TriliumNext/discussions">GitHub Discussions</a>.</p>
 </aside>
 <aside class="admonition important">
-  <p>See also the dedicated&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/GBBMSlVSOIGP/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;section
+  <p>See also the dedicated&nbsp;<a class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;section
     to better understand what data is being sent to a cloud provider.</p>
 </aside>
 <h2>Subscription-based providers</h2>
@@ -67,7 +67,7 @@
     both Claude Code and Trilium updated to the latest version.</p>
 </aside>
 <aside class="admonition important">
-  <p>See also the dedicated&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/GBBMSlVSOIGP/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;section
+  <p>See also the dedicated&nbsp;<a class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;section
     to better understand what data is being sent to a cloud provider.</p>
 </aside>
 <h2>Local/self-hosted providers</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
@@ -33,11 +33,27 @@
   <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>&nbsp;with
     different bullet types.</li>
   <li><a class="reference-link" href="#root/_help_NdowYOC1GFKS">Tables</a>
+    <ul>
+      <li>Cell backgrounds are preserved, including a best-effort hue correction
+        because the colors returned by the Graph API are sometimes incorrect.</li>
+      <li>Cell widths are also preserved proportionally, with the only difference
+        that tables in Trilium have a percentage-based width, not fixed pixel sizes.</li>
+    </ul>
   </li>
-  <li>Images and&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
+  <li>Images and&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.
+    <ul>
+      <li>Screen clippings are also properly supported since v0.104.1, displaying
+        their timestamp as a figure caption.</li>
+    </ul>
+  </li>
   <li>To-do lists</li>
-  <li>Hand-drawing is preserved and displayed as an SVG image (however there
-    are some</li>
+  <li>Hand-drawing is preserved and displayed as an SVG image inside the note
+    <ul>
+      <li>OneNote's default color (black) is special since it also renders as white
+        for dark themes. Since v0.104.1, this is also supported by using a special
+        SVG tweak which reacts to light/dark themes.</li>
+    </ul>
+  </li>
   <li>Links between other imported pages are converted to&nbsp;<a class="reference-link"
     href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;if the text
     of the link matches the name of the page, or plain links otherwise. If
@@ -125,6 +141,7 @@
   <li>Revision history.</li>
   <li>Paragraph indentation.</li>
   <li>Section colors.</li>
+  <li>Drawings inside titles, the title might appear incomplete or “Untitled”.</li>
 </ul>
 <h2>Reporting issues</h2>
 <p>When importing notes, you might find that some text is not rendered properly

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -214,6 +214,26 @@ const RESOURCE_SAMPLE = `<html lang="en-US">
     </body>
 </html>`;
 
+// Real OneNote source (debug-captured): a "screen clipping" page — two standalone images, each
+// floating directly in the outline <div> and separated from its <cite> caption by OneNote's <br>
+// spacing. Left verbatim the caption renders as loose body text next to the image.
+const SCREEN_CLIPPING_SAMPLE = `<html lang="ro-RO">
+    <body data-absolute-enabled="true" style="font-family:Calibri;font-size:11pt">
+        <div style="position:absolute;left:48px;top:115px;width:720px">
+            <img width="577.5" height="277.5" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-aaa!1-BBB!sccc/$value" data-src-type="image/png" data-fullres-src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-aaa!1-BBB!sccc/$value" data-fullres-src-type="image/png" />
+            <br />
+            <cite lang="en-US" style="font-size:9pt;color:#595959;margin-top:0pt;margin-bottom:0pt">Screen clipping taken: 23.07.2026 21:40</cite>
+            <br />
+            <br />
+            <img width="385" height="509" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-ddd!1-BBB!sccc/$value" data-src-type="image/png" data-fullres-src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-ddd!1-BBB!sccc/$value" data-fullres-src-type="image/png" />
+            <br />
+            <cite lang="en-US" style="font-size:9pt;color:#595959;margin-top:0pt;margin-bottom:0pt">Screen clipping taken: 23.07.2026 21:40</cite>
+            <br />
+            <br />
+        </div>
+    </body>
+</html>`;
+
 // Real OneNote source (debug-captured): OneNote puts the list marker type on each <li> and wraps
 // item text in a margin-0 <p>. The marker type belongs on the <ul>/<ol> (CKEditor's representation),
 // and OneNote's lower-alpha/upper-alpha map to CKEditor's lower-latin/upper-latin.
@@ -435,6 +455,52 @@ describe("convertPageHtml", () => {
         expect(out).not.toContain("data-fullres-src");
         expect(out).not.toContain("data-src-type");
         expect(out).not.toContain("0-eee"); // the full-resolution resource id is gone
+    });
+
+    it("wraps a floating image and its trailing cite caption into a figure with a figcaption", () => {
+        const out = converter.convertPageHtml(SCREEN_CLIPPING_SAMPLE);
+        const root = parse(out);
+
+        // Each standalone image becomes a CKEditor block image (<figure class="image">).
+        const figures = root.querySelectorAll("figure.image");
+        expect(figures).toHaveLength(2);
+
+        const firstImg = figures[0].querySelector("img");
+        // The display dimensions are kept and carried into an aspect-ratio (CKEditor's stored form).
+        expect(firstImg?.getAttribute("width")).toBe("577.5");
+        expect(firstImg?.getAttribute("height")).toBe("277.5");
+        expect(firstImg?.getAttribute("style")).toContain("aspect-ratio:577.5/277.5");
+        // The Graph URL is left intact for the importer to swap for a local attachment reference.
+        expect(firstImg?.getAttribute("src")).toContain("/resources/0-aaa!1-BBB!sccc/$value");
+
+        // The caption is pulled in as the figure's <figcaption>, small and wrapped in a bare <cite>.
+        const figcaption = figures[0].querySelector("figcaption");
+        expect(figcaption?.querySelector("span.text-small cite")?.textContent).toContain("Screen clipping taken: 23.07.2026 21:40");
+        // OneNote's grey caption colour is dropped so the caption inherits the theme foreground.
+        expect(figcaption?.querySelector("cite")?.getAttribute("style") ?? "").not.toContain("color");
+
+        // Both captions are absorbed into a figcaption — none left floating as body text — and the
+        // <br> spacing between image and caption is gone.
+        expect(root.querySelectorAll("cite")).toHaveLength(2);
+        expect(root.querySelectorAll("figcaption cite")).toHaveLength(2);
+        expect(root.querySelectorAll("br")).toHaveLength(0);
+    });
+
+    it("wraps a caption-less floating image in a figure carrying its aspect ratio", () => {
+        const out = converter.convertPageHtml(`<body><div><img width="480" height="441" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /><br /></div></body>`);
+        const figure = parse(out).querySelector("figure.image");
+
+        expect(figure).toBeTruthy();
+        expect(figure?.querySelector("figcaption")).toBeFalsy();
+        expect(figure?.querySelector("img")?.getAttribute("style")).toContain("aspect-ratio:480/441");
+    });
+
+    it("leaves an inline image (inside a paragraph) unwrapped", () => {
+        const out = converter.convertPageHtml(`<body><div><p>before <img width="16" height="16" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /> after</p></div></body>`);
+        const root = parse(out);
+
+        expect(root.querySelectorAll("figure")).toHaveLength(0);
+        expect(root.querySelector("p img")).toBeTruthy();
     });
 
     it("converts inline-style formatting (bold/italic/underline) to semantic tags", () => {

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -359,6 +359,16 @@ describe("convertPageHtml", () => {
         ]);
     });
 
+    it("sorts outlines missing position coordinates as 0 and breaks top ties by left", () => {
+        const sample = `<body>
+            <div style="position:absolute;left:200px;top:100px"><p>right</p></div>
+            <div style="position:absolute;left:50px;top:100px"><p>left</p></div>
+            <div style="position:absolute"><p>unplaced</p></div>
+        </body>`;
+        const paragraphs = parse(converter.convertPageHtml(sample)).querySelectorAll("p").map((p) => p.textContent.trim());
+        expect(paragraphs).toEqual(["unplaced", "left", "right"]);
+    });
+
     it("moves OneNote list marker types from <li> onto the list, mapping alpha to latin", () => {
         const out = converter.convertPageHtml(LISTS_SAMPLE);
         const root = parse(out);
@@ -440,6 +450,22 @@ describe("convertPageHtml", () => {
         expect(parse(converter.convertPageHtml(sample)).querySelector("colgroup")).toBeFalsy();
     });
 
+    it("keeps a resized cell's other styles and appends to the table's existing class", () => {
+        // Both columns carry a width on the first row; the second row's cells have no style at all.
+        // Stripping the redundant widths must keep the shaded cell's background, leave the style-less
+        // cells alone, and append the resized marker to the table's pre-existing class.
+        const sample = `<body><div><table class="layout"><tr><td style="width:100;background-color:#b6d9a1">A</td><td style="width:300">B</td></tr><tr><td>C</td><td>D</td></tr></table></div></body>`;
+        const root = parse(converter.convertPageHtml(sample));
+
+        expect(root.querySelector("table")?.getAttribute("class")).toContain("ck-table-resized");
+        const cols = root.querySelectorAll("colgroup col").map((col) => col.getAttribute("style"));
+        expect(cols).toEqual(["width:25%", "width:75%"]);
+
+        const shaded = root.querySelectorAll("td").find((td) => td.textContent === "A");
+        expect(shaded?.getAttribute("style")).toContain("background-color:#b6d9a1");
+        expect(shaded?.getAttribute("style") ?? "").not.toContain("width");
+    });
+
     it("recovers OneNote's over-darkened table cell shading by reflecting its lightness", () => {
         // OneNote's Graph export returns cell shading as a dark shade of the colour it displays (same
         // hue and saturation, inverted lightness): a cell shown as #b6d9a1 comes back as #375623.
@@ -456,6 +482,24 @@ describe("convertPageHtml", () => {
         // so only dark cell backgrounds are reflected.
         const sample = `<body><div><table><tr><td style="background-color:#b6d9a1">A</td><td>B</td></tr></table></div></body>`;
         expect(converter.convertPageHtml(sample)).toContain("background-color:#b6d9a1");
+    });
+
+    it("reflects dark shading across the hue wheel, including grays and short hex", () => {
+        // One dark cell per rgbToHsl hue sector (the green-dominant sector is covered above): plain
+        // dark red, a magenta whose hue wraps past the top of the wheel, a blue-dominant navy, and an
+        // achromatic gray in the short #rgb form.
+        const sample = `<body><div><table><tr>
+            <td style="background-color:#8b0000">Dark red</td>
+            <td style="background-color:#400040">Dark magenta</td>
+            <td style="background-color:#000080">Navy</td>
+            <td style="background-color:#333">Dark gray</td>
+        </tr></table></div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).toContain("background-color:#ff7474"); // dark red -> light red, hue preserved
+        expect(out).toContain("background-color:#ffbfff"); // dark magenta -> light magenta
+        expect(out).toContain("background-color:#7f7fff"); // navy -> light blue
+        expect(out).toContain("background-color:#cccccc"); // gray stays achromatic, just lightened
     });
 
     it("converts OneNote to-do tags into a Trilium task list", () => {
@@ -543,6 +587,16 @@ describe("convertPageHtml", () => {
         expect(out).not.toContain("0-eee"); // the full-resolution resource id is gone
     });
 
+    it("fills in defaults for an attachment object with missing metadata", () => {
+        // An <object> tagged as an attachment but with an empty name and no type/data still becomes a
+        // marker anchor, with placeholder filename and mime.
+        const out = converter.convertPageHtml(`<body><div><object data-attachment="" /></div></body>`);
+        const anchor = parse(out).querySelector("a.onenote-attachment");
+
+        expect(anchor?.textContent).toBe("attachment");
+        expect(anchor?.getAttribute("data-mime")).toBe("application/octet-stream");
+    });
+
     it("wraps a floating image and its trailing cite caption into a figure with a figcaption", () => {
         const out = converter.convertPageHtml(SCREEN_CLIPPING_SAMPLE);
         const root = parse(out);
@@ -587,6 +641,26 @@ describe("convertPageHtml", () => {
 
         expect(root.querySelectorAll("figure")).toHaveLength(0);
         expect(root.querySelector("p img")).toBeTruthy();
+    });
+
+    it("keeps an unstyled trailing caption as a bare cite (no font-size wrapper)", () => {
+        // A cite with no style has no font-size class, so the figcaption holds the cite directly.
+        const out = converter.convertPageHtml(`<body><div><img width="10" height="10" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /><br /><cite>Plain caption</cite></div></body>`);
+        const figcaption = parse(out).querySelector("figure.image figcaption");
+
+        expect(figcaption?.querySelector("cite")?.textContent).toBe("Plain caption");
+        expect(figcaption?.querySelector("span")).toBeFalsy();
+    });
+
+    it("leaves an image and break with no block container (fragment root) untouched", () => {
+        // Content directly at the fragment root (no <body>, no outline <div>) has no recognized block
+        // parent: the image is not wrapped into a figure and the break is not treated as block spacing.
+        const out = converter.convertPageHtml(`<img src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /><br />`);
+        const root = parse(out);
+
+        expect(root.querySelector("figure")).toBeFalsy();
+        expect(root.querySelector("img")).toBeTruthy();
+        expect(root.querySelectorAll("br")).toHaveLength(1);
     });
 
     it("converts inline-style formatting (bold/italic/underline) to semantic tags", () => {
@@ -681,6 +755,34 @@ describe("convertPageHtml", () => {
         expect(out).toContain(`<span class="text-big">Size 26</span>`);
         expect(out).toContain(`<span class="text-huge">Size 28</span>`);
         expect(out).toContain(`<span class="text-huge">Size 72</span>`);
+    });
+
+    it("converts px font sizes on the pt scale and ignores unparseable ones", () => {
+        const sample = `<body><div style="position:absolute;left:0px;top:0px">
+            <p style="margin-top:0pt;margin-bottom:0pt"><span style="font-size:24px">Pixel size</span></p>
+            <p style="margin-top:0pt;margin-bottom:0pt"><span style="font-size:medium">Named size</span></p>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        // 24px = 18pt, the bottom of the big band; a named (unparseable) size gets no size class.
+        expect(out).toContain(`<span class="text-big">Pixel size</span>`);
+        expect(out).toContain("Named size");
+        expect(out).not.toMatch(/text-\w+">Named size</);
+    });
+
+    it("keeps a non-span element that loses its default black color, with its other styles", () => {
+        const sample = `<body><div style="position:absolute;left:0px;top:0px">
+            <p style="color:#000000">Black paragraph</p>
+            <ul><li style="list-style-type:circle;background-color:#ffff00">Styled item</li></ul>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        // The default black is dropped but the <p> itself stays (only bare <span>s are unwrapped).
+        expect(out).toContain("Black paragraph");
+        expect(out).not.toContain("color:#000000");
+        // A list item keeps its remaining styles once its marker type moves onto the list.
+        expect(out).toContain("background-color:#ffff00");
+        expect(out).not.toMatch(/<li[^>]*list-style-type/);
     });
 
     it("maps the 20pt Title style to text-big and the Code style to <code>", () => {

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -791,3 +791,17 @@ describe("convertPageHtml", () => {
         expect(out).toContain("<code>Code</code>");
     });
 });
+
+describe("extractPageCreatedDate", () => {
+    it("returns the authored timestamp from the document's created meta header", () => {
+        expect(converter.extractPageCreatedDate(SAMPLE)).toBe("2020-09-02T09:37:00.0000000");
+    });
+
+    it("returns undefined when the meta is absent, empty or unparseable", () => {
+        // A body-only document (as placeholder-adjacent captures can be) has no head to read.
+        expect(converter.extractPageCreatedDate(FORMATTING_SAMPLE)).toBeUndefined();
+        expect(converter.extractPageCreatedDate(`<html><head><meta name="created" content="" /></head><body></body></html>`)).toBeUndefined();
+        expect(converter.extractPageCreatedDate(`<html><head><meta name="created" content="not a date" /></head><body></body></html>`)).toBeUndefined();
+        expect(converter.extractPageCreatedDate(`<html><head><meta name="created" /></head><body></body></html>`)).toBeUndefined();
+    });
+});

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -440,6 +440,24 @@ describe("convertPageHtml", () => {
         expect(parse(converter.convertPageHtml(sample)).querySelector("colgroup")).toBeFalsy();
     });
 
+    it("recovers OneNote's over-darkened table cell shading by reflecting its lightness", () => {
+        // OneNote's Graph export returns cell shading as a dark shade of the colour it displays (same
+        // hue and saturation, inverted lightness): a cell shown as #b6d9a1 comes back as #375623.
+        // Reflecting the lightness recovers the light tint (#bddca9, a barely-perceptible delta off).
+        const sample = `<body><div><table><tr><td style="background-color:#375623"><span lang="en-US">A</span></td><td>B</td></tr></table></div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).toContain("background-color:#bddca9");
+        expect(out).not.toContain("#375623");
+    });
+
+    it("leaves an already-light table cell shading untouched", () => {
+        // A light background is plausible shading as-is (and correctly-exported colours arrive light),
+        // so only dark cell backgrounds are reflected.
+        const sample = `<body><div><table><tr><td style="background-color:#b6d9a1">A</td><td>B</td></tr></table></div></body>`;
+        expect(converter.convertPageHtml(sample)).toContain("background-color:#b6d9a1");
+    });
+
     it("converts OneNote to-do tags into a Trilium task list", () => {
         const out = converter.convertPageHtml(TAGS_SAMPLE);
         const root = parse(out);

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -287,6 +287,36 @@ const TABLE_SAMPLE = `<html lang="en-US">
     </body>
 </html>`;
 
+// Real OneNote source (debug-captured): a column-resized table. OneNote stamps the resized width as a
+// bare pixel `width` on every cell of the column (150/49/399/136 across the four columns), a form the
+// sanitizer drops — so the widths are lost unless translated to CKEditor's colgroup representation.
+const TABLE_RESIZE_SAMPLE = `<html lang="ro-RO">
+    <body data-absolute-enabled="true" style="font-family:Calibri;font-size:11pt">
+        <div style="position:absolute;left:48px;top:115px;width:689px">
+            <table style="border:1px solid;border-collapse:collapse">
+                <tr>
+                    <td style="width:150;border:1px solid"><span lang="en-US">Mid</span></td>
+                    <td style="width:49;border:1px solid"><span lang="en-US">SM</span></td>
+                    <td style="width:399;border:1px solid"><span lang="en-US">Large</span></td>
+                    <td style="width:136;border:1px solid"><br /></td>
+                </tr>
+                <tr>
+                    <td style="width:150;border:1px solid"><span lang="en-US">Mid</span></td>
+                    <td style="width:49;border:1px solid"><span lang="en-US">SM</span></td>
+                    <td style="width:399;border:1px solid"><span lang="en-US">Large</span></td>
+                    <td style="width:136;border:1px solid"><br /></td>
+                </tr>
+                <tr>
+                    <td style="width:150;border:1px solid"><br /></td>
+                    <td style="width:49;border:1px solid"><br /></td>
+                    <td style="width:399;border:1px solid"><br /></td>
+                    <td style="width:136;border:1px solid"><br /></td>
+                </tr>
+            </table>
+        </div>
+    </body>
+</html>`;
+
 // Tests assert the end result (the HTML actually stored on the note, i.e. after sanitization).
 describe("convertPageHtml", () => {
     it("strips OneNote's block-level <br> spacing and empty list items, keeping real content", () => {
@@ -370,6 +400,44 @@ describe("convertPageHtml", () => {
 
         expect(out).not.toContain("border:0px");
         expect(out).not.toContain("border-collapse");
+    });
+
+    it("preserves OneNote per-column widths as a CKEditor resized-table colgroup", () => {
+        const out = converter.convertPageHtml(TABLE_RESIZE_SAMPLE);
+        const root = parse(out);
+
+        // The table becomes a full-width table figure, tagged as column-resized, with its rows in a
+        // <tbody> beneath the <colgroup> — CKEditor's resized-table shape.
+        const figure = root.querySelector("figure.table");
+        expect(figure?.getAttribute("style")).toContain("width:100%");
+        expect(figure?.querySelector("table")?.getAttribute("class")).toContain("ck-table-resized");
+        expect(root.querySelector("figure.table table colgroup")).toBeTruthy();
+        expect(root.querySelectorAll("figure.table table tbody tr")).toHaveLength(3);
+
+        // Each column's pixel width (150/49/399/136 of 734) becomes a proportional percentage in the
+        // colgroup, and the set sums to exactly 100 (the rounding remainder settles on the last column).
+        const cols = root.querySelectorAll("colgroup col").map((col) => col.getAttribute("style"));
+        expect(cols).toEqual(["width:20.44%", "width:6.68%", "width:54.36%", "width:18.52%"]);
+
+        // The now-redundant per-cell widths are gone, and the cell content survives.
+        expect(root.querySelectorAll("td").every((td) => !(td.getAttribute("style") ?? "").includes("width"))).toBe(true);
+        expect(out).toContain("Mid");
+        expect(out).toContain("Large");
+    });
+
+    it("leaves a table without a full set of column widths unresized", () => {
+        // Only the first column carries a width — the resize would be ambiguous, so the table is left as-is.
+        const sample = `<body><div><table style="border:1px solid;border-collapse:collapse"><tr><td style="width:220;border:1px solid">A</td><td style="border:1px solid">B</td></tr></table></div></body>`;
+        const root = parse(converter.convertPageHtml(sample));
+
+        expect(root.querySelector("figure.table")).toBeFalsy();
+        expect(root.querySelector("colgroup")).toBeFalsy();
+        expect(root.querySelector("table")?.getAttribute("class") ?? "").not.toContain("ck-table-resized");
+    });
+
+    it("does not resize a table that merges cells (colspan/rowspan)", () => {
+        const sample = `<body><div><table><tr><td colspan="2" style="width:100">A</td></tr><tr><td style="width:50">B</td><td style="width:50">C</td></tr></table></div></body>`;
+        expect(parse(converter.convertPageHtml(sample)).querySelector("colgroup")).toBeFalsy();
     });
 
     it("converts OneNote to-do tags into a Trilium task list", () => {

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -676,6 +676,7 @@ function hslToHex(h: number, s: number, l: number): string {
     if (s === 0) {
         return `#${channel(l).repeat(3)}`;
     }
+    /* v8 ignore next -- only called from correctTableShadingColors with l strictly above 0.5 */
     const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
     const p = 2 * l - q;
     const component = (t: number) => {

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -107,6 +107,7 @@ export function convertPageHtml(rawHtml: string): string {
 
     sortPositionedOutlines(scope);
     convertResourceReferences(scope);
+    wrapFloatingImages(scope);
     convertTags(scope);
     convertInlineFormatting(scope);
     normalizeNamedColors(scope);
@@ -174,6 +175,70 @@ function convertResourceReferences(scope: HTMLElement) {
             }
         }
     }
+}
+
+/** Block contexts whose direct <img> children are standalone (block) images, not inline runs. */
+const FLOATING_IMAGE_PARENTS = new Set(["body", "div", "section", "article"]);
+
+/**
+ * OneNote lays a standalone image out as a bare <img> floating in the outline <div>, frequently
+ * trailed — across OneNote's block-level <br> spacing — by a <cite> caption (e.g. a screen clipping's
+ * "Screen clipping taken: …"). Left verbatim the caption renders as loose body text beside the image.
+ *
+ * CKEditor represents a block image as `<figure class="image">`, with any caption as its
+ * `<figcaption>`, so wrap each floating image in a figure, carry its width/height into an
+ * `aspect-ratio` (the form CKEditor stores so the image reserves space and resizes proportionally),
+ * and pull a trailing <cite> in as the caption. Inline images (inside a <p>/<a>/<span>) are left alone.
+ */
+function wrapFloatingImages(scope: HTMLElement) {
+    for (const img of scope.querySelectorAll("img")) {
+        const parent = img.parentNode;
+        if (!(parent instanceof HTMLElement) || !FLOATING_IMAGE_PARENTS.has(parent.tagName?.toLowerCase() ?? "")) {
+            continue;
+        }
+
+        const width = img.getAttribute("width");
+        const height = img.getAttribute("height");
+        const style = parseStyle(img.getAttribute("style") ?? "");
+        if (width && height && !style.has("aspect-ratio") && /^\d+(\.\d+)?$/.test(width) && /^\d+(\.\d+)?$/.test(height)) {
+            style.set("aspect-ratio", `${width}/${height}`);
+            img.setAttribute("style", serializeStyle(style));
+        }
+
+        const caption = takeTrailingCaption(img);
+        const figcaption = caption ? `<figcaption>${caption}</figcaption>` : "";
+        img.insertAdjacentHTML("beforebegin", `<figure class="image">${img.toString()}${figcaption}</figure>`);
+        img.remove();
+    }
+}
+
+/**
+ * Consumes the <cite> caption that trails a floating image (OneNote separates the two with block-level
+ * <br>s), returning the markup for the image's <figcaption> and removing the cite and the intervening
+ * breaks from the document. The caption's text is placed in a fresh <cite>, wrapped in its font-size
+ * class (e.g. text-small) — OneNote's inline caption styling (its grey chrome colour, point size and
+ * zero margins) is dropped so the caption inherits the theme foreground. Returns null when the image
+ * has no trailing cite. Runs before convertInlineFormatting so the fresh cite's content is still
+ * formatted (a caption's own bold/italic runs survive).
+ */
+function takeTrailingCaption(img: HTMLElement): string | null {
+    const breaks: HTMLElement[] = [];
+    let sibling = img.nextElementSibling;
+    while (sibling && sibling.tagName?.toLowerCase() === "br") {
+        breaks.push(sibling);
+        sibling = sibling.nextElementSibling;
+    }
+    if (!sibling || sibling.tagName?.toLowerCase() !== "cite") {
+        return null;
+    }
+
+    const sizeClass = fontSizeClass(parseStyle(sibling.getAttribute("style") ?? "").get("font-size"), sibling);
+    const cite = `<cite>${sibling.innerHTML}</cite>`;
+    const caption = sizeClass ? `<span class="${sizeClass}">${cite}</span>` : cite;
+
+    breaks.forEach((br) => br.remove());
+    sibling.remove();
+    return caption;
 }
 
 /**

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -117,6 +117,7 @@ export function convertPageHtml(rawHtml: string): string {
     normalizeTableBorders(scope);
     removeEmptyListItems(scope);
     removeBlockLevelBreaks(scope);
+    resizeTables(scope);
 
     return sanitize.sanitizeHtml(scope.innerHTML);
 }
@@ -519,6 +520,90 @@ function normalizeTableBorders(scope: HTMLElement) {
             el.setAttribute("style", serializeStyle(style));
         }
     }
+}
+
+/**
+ * OneNote carries a resized column's width as a bare pixel `width` on every cell of that column
+ * (e.g. `<td style="width:150;…">`), a per-cell form the sanitizer drops — so column widths are lost.
+ * CKEditor instead stores column widths as percentages in a <colgroup> on a `ck-table-resized` table
+ * wrapped in `<figure class="table" style="width:100%;">`. When every column carries an explicit width,
+ * translate OneNote's pixel widths into that representation: emit a <colgroup> of proportional
+ * percentages (summing to 100), strip the now-redundant per-cell widths, tag the table resized and wrap
+ * it in a table figure. Tables that don't width every column, or that merge cells (colspan/rowspan,
+ * which this flat column model can't represent), are left untouched.
+ */
+function resizeTables(scope: HTMLElement) {
+    for (const table of scope.querySelectorAll("table")) {
+        const cellRows = table.querySelectorAll("tr").map((row) => row.querySelectorAll("td, th"));
+        const columnCount = Math.max(0, ...cellRows.map((cells) => cells.length));
+        if (columnCount === 0 || cellRows.some((cells) => cells.some(hasCellSpan))) {
+            continue;
+        }
+
+        // A resized column repeats its width on every cell; take the first one seen per column. Bail
+        // unless every column has one — a partial set can't be faithfully turned into a full colgroup.
+        const widths: number[] = [];
+        for (let column = 0; column < columnCount; column++) {
+            const width = cellRows.map((cells) => columnWidth(cells[column])).find((value) => value !== undefined);
+            if (width === undefined) {
+                break;
+            }
+            widths.push(width);
+        }
+        if (widths.length !== columnCount) {
+            continue;
+        }
+
+        for (const cells of cellRows) {
+            for (const cell of cells) {
+                const style = parseStyle(cell.getAttribute("style") ?? "");
+                if (style.delete("width")) {
+                    if (style.size === 0) {
+                        cell.removeAttribute("style");
+                    } else {
+                        cell.setAttribute("style", serializeStyle(style));
+                    }
+                }
+            }
+        }
+
+        const colgroup = `<colgroup>${columnPercentages(widths).map((percent) => `<col style="width:${percent}%;">`).join("")}</colgroup>`;
+        const existingClass = table.getAttribute("class");
+        table.setAttribute("class", existingClass ? `${existingClass} ck-table-resized` : "ck-table-resized");
+        table.set_content(`${colgroup}<tbody>${table.innerHTML}</tbody>`);
+        table.insertAdjacentHTML("beforebegin", `<figure class="table" style="width:100%;">${table.toString()}</figure>`);
+        table.remove();
+    }
+}
+
+/** Whether a cell spans multiple rows/columns, which the flat column model in resizeTables can't map. */
+function hasCellSpan(cell: HTMLElement): boolean {
+    return cell.getAttribute("colspan") != null || cell.getAttribute("rowspan") != null;
+}
+
+/** A cell's positive pixel `width` (OneNote writes it unit-less, e.g. `width:150`), or undefined. */
+function columnWidth(cell: HTMLElement | undefined): number | undefined {
+    const value = cell && parseStyle(cell.getAttribute("style") ?? "").get("width");
+    const pixels = value ? parseFloat(value) : NaN;
+    return Number.isFinite(pixels) && pixels > 0 ? pixels : undefined;
+}
+
+/**
+ * Turns pixel column widths into percentages of their total, rounded to two decimals. The last column
+ * takes the remainder so the set sums to exactly 100% (matching CKEditor's normalized colgroup) rather
+ * than drifting a hundredth off through independent rounding.
+ */
+function columnPercentages(widths: number[]): number[] {
+    const total = widths.reduce((sum, width) => sum + width, 0);
+    let allocated = 0;
+    return widths.map((width, index) => {
+        if (index === widths.length - 1) {
+            return Math.round((100 - allocated) * 100) / 100;
+        }
+        const percent = Math.round((width / total) * 10000) / 100;
+        allocated += percent;
+        return percent;
+    });
 }
 
 /** Drops list items that hold nothing but whitespace/<br> (OneNote's "exited the list" remnant). */

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -124,6 +124,22 @@ export function convertPageHtml(rawHtml: string): string {
 }
 
 /**
+ * Extracts the page's authored creation timestamp from the Graph page document's
+ * `<meta name="created">` header, or undefined when the meta is absent or unparseable.
+ *
+ * This is the creation date OneNote displays under the page title: it lives in the page *content*
+ * and survives moves, copies and notebook migrations, whereas the page object's `createdDateTime`
+ * metadata is re-stamped by them (a moved page can report an object date years after the authored
+ * one). Graph emits the value without a UTC offset (e.g. "2026-07-23T21:28:00.0000000"), i.e. as
+ * wall-clock time, so `new Date()` parses it as server-local time — exact when the server runs in
+ * the notebook owner's timezone, and still the right day otherwise.
+ */
+export function extractPageCreatedDate(rawHtml: string): string | undefined {
+    const content = parse(rawHtml).querySelector('meta[name="created"]')?.getAttribute("content");
+    return content && !Number.isNaN(Date.parse(content)) ? content : undefined;
+}
+
+/**
  * A OneNote page is a free-form canvas of absolutely-positioned text boxes (the top-level outline
  * <div>s). Their document order need not match their visual order, so reorder them top-to-bottom then
  * left-to-right to linearize the page into a sensible reading order. A no-op for the common
@@ -721,4 +737,4 @@ function removeBlockLevelBreaks(scope: HTMLElement) {
     }
 }
 
-export default { convertPageHtml };
+export default { convertPageHtml, extractPageCreatedDate };

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -115,6 +115,7 @@ export function convertPageHtml(rawHtml: string): string {
     unwrapListItemParagraphs(scope);
     normalizeListMarkers(scope);
     normalizeTableBorders(scope);
+    correctTableShadingColors(scope);
     removeEmptyListItems(scope);
     removeBlockLevelBreaks(scope);
     resizeTables(scope);
@@ -604,6 +605,98 @@ function columnPercentages(widths: number[]): number[] {
         allocated += percent;
         return percent;
     });
+}
+
+/**
+ * OneNote's Graph API exports table cell shading as a dark *shade* of the colour OneNote actually
+ * displays: it keeps the hue and saturation but inverts the lightness (e.g. a cell shown as #b6d9a1
+ * comes back as #375623). Left as-is the cell imports far too dark — commonly dark-on-dark and
+ * unreadable. So for a cell whose background is dark, reflect its lightness (L → 1 − L, hue/saturation
+ * untouched) to recover the displayed light tint; light backgrounds (plausible shading as-is, and the
+ * form correctly-exported colours arrive in) are left alone. Runs after normalizeNamedColors, so a
+ * named background has already become the hex this keys on.
+ */
+function correctTableShadingColors(scope: HTMLElement) {
+    for (const cell of scope.querySelectorAll("td, th")) {
+        const style = parseStyle(cell.getAttribute("style") ?? "");
+        const rgb = parseHexColor(style.get("background-color") ?? "");
+        if (!rgb) {
+            continue;
+        }
+        const [hue, saturation, lightness] = rgbToHsl(rgb);
+        if (lightness >= 0.5) {
+            continue;
+        }
+        style.set("background-color", hslToHex(hue, saturation, 1 - lightness));
+        cell.setAttribute("style", serializeStyle(style));
+    }
+}
+
+/** Parses a `#rgb` or `#rrggbb` colour to [r, g, b] (0-255), or null if it isn't a hex colour. */
+function parseHexColor(value: string): [number, number, number] | null {
+    const match = value.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (!match) {
+        return null;
+    }
+    const hex = match[1].length === 3 ? match[1].replace(/(.)/g, "$1$1") : match[1];
+    return [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)];
+}
+
+/** Converts an [r, g, b] (0-255) colour to [h, s, l], each in [0, 1]. */
+function rgbToHsl([r, g, b]: [number, number, number]): [number, number, number] {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const lightness = (max + min) / 2;
+    const delta = max - min;
+    if (delta === 0) {
+        return [0, 0, lightness];
+    }
+    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+    let hue: number;
+    switch (max) {
+        case r:
+            hue = (g - b) / delta + (g < b ? 6 : 0);
+            break;
+        case g:
+            hue = (b - r) / delta + 2;
+            break;
+        default:
+            hue = (r - g) / delta + 4;
+            break;
+    }
+    return [hue / 6, saturation, lightness];
+}
+
+/** Converts [h, s, l] (each in [0, 1]) back to a `#rrggbb` hex colour. */
+function hslToHex(h: number, s: number, l: number): string {
+    const channel = (value: number) => Math.round(value * 255).toString(16).padStart(2, "0");
+    if (s === 0) {
+        return `#${channel(l).repeat(3)}`;
+    }
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const component = (t: number) => {
+        if (t < 0) {
+            t += 1;
+        }
+        if (t > 1) {
+            t -= 1;
+        }
+        if (t < 1 / 6) {
+            return p + (q - p) * 6 * t;
+        }
+        if (t < 1 / 2) {
+            return q;
+        }
+        if (t < 2 / 3) {
+            return p + (q - p) * (2 / 3 - t) * 6;
+        }
+        return p;
+    };
+    return `#${channel(component(h + 1 / 3))}${channel(component(h))}${channel(component(h - 1 / 3))}`;
 }
 
 /** Drops list items that hold nothing but whitespace/<br> (OneNote's "exited the list" remnant). */

--- a/apps/server/src/services/import/onenote/importer.spec.ts
+++ b/apps/server/src/services/import/onenote/importer.spec.ts
@@ -198,6 +198,47 @@ describe("importSelection (real DB)", () => {
         expect(content).toContain(`href="#root/${badNote?.noteId}"`);
     });
 
+    it("preserves the OneNote page order even when #newNotesOnTop is inherited onto the target", async () => {
+        graphMock.listPages.mockResolvedValue([
+            { id: "1-ord-a", title: "Order Page A", level: 0 },
+            { id: "1-ord-b", title: "Order Page B", level: 0 },
+            { id: "1-ord-c", title: "Order Page C", level: 0 }
+        ]);
+        graphMock.getPageContent.mockResolvedValue({ html: "<p>hi</p>", inkml: "" });
+
+        // The label the user reported: inheritable on the import target, so every note created during the
+        // import (root, section, pages) sees it. Without explicit positions it would invert the page order.
+        const parent = cls.init(() => {
+            const note = noteService.createNewNote({
+                parentNoteId: "root",
+                title: "order parent",
+                content: "",
+                type: "text",
+                mime: "text/html"
+            }).note;
+            note.addLabel("newNotesOnTop", "", true);
+            return note;
+        });
+
+        await cls.init(() => importSelection({
+            getAccessToken: () => Promise.resolve("token"),
+            parentNoteId: parent.noteId,
+            sections: [{ id: "sec-order", title: "Order Section", groupPath: [], notebookId: "nb-order", notebookTitle: "Order Notebook" }],
+            taskId: "task-order"
+        }));
+
+        // Order lives in notePosition (becca's in-memory `children` is insertion order); the tree sorts
+        // by it the way the client does. With the newNotesOnTop default each page would land above the
+        // last (positions -10, -20, -30 → C, B, A); the fix's explicit ascending positions keep A, B, C.
+        const sectionNote = Object.values(becca.notes).find((note) => note.title === "Order Section");
+        const orderedTitles = sectionNote
+            ?.getChildBranches()
+            .slice()
+            .sort((a, b) => a.notePosition - b.notePosition)
+            .map((branch) => branch.getNote().title);
+        expect(orderedTitles).toEqual(["Order Page A", "Order Page B", "Order Page C"]);
+    });
+
     it("aborts the import when too many consecutive pages fail (systemic failure)", async () => {
         graphMock.listPages.mockResolvedValue(
             Array.from({ length: 8 }, (_, i) => ({ id: `1-cb${i}`, title: `CB Page ${i}`, level: 0 }))

--- a/apps/server/src/services/import/onenote/importer.spec.ts
+++ b/apps/server/src/services/import/onenote/importer.spec.ts
@@ -1,4 +1,4 @@
-import { becca, cls, note_service as noteService } from "@triliumnext/core";
+import { becca, cls, date_utils, note_service as noteService } from "@triliumnext/core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import sqlInit from "../../sql_init.js";
@@ -300,5 +300,39 @@ describe("importSelection (real DB)", () => {
         expect(pages.size).toBe(8);
         expect([...pages.values()].every((note) => note.hasOwnedLabel("oneNoteImportFailed"))).toBe(true);
         expect([...pages.values()][0]?.getContent()).toContain("could not be imported");
+    });
+
+    it("prefers the authored created date from the page HTML over the Graph object's metadata", async () => {
+        // A moved/copied/migrated page: the Graph page *object*'s createdDateTime is re-stamped to the
+        // time of the move, while the date OneNote actually displays under the title lives in the page
+        // HTML's `<meta name="created">`. The authored date must win; the object date remains the
+        // fallback for pages whose HTML carries no meta.
+        graphMock.listPages.mockResolvedValue([
+            { id: "1-meta", title: "Authored Date Page", level: 0, createdDateTime: "2020-10-20T10:00:00Z", lastModifiedDateTime: "2021-03-04T05:06:07Z" },
+            { id: "1-nometa", title: "Fallback Date Page", level: 0, createdDateTime: "2020-10-20T10:00:00Z" }
+        ]);
+        graphMock.getPageContent.mockImplementation(async (_token, pageId) => ({
+            html: pageId === "1-meta"
+                ? `<html><head><title>Authored Date Page</title><meta name="created" content="2019-01-19T20:24:00.0000000" /></head><body><p>hi</p></body></html>`
+                : "<p>hi</p>",
+            inkml: ""
+        }));
+
+        await cls.init(() => importSelection({
+            getAccessToken: () => Promise.resolve("token"),
+            parentNoteId: "root",
+            sections: [{ id: "sec-dates", title: "Date Section", groupPath: [], notebookId: "nb-dates", notebookTitle: "Date Notebook" }],
+            taskId: "task-authored-dates"
+        }));
+
+        const authored = Object.values(becca.notes).find((note) => note.title === "Authored Date Page");
+        // The meta value is offset-less wall-clock time and is parsed as server-local, so the expected
+        // value goes through the same Date conversion to stay timezone-independent.
+        expect(authored?.utcDateCreated).toBe(date_utils.utcDateTimeStr(new Date("2019-01-19T20:24:00.0000000")));
+        // The modification date has no in-content counterpart and stays the Graph object's value.
+        expect(authored?.utcDateModified).toBe("2021-03-04 05:06:07.000Z");
+
+        const fallback = Object.values(becca.notes).find((note) => note.title === "Fallback Date Page");
+        expect(fallback?.utcDateCreated).toBe("2020-10-20 10:00:00.000Z");
     });
 });

--- a/apps/server/src/services/import/onenote/importer.ts
+++ b/apps/server/src/services/import/onenote/importer.ts
@@ -6,7 +6,7 @@
  */
 
 import type { OneNoteFolderRef, OneNoteSectionSelection } from "@triliumnext/commons";
-import { becca, binary_utils, type BNote, date_utils, getLog, imageService, note_service as noteService, protected_session as protectedSession, TaskContext } from "@triliumnext/core";
+import { becca, binary_utils, type BNote, cls, date_utils, getLog, imageService, note_service as noteService, protected_session as protectedSession, TaskContext } from "@triliumnext/core";
 import { t } from "i18next";
 import { parse } from "node-html-parser";
 
@@ -180,6 +180,10 @@ function createNotes(parentNoteId: string, sections: FetchedSection[], debug: bo
 
     const rootNote = createFolder(parentNoteId, t("onenote_import.root-title"));
     rootNote.addLabel("iconClass", "bx bx-import");
+
+    // Root created; keep the OneNote notebooks/sections/pages in their display order under an inherited
+    // #newNotesOnTop (the root above still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     // Created page notes with their content-so-far (resources/ink applied), plus a map from each
     // page's OneNote page-id GUID to its imported note (and title) — both feed the link-resolution pass.

--- a/apps/server/src/services/import/onenote/importer.ts
+++ b/apps/server/src/services/import/onenote/importer.ts
@@ -40,7 +40,13 @@ interface FetchedPage {
     resources: DownloadedResource[];
     /** How many of the page's resources failed to download (skipped, reported in the import report). */
     failedResourceCount: number;
-    /** OneNote's page creation timestamp (ISO 8601), preserved on the imported note. */
+    /**
+     * OneNote's page creation timestamp (ISO 8601), preserved on the imported note. The authored
+     * date from the page HTML's `<meta name="created">` when available — the date OneNote itself
+     * displays, which survives page moves/copies and notebook migrations — otherwise the Graph
+     * page object's `createdDateTime` (re-stamped by those operations; placeholder pages have no
+     * HTML to read the authored date from).
+     */
     createdDateTime?: string;
     /** OneNote's last-modified timestamp (ISO 8601), preserved on the imported note. */
     lastModifiedDateTime?: string;
@@ -134,7 +140,7 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
                 try {
                     const html = converter.convertPageHtml(rawHtml);
                     const { resources, failedResourceCount } = await downloadPageResources(getAccessToken, page.title, html);
-                    fetchedPages.push({ id: page.id, title: page.title, level: page.level, pageId: page.pageId, html, rawHtml, rawInkml: inkml, inkSvg: inkmlToSvg(inkml), resources, failedResourceCount, createdDateTime: page.createdDateTime, lastModifiedDateTime: page.lastModifiedDateTime });
+                    fetchedPages.push({ id: page.id, title: page.title, level: page.level, pageId: page.pageId, html, rawHtml, rawInkml: inkml, inkSvg: inkmlToSvg(inkml), resources, failedResourceCount, createdDateTime: converter.extractPageCreatedDate(rawHtml) ?? page.createdDateTime, lastModifiedDateTime: page.lastModifiedDateTime });
                 } catch (e: unknown) {
                     const message = e instanceof Error ? e.message : String(e);
                     getLog().error(`OneNote import: fetched page '${page.title}' (${page.id}) but could not process its content; a placeholder note will be imported instead: ${message}`);

--- a/apps/server/src/services/import/onenote/inkml.spec.ts
+++ b/apps/server/src/services/import/onenote/inkml.spec.ts
@@ -49,13 +49,49 @@ describe("inkmlToSvg", () => {
         const svg = inkmlToSvg(dot) ?? "";
         expect(svg).toContain("<circle");
         expect(svg).not.toContain("<path");
+        // The default brush is OneNote's automatic ink, so the dot fills adaptively via the class.
+        expect(svg).toContain(`class="ink-auto"`);
+        expect(svg).toContain("circle.ink-auto{fill:light-dark(#000,#fff)}");
     });
 
-    it("works without namespace prefixes and falls back to a default brush", () => {
+    it("works without namespace prefixes and falls back to a default (automatic) brush", () => {
         const plain = `<ink><trace>0 0, 10 10</trace></ink>`;
         const svg = inkmlToSvg(plain) ?? "";
         expect(svg).toContain("<path");
-        expect(svg).toContain(`stroke="#000000"`);
+        // The default brush is OneNote's automatic ink: rendered theme-adaptively, never hard black.
+        expect(svg).toContain(`class="ink-auto"`);
+        expect(svg).not.toContain(`stroke="#000000"`);
+        expect(svg).toContain("light-dark(#000,#fff)");
+    });
+
+    it("renders OneNote's automatic ink (default black and its white inverse) theme-adaptively", () => {
+        const automatic = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="black"><inkml:brushProperty name="color" value="#000000"/></inkml:brush>
+                <inkml:brush xml:id="white"><inkml:brushProperty name="color" value="#FFFFFF"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#black">0 0, 10 10</inkml:trace>
+            <inkml:trace brushRef="#white">20 20, 30 30</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(automatic) ?? "";
+
+        // Both default black and its dark-mode inverse (white) become the adaptive class, not a color.
+        expect((svg.match(/class="ink-auto"/g) ?? [])).toHaveLength(2);
+        expect(svg).not.toContain(`stroke="#000000"`);
+        expect(svg).not.toContain(`stroke="#FFFFFF"`);
+
+        // The adaptive <style> is emitted once, keyed to the embedding context's color-scheme.
+        expect((svg.match(/<style>/g) ?? [])).toHaveLength(1);
+        expect(svg).toContain("svg{color-scheme:light dark}");
+        expect(svg).toContain("path.ink-auto{stroke:light-dark(#000,#fff)}");
+    });
+
+    it("leaves deliberately-colored ink literal and omits the adaptive style", () => {
+        // #FF0000 is a chosen color — untouched — and with no automatic strokes there's no <style> block.
+        const svg = inkmlToSvg(INKML) ?? "";
+        expect(svg).toContain(`stroke="#FF0000"`);
+        expect(svg).not.toContain("ink-auto");
+        expect(svg).not.toContain("<style>");
     });
 
     it("returns null for empty input or ink with no traces", () => {

--- a/apps/server/src/services/import/onenote/inkml.spec.ts
+++ b/apps/server/src/services/import/onenote/inkml.spec.ts
@@ -54,6 +54,22 @@ describe("inkmlToSvg", () => {
         expect(svg).toContain("circle.ink-auto{fill:light-dark(#000,#fff)}");
     });
 
+    it("renders a deliberately-colored single-point trace with a literal fill", () => {
+        const dot = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="br0"><inkml:brushProperty name="color" value="#FF0000"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#br0">50 60</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(dot) ?? "";
+
+        // A chosen color is baked into the dot's fill; no adaptive class or style block is emitted.
+        expect(svg).toContain("<circle");
+        expect(svg).toContain(`fill="#FF0000"`);
+        expect(svg).not.toContain("ink-auto");
+        expect(svg).not.toContain("<style>");
+    });
+
     it("works without namespace prefixes and falls back to a default (automatic) brush", () => {
         const plain = `<ink><trace>0 0, 10 10</trace></ink>`;
         const svg = inkmlToSvg(plain) ?? "";
@@ -92,6 +108,38 @@ describe("inkmlToSvg", () => {
         expect(svg).toContain(`stroke="#FF0000"`);
         expect(svg).not.toContain("ink-auto");
         expect(svg).not.toContain("<style>");
+    });
+
+    it("tolerates malformed brush and trace data, falling back to defaults", () => {
+        // An id-less brush is skipped; a name-less property and non-numeric width/height are ignored
+        // (keeping the defaults); a bare (un-prefixed) brushRef still resolves; a trace with
+        // unparseable coordinates contributes nothing.
+        const messy = `<ink>
+            <definitions>
+                <brush><brushProperty name="color" value="#123456"/></brush>
+                <brush xml:id="b1">
+                    <brushProperty value="orphan"/>
+                    <brushProperty name="width" value="wide"/>
+                    <brushProperty name="height" value="tall"/>
+                    <brushProperty name="color" value="#00AA00"/>
+                </brush>
+            </definitions>
+            <trace brushRef="b1">0 0, 10 10</trace>
+            <trace>squiggle</trace>
+        </ink>`;
+        const svg = inkmlToSvg(messy) ?? "";
+
+        expect((svg.match(/<path/g) ?? [])).toHaveLength(1);
+        expect(svg).toContain(`stroke="#00AA00"`);
+        expect(svg).toContain(`stroke-width="70"`); // default width kept over the unparseable one
+        expect(svg).not.toContain("#123456"); // the id-less brush is never referenced
+    });
+
+    it("scales fractional coordinates and survives a missing closing tag", () => {
+        // Fractional coords are scaled up 10000x for precision; the truncated document (no </ink>)
+        // still parses. 1.5→15000, 3.5→35000: 20000 wide + 2*padding(10).
+        const svg = inkmlToSvg(`<ink><trace>1.5 2.5, 3.5 4.5</trace>`) ?? "";
+        expect(svg).toContain(`viewBox="0 0 20020 20020"`);
     });
 
     it("returns null for empty input or ink with no traces", () => {

--- a/apps/server/src/services/import/onenote/inkml.ts
+++ b/apps/server/src/services/import/onenote/inkml.ts
@@ -39,12 +39,43 @@ interface Trace {
 const DEFAULT_BRUSH: Brush = { color: "#000000", width: 70, height: 70, transparency: 0 };
 
 /**
+ * OneNote's automatic ink colors. Like its automatic *text* color (see removeDefaultTextColor in
+ * converter.ts), the default pen isn't a chosen color: it's black on OneNote's light canvas but
+ * inverts to white in dark mode. These two are rendered theme-adaptively (see AUTO_INK_STYLE) rather
+ * than baked as a hard color that would be unreadable under the opposite theme; every deliberately
+ * picked color is left exactly as OneNote sent it.
+ */
+const AUTOMATIC_INK_COLORS = new Set(["#000000", "#000", "black", "#ffffff", "#fff", "white"]);
+
+/** The class carried by an automatic-colored shape; the color itself comes from {@link AUTO_INK_STYLE}. */
+const AUTO_INK_CLASS = "ink-auto";
+
+/**
+ * Theme-adaptive styling for automatic-colored strokes. `color-scheme: light dark` enables the
+ * `light-dark()` function; the used scheme is inherited from the embedding `<img>` — Trilium sets
+ * `color-scheme` from its active theme on `:root` (theme-next/base.css) and Chromium propagates it
+ * into the referenced SVG — so the ink follows Trilium's light/dark toggle instead of rendering as
+ * unreadable black-on-dark. Paths take the color on `stroke`, single-point dots on `fill`; qualifying
+ * each rule by element keeps the fill rule from overriding a path's `fill="none"` and flooding it solid.
+ * Emitted only when at least one automatic stroke is present.
+ */
+const AUTO_INK_STYLE =
+    `<style>svg{color-scheme:light dark}` +
+    `path.${AUTO_INK_CLASS}{stroke:light-dark(#000,#fff)}` +
+    `circle.${AUTO_INK_CLASS}{fill:light-dark(#000,#fff)}</style>`;
+
+/**
  * The on-screen stroke thickness. Pens carry equal width/height, but highlighters (rectangle tip)
  * carry a small width and a large height — so taking the larger dimension renders highlighters as the
  * wide swath they are rather than a thin pen line.
  */
 function strokeWidth(brush: Brush): number {
     return Math.max(brush.width, brush.height);
+}
+
+/** Whether a brush color is OneNote's mode-adaptive automatic ink (default black / its white inverse). */
+function isAutomaticColor(color: string): boolean {
+    return AUTOMATIC_INK_COLORS.has(color.trim().toLowerCase());
 }
 
 export function inkmlToSvg(inkml: string): string | null {
@@ -68,10 +99,11 @@ export function inkmlToSvg(inkml: string): string | null {
     const height = maxY - minY + PADDING * 2;
     const scale = Math.min(1, MAX_DISPLAY_SIZE / Math.max(width, height, 1));
 
+    const hasAutomaticInk = traces.some((trace) => isAutomaticColor(trace.brush.color));
     const shapes = traces.flatMap((trace) => traceToSvg(trace, minX, minY)).join("");
     return (
         `<svg xmlns="http://www.w3.org/2000/svg" width="${Math.round(width * scale)}" height="${Math.round(height * scale)}" ` +
-        `viewBox="0 0 ${width} ${height}">${shapes}</svg>`
+        `viewBox="0 0 ${width} ${height}">${hasAutomaticInk ? AUTO_INK_STYLE : ""}${shapes}</svg>`
     );
 }
 
@@ -170,14 +202,17 @@ function traceToSvg(trace: Trace, minX: number, minY: number): string[] {
     const opacity = 1 - transparency;
     const opacityAttr = opacity < 1 ? ` opacity="${opacity.toFixed(2)}"` : "";
     const point = (coord: number[]) => [coord[0] - minX + PADDING, coord[1] - minY + PADDING];
+    const automatic = isAutomaticColor(color);
 
     if (trace.coords.length === 1) {
         const [x, y] = point(trace.coords[0]);
-        return [`<circle cx="${x}" cy="${y}" r="${width / 2}" fill="${color}"${opacityAttr}/>`];
+        const fillAttr = automatic ? ` class="${AUTO_INK_CLASS}"` : ` fill="${color}"`;
+        return [`<circle cx="${x}" cy="${y}" r="${width / 2}"${fillAttr}${opacityAttr}/>`];
     }
 
     const path = trace.coords.map((coord, index) => `${index === 0 ? "M" : "L"} ${point(coord).join(" ")}`).join(" ");
-    return [`<path d="${path}" stroke="${color}" stroke-width="${width}" fill="none" stroke-linecap="round" stroke-linejoin="round"${opacityAttr}/>`];
+    const strokeAttr = automatic ? ` class="${AUTO_INK_CLASS}"` : ` stroke="${color}"`;
+    return [`<path d="${path}"${strokeAttr} stroke-width="${width}" fill="none" stroke-linecap="round" stroke-linejoin="round"${opacityAttr}/>`];
 }
 
 export default { inkmlToSvg };

--- a/apps/server/src/services/utils.spec.ts
+++ b/apps/server/src/services/utils.spec.ts
@@ -108,7 +108,7 @@ describe("deprecated core delegations", () => {
         expect(randomString(10)).toHaveLength(10);
         expect(hashedBlobId("content")).toBe("stHShbUZnIX5iNA2ScNX");
         expect(getContentDisposition("file.txt"))
-            .toBe("file; filename=\"file.txt\"; filename*=UTF-8''file.txt");
+            .toBe("attachment; filename=\"file.txt\"; filename*=UTF-8''file.txt");
         expect(isStringNote("text", "text/html")).toBe(true);
         expect(quoteRegex("a.b")).toBe("a\\.b");
         expect(replaceAll("a-b-c", "-", "+")).toBe("a+b+c");

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -7415,13 +7415,6 @@
                                                 {
                                                     "type": "relation",
                                                     "name": "internalLink",
-                                                    "value": "NdowYOC1GFKS",
-                                                    "isInheritable": false,
-                                                    "position": 30
-                                                },
-                                                {
-                                                    "type": "relation",
-                                                    "name": "internalLink",
                                                     "value": "0vhv7lsOLy82",
                                                     "isInheritable": false,
                                                     "position": 40
@@ -7481,6 +7474,13 @@
                                                     "value": "bx bx-window-open",
                                                     "isInheritable": false,
                                                     "position": 20
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "NdowYOC1GFKS",
+                                                    "isInheritable": false,
+                                                    "position": 110
                                                 }
                                             ],
                                             "format": "markdown",
@@ -19180,114 +19180,128 @@
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "MgibgPcfeuGz",
+                            "value": "bkPZAMT7d2sR",
                             "isInheritable": false,
                             "position": 10
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "HcABDtFCkbFN",
+                            "value": "cRRrdZjgyhNc",
                             "isInheritable": false,
                             "position": 20
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "IF7Q6I9x7zuw",
+                            "value": "MgibgPcfeuGz",
                             "isInheritable": false,
                             "position": 30
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
+                            "value": "HcABDtFCkbFN",
+                            "isInheritable": false,
+                            "position": 40
+                        },
+                        {
+                            "type": "relation",
+                            "name": "internalLink",
+                            "value": "IF7Q6I9x7zuw",
+                            "isInheritable": false,
+                            "position": 50
+                        },
+                        {
+                            "type": "relation",
+                            "name": "internalLink",
                             "value": "4TIF1oA4VQRO",
                             "isInheritable": false,
-                            "position": 70
+                            "position": 60
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "RnaPdbciOfeq",
                             "isInheritable": false,
-                            "position": 80
+                            "position": 70
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "l0tKav7yLHGF",
                             "isInheritable": false,
-                            "position": 90
+                            "position": 80
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "2mUhVmZK8RF3",
                             "isInheritable": false,
-                            "position": 100
+                            "position": 90
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "KC1HB96bqqHX",
                             "isInheritable": false,
-                            "position": 110
+                            "position": 100
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "vZWERwf8U3nx",
                             "isInheritable": false,
-                            "position": 120
+                            "position": 110
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "0vhv7lsOLy82",
                             "isInheritable": false,
-                            "position": 130
+                            "position": 120
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "TiQbQDgP8L5t",
                             "isInheritable": false,
-                            "position": 140
+                            "position": 130
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "hrZ1D00cLbal",
                             "isInheritable": false,
-                            "position": 150
+                            "position": 140
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "eIg8jdvaoNNd",
                             "isInheritable": false,
-                            "position": 160
+                            "position": 150
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "SPirpZypehBG",
                             "isInheritable": false,
-                            "position": 170
+                            "position": 160
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "yIhgI5H7A2Sm",
                             "isInheritable": false,
-                            "position": 180
+                            "position": 170
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "6f9hih2hXXZk",
                             "isInheritable": false,
-                            "position": 190
+                            "position": 180
                         },
                         {
                             "type": "label",
@@ -19302,20 +19316,6 @@
                             "value": "bx bx-bot",
                             "isInheritable": false,
                             "position": 30
-                        },
-                        {
-                            "type": "relation",
-                            "name": "internalLink",
-                            "value": "bkPZAMT7d2sR",
-                            "isInheritable": false,
-                            "position": 200
-                        },
-                        {
-                            "type": "relation",
-                            "name": "internalLink",
-                            "value": "cRRrdZjgyhNc",
-                            "isInheritable": false,
-                            "position": 210
                         }
                     ],
                     "format": "markdown",
@@ -19339,6 +19339,41 @@
                             "mime": "text/html",
                             "attributes": [
                                 {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "cRRrdZjgyhNc",
+                                    "isInheritable": false,
+                                    "position": 10
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "wy8So3yZZlH9",
+                                    "isInheritable": false,
+                                    "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "poXkQfguuA0U",
+                                    "isInheritable": false,
+                                    "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "WOcw2SLH6tbX",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "4TIF1oA4VQRO",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
                                     "type": "label",
                                     "name": "shareAlias",
                                     "value": "providers",
@@ -19351,41 +19386,6 @@
                                     "value": "bx bx-cog",
                                     "isInheritable": false,
                                     "position": 40
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "wy8So3yZZlH9",
-                                    "isInheritable": false,
-                                    "position": 50
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "poXkQfguuA0U",
-                                    "isInheritable": false,
-                                    "position": 60
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "WOcw2SLH6tbX",
-                                    "isInheritable": false,
-                                    "position": 70
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "4TIF1oA4VQRO",
-                                    "isInheritable": false,
-                                    "position": 80
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "cRRrdZjgyhNc",
-                                    "isInheritable": false,
-                                    "position": 90
                                 }
                             ],
                             "format": "markdown",
@@ -19410,16 +19410,16 @@
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "CdNpE2pqjmI6",
+                                    "value": "bwg0e8ewQMak",
                                     "isInheritable": false,
-                                    "position": 30
+                                    "position": 10
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "bwg0e8ewQMak",
+                                    "value": "CdNpE2pqjmI6",
                                     "isInheritable": false,
-                                    "position": 40
+                                    "position": 20
                                 },
                                 {
                                     "type": "label",

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.md
@@ -19,9 +19,13 @@ The following features are preserved by Trilium during the import process:
     *   Black-colored text is intentionally stripped to allow it to work in dark themes.
 *   <a class="reference-link" href="../../../Note%20Types/Text/Lists.md">Lists</a> with different bullet types.
 *   <a class="reference-link" href="../../../Note%20Types/Text/Tables.md">Tables</a>
+    *   Cell backgrounds are preserved, including a best-effort hue correction because the colors returned by the Graph API are sometimes incorrect.
+    *   Cell widths are also preserved proportionally, with the only difference that tables in Trilium have a percentage-based width, not fixed pixel sizes.
 *   Images and <a class="reference-link" href="../../Notes/Attachments.md">Attachments</a>.
+    *   Screen clippings are also properly supported since v0.104.1, displaying their timestamp as a figure caption.
 *   To-do lists
-*   Hand-drawing is preserved and displayed as an SVG image (however there are some
+*   Hand-drawing is preserved and displayed as an SVG image inside the note
+    *   OneNote's default color (black) is special since it also renders as white for dark themes. Since v0.104.1, this is also supported by using a special SVG tweak which reacts to light/dark themes.
 *   Links between other imported pages are converted to <a class="reference-link" href="../../../Note%20Types/Text/Links/Internal%20(reference)%20links.md">Internal (reference) links</a> if the text of the link matches the name of the page, or plain links otherwise. If the pages are not part of the import, the original `onenote:` link is kept.
 *   Tags (apart from to-do lists) are mildly preserved by converting them to emojis. This loses their searchability. Since Trilium has no concept of inline attributes or badges, this is considered a middle-ground.
 
@@ -77,6 +81,7 @@ The following are known limitations due to how the information comes from the im
 *   Revision history.
 *   Paragraph indentation.
 *   Section colors.
+*   Drawings inside titles, the title might appear incomplete or “Untitled”.
 
 ## Reporting issues
 

--- a/packages/trilium-core/src/services/context.ts
+++ b/packages/trilium-core/src/services/context.ts
@@ -73,6 +73,24 @@ export function isMigrationRunning() {
     return !!getContext().get("migrationRunning");
 }
 
+/**
+ * While an import materializes its content tree, a `#newNotesOnTop` label inherited onto the import target
+ * would otherwise make {@link getNewNotePosition} insert each created note *above* the previous one, silently
+ * reversing the source order. Importers turn this on to keep imported content in its original order.
+ *
+ * It is turned on deliberately *after* an importer has created its own top-level root note, so that single
+ * root note still honours `newNotesOnTop` and floats to the top of the target (the reason users set the
+ * label) — only the content *underneath* it is order-preserved. The flag lives for the import's CLS context
+ * only, so it never needs clearing (each import runs in its own context, like `disableEntityEvents`).
+ */
+export function setImportOrderPreserved(preserved: boolean) {
+    getContext().set("importOrderPreserved", !!preserved);
+}
+
+export function isImportOrderPreserved() {
+    return !!getContext().get("importOrderPreserved");
+}
+
 export function putEntityChange(entityChange: EntityChange) {
     if (getContext().get("ignoreEntityChangeIds")) {
         return;

--- a/packages/trilium-core/src/services/import/anytype/importer.ts
+++ b/packages/trilium-core/src/services/import/anytype/importer.ts
@@ -31,6 +31,7 @@ import { parse } from "node-html-parser";
 
 import type BNote from "../../../becca/entities/bnote.js";
 import cloningService from "../../cloning.js";
+import * as cls from "../../context.js";
 import imageService from "../../image.js";
 import noteService from "../../notes.js";
 import protectedSessionService from "../../protected_session.js";
@@ -328,6 +329,10 @@ function createNotes(importRootNote: BNote, pages: ParsedObject[], targets: Map<
         applyCollectionView(rootNote, "table", rootColumns);
     }
     rootNote.addLabel("iconClass", "bx bx-import");
+
+    // Root created; keep the imported pages/collections in order under an inherited #newNotesOnTop (the root
+    // above still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     // Each member's primary parent is the first collection that lists it (a collection itself stays at the
     // root, so it's never reparented — it's cloned into an owning collection by the membership pass below).

--- a/packages/trilium-core/src/services/import/enex.ts
+++ b/packages/trilium-core/src/services/import/enex.ts
@@ -1,6 +1,7 @@
 import type { AttributeType } from "@triliumnext/commons";
 
 import type BNote from "../../becca/entities/bnote.js";
+import * as cls from "../context.js";
 import * as utils from "../utils/index.js";
 import imageService from "../image.js";
 import { getLog } from "../log.js";
@@ -73,6 +74,10 @@ async function importEnex(taskContext: TaskContext<"importNotes">, file: File, p
         mime: "text/html",
         isProtected: parentNote.isProtected && protectedSessionService.isProtectedSessionAvailable()
     }).note;
+
+    // Root created; keep the imported notes in their ENEX order under an inherited #newNotesOnTop (the root
+    // above still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     function extractContent(content: string, tasks: EnexTask[] = []) {
         const openingNoteIndex = content.indexOf("<en-note>");

--- a/packages/trilium-core/src/services/import/import_order.spec.ts
+++ b/packages/trilium-core/src/services/import/import_order.spec.ts
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import becca from "../../becca/becca.js";
+import { getContext } from "../context.js";
+import noteService from "../notes.js";
+import sql_init from "../sql_init.js";
+import TaskContext from "../task_context.js";
+import type { File } from "./common.js";
+import importFile, { type ImportOptions } from "./dispatch.js";
+
+const options: ImportOptions = {
+    safeImport: true,
+    shrinkImages: false,
+    textImportedAsText: true,
+    codeImportedAsCode: true,
+    spreadsheetImportedAsSpreadsheet: true,
+    explodeArchives: true, // required so a `.enex` routes to the ENEX importer rather than being kept as a single file
+    replaceUnderscoresWithSpaces: false
+};
+
+/** An ENEX export whose notes appear in a fixed document order; the importer creates them in that order. */
+function orderedEnex(titles: string[]): string {
+    const notes = titles
+        .map(
+            (title) => `  <note>
+    <title>${title}</title>
+    <created>20200101T000000Z</created>
+    <content><![CDATA[<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd"><en-note><div>${title}</div></en-note>]]></content>
+  </note>`
+        )
+        .join("\n");
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE en-export SYSTEM "http://xml.evernote.com/pub/evernote-export4.dtd">
+<en-export export-date="20260101T000000Z" application="Evernote" version="11">
+${notes}
+</en-export>`;
+}
+
+describe("import ordering (via the import dispatcher)", () => {
+    beforeAll(async () => {
+        sql_init.initializeDb();
+        await sql_init.dbReady;
+    });
+
+    // Regression guard for the whole import path — not one importer. A `#newNotesOnTop` label inherited onto
+    // the import target (the user's own root, say) makes createNewNote insert each new note *above* the last,
+    // which silently reverses every importer's output. ENEX stands in here for any importer that builds its
+    // tree with plain createNewNote calls (enex, keep, obsidian, notion, anytype, opml, onenote); only the
+    // generic zip importer is immune, because it restores explicit positions from the export metadata.
+    it("preserves the imported note order even when #newNotesOnTop is inherited onto the target", async () => {
+        const enex = orderedEnex(["Order Note A", "Order Note B", "Order Note C"]);
+
+        const orderedTitles = await new Promise<(string | undefined)[]>((resolve, reject) => {
+            void getContext().init(async () => {
+                try {
+                    // The label the user reported: inheritable on the import target, so every note the import
+                    // creates below it (the ENEX root and its children) inherits it.
+                    const parent = noteService.createNewNote({
+                        parentNoteId: "root",
+                        title: "import-order target",
+                        content: "",
+                        type: "text",
+                        mime: "text/html"
+                    }).note;
+                    parent.addLabel("newNotesOnTop", "", true);
+
+                    const taskContext = TaskContext.getInstance("import-order", "importNotes", options);
+                    const file: File = { originalname: "Ordered.enex", mimetype: "application/enex+xml", buffer: Buffer.from(enex) };
+                    const importRoot = await importFile(taskContext, file, parent, options);
+                    if (!importRoot || Array.isArray(importRoot)) {
+                        throw new Error("ENEX import did not return a root note");
+                    }
+
+                    // Order lives in notePosition (becca's in-memory `children` is insertion order); the tree
+                    // sorts by it the way the client renders it. Without the fix each note lands above the last
+                    // (positions -10, -20, -30 → C, B, A); the fix keeps the ENEX document order A, B, C.
+                    const titles = becca
+                        .getNoteOrThrow(importRoot.noteId)
+                        .getChildBranches()
+                        .slice()
+                        .sort((a, b) => a.notePosition - b.notePosition)
+                        .map((branch) => branch.getNote().title);
+                    resolve(titles);
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
+
+        expect(orderedTitles).toEqual(["Order Note A", "Order Note B", "Order Note C"]);
+    });
+});

--- a/packages/trilium-core/src/services/import/keep/importer.ts
+++ b/packages/trilium-core/src/services/import/keep/importer.ts
@@ -16,6 +16,7 @@
 import { t } from "i18next";
 
 import type BNote from "../../../becca/entities/bnote.js";
+import * as cls from "../../context.js";
 import imageService from "../../image.js";
 import noteService from "../../notes.js";
 import protectedSessionService from "../../protected_session.js";
@@ -217,6 +218,10 @@ function createNotes(importRootNote: BNote, notes: ParsedNote[], binaries: Map<s
 
     const rootNote = noteService.createNewNote({ parentNoteId: importRootNote.noteId, title: t("keep_import.root-title"), content: "", type: "text", mime: "text/html", isProtected }).note;
     rootNote.addLabel("iconClass", "bx bx-import");
+
+    // Root created; keep the imported notes in export order under an inherited #newNotesOnTop (the root above
+    // still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     for (const parsed of notes) {
         const { note } = noteService.createNewNote({

--- a/packages/trilium-core/src/services/import/notion/importer.ts
+++ b/packages/trilium-core/src/services/import/notion/importer.ts
@@ -18,6 +18,7 @@ import { t } from "i18next";
 import { type HTMLElement, parse } from "node-html-parser";
 
 import type BNote from "../../../becca/entities/bnote.js";
+import * as cls from "../../context.js";
 import imageService from "../../image.js";
 import noteService from "../../notes.js";
 import protectedSessionService from "../../protected_session.js";
@@ -195,6 +196,10 @@ function createNotes(importRootNote: BNote, pages: ParsedPage[], resources: Map<
 
     const rootNote = noteService.createNewNote({ parentNoteId: importRootNote.noteId, title: t("notion_import.root-title"), content: "", type: "text", mime: "text/html", isProtected }).note;
     rootNote.addLabel("iconClass", "bx bx-import");
+
+    // Root created; keep the imported pages in export order under an inherited #newNotesOnTop (the root above
+    // still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     const noteByFolder = new Map<string, BNote>();
     const targetByPageId = new Map<string, LinkTarget>();

--- a/packages/trilium-core/src/services/import/obsidian/importer.ts
+++ b/packages/trilium-core/src/services/import/obsidian/importer.ts
@@ -35,6 +35,7 @@
 import { t } from "i18next";
 
 import type BNote from "../../../becca/entities/bnote.js";
+import * as cls from "../../context.js";
 import noteService from "../../notes.js";
 import protectedSessionService from "../../protected_session.js";
 import type TaskContext from "../../task_context.js";
@@ -130,6 +131,10 @@ function createNotes(importRootNote: BNote, notes: VaultNote[], attachments: Map
 
     const rootNote = noteService.createNewNote({ parentNoteId: importRootNote.noteId, title: rootTitle, content: "", type: "text", mime: "text/html", isProtected }).note;
     rootNote.addLabel("iconClass", "bx bx-import");
+
+    // Root created; keep the vault's notes/folders in order under an inherited #newNotesOnTop (the root above
+    // still floats to the top of the target). See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     const attachmentIndex = buildAttachmentIndex(attachments);
     const shrinkImages = !!taskContext.data?.shrinkImages;

--- a/packages/trilium-core/src/services/import/opml.ts
+++ b/packages/trilium-core/src/services/import/opml.ts
@@ -1,6 +1,7 @@
 import xml2js from "xml2js";
 
 import type BNote from "../../becca/entities/bnote.js";
+import * as cls from "../context.js";
 import noteService from "../../services/notes.js";
 import protectedSessionService from "../protected_session.js";
 import type TaskContext from "../task_context.js";
@@ -84,6 +85,11 @@ async function importOpml(taskContext: TaskContext<"importNotes">, fileBuffer: s
 
     const outlines = xml.opml.body[0].outline || [];
     let returnNote: BNote | null = null;
+
+    // Unlike the other importers, OPML has no single wrapper root — its top-level outlines are imported
+    // directly under the target. So order-preservation covers the whole import (including those top-level
+    // outlines), otherwise an inherited #newNotesOnTop would reverse them. See cls.setImportOrderPreserved.
+    cls.setImportOrderPreserved(true);
 
     for (const outline of outlines) {
         const note = importOutline(outline, parentNote.noteId);

--- a/packages/trilium-core/src/services/import/zip.spec.ts
+++ b/packages/trilium-core/src/services/import/zip.spec.ts
@@ -8,6 +8,7 @@ import { PassThrough } from "stream";
 import zip, { removeTriliumTags } from "./zip.js";
 import becca from "../../becca/becca.js";
 import BNote from "../../becca/entities/bnote.js";
+import noteService from "../notes.js";
 import TaskContext from "../task_context.js";
 import sql_init from "../sql_init.js";
 import { trimIndentation } from "@triliumnext/commons";
@@ -470,6 +471,37 @@ describe("processNoteContent", () => {
         expect(child?.getParentNotes().map((n) => n.noteId)).toEqual(["root"]);
         expect(child?.getContent().toString()).toContain("child content");
         expect(becca.getBranchFromChildAndParent("root", "root")).toBeFalsy();
+    });
+
+    it("keeps a folder zip's entries in archive order under an inherited #newNotesOnTop (no position metadata)", async () => {
+        // A plain folder zip carries no !!!meta.json, so its notes have no stored positions and fall back to
+        // getNewNotePosition. With #newNotesOnTop inherited onto the target that default would reverse them
+        // (each note inserted above the last); the import must preserve the archive order instead.
+        const zipBuffer = await createZipBuffer({ "a.txt": "first", "b.txt": "second", "c.txt": "third" });
+
+        const orderedTitles = await new Promise<(string | undefined)[]>((resolve, reject) => {
+            void getContext().init(async () => {
+                try {
+                    const parent = noteService.createNewNote({ parentNoteId: "root", title: "zip-order target", content: "", type: "text", mime: "text/html" }).note;
+                    parent.addLabel("newNotesOnTop", "", true);
+
+                    const taskContext = TaskContext.getInstance("import-zip-order", "importNotes", { textImportedAsText: true });
+                    await zip.importZip(taskContext, zipBuffer, parent);
+
+                    // Sort by notePosition the way the tree renders it (becca's `children` is insertion order).
+                    const titles = parent
+                        .getChildBranches()
+                        .slice()
+                        .sort((a, b) => a.notePosition - b.notePosition)
+                        .map((branch) => branch.getNote().title);
+                    resolve(titles);
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
+
+        expect(orderedTitles).toEqual(["a.txt", "b.txt", "c.txt"]);
     });
 
     it("imports a CSV entry as a plain file note when the spreadsheet option is off", async () => {

--- a/packages/trilium-core/src/services/import/zip.ts
+++ b/packages/trilium-core/src/services/import/zip.ts
@@ -7,6 +7,7 @@ import BAttachment from "../../becca/entities/battachment.js";
 import BAttribute from "../../becca/entities/battribute.js";
 import BBranch from "../../becca/entities/bbranch.js";
 import type BNote from "../../becca/entities/bnote.js";
+import * as cls from "../context.js";
 import attributeService from "../../services/attributes.js";
 import { getLog } from "../../services/log.js";
 import noteService from "../../services/notes.js";
@@ -74,6 +75,19 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
     let firstNote: BNote | null = null;
     let topLevelPath = "";
     const createdNoteIds = new Set<string>();
+
+    // Records the first created note as the de-facto import root (its position is deliberately left to float
+    // per any inherited #newNotesOnTop — see the notePosition logic below). Once it exists, order-preservation
+    // is turned on so the remaining entries keep their archive order: this only matters for a non-Trilium
+    // folder zip, which carries no position metadata, since a Trilium export restores explicit positions for
+    // every non-root note and so never consults getNewNotePosition. See cls.setImportOrderPreserved.
+    function trackFirstNote(note: BNote) {
+        if (firstNote) {
+            return;
+        }
+        firstNote = note;
+        cls.setImportOrderPreserved(true);
+    }
 
     function getNewNoteId(origNoteId: string) {
         if (!origNoteId.trim()) {
@@ -305,7 +319,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
 
         saveAttributes(note, noteMeta);
 
-        firstNote = firstNote || note;
+        trackFirstNote(note);
         return noteId;
     }
 
@@ -644,7 +658,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
             }
 
             if (opts?.preserveIds || isImportRootNote) {
-                firstNote = firstNote || note;
+                trackFirstNote(note);
             }
         } else {
             if (detectedType as string === "geoMap") {
@@ -691,7 +705,7 @@ async function importZip(taskContext: TaskContext<"importNotes">, source: ZipSou
                 note.addLabel(attribute.name, attribute.value);
             }
 
-            firstNote = firstNote || note;
+            trackFirstNote(note);
         }
 
         if (!noteMeta && (type === "file" || type === "image")) {

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -74,7 +74,10 @@ export interface NoteParams {
 }
 
 function getNewNotePosition(parentNote: BNote) {
-    if (parentNote.isLabelTruthy("newNotesOnTop")) {
+    // An import that preserves its source order suspends newNotesOnTop for the content it creates, so an
+    // inherited `#newNotesOnTop` on the import target doesn't reverse the imported tree (see
+    // {@link cls.setImportOrderPreserved}).
+    if (!cls.isImportOrderPreserved() && parentNote.isLabelTruthy("newNotesOnTop")) {
         const minNotePos = parentNote
             .getChildBranches()
             .filter((branch) => branch?.noteId !== "_hidden") // has "always last" note position

--- a/packages/trilium-core/src/services/sanitizer.spec.ts
+++ b/packages/trilium-core/src/services/sanitizer.spec.ts
@@ -68,6 +68,15 @@ describe("sanitize", () => {
         expect(sanitizeHtml(dirty)).toBe(dirty);
     });
 
+    it("keeps a fractional image aspect-ratio (OneNote reports fractional pixel dimensions)", () => {
+        // CKEditor's usual integer ratio still passes...
+        expect(sanitizeHtml(`<img style="aspect-ratio:991/403" src="x.png" />`)).toContain("aspect-ratio:991/403");
+        // ...and a fractional ratio (e.g. a 577.5×277.5 OneNote screen clipping) is no longer stripped.
+        expect(sanitizeHtml(`<img style="aspect-ratio:577.5/277.5" src="x.png" />`)).toContain("aspect-ratio:577.5/277.5");
+        // A non-ratio value is still rejected.
+        expect(sanitizeHtml(`<img style="aspect-ratio:auto" src="x.png" />`)).not.toContain("aspect-ratio");
+    });
+
     describe("bookmark anchors", () => {
         it("preserves id attribute on empty <a> tags (CKEditor bookmarks)", () => {
             const dirty = `<a id="my-bookmark"></a>`;

--- a/packages/trilium-core/src/services/sanitizer.ts
+++ b/packages/trilium-core/src/services/sanitizer.ts
@@ -70,7 +70,8 @@ export function sanitizeHtml(dirtyHtml: string) {
                 height: sizeRegex
             },
             img: {
-                "aspect-ratio": [ /^\d+\/\d+$/ ],
+                // Allow fractional ratios too (e.g. OneNote reports 577.5×277.5 screen clippings).
+                "aspect-ratio": [ /^\d+(\.\d+)?\/\d+(\.\d+)?$/ ],
                 width: sizeRegex,
                 height: sizeRegex
             },

--- a/packages/trilium-core/src/services/utils/index.spec.ts
+++ b/packages/trilium-core/src/services/utils/index.spec.ts
@@ -215,7 +215,9 @@ describe.todo("#crash", () => {});
 
 describe("#getContentDisposition", () => {
 
-    const defaultFallBackDisposition = `file; filename="file"; filename*=UTF-8''file`;
+    // "attachment" is one of the two disposition types defined by RFC 6266 — Safari renders
+    // responses with an unknown type (e.g. the former "file") inline instead of downloading them.
+    const defaultFallBackDisposition = `attachment; filename="file"; filename*=UTF-8''file`;
     const testCases: TestCase<typeof utils.getContentDisposition>[] = [
         [
             "when passed filename is empty, it should fallback to default value 'file'",
@@ -236,7 +238,7 @@ describe("#getContentDisposition", () => {
         [
             "sanitized passed filename should be returned URIEncoded",
             [ "test file.csv" ],
-            `file; filename="test%20file.csv"; filename*=UTF-8''test%20file.csv`
+            `attachment; filename="test%20file.csv"; filename*=UTF-8''test%20file.csv`
         ]
     ];
 

--- a/packages/trilium-core/src/services/utils/index.ts
+++ b/packages/trilium-core/src/services/utils/index.ts
@@ -173,7 +173,7 @@ export function sanitizeSvg(svg: string): string {
 export function getContentDisposition(filename: string) {
     const sanitizedFilename = sanitizeFileName(filename).trim() || "file";
     const uriEncodedFilename = encodeURIComponent(sanitizedFilename);
-    return `file; filename="${uriEncodedFilename}"; filename*=UTF-8''${uriEncodedFilename}`;
+    return `attachment; filename="${uriEncodedFilename}"; filename*=UTF-8''${uriEncodedFilename}`;
 }
 
 export function formatDownloadTitle(fileName: string, type: string | null, mime: string) {


### PR DESCRIPTION
## Summary

A batch of OneNote-import rendering refinements, plus a general import-ordering fix that turned out to affect every importer (not just OneNote).

## OneNote import rendering

- **Floating images render as figures, with captions** — OneNote lays a standalone image out as a bare `<img>` floating in the outline `<div>`, often trailed by a `<cite>` caption (e.g. a screen clipping's "Screen clipping taken: …"). Each floating image is now wrapped in `<figure class="image">`, its width/height carried into an `aspect-ratio` (CKEditor's stored form), and a trailing `<cite>` pulled in as a `<figcaption>`.
- **Table column widths preserved** — OneNote carries a resized column's width as a bare pixel `width` on every cell (`<td style="width:150;…">`), which the sanitizer dropped. When every column of a table is width-annotated, this is translated into CKEditor's resized-table shape (a `<colgroup>` of proportional percentages on a `ck-table-resized` table inside `<figure class="table">`). Tables with merged cells (`colspan`/`rowspan`) or partial widths are left untouched.
- **Table cell shading un-darkened** — Graph exports cell shading as a dark shade of the colour it actually displays (hue/saturation kept, lightness inverted, e.g. `#b6d9a1` comes back as `#375623`), so shaded cells imported dark-on-dark and unreadable. Dark cell backgrounds now have their lightness reflected (`L → 1 − L`) to recover the displayed tint; light backgrounds are left alone. This is a best-effort inverse of a known, undocumented OneNote quirk (also seen by the OneMore add-in and the Obsidian importer).
- **Default (automatic) ink renders theme-adaptively** — OneNote's default pen, like its automatic text colour, is black on a light canvas but inverts to white in dark mode. The InkML→SVG converter had baked it as hard `#000000`, so dark-theme strokes were black-on-dark. Automatic ink is now emitted via a `.ink-auto` class backed by `light-dark()`, keyed to the embedding `<img>`'s inherited `color-scheme`; deliberately-chosen colours are left as-is. Mirrors the existing `removeDefaultTextColor` handling on the HTML side.

## Import ordering (all importers)

- **Preserve source order under an inherited `#newNotesOnTop`** — a `#newNotesOnTop` label inherited onto the import target made `createNewNote` insert each imported note *above* the previous one, silently reversing every importer's output (sections, pages, notes). The fix suspends `newNotesOnTop` for the content an import creates, via a CLS flag (`cls.setImportOrderPreserved`) consulted in `getNewNotePosition` — the one place `newNotesOnTop` is honored. Each importer turns it on *after* creating its own root note, so that root still floats to the top of the target while its contents keep their source order. Covers enex, keep, notion, obsidian, anytype, opml, zip (non-Trilium folder zips) and onenote; Trilium exports and single-file imports are unaffected.

## Testing

- New/extended unit tests: `converter.spec.ts` and `inkml.spec.ts` (OneNote rendering), `sanitizer.spec.ts`, `importer.spec.ts` (OneNote order), plus `import_order.spec.ts` (import path via the dispatcher) and `zip.spec.ts` (folder-zip ordering) for the ordering fix.
- Full server + trilium-core import/notes/context test sweep is green; `pnpm typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
