### PR TITLE
fix(client): update notification never shown outside standalone

### DIFF
--- a/apps/client/src/widgets/buttons/global_menu.spec.tsx
+++ b/apps/client/src/widgets/buttons/global_menu.spec.tsx
@@ -1,0 +1,151 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared, mutable control state for the mocks below. `vi.hoisted` runs before the hoisted `vi.mock`
+// factories, so they can safely reference it.
+const ctrl = vi.hoisted(() => ({ standalone: false, checkForUpdates: true }));
+
+// `isStandalone` is a const in the target, read here as a live getter so each scenario can flip the
+// kind of client we are pretending to be. Partial-mock so the rest of utils stays real — in
+// particular `isUpdateAvailable`, which is the version comparison under test.
+vi.mock("../../services/utils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../services/utils")>()),
+    get isStandalone() {
+        return ctrl.standalone;
+    }
+}));
+
+// The hook reads the user's preference through `useTriliumOptionBool`; stub just that one, so the
+// other hooks the menu pulls in keep their real implementation.
+vi.mock("../react/hooks", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../react/hooks")>()),
+    useTriliumOptionBool: () => [ ctrl.checkForUpdates, vi.fn() ]
+}));
+
+// Import AFTER the mocks (vi.mock is hoisted, but the import must resolve the mocked deps).
+import { parseLatestVersion, RELEASES_API_URL, UPDATE_CHECK_INTERVAL, useTriliumUpdateStatus } from "./global_menu";
+
+let status: ReturnType<typeof useTriliumUpdateStatus> | undefined;
+let container: HTMLDivElement | undefined;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function Probe() {
+    status = useTriliumUpdateStatus();
+    return null;
+}
+
+async function mount() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    await act(async () => {
+        if (container) {
+            render(<Probe />, container);
+        }
+    });
+    await advance(1);
+}
+
+function unmount() {
+    if (container) {
+        render(null, container);
+        container.remove();
+        container = undefined;
+    }
+}
+
+/** Runs the fake clock forward, flushing the promise chain of any fetch it kicks off along the way. */
+async function advance(ms: number) {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+    });
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    ctrl.standalone = false;
+    ctrl.checkForUpdates = true;
+    status = undefined;
+
+    window.glob = { ...window.glob, triliumVersion: "0.104.0" };
+    fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ tag_name: "v0.104.1" }) });
+    vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+    unmount();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe("useTriliumUpdateStatus", () => {
+    it("polls GitHub and flags the update on clients the user updates by hand", async () => {
+        await mount();
+
+        expect(fetchMock).toHaveBeenCalledWith(RELEASES_API_URL);
+        expect(status?.latestVersion).toBe("0.104.1");
+        expect(status?.isUpdateAvailable).toBe(true);
+    });
+
+    it("stays quiet in standalone, which picks up new versions on reload", async () => {
+        ctrl.standalone = true;
+
+        await mount();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(status?.latestVersion).toBeUndefined();
+        expect(status?.isUpdateAvailable).toBe(false);
+    });
+
+    it("stays quiet when the user switched the check off", async () => {
+        ctrl.checkForUpdates = false;
+
+        await mount();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(status?.isUpdateAvailable).toBe(false);
+    });
+
+    it("reports no update once the running version has caught up", async () => {
+        window.glob = { ...window.glob, triliumVersion: "0.104.1" };
+
+        await mount();
+
+        expect(status?.latestVersion).toBe("0.104.1");
+        expect(status?.isUpdateAvailable).toBe(false);
+    });
+
+    it("re-checks on the interval, and stops once unmounted", async () => {
+        await mount();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        await advance(UPDATE_CHECK_INTERVAL);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        unmount();
+        await advance(UPDATE_CHECK_INTERVAL * 2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps the badge hidden when GitHub cannot be reached", async () => {
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        fetchMock.mockRejectedValue(new Error("offline"));
+
+        await mount();
+
+        expect(status?.latestVersion).toBeUndefined();
+        expect(status?.isUpdateAvailable).toBe(false);
+        expect(warn).toHaveBeenCalled();
+    });
+});
+
+describe("parseLatestVersion", () => {
+    it("strips the tag prefix, and ignores payloads without a usable tag", () => {
+        expect(parseLatestVersion({ tag_name: "v0.104.1" })).toBe("0.104.1");
+        expect(parseLatestVersion({ tag_name: "0.104.1" })).toBe("0.104.1");
+        expect(parseLatestVersion({})).toBeUndefined();
+        expect(parseLatestVersion(undefined)).toBeUndefined();
+        expect(parseLatestVersion({ tag_name: 104 })).toBeUndefined();
+    });
+});

--- a/apps/client/src/widgets/buttons/global_menu.tsx
+++ b/apps/client/src/widgets/buttons/global_menu.tsx
@@ -11,7 +11,7 @@ import { t } from "../../services/i18n";
 import utils, { isElectron, isMobile, isStandalone, reloadFrontendApp } from "../../services/utils";
 import Dropdown from "../react/Dropdown";
 import { FormDropdownDivider, FormDropdownSubmenu, FormListHeader, FormListItem } from "../react/FormList";
-import { useStaticTooltip, useStaticTooltipWithKeyboardShortcut, useTriliumOption, useTriliumOptionBool, useTriliumOptionInt } from "../react/hooks";
+import { useStaticTooltip, useStaticTooltipWithKeyboardShortcut, useTriliumOption, useTriliumOptionBool } from "../react/hooks";
 import KeyboardShortcut from "../react/KeyboardShortcut";
 import { ParentComponent } from "../react/react_utils";
 
@@ -249,37 +249,64 @@ function ToggleWindowOnTop() {
     );
 }
 
-function useTriliumUpdateStatus() {
+/** GitHub's "latest release" endpoint, which already excludes drafts and pre-releases. */
+export const RELEASES_API_URL = "https://api.github.com/repos/TriliumNext/Trilium/releases/latest";
+
+/** How often to re-check for a newer release, in milliseconds. */
+export const UPDATE_CHECK_INTERVAL = 8 * 60 * 60 * 1000;
+
+/**
+ * Watches GitHub for a release newer than the version this client is running, so the menu can show
+ * the update badge and a download link.
+ *
+ * Standalone is left out: it is served from the web and picks up new versions on reload, so there is
+ * no release for the user to go and download. Every other client — desktop and server alike — is
+ * updated by hand and wants the hint.
+ */
+export function useTriliumUpdateStatus() {
     const [ latestVersion, setLatestVersion ] = useState<string>();
     const [ checkForUpdates ] = useTriliumOptionBool("checkForUpdates");
     const isUpdateAvailable = utils.isUpdateAvailable(latestVersion, window.glob.triliumVersion);
 
-    async function updateVersionStatus() {
-        const RELEASES_API_URL = "https://api.github.com/repos/TriliumNext/Trilium/releases/latest";
-
-        let latestVersion: string | undefined;
-        try {
-            const resp = await fetch(RELEASES_API_URL);
-            const data = await resp.json();
-            latestVersion = data?.tag_name?.substring(1);
-        } catch (e) {
-            console.warn("Unable to fetch latest version info from GitHub releases API", e);
-        }
-
-        setLatestVersion(latestVersion);
-    }
-
     useEffect(() => {
-        if (!checkForUpdates || !isStandalone) {
+        if (!checkForUpdates || isStandalone) {
             setLatestVersion(undefined);
             return;
         }
 
-        updateVersionStatus();
+        // A request still in flight when the option is switched off (or the menu unmounts) must not
+        // resurrect the version afterwards, so ignore whatever it resolves to.
+        let cancelled = false;
 
-        const interval = setInterval(() => updateVersionStatus(), 8 * 60 * 60 * 1000);
-        return () => clearInterval(interval);
+        async function updateVersionStatus() {
+            let latestVersion: string | undefined;
+            try {
+                const resp = await fetch(RELEASES_API_URL);
+                const data = await resp.json();
+                latestVersion = parseLatestVersion(data);
+            } catch (e) {
+                console.warn("Unable to fetch latest version info from GitHub releases API", e);
+            }
+
+            if (!cancelled) {
+                setLatestVersion(latestVersion);
+            }
+        }
+
+        void updateVersionStatus();
+
+        const interval = setInterval(() => void updateVersionStatus(), UPDATE_CHECK_INTERVAL);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
     }, [ checkForUpdates ]);
 
     return { isUpdateAvailable, latestVersion };
+}
+
+/** Reads the version off a GitHub release payload, stripping the tag prefix (`v0.104.1` → `0.104.1`). */
+export function parseLatestVersion(payload: unknown): string | undefined {
+    const tagName = (payload as { tag_name?: unknown } | null | undefined)?.tag_name;
+    return typeof tagName === "string" ? tagName.replace(/^v/, "") : undefined;
 }


### PR DESCRIPTION
## The bug

The update badge on the global menu logo has been dead on **desktop and server clients since 0.104.0**. It only ever appears in the standalone WASM build.

`useTriliumUpdateStatus` gated the GitHub poll on `!isStandalone`:

```ts
if (!checkForUpdates || !isStandalone) {
    setLatestVersion(undefined);
    return;
}
```

`window.glob.isStandalone` is hardcoded `false` in `apps/server/src/routes/index.ts` (the route that serves desktop and server clients) and `true` only in `apps/standalone/src/lightweight/browser_routes.ts`. So the check ran exclusively in the one client that cannot act on the result — standalone is served from the web and picks up new versions on reload, so there is no release to go and download. Everywhere else `latestVersion` stayed `undefined` and the badge never rendered, for *any* version bump, patch or minor.

There is no fallback path: the desktop app ships no auto-updater (`electron-updater` / `update-electron-app` appear nowhere in the repo), so this badge is the only update notification users get.

Introduced in af346f455a, `git tag --contains` puts it in **0.104.0 and 0.104.1 only**. The badge was added in 0.100.0 and worked through 0.103.0. Reported by a user on 0.104.0 who saw no notification for 0.104.1.

Ruled out as causes: `v0.104.1` is published as a normal (non-prerelease) release and `GET /releases/latest` returns it correctly; `compareVersions()` handles the patch component fine.

## The fix

`!isStandalone` → `isStandalone`, keeping standalone excluded deliberately rather than just un-inverting the typo — it is the client for which a "download the release" prompt is meaningless.

The hook is now exported and covered by tests that pin down **both** directions — desktop/server must poll, standalone must not — so the condition cannot be flipped back unnoticed. Verified red-then-green: with `!isStandalone` restored, 5 of the 7 tests fail.

Three smaller fixes ride along:

- Release-tag parsing now strips a leading `v` instead of `substring(1)`, which blindly dropped the first character of whatever tag came back.
- A fetch that resolves after the option is switched off (or the menu unmounts) no longer resurrects a stale version.
- Dropped the already-unused `useTriliumOptionInt` import.

## Testing

New `apps/client/src/widgets/buttons/global_menu.spec.tsx` — 7 tests using the `Probe` + `act()` pattern from the existing `hooks.spec.tsx`, with `isStandalone` partial-mocked as a live getter (same approach as `experimental_features.spec.ts`) and fake timers driving the 8-hour re-check. Covers: polling and flagging an update, silence in standalone, silence when the option is off, no badge once the running version has caught up, interval re-check plus cleanup on unmount, and an unreachable GitHub.

All 7 pass; the 15 existing react specs (116 tests) still pass; `tsc -p apps/client/tsconfig.app.json` is clean and ESLint reports no new warnings on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)