### PR TITLE
test(onenote): cover the remaining importer conversion branches

### DIFF
--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -359,6 +359,16 @@ describe("convertPageHtml", () => {
         ]);
     });
 
+    it("sorts outlines missing position coordinates as 0 and breaks top ties by left", () => {
+        const sample = `<body>
+            <div style="position:absolute;left:200px;top:100px"><p>right</p></div>
+            <div style="position:absolute;left:50px;top:100px"><p>left</p></div>
+            <div style="position:absolute"><p>unplaced</p></div>
+        </body>`;
+        const paragraphs = parse(converter.convertPageHtml(sample)).querySelectorAll("p").map((p) => p.textContent.trim());
+        expect(paragraphs).toEqual(["unplaced", "left", "right"]);
+    });
+
     it("moves OneNote list marker types from <li> onto the list, mapping alpha to latin", () => {
         const out = converter.convertPageHtml(LISTS_SAMPLE);
         const root = parse(out);
@@ -440,6 +450,22 @@ describe("convertPageHtml", () => {
         expect(parse(converter.convertPageHtml(sample)).querySelector("colgroup")).toBeFalsy();
     });
 
+    it("keeps a resized cell's other styles and appends to the table's existing class", () => {
+        // Both columns carry a width on the first row; the second row's cells have no style at all.
+        // Stripping the redundant widths must keep the shaded cell's background, leave the style-less
+        // cells alone, and append the resized marker to the table's pre-existing class.
+        const sample = `<body><div><table class="layout"><tr><td style="width:100;background-color:#b6d9a1">A</td><td style="width:300">B</td></tr><tr><td>C</td><td>D</td></tr></table></div></body>`;
+        const root = parse(converter.convertPageHtml(sample));
+
+        expect(root.querySelector("table")?.getAttribute("class")).toContain("ck-table-resized");
+        const cols = root.querySelectorAll("colgroup col").map((col) => col.getAttribute("style"));
+        expect(cols).toEqual(["width:25%", "width:75%"]);
+
+        const shaded = root.querySelectorAll("td").find((td) => td.textContent === "A");
+        expect(shaded?.getAttribute("style")).toContain("background-color:#b6d9a1");
+        expect(shaded?.getAttribute("style") ?? "").not.toContain("width");
+    });
+
     it("recovers OneNote's over-darkened table cell shading by reflecting its lightness", () => {
         // OneNote's Graph export returns cell shading as a dark shade of the colour it displays (same
         // hue and saturation, inverted lightness): a cell shown as #b6d9a1 comes back as #375623.
@@ -456,6 +482,24 @@ describe("convertPageHtml", () => {
         // so only dark cell backgrounds are reflected.
         const sample = `<body><div><table><tr><td style="background-color:#b6d9a1">A</td><td>B</td></tr></table></div></body>`;
         expect(converter.convertPageHtml(sample)).toContain("background-color:#b6d9a1");
+    });
+
+    it("reflects dark shading across the hue wheel, including grays and short hex", () => {
+        // One dark cell per rgbToHsl hue sector (the green-dominant sector is covered above): plain
+        // dark red, a magenta whose hue wraps past the top of the wheel, a blue-dominant navy, and an
+        // achromatic gray in the short #rgb form.
+        const sample = `<body><div><table><tr>
+            <td style="background-color:#8b0000">Dark red</td>
+            <td style="background-color:#400040">Dark magenta</td>
+            <td style="background-color:#000080">Navy</td>
+            <td style="background-color:#333">Dark gray</td>
+        </tr></table></div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).toContain("background-color:#ff7474"); // dark red -> light red, hue preserved
+        expect(out).toContain("background-color:#ffbfff"); // dark magenta -> light magenta
+        expect(out).toContain("background-color:#7f7fff"); // navy -> light blue
+        expect(out).toContain("background-color:#cccccc"); // gray stays achromatic, just lightened
     });
 
     it("converts OneNote to-do tags into a Trilium task list", () => {
@@ -543,6 +587,16 @@ describe("convertPageHtml", () => {
         expect(out).not.toContain("0-eee"); // the full-resolution resource id is gone
     });
 
+    it("fills in defaults for an attachment object with missing metadata", () => {
+        // An <object> tagged as an attachment but with an empty name and no type/data still becomes a
+        // marker anchor, with placeholder filename and mime.
+        const out = converter.convertPageHtml(`<body><div><object data-attachment="" /></div></body>`);
+        const anchor = parse(out).querySelector("a.onenote-attachment");
+
+        expect(anchor?.textContent).toBe("attachment");
+        expect(anchor?.getAttribute("data-mime")).toBe("application/octet-stream");
+    });
+
     it("wraps a floating image and its trailing cite caption into a figure with a figcaption", () => {
         const out = converter.convertPageHtml(SCREEN_CLIPPING_SAMPLE);
         const root = parse(out);
@@ -587,6 +641,26 @@ describe("convertPageHtml", () => {
 
         expect(root.querySelectorAll("figure")).toHaveLength(0);
         expect(root.querySelector("p img")).toBeTruthy();
+    });
+
+    it("keeps an unstyled trailing caption as a bare cite (no font-size wrapper)", () => {
+        // A cite with no style has no font-size class, so the figcaption holds the cite directly.
+        const out = converter.convertPageHtml(`<body><div><img width="10" height="10" src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /><br /><cite>Plain caption</cite></div></body>`);
+        const figcaption = parse(out).querySelector("figure.image figcaption");
+
+        expect(figcaption?.querySelector("cite")?.textContent).toBe("Plain caption");
+        expect(figcaption?.querySelector("span")).toBeFalsy();
+    });
+
+    it("leaves an image and break with no block container (fragment root) untouched", () => {
+        // Content directly at the fragment root (no <body>, no outline <div>) has no recognized block
+        // parent: the image is not wrapped into a figure and the break is not treated as block spacing.
+        const out = converter.convertPageHtml(`<img src="https://graph.microsoft.com/v1.0/users('me')/onenote/resources/0-x!1-y!sz/$value" /><br />`);
+        const root = parse(out);
+
+        expect(root.querySelector("figure")).toBeFalsy();
+        expect(root.querySelector("img")).toBeTruthy();
+        expect(root.querySelectorAll("br")).toHaveLength(1);
     });
 
     it("converts inline-style formatting (bold/italic/underline) to semantic tags", () => {
@@ -681,6 +755,34 @@ describe("convertPageHtml", () => {
         expect(out).toContain(`<span class="text-big">Size 26</span>`);
         expect(out).toContain(`<span class="text-huge">Size 28</span>`);
         expect(out).toContain(`<span class="text-huge">Size 72</span>`);
+    });
+
+    it("converts px font sizes on the pt scale and ignores unparseable ones", () => {
+        const sample = `<body><div style="position:absolute;left:0px;top:0px">
+            <p style="margin-top:0pt;margin-bottom:0pt"><span style="font-size:24px">Pixel size</span></p>
+            <p style="margin-top:0pt;margin-bottom:0pt"><span style="font-size:medium">Named size</span></p>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        // 24px = 18pt, the bottom of the big band; a named (unparseable) size gets no size class.
+        expect(out).toContain(`<span class="text-big">Pixel size</span>`);
+        expect(out).toContain("Named size");
+        expect(out).not.toMatch(/text-\w+">Named size</);
+    });
+
+    it("keeps a non-span element that loses its default black color, with its other styles", () => {
+        const sample = `<body><div style="position:absolute;left:0px;top:0px">
+            <p style="color:#000000">Black paragraph</p>
+            <ul><li style="list-style-type:circle;background-color:#ffff00">Styled item</li></ul>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        // The default black is dropped but the <p> itself stays (only bare <span>s are unwrapped).
+        expect(out).toContain("Black paragraph");
+        expect(out).not.toContain("color:#000000");
+        // A list item keeps its remaining styles once its marker type moves onto the list.
+        expect(out).toContain("background-color:#ffff00");
+        expect(out).not.toMatch(/<li[^>]*list-style-type/);
     });
 
     it("maps the 20pt Title style to text-big and the Code style to <code>", () => {

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -676,6 +676,7 @@ function hslToHex(h: number, s: number, l: number): string {
     if (s === 0) {
         return `#${channel(l).repeat(3)}`;
     }
+    /* v8 ignore next -- only called from correctTableShadingColors with l strictly above 0.5 */
     const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
     const p = 2 * l - q;
     const component = (t: number) => {

--- a/apps/server/src/services/import/onenote/inkml.spec.ts
+++ b/apps/server/src/services/import/onenote/inkml.spec.ts
@@ -54,6 +54,22 @@ describe("inkmlToSvg", () => {
         expect(svg).toContain("circle.ink-auto{fill:light-dark(#000,#fff)}");
     });
 
+    it("renders a deliberately-colored single-point trace with a literal fill", () => {
+        const dot = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="br0"><inkml:brushProperty name="color" value="#FF0000"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#br0">50 60</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(dot) ?? "";
+
+        // A chosen color is baked into the dot's fill; no adaptive class or style block is emitted.
+        expect(svg).toContain("<circle");
+        expect(svg).toContain(`fill="#FF0000"`);
+        expect(svg).not.toContain("ink-auto");
+        expect(svg).not.toContain("<style>");
+    });
+
     it("works without namespace prefixes and falls back to a default (automatic) brush", () => {
         const plain = `<ink><trace>0 0, 10 10</trace></ink>`;
         const svg = inkmlToSvg(plain) ?? "";
@@ -92,6 +108,38 @@ describe("inkmlToSvg", () => {
         expect(svg).toContain(`stroke="#FF0000"`);
         expect(svg).not.toContain("ink-auto");
         expect(svg).not.toContain("<style>");
+    });
+
+    it("tolerates malformed brush and trace data, falling back to defaults", () => {
+        // An id-less brush is skipped; a name-less property and non-numeric width/height are ignored
+        // (keeping the defaults); a bare (un-prefixed) brushRef still resolves; a trace with
+        // unparseable coordinates contributes nothing.
+        const messy = `<ink>
+            <definitions>
+                <brush><brushProperty name="color" value="#123456"/></brush>
+                <brush xml:id="b1">
+                    <brushProperty value="orphan"/>
+                    <brushProperty name="width" value="wide"/>
+                    <brushProperty name="height" value="tall"/>
+                    <brushProperty name="color" value="#00AA00"/>
+                </brush>
+            </definitions>
+            <trace brushRef="b1">0 0, 10 10</trace>
+            <trace>squiggle</trace>
+        </ink>`;
+        const svg = inkmlToSvg(messy) ?? "";
+
+        expect((svg.match(/<path/g) ?? [])).toHaveLength(1);
+        expect(svg).toContain(`stroke="#00AA00"`);
+        expect(svg).toContain(`stroke-width="70"`); // default width kept over the unparseable one
+        expect(svg).not.toContain("#123456"); // the id-less brush is never referenced
+    });
+
+    it("scales fractional coordinates and survives a missing closing tag", () => {
+        // Fractional coords are scaled up 10000x for precision; the truncated document (no </ink>)
+        // still parses. 1.5→15000, 3.5→35000: 20000 wide + 2*padding(10).
+        const svg = inkmlToSvg(`<ink><trace>1.5 2.5, 3.5 4.5</trace>`) ?? "";
+        expect(svg).toContain(`viewBox="0 0 20020 20020"`);
     });
 
     it("returns null for empty input or ink with no traces", () => {


### PR DESCRIPTION
## Summary

Closes the patch-coverage gaps Codecov flagged on #10636 (85.13% → 100%), all in `converter.ts` and `inkml.ts`. Adds 11 test cases (96 → 107 passing), all going through the public `convertPageHtml` / `inkmlToSvg` API in the existing spec style.

### converter.spec.ts

- **Cell-shading color math**: a table with dark red, wrap-around magenta (`#400040`), navy, and short-hex achromatic gray (`#333`) cells, asserting the exact lightness-reflected hex outputs — exercises every `rgbToHsl` switch arm and all reachable `hslToHex` component branches (existing tests only hit the green-dominant sector).
- **Table resizing**: a resized table whose shaded cell keeps its remaining `background-color` after the redundant width is stripped, whose style-less cells are left alone, and whose pre-existing `class` gets `ck-table-resized` appended.
- **Floating images**: an unstyled trailing `<cite>` caption (bare cite, no font-size wrapper) and an image/`<br>` at the fragment root with no recognized block container.
- **Smaller branches**: attachment `<object>` with missing metadata defaults, px and unparseable font sizes, outline ordering with missing coordinates and tied tops, non-span elements losing the default black color while keeping other styles.

### inkml.spec.ts

- Literal `fill` on a deliberately-colored single-point trace (the flagged partial), malformed brush/trace fallbacks, fractional-coordinate scaling, and a document missing its closing `</ink>`.

### converter.ts

- One-line annotation: `hslToHex`'s `l < 0.5` arm is provably unreachable (its only caller passes `1 − lightness` with `lightness < 0.5`), so it's marked `/* v8 ignore next */` with the reason, per the repo's existing convention.

The few remaining partial branches in both files are pre-existing dead defensive fallbacks (e.g. `?? ""` behind `[style]` selectors) outside this PR's diff, left untouched to avoid churn.

## Testing

- `vitest run src/services/import/onenote/` — 7 files, 107 tests pass
- ESLint clean on the three changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqasnEAj2UL1gsZe49Uxpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqasnEAj2UL1gsZe49Uxpa)_