### PR TITLE
fix(dashboard): handle gridstack v13 returning no grid from init

### DIFF
--- a/apps/client/src/widgets/collections/dashboard/index.tsx
+++ b/apps/client/src/widgets/collections/dashboard/index.tsx
@@ -207,6 +207,10 @@ function useDashboardGrid({ note, notes, viewConfig, saveConfig, containerRef, g
                 breakpoints: [{ w: SINGLE_COLUMN_BREAKPOINT, c: 1 }]
             }
         }, container);
+        // Gridstack only declines to initialize without a DOM (server-side rendering) or without the
+        // element it was pointed at — neither happens once the container ref is attached.
+        if (!grid) return;
+
         gridRef.current = grid;
         grid.on("change", () => persistLayout(grid));
 


### PR DESCRIPTION
Unblocks #10699.

## Problem

Gridstack 13 changed `GridStack.init()` to return `GridStack | null` — it declines to initialize without a DOM (SSR) or without the element it was pointed at. The dashboard used the result directly, so the bump failed `pnpm typecheck` with 11 errors.

Only **three** of those were real (all in `dashboard/index.tsx`). The other eight — in `AddProviderModal.spec.ts`, `locales.spec.ts` and `frontend_script_entrypoint.ts` — were cascade fallout: `tsc --build` stops emitting declarations for `apps/client` once it errors, so the downstream spec and build-docs projects lost their types (`Property 'apiKey' does not exist on type '{}'`, unused `@ts-expect-error`). `scripts/filter-tsc-output.mts` suppresses the `TS6305` noise that would have made that obvious. Fixing the three real errors clears all eleven.

## Fix

Bail out of the effect when there is no grid. Neither null case can actually happen here — the effect already returns early unless the container ref is attached.

## Verification

- `pnpm typecheck` — was 11 errors, now clean
- `pnpm --filter client test src/widgets/collections/dashboard` — 15/15 pass
- ESLint on the changed file — 0 errors

Since this is a major bump and the dashboard has no E2E coverage (the unit tests only cover pure helpers), the grid was also driven in a real browser against a fixture instance. Zero console errors:

| Behavior | Result |
|---|---|
| Grid init + 12-column layout | widgets placed at 4×3 |
| Drag by header handle | B moved 4,0 → 8,1; C pushed down |
| Resize by SE handle | A grew 4×3 → 8×5 |
| Persistence across reload | geometry restored exactly |
| Responsive collapse → `setStatic` | `grid-stack-static gs-1`, columns = 1 |

Also checked the v12 → v13 CSS diff (only removes `.grid-stack-rtl` and adds `user-select`/`z-index` on resize handles; `.grid-stack-static`, the one class the dashboard styles, is unchanged) and confirmed the core does not reorder DOM children, which would otherwise fight Preact for ownership of the widget elements.

## Note

Targeted at `renovate/gridstack-13.x` rather than pushed onto it directly, but merging still puts a non-Renovate commit on that branch — Renovate will then treat it as modified and stop updating it. If that is not wanted, this can be retargeted at `main` instead: the guard compiles against v12 too, so main stays green and #10699 would go green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)