### PR TITLE
fix(nix): make flake more robust, reduce log spam

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779201759,
-        "narHash": "sha256-cako3/kPRtMVWkbAJsQHW4MF5Rr8antZXHR4VAO8DHg=",
+        "lastModified": 1784812282,
+        "narHash": "sha256-Na4aTmdz22ovtSvcvNKaRwEWkg801hDyX6t8JqvW+sE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fee0aaa25f0714c7c9281d11054c007a21fd3637",
+        "rev": "6d12004108e0e4a5cfa4bd83b14477f040b15773",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -43,15 +44,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1778690633,
-        "narHash": "sha256-aCw5ZrbO02VTuF+Pf6APotGvDR0dH+0N1HqocK1UhU8=",
-        "owner": "TriliumNext",
+        "lastModified": 1784968304,
+        "narHash": "sha256-NPXKyp40QNCk9r6kavSwqi/zv7OcLgrSRtPmHW+e74w=",
+        "owner": "FliegendeWurst",
         "repo": "pnpm2nix-nzbr",
-        "rev": "31d00012c26b14303702a35885ccc97943888366",
+        "rev": "9b15300b711a50bb96e553b66aad5cad94df9c7e",
         "type": "github"
       },
       "original": {
-        "owner": "TriliumNext",
+        "owner": "FliegendeWurst",
         "ref": "main",
         "repo": "pnpm2nix-nzbr",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "Trilium Notes (experimental flake)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     pnpm2nix = {
-      url = "github:TriliumNext/pnpm2nix-nzbr/main";
+      url = "github:FliegendeWurst/pnpm2nix-nzbr/main";
       inputs = {
         flake-utils.follows = "flake-utils";
         nixpkgs.follows = "nixpkgs";
@@ -303,14 +303,15 @@ nodejs.python
 
         server = makeApp {
           app = "server";
-          # pnpm throws an error at the end of `pnpm rebuild`, but it doesn't seem to matter:
+          # Important note: if pnpm throws an error similar to the follow at the end of `pnpm rebuild`,
+          # you should ensure the version of tsx (and other dependencies mentioned in the error) is identical project-wide.
           # ERR_PNPM_MISSING_HOISTED_LOCATIONS
           # vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(less@4.1.3)(lightningcss@1.30.1)
           # (sass-embedded@1.91.0)(sass@1.91.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.1)
           # is not found in hoistedLocations inside node_modules/.modules.yaml
           preBuildCommands = ''
             pushd apps/server
-            pnpm rebuild || true
+            pnpm rebuild
             popd
           '';
           buildTask = "server:build";


### PR DESCRIPTION
The `pnpm rebuild` command is critical for a working server build, so the build should fail if it does not succeed. I added a comment that explains how to fix the error that occured previously.

pnpm v11 `store add` prints O(n^2) lines when adding n packages, so we pass --silent in the updated pnpm2nix-nzbr fork. (I also incorporated your other fixes from TriliumNext/pnpm2nix-nzbr.)

I also changed the `nixpkgs` source URL to point to the `nixpkgs-unstable` channel. This ensures we always get a cached copy of the build tools (the channel only advances after all packages have been built).