### PR TITLE
feat(onenote): import polish + syntax-highlighted file/attachment previews

### DIFF
--- a/apps/client/src/services/import.spec.ts
+++ b/apps/client/src/services/import.spec.ts
@@ -197,6 +197,25 @@ describe("importNotes ws handler", () => {
         tSpy.mockRestore();
     });
 
+    it("shows the explicit throttled message while Graph rate-limits, with and without a total", async () => {
+        const tSpy = vi.spyOn(i18n, "t").mockImplementation(((key: string) => key) as typeof i18n.t);
+
+        // The count can legitimately sit still for a long time, so the throttled phase overrides the
+        // usual count message — but the bar stays, since the counted progress is still real.
+        await handler()({ type: "taskProgressCount", taskType: "importNotes", taskId: "t2", progressCount: 3, totalCount: 12, phase: "throttled" } as any);
+        let toast = (toastService.showPersistent as any).mock.calls.at(-1)[0];
+        expect(toast.message).toBe("import.throttled-with-total");
+        expect(toast.progress).toBe(3 / 12);
+
+        // Throttled before any total is known: no count to show, no bar.
+        await handler()({ type: "taskProgressCount", taskType: "importNotes", taskId: "t2", progressCount: 0, phase: "throttled" } as any);
+        toast = (toastService.showPersistent as any).mock.calls.at(-1)[0];
+        expect(toast.message).toBe("import.throttled");
+        expect(toast.progress).toBeUndefined();
+
+        tSpy.mockRestore();
+    });
+
     it("shows a generic 'starting' message (no bar) before anything is counted", async () => {
         const tSpy = vi.spyOn(i18n, "t").mockImplementation(((key: string) => key) as typeof i18n.t);
         await handler()({ type: "taskProgressCount", taskType: "importNotes", taskId: "t2", progressCount: 0 } as any);

--- a/apps/client/src/services/import.ts
+++ b/apps/client/src/services/import.ts
@@ -80,6 +80,8 @@ function makeToast(id: string, message: string): ToastOptionsWithRequiredId {
 
 /**
  * Builds the persistent "import in progress" toast:
+ *  - the "throttled" phase (OneNote under Graph rate limiting) → an explicit "waiting for the service"
+ *    message, since the count can legitimately sit still for up to an hour and must not look hung;
  *  - a phase is known (zip import) → a phase-specific message: "Extracted X items of N" while extracting
  *    archive entries, "Processed X notes of N" while post-processing the created notes;
  *  - a total but no phase (single-format importers like Notion/Obsidian) → "Imported X notes of N";
@@ -90,7 +92,11 @@ function makeToast(id: string, message: string): ToastOptionsWithRequiredId {
 function makeProgressToast(taskId: string, progressCount: number, totalCount?: number, phase?: ProgressPhase): ToastOptionsWithRequiredId {
     const hasTotal = typeof totalCount === "number" && totalCount > 0;
     let message: string;
-    if (hasTotal && phase === "extracting") {
+    if (phase === "throttled") {
+        message = hasTotal
+            ? t("import.throttled-with-total", { progress: progressCount, total: totalCount })
+            : t("import.throttled");
+    } else if (hasTotal && phase === "extracting") {
         message = t("import.extracting", { progress: progressCount, total: totalCount });
     } else if (hasTotal && phase === "processing") {
         message = t("import.processing", { progress: progressCount, total: totalCount });

--- a/apps/client/src/services/onenote_import.spec.ts
+++ b/apps/client/src/services/onenote_import.spec.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { buildSectionSelections, collectSectionIds, extractServerMessage, type OneNoteNotebook, orderedChildren } from "./onenote_import.js";
+vi.mock("./server.js", () => ({
+    default: {
+        // Resolves to an array: onenote_import's module graph eagerly loads services (e.g.
+        // keyboard_actions) that fetch on load and iterate the response.
+        get: vi.fn(async () => []),
+        getWithSilentUnauthorized: vi.fn(async () => ({ notebooks: [] })),
+        post: vi.fn(async () => ({}))
+    }
+}));
+
+import onenoteImport, { buildSectionSelections, collectSectionIds, extractServerMessage, type OneNoteNotebook, orderedChildren } from "./onenote_import.js";
+import server from "./server.js";
 
 const NOTEBOOKS: OneNoteNotebook[] = [
     {
@@ -59,6 +70,44 @@ describe("orderedChildren", () => {
         // sections[] is [late, early] and the group is dated between them; the group's own date (not its
         // contents') decides its slot, so the rail order is early, group, late.
         expect(describeChild(INTERLEAVE)).toEqual(["section:early", "group:grp", "section:late"]);
+    });
+
+    it("sorts a child with no creation date first (empty key), keeping the rest ordered", () => {
+        const undated: OneNoteNotebook[] = [{
+            id: "nb",
+            title: "NB",
+            sections: [
+                { id: "dated", title: "Dated", createdDateTime: "2020-01-01T00:00:00Z" },
+                { id: "undated", title: "Undated" }
+            ],
+            sectionGroups: []
+        }];
+        expect(describeChild(undated)).toEqual(["section:undated", "section:dated"]);
+    });
+});
+
+describe("service endpoints", () => {
+    it("routes each operation to its endpoint, listing notebooks without the generic 401 toast", async () => {
+        await onenoteImport.deviceLogin();
+        expect(server.post).toHaveBeenCalledWith("onenote-import/device-login");
+
+        await onenoteImport.devicePoll();
+        expect(server.post).toHaveBeenCalledWith("onenote-import/device-poll");
+
+        await onenoteImport.getStatus();
+        expect(server.get).toHaveBeenCalledWith("onenote-import/status");
+
+        await onenoteImport.disconnect();
+        expect(server.post).toHaveBeenCalledWith("onenote-import/disconnect");
+
+        // A 401 (expired connection) is shown inline by the dialog, so the silent variant is used —
+        // the plain get() would double-report through the generic error toast.
+        await onenoteImport.getNotebooks();
+        expect(server.getWithSilentUnauthorized).toHaveBeenCalledWith("onenote-import/notebooks");
+
+        const payload = { parentNoteId: "p1", sections: [], taskId: "t1" };
+        await onenoteImport.runImport(payload);
+        expect(server.post).toHaveBeenCalledWith("onenote-import/import", payload);
     });
 });
 

--- a/apps/client/src/services/onenote_import.spec.ts
+++ b/apps/client/src/services/onenote_import.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildSectionSelections, extractServerMessage, type OneNoteNotebook, orderedChildren } from "./onenote_import.js";
+import { buildSectionSelections, collectSectionIds, extractServerMessage, type OneNoteNotebook, orderedChildren } from "./onenote_import.js";
 
 const NOTEBOOKS: OneNoteNotebook[] = [
     {
@@ -109,5 +109,14 @@ describe("extractServerMessage", () => {
         expect(extractServerMessage('{"status":500}')).toBeNull();
         expect(extractServerMessage("   ")).toBeNull();
         expect(extractServerMessage(undefined)).toBeNull();
+    });
+});
+
+describe("collectSectionIds", () => {
+    it("collects every section id across all notebooks, including those nested in section groups", () => {
+        // s1 is a direct section, s2 lives in a group, s3 in a nested subgroup — all must be found;
+        // group ids themselves must not be (groups are structure, never selectable).
+        expect(collectSectionIds(NOTEBOOKS)).toEqual(new Set(["s1", "s2", "s3"]));
+        expect(collectSectionIds([])).toEqual(new Set());
     });
 });

--- a/apps/client/src/services/onenote_import.ts
+++ b/apps/client/src/services/onenote_import.ts
@@ -128,6 +128,21 @@ export function buildSectionSelections(notebooks: OneNoteNotebook[], selectedIds
 }
 
 /**
+ * Collects the ids of every section anywhere in the given notebooks, including those nested inside
+ * section groups. Used to prune a selection after the notebook list is refreshed, so ids of sections
+ * that no longer exist can't linger in the selection (and inflate the import button's count).
+ */
+export function collectSectionIds(containers: OneNoteContainer[], into = new Set<string>()): Set<string> {
+    for (const container of containers) {
+        for (const section of container.sections) {
+            into.add(section.id);
+        }
+        collectSectionIds(container.sectionGroups, into);
+    }
+    return into;
+}
+
+/**
  * Returns a container's direct children — its sections and section groups — interleaved into a single
  * list ordered by creation date. OneNote shows sections and groups intermixed in one ordered rail but
  * the Graph API exposes no ordering field for them, so creation date is a best-effort approximation

--- a/apps/client/src/services/onenote_import.ts
+++ b/apps/client/src/services/onenote_import.ts
@@ -43,7 +43,9 @@ function disconnect() {
 }
 
 function getNotebooks() {
-    return server.get<{ notebooks: OneNoteNotebook[] }>("onenote-import/notebooks");
+    // silent: a 401 here (expired/lost connection) is presented inline by the import dialog with the
+    // server's reason and a retry button — the generic "unknown HTTP error" toast would double-report.
+    return server.getWithSilentUnauthorized<{ notebooks: OneNoteNotebook[] }>("onenote-import/notebooks");
 }
 
 // Kicks off the import and returns as soon as the server has accepted it. The import itself runs in the

--- a/apps/client/src/services/server.spec.ts
+++ b/apps/client/src/services/server.spec.ts
@@ -206,6 +206,16 @@ describe("ajax error handling", () => {
         expect((window as any).logError).not.toHaveBeenCalled();
     });
 
+    it("stays silent on 401 when silentUnauthorized is set, still rejecting with the body", async () => {
+        (window as any).$.ajax = (opts: AjaxOptions) => {
+            opts.error({ status: 401, responseText: "The OneNote connection was lost." });
+        };
+        // The caller presents the failure itself, so it must still receive the server's reason.
+        await expect(server.getWithSilentUnauthorized("url")).rejects.toBe("The OneNote connection was lost.");
+        expect(toastMock.showError).not.toHaveBeenCalled();
+        expect((window as any).logError).not.toHaveBeenCalled();
+    });
+
     it("reports validation errors (400) and still rejects when reportError throws", async () => {
         (window as any).$.ajax = (opts: AjaxOptions) => {
             opts.error({ status: 400, responseText: JSON.stringify({ message: "Bad input" }) });

--- a/apps/client/src/services/server.ts
+++ b/apps/client/src/services/server.ts
@@ -49,6 +49,10 @@ async function get<T>(url: string, componentId?: string, raw?: boolean) {
     return await call<T>("GET", url, componentId, { raw });
 }
 
+async function getWithSilentUnauthorized<T>(url: string, componentId?: string) {
+    return await call<T>("GET", url, componentId, { silentUnauthorized: true });
+}
+
 async function post<T>(url: string, data?: unknown, componentId?: string) {
     return await call<T>("POST", url, componentId, { data });
 }
@@ -145,6 +149,9 @@ interface CallOptions {
     data?: unknown;
     silentNotFound?: boolean;
     silentInternalServerError?: boolean;
+    /** Suppresses the generic error toast for a 401, for callers that present the failure themselves
+     *  (e.g. the OneNote import dialog showing an expired connection inline, with the server's reason). */
+    silentUnauthorized?: boolean;
     // If `true`, the value will be returned as a string instead of a JavaScript object if JSON, XMLDocument if XML, etc.
     raw?: boolean;
     /** Used internally to prevent infinite retry loops on CSRF refresh. */
@@ -226,6 +233,8 @@ function ajax(url: string, method: string, data: unknown, headers: Headers, opts
                     // report nothing
                 } else if (opts.silentInternalServerError && jqXhr.status === 500) {
                     // report nothing
+                } else if (opts.silentUnauthorized && jqXhr.status === 401) {
+                    // report nothing
                 } else {
                     try {
                         await reportError(method, url, jqXhr.status, jqXhr.responseText);
@@ -299,6 +308,7 @@ async function reportError(method: string, url: string, statusCode: number, resp
 export default {
     get,
     getWithSilentNotFound,
+    getWithSilentUnauthorized,
     post,
     postWithSilentInternalServerError,
     put,

--- a/apps/client/src/stylesheets/theme-next/forms.css
+++ b/apps/client/src/stylesheets/theme-next/forms.css
@@ -61,13 +61,16 @@ button.ck.ck-button:is(.ck-button-action, .ck-button-save, .ck-button-cancel, .c
     outline: 2px solid var(--input-focus-outline-color);
 }
 
-/* Button's icon */
+/* Button's icon. The text spacing is a margin rather than padding on purpose: transforms rotate the
+   padding-box, so with one-sided padding a spinning icon (`bx-spin`, e.g. a refresh button while
+   loading) orbits an off-center axis instead of rotating in place. Margin stays outside the
+   transformed box, keeping the spacing identical while the glyph spins about its own center. */
 button.btn.btn-primary span.tn-icon,
 button.btn.btn-secondary span.tn-icon,
 button.btn.btn-sm span.tn-icon,
 button.btn.btn-success span.tn-icon {
     color: var(--cmd-button-icon-color);
-    padding-inline-end: 0.35em;
+    margin-inline-end: 0.35em;
     font-size: 1.2em;
 }
 

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -270,6 +270,7 @@
     "device_cancel": "Cancel sign-in",
     "connected_as": "Connected as {{name}}",
     "disconnect": "Disconnect",
+    "refresh": "Refresh",
     "load_failed": "Could not load your OneNote notebooks.",
     "load_retry": "Try again",
     "no_notebooks": "No notebooks were found in this account.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -243,6 +243,8 @@
     "in-progress-with-total": "Imported {{progress}} notes out of {{total}}",
     "extracting": "Extracted {{progress}} items out of {{total}}",
     "processing": "Processed {{progress}} notes out of {{total}}",
+    "throttled": "The service is rate limiting requests; the import is waiting for access to resume…",
+    "throttled-with-total": "Imported {{progress}} notes out of {{total}} — the service is rate limiting requests, waiting for access to resume…",
     "successful": "Import finished successfully."
   },
   "file_upload": {

--- a/apps/client/src/widgets/dialogs/import/import_dialog.css
+++ b/apps/client/src/widgets/dialogs/import/import_dialog.css
@@ -56,6 +56,13 @@
         border-bottom: 1px solid var(--main-border-color);
     }
 
+    /* Refresh + Disconnect stay grouped on the row's right edge. */
+    .onenote-account-actions {
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+    }
+
     .onenote-status {
         display: flex;
         align-items: center;

--- a/apps/client/src/widgets/dialogs/import/import_dialog.css
+++ b/apps/client/src/widgets/dialogs/import/import_dialog.css
@@ -63,6 +63,12 @@
         gap: 0.5em;
     }
 
+    /* Secondary explanation under a message (e.g. why an account can look notebook-less). */
+    .onenote-hint {
+        color: var(--muted-text-color);
+        font-size: 0.9em;
+    }
+
     .onenote-status {
         display: flex;
         align-items: center;

--- a/apps/client/src/widgets/dialogs/import/onenote.spec.tsx
+++ b/apps/client/src/widgets/dialogs/import/onenote.spec.tsx
@@ -1,0 +1,249 @@
+import { type ComponentChildren, render } from "preact";
+import { useState } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+import * as i18n from "../../../services/i18n.js";
+import type { OneNoteNotebook } from "../../../services/onenote_import.js";
+
+// The service's default export is the API surface the panel drives; the named helpers
+// (buildSectionSelections, collectSectionIds, …) stay real so the tree/selection logic under test
+// is the production one.
+const api = vi.hoisted(() => ({
+    getStatus: vi.fn(),
+    getNotebooks: vi.fn(),
+    deviceLogin: vi.fn(),
+    devicePoll: vi.fn(),
+    disconnect: vi.fn(async () => ({})),
+    runImport: vi.fn(async () => {})
+}));
+const showError = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../services/onenote_import.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/onenote_import.js")>()),
+    default: api
+}));
+vi.mock("../../../services/toast.js", () => ({ default: { showError } }));
+// The shrink-images preference; the panel only reads it, so a fixed "on" is enough.
+vi.mock("../../react/hooks.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../react/hooks.js")>()),
+    useTriliumOptionBool: () => [true, vi.fn()]
+}));
+
+const { default: provider } = await import("./onenote.js");
+
+const NOTEBOOKS: OneNoteNotebook[] = [{
+    id: "nb1",
+    title: "Notebook 1",
+    createdDateTime: "2020-01-01T00:00:00Z",
+    sections: [
+        { id: "s1", title: "Section 1", createdDateTime: "2020-01-01T00:00:00Z" },
+        { id: "s2", title: "Section 2", createdDateTime: "2020-02-01T00:00:00Z" }
+    ],
+    sectionGroups: []
+}];
+
+let container: HTMLDivElement;
+let closeDialog: Mock<() => void>;
+let footer: ComponentChildren;
+let applyFooter: ((node: ComponentChildren) => void) | null = null;
+
+/** Mirrors the dialog shell: the footer the panel pushes up is rendered through state, exactly as
+ *  the production dialog does, so the panel's footer effect drives a live subtree. */
+function FooterHost() {
+    const [node, setNode] = useState<ComponentChildren>(null);
+    applyFooter = setNode;
+    return <div className="footer-host">{node}</div>;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    api.getStatus.mockResolvedValue({ connected: true, account: { name: "Ada", email: "ada@example.com" } });
+    api.getNotebooks.mockResolvedValue({ notebooks: NOTEBOOKS });
+    closeDialog = vi.fn<() => void>();
+    footer = null;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    render(null, container);
+    container.remove();
+    applyFooter = null;
+});
+
+async function mount() {
+    const Panel = provider.Panel;
+    await act(async () => {
+        render(
+            <div>
+                <Panel
+                    parentNoteId="root"
+                    closeDialog={closeDialog}
+                    setFooter={(node: ComponentChildren) => {
+                        footer = node;
+                        applyFooter?.(node);
+                    }}
+                />
+                <FooterHost />
+            </div>,
+            container
+        );
+    });
+    // The status → notebooks → ready chain spans several microtask hops; one extra flush lets the
+    // footer effect settle before assertions.
+    await act(async () => {});
+    // The panel's footer effect can fire between act flushes, before FooterHost's setter processes
+    // the update — sync the host with whatever the panel pushed last.
+    await act(async () => {
+        applyFooter?.(footer);
+    });
+}
+
+async function click(button: Element | null | undefined) {
+    expect(button).toBeTruthy();
+    await act(async () => {
+        (button as HTMLButtonElement).click();
+    });
+    await act(async () => {});
+}
+
+const importButton = () => container.querySelector<HTMLButtonElement>(".footer-host button");
+
+/** The panel's account action buttons in DOM order: refresh, then disconnect. */
+function accountButtons() {
+    return [...container.querySelectorAll<HTMLButtonElement>(".onenote-account-actions button")];
+}
+
+describe("OneNotePanel", () => {
+    it("shows the connect screen and no footer when the session is not connected", async () => {
+        api.getStatus.mockResolvedValue({ connected: false, account: null });
+        await mount();
+
+        expect(container.querySelector(".onenote-account")).toBeNull();
+        expect(container.querySelector(".bxl-microsoft")).not.toBeNull();
+        expect(footer).toBeNull();
+    });
+
+    it("reports a failed status check via toast (server reason first) and falls back to connect", async () => {
+        api.getStatus.mockRejectedValue(new Error("status check exploded"));
+        await mount();
+
+        expect(showError).toHaveBeenCalledWith("status check exploded");
+        expect(container.querySelector(".bxl-microsoft")).not.toBeNull();
+    });
+
+    it("lists the connected account's notebooks as a section picker with an import footer", async () => {
+        await mount();
+
+        expect(container.querySelector(".checkbox-tree")).not.toBeNull();
+        expect(container.querySelectorAll(".checkbox-tree input[type=checkbox]").length).toBeGreaterThanOrEqual(2);
+        // Nothing selected yet: the footer import button exists but is disabled.
+        expect(importButton()?.disabled).toBe(true);
+    });
+
+    it("imports the selected sections and reports an upfront failure with the server's reason", async () => {
+        api.runImport.mockRejectedValue(new Error('{"message":"Not connected to OneNote."}'));
+        await mount();
+
+        // Select one section leaf, which enables the footer button.
+        await click(container.querySelector(".checkbox-tree-leaf input[type=checkbox]"));
+        expect(importButton()?.disabled).toBe(false);
+
+        await click(importButton());
+        expect(closeDialog).toHaveBeenCalled();
+        expect(api.runImport).toHaveBeenCalledWith(expect.objectContaining({
+            parentNoteId: "root",
+            sections: [expect.objectContaining({ id: "s1" })],
+            shrinkImages: true
+        }));
+        expect(showError).toHaveBeenCalledWith("Not connected to OneNote.");
+
+        // A rejection carrying no usable text is stringified as the last resort.
+        api.runImport.mockRejectedValueOnce(42);
+        await click(importButton());
+        expect(showError).toHaveBeenCalledWith("42");
+    });
+
+    it("shows a listing failure inline with the server's reason, and recovers via retry", async () => {
+        api.getNotebooks
+            .mockRejectedValueOnce(new Error('{"message":"The OneNote connection has expired."}'))
+            .mockResolvedValueOnce({ notebooks: NOTEBOOKS });
+        await mount();
+
+        // The failure is inline (no toast) and the stale/empty tree is not offered.
+        const inlineError = container.querySelector(".no-items");
+        expect(inlineError?.textContent).toContain("The OneNote connection has expired.");
+        expect(container.querySelector(".checkbox-tree")).toBeNull();
+        expect(showError).not.toHaveBeenCalled();
+
+        await click(inlineError?.querySelector("button"));
+        expect(container.querySelector(".no-items")).toBeNull();
+        expect(container.querySelector(".checkbox-tree")).not.toBeNull();
+    });
+
+    it("prunes selected ids that no longer exist when the list is refreshed", async () => {
+        await mount();
+        await click(container.querySelector(".checkbox-tree-leaf input[type=checkbox]"));
+        expect(importButton()?.disabled).toBe(false);
+
+        // The refresh returns a list without the selected section — the selection must not keep
+        // counting the phantom id, so the import button drops back to disabled.
+        api.getNotebooks.mockResolvedValue({ notebooks: [{ ...NOTEBOOKS[0], sections: [NOTEBOOKS[0].sections[1]] }] });
+        await click(accountButtons()[0]);
+        expect(importButton()?.disabled).toBe(true);
+    });
+
+    it("shows the empty-account hint when the connected account has no notebooks", async () => {
+        api.getNotebooks.mockResolvedValue({ notebooks: [] });
+        await mount();
+
+        expect(container.querySelector(".onenote-hint")).not.toBeNull();
+        expect(container.querySelector(".checkbox-tree")).toBeNull();
+    });
+
+    it("clears the account, notebooks and selection on disconnect", async () => {
+        await mount();
+        await click(accountButtons()[1]);
+
+        expect(api.disconnect).toHaveBeenCalled();
+        expect(container.querySelector(".onenote-account")).toBeNull();
+        expect(container.querySelector(".bxl-microsoft")).not.toBeNull();
+        expect(footer).toBeNull();
+    });
+
+    it("surfaces a failed sign-in start with the server's reason and stays disconnected", async () => {
+        api.getStatus.mockResolvedValue({ connected: false, account: null });
+        api.deviceLogin.mockRejectedValue(new Error('{"message":"Sign-in could not be started."}'));
+        await mount();
+
+        await click(container.querySelector(".bxl-microsoft")?.closest("button"));
+        expect(showError).toHaveBeenCalledWith("Sign-in could not be started.");
+        expect(container.querySelector(".bxl-microsoft")).not.toBeNull();
+
+        // A rejection carrying no usable text is stringified as the last resort.
+        api.deviceLogin.mockRejectedValueOnce(42);
+        await click(container.querySelector(".bxl-microsoft")?.closest("button"));
+        expect(showError).toHaveBeenCalledWith("42");
+    });
+
+    it("falls back to generic wording when a failure carries no server message", async () => {
+        // i18next is uninitialised under test, so pin t() to return its key — asserting the key
+        // proves the fallback path was taken without depending on the wording.
+        const tSpy = vi.spyOn(i18n, "t").mockImplementation(((key: string) => key) as typeof i18n.t);
+        try {
+            api.getStatus.mockRejectedValue(new Error(""));
+            await mount();
+            expect(showError).toHaveBeenCalledWith("onenote_import.load_failed");
+
+            // The same fallback feeds the inline listing error.
+            render(null, container);
+            api.getStatus.mockResolvedValue({ connected: true, account: { name: "Ada", email: "ada@example.com" } });
+            api.getNotebooks.mockRejectedValue(new Error(""));
+            await mount();
+            expect(container.querySelector(".no-items")?.textContent).toContain("onenote_import.load_failed");
+        } finally {
+            tSpy.mockRestore();
+        }
+    });
+});

--- a/apps/client/src/widgets/dialogs/import/onenote.tsx
+++ b/apps/client/src/widgets/dialogs/import/onenote.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 
 import { t } from "../../../services/i18n.js";
-import onenoteImport, { buildSectionSelections, type OneNoteAccount, type OneNoteContainer, type OneNoteDeviceLogin, type OneNoteNotebook, orderedChildren } from "../../../services/onenote_import.js";
+import onenoteImport, { buildSectionSelections, collectSectionIds, type OneNoteAccount, type OneNoteContainer, type OneNoteDeviceLogin, type OneNoteNotebook, orderedChildren } from "../../../services/onenote_import.js";
 import toast from "../../../services/toast.js";
 import { isElectron, randomString } from "../../../services/utils.js";
 import Button from "../../react/Button.js";
@@ -21,6 +21,8 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     const [account, setAccount] = useState<OneNoteAccount | null>(null);
     const [notebooks, setNotebooks] = useState<OneNoteNotebook[]>([]);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    // Set while a user-triggered notebook reload is in flight, to spin and disable the refresh button.
+    const [refreshing, setRefreshing] = useState(false);
     const [debug, setDebug] = useState(false);
     const [compressImages] = useTriliumOptionBool("compressImages");
     const [shrinkImages, setShrinkImages] = useState(compressImages);
@@ -43,10 +45,25 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
         try {
             const { notebooks } = await onenoteImport.getNotebooks();
             setNotebooks(notebooks);
+            // Drop selected ids whose section no longer exists (deleted/moved in OneNote since the
+            // last load), so a refresh can't leave the import button counting phantom sections.
+            const validIds = collectSectionIds(notebooks);
+            setSelectedIds((prev) => new Set([...prev].filter((id) => validIds.has(id))));
         } catch {
             toast.showError(t("onenote_import.load_failed"));
         }
     }, []);
+
+    // User-triggered reload of the notebook list, e.g. after creating a section in OneNote while the
+    // dialog is open. Wraps loadNotebooks purely to drive the refresh button's spinner/disabled state.
+    const refresh = useCallback(async () => {
+        setRefreshing(true);
+        try {
+            await loadNotebooks();
+        } finally {
+            setRefreshing(false);
+        }
+    }, [loadNotebooks]);
 
     // On mount, see whether this session is already connected.
     useEffect(() => {
@@ -246,7 +263,17 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
             <CardSection className="onenote-panel">
                 <div className="onenote-account">
                     <span>{t("onenote_import.connected_as", { name: account?.name ?? "" })}</span>
-                    <Button text={t("onenote_import.disconnect")} kind="lowProfile" size="small" onClick={disconnect} />
+                    <div className="onenote-account-actions">
+                        <Button
+                            text={t("onenote_import.refresh")}
+                            kind="lowProfile"
+                            size="small"
+                            icon={refreshing ? "bx-refresh bx-spin" : "bx-refresh"}
+                            disabled={refreshing}
+                            onClick={() => void refresh()}
+                        />
+                        <Button text={t("onenote_import.disconnect")} kind="lowProfile" size="small" onClick={disconnect} />
+                    </div>
                 </div>
 
                 {notebooks.length === 0

--- a/apps/client/src/widgets/dialogs/import/onenote.tsx
+++ b/apps/client/src/widgets/dialogs/import/onenote.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 
 import { t } from "../../../services/i18n.js";
-import onenoteImport, { buildSectionSelections, collectSectionIds, type OneNoteAccount, type OneNoteContainer, type OneNoteDeviceLogin, type OneNoteNotebook, orderedChildren } from "../../../services/onenote_import.js";
+import onenoteImport, { buildSectionSelections, collectSectionIds, extractServerMessage, type OneNoteAccount, type OneNoteContainer, type OneNoteDeviceLogin, type OneNoteNotebook, orderedChildren } from "../../../services/onenote_import.js";
 import toast from "../../../services/toast.js";
 import { isElectron, randomString } from "../../../services/utils.js";
 import Button from "../../react/Button.js";
@@ -20,6 +20,9 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     const [phase, setPhase] = useState<Phase>("checking");
     const [account, setAccount] = useState<OneNoteAccount | null>(null);
     const [notebooks, setNotebooks] = useState<OneNoteNotebook[]>([]);
+    // Set when listing the notebooks failed, so the panel can say so instead of reporting an empty
+    // account — an expired connection or a Graph error is not "you have no notebooks".
+    const [loadError, setLoadError] = useState<string | null>(null);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     // Set while a user-triggered notebook reload is in flight, to spin and disable the refresh button.
     const [refreshing, setRefreshing] = useState(false);
@@ -42,6 +45,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
     }, []);
 
     const loadNotebooks = useCallback(async () => {
+        setLoadError(null);
         try {
             const { notebooks } = await onenoteImport.getNotebooks();
             setNotebooks(notebooks);
@@ -49,8 +53,13 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
             // last load), so a refresh can't leave the import button counting phantom sections.
             const validIds = collectSectionIds(notebooks);
             setSelectedIds((prev) => new Set([...prev].filter((id) => validIds.has(id))));
-        } catch {
-            toast.showError(t("onenote_import.load_failed"));
+        } catch (e) {
+            // The server's wording is the useful part (an expired sign-in says to sign in again, a
+            // Graph failure names the Graph error); fall back to the generic message only when the
+            // response carried none. The stale list is cleared: a tree that can't import (the same
+            // dead connection would fail the import too) is worse than the explanation.
+            setNotebooks([]);
+            setLoadError(extractServerMessage(e) ?? t("onenote_import.load_failed"));
         }
     }, []);
 
@@ -76,7 +85,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
                 setPhase("disconnected");
             }
         }).catch((e) => {
-            toast.showError(e instanceof Error ? e.message : String(e));
+            toast.showError(extractServerMessage(e) ?? t("onenote_import.load_failed"));
             setPhase("disconnected");
         });
         return stopPolling;
@@ -153,7 +162,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
             };
             pollRef.current = setTimeout(() => void poll(), intervalMs);
         } catch (e) {
-            toast.showError(e instanceof Error ? e.message : String(e));
+            toast.showError(extractServerMessage(e) ?? String(e));
             setPhase("disconnected");
         }
     }, [loadNotebooks, stopPolling]);
@@ -169,6 +178,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
         await onenoteImport.disconnect();
         setAccount(null);
         setNotebooks([]);
+        setLoadError(null);
         setSelectedIds(new Set());
         setPhase("disconnected");
     }, [stopPolling]);
@@ -192,7 +202,7 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
         try {
             await onenoteImport.runImport({ parentNoteId, sections, taskId: randomString(10), debug, shrinkImages: compressImages && shrinkImages });
         } catch (e) {
-            toast.showError(e instanceof Error ? e.message : String(e));
+            toast.showError(extractServerMessage(e) ?? String(e));
         }
     }, [notebooks, selectedIds, parentNoteId, debug, compressImages, shrinkImages, closeDialog]);
 
@@ -276,32 +286,48 @@ function OneNotePanel({ parentNoteId, closeDialog, setFooter }: ImportProviderPa
                     </div>
                 </div>
 
-                {notebooks.length === 0
-                    ? <p>{t("onenote_import.no_notebooks")}</p>
-                    : (
-                        <>
-                            <OptionsRow name="onenote-sections" label={t("onenote_import.select_sections")} description={t("onenote_import.select_sections_hint")} stacked>
-                                <div className="onenote-notebooks">
-                                    <CheckboxTree nodes={treeNodes} selectedIds={selectedIds} onChange={setSelectedIds} />
-                                </div>
-                            </OptionsRow>
-                            <OptionsRowWithToggle
-                                name="onenote-shrink-images"
-                                label={t("import.shrinkImages")}
-                                description={t("import.shrinkImagesProviderTooltip")}
-                                currentValue={compressImages && shrinkImages}
-                                onChange={setShrinkImages}
-                                disabled={!compressImages}
-                            />
-                            <OptionsRowWithToggle
-                                name="onenote-debug"
-                                label={t("onenote_import.attach_source")}
-                                description={t("onenote_import.attach_source_hint")}
-                                currentValue={debug}
-                                onChange={setDebug}
-                            />
-                        </>
-                    )}
+                {loadError && (
+                    <NoItems icon="bx bx-error-circle" text={loadError}>
+                        <Button
+                            text={t("onenote_import.load_retry")}
+                            kind="primary"
+                            disabled={refreshing}
+                            onClick={() => void refresh()}
+                        />
+                    </NoItems>
+                )}
+
+                {!loadError && notebooks.length === 0 && (
+                    <>
+                        <p>{t("onenote_import.no_notebooks")}</p>
+                        <p className="onenote-hint">{t("onenote_import.no_notebooks_hint")}</p>
+                    </>
+                )}
+
+                {!loadError && notebooks.length > 0 && (
+                    <>
+                        <OptionsRow name="onenote-sections" label={t("onenote_import.select_sections")} description={t("onenote_import.select_sections_hint")} stacked>
+                            <div className="onenote-notebooks">
+                                <CheckboxTree nodes={treeNodes} selectedIds={selectedIds} onChange={setSelectedIds} />
+                            </div>
+                        </OptionsRow>
+                        <OptionsRowWithToggle
+                            name="onenote-shrink-images"
+                            label={t("import.shrinkImages")}
+                            description={t("import.shrinkImagesProviderTooltip")}
+                            currentValue={compressImages && shrinkImages}
+                            onChange={setShrinkImages}
+                            disabled={!compressImages}
+                        />
+                        <OptionsRowWithToggle
+                            name="onenote-debug"
+                            label={t("onenote_import.attach_source")}
+                            description={t("onenote_import.attach_source_hint")}
+                            currentValue={debug}
+                            onChange={setDebug}
+                        />
+                    </>
+                )}
             </CardSection>
         </Card>
     );

--- a/apps/client/src/widgets/type_widgets/Attachment.tsx
+++ b/apps/client/src/widgets/type_widgets/Attachment.tsx
@@ -268,7 +268,7 @@ function AttachmentInfo({ attachment, isFullDetail, ownerNote, noteContext, view
                 </div>
 
                 {scheduledForErasureSince && <DeletionAlert utcDateScheduledForErasureSince={scheduledForErasureSince} />}
-                {textContent && <TextPreview content={textContent} />}
+                {textContent && <TextPreview content={textContent} mime={attachment.mime} />}
                 {isZoomableImage ? (
                     <div key="image-viewer" ref={imageViewerWrapper} className="attachment-content-wrapper attachment-image-viewer">
                         <ImageViewer key={`${attachment.attachmentId}-${modified}`} src={imageSrc} alt={attachment.title} />

--- a/apps/client/src/widgets/type_widgets/File.css
+++ b/apps/client/src/widgets/type_widgets/File.css
@@ -16,12 +16,19 @@
     overflow: hidden;
 }
 
-.file-preview-content {
-    background-color: var(--accented-background-color);
+/* Rendered by CodeBlock, so the same <pre> also carries .code-block; the element selector keeps
+   these layout rules winning that equal-specificity fight regardless of bundle order. */
+pre.file-preview-content {
     padding: 15px;
     height: 100%;
     overflow: auto;
     margin: 10px;
+}
+
+/* Only when not highlighted: a highlighted block carries `hljs`, whose runtime-injected theme
+   stylesheet brings its own background (see CodeBlock.css). */
+pre.file-preview-content:not(.hljs) {
+    background-color: var(--accented-background-color);
 }
 
 .note-detail-file > .pdf-preview {

--- a/apps/client/src/widgets/type_widgets/File.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/File.spec.tsx
@@ -51,6 +51,17 @@ describe("TextPreview", () => {
         expect(applySingleBlockSyntaxHighlight.mock.calls[0][1]).toBe("text-html");
     });
 
+    it("highlights structured-syntax suffixes (+xml, +json) as their base syntax", async () => {
+        render(<TextPreview content={"<ink/>"} mime="application/inkml+xml" />, container);
+        await vi.waitFor(() => expect(applySingleBlockSyntaxHighlight).toHaveBeenCalledTimes(1));
+        expect(applySingleBlockSyntaxHighlight.mock.calls[0][1]).toBe("text-xml");
+
+        render(null, container);
+        render(<TextPreview content={"{}"} mime="application/fhir+json" />, container);
+        await vi.waitFor(() => expect(applySingleBlockSyntaxHighlight).toHaveBeenCalledTimes(2));
+        expect(applySingleBlockSyntaxHighlight.mock.calls[1][1]).toBe("application-json");
+    });
+
     it("does not highlight without a MIME type, but still renders the content", () => {
         render(<TextPreview content={"plain"} />, container);
 

--- a/apps/client/src/widgets/type_widgets/File.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/File.spec.tsx
@@ -1,0 +1,76 @@
+import { render } from "preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const applySingleBlockSyntaxHighlight = vi.fn(async (_codeBlock: unknown, _normalizedMimeType: string) => {});
+const isSyntaxHighlightEnabled = vi.fn(() => true);
+
+vi.mock("../../services/syntax_highlight", () => ({
+    applySingleBlockSyntaxHighlight,
+    isSyntaxHighlightEnabled
+}));
+
+vi.mock("../../services/clipboard_ext", () => ({ copyTextWithToast: vi.fn() }));
+
+// ActionButton drags in tooltips and command wiring that are irrelevant here.
+vi.mock("../react/ActionButton", () => ({ default: () => <button class="code-block-copy" /> }));
+
+// Only TextPreview is under test; stub the sibling previews (and the blob hook they feed on)
+// so their service imports stay out of the module graph.
+vi.mock("../react/hooks", () => ({ useNoteBlob: vi.fn(() => null) }));
+vi.mock("./file/MediaPreview", () => ({ default: () => null }));
+vi.mock("./file/Pdf", () => ({ default: () => null }));
+
+const { TextPreview } = await import("./File");
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+    // TextPreview's CodeBlock hands the <code> element to jQuery before delegating to the
+    // highlighter; the identity wrapper is enough since the helper itself is mocked.
+    (globalThis as unknown as { $: (el: unknown) => unknown }).$ = (el) => el;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    render(null, container);
+    container.remove();
+    vi.clearAllMocks();
+});
+
+describe("TextPreview", () => {
+    it("renders the content as text in a code block and highlights it with the normalized MIME type", async () => {
+        render(<TextPreview content={"<p>hello</p>"} mime="text/html" />, container);
+
+        const code = container.querySelector("pre.file-preview-content > code");
+        expect(code?.textContent).toBe("<p>hello</p>");
+        // Rendered verbatim rather than parsed — no element was created from it.
+        expect(container.querySelector("p")).toBeNull();
+
+        await vi.waitFor(() => expect(applySingleBlockSyntaxHighlight).toHaveBeenCalledTimes(1));
+        expect(applySingleBlockSyntaxHighlight.mock.calls[0][1]).toBe("text-html");
+    });
+
+    it("does not highlight without a MIME type, but still renders the content", () => {
+        render(<TextPreview content={"plain"} />, container);
+
+        expect(container.querySelector("pre.file-preview-content > code")?.textContent).toBe("plain");
+        expect(applySingleBlockSyntaxHighlight).not.toHaveBeenCalled();
+    });
+
+    it("truncates oversized content, shows the size warning and drops the copy button", () => {
+        render(<TextPreview content={"x".repeat(6000)} mime="text/plain" />, container);
+
+        expect(container.querySelector("pre.file-preview-content > code")?.textContent).toHaveLength(5000);
+        expect(container.querySelector(".alert")).not.toBeNull();
+        // Copying only the visible half of the file would read as copying all of it.
+        expect(container.querySelector(".code-block-copy")).toBeNull();
+    });
+
+    it("shows the copy button when the content fits the preview", () => {
+        render(<TextPreview content={"short"} mime="text/plain" />, container);
+
+        expect(container.querySelector(".alert")).toBeNull();
+        expect(container.querySelector(".code-block-copy")).not.toBeNull();
+    });
+});

--- a/apps/client/src/widgets/type_widgets/File.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/File.spec.tsx
@@ -14,13 +14,14 @@ vi.mock("../../services/clipboard_ext", () => ({ copyTextWithToast: vi.fn() }));
 // ActionButton drags in tooltips and command wiring that are irrelevant here.
 vi.mock("../react/ActionButton", () => ({ default: () => <button class="code-block-copy" /> }));
 
-// Only TextPreview is under test; stub the sibling previews (and the blob hook they feed on)
-// so their service imports stay out of the module graph.
+// Stub the sibling previews (and the blob hook they feed on) so their service imports stay out of
+// the module graph; the markers let FileTypeWidget's mime routing be asserted without rendering them.
 vi.mock("../react/hooks", () => ({ useNoteBlob: vi.fn(() => null) }));
-vi.mock("./file/MediaPreview", () => ({ default: () => null }));
-vi.mock("./file/Pdf", () => ({ default: () => null }));
+vi.mock("./file/MediaPreview", () => ({ default: () => <div class="media-preview-stub" /> }));
+vi.mock("./file/Pdf", () => ({ default: () => <div class="pdf-preview-stub" /> }));
 
-const { TextPreview } = await import("./File");
+const { useNoteBlob } = await import("../react/hooks");
+const { default: FileTypeWidget, TextPreview } = await import("./File");
 
 let container: HTMLDivElement;
 
@@ -36,6 +37,41 @@ afterEach(() => {
     render(null, container);
     container.remove();
     vi.clearAllMocks();
+});
+
+describe("FileTypeWidget", () => {
+    const mount = (mime: string, noteContext?: unknown) => {
+        const props = { note: { mime }, noteContext } as unknown as Parameters<typeof FileTypeWidget>[0];
+        render(<FileTypeWidget {...props} />, container);
+    };
+
+    it("previews text content through TextPreview, forwarding the note's mime to the highlighter", async () => {
+        vi.mocked(useNoteBlob).mockReturnValue({ content: "<ink/>" } as ReturnType<typeof useNoteBlob>);
+        mount("application/inkml+xml");
+
+        expect(container.querySelector("pre.file-preview-content > code")?.textContent).toBe("<ink/>");
+        // The mime reached TextPreview: the +xml suffix resolves to the base XML syntax.
+        await vi.waitFor(() => expect(applySingleBlockSyntaxHighlight).toHaveBeenCalledTimes(1));
+        expect(applySingleBlockSyntaxHighlight.mock.calls[0][1]).toBe("text-xml");
+    });
+
+    it("routes non-text blobs by mime: PDF, media, and a no-preview fallback", () => {
+        // mockReturnValue outlives clearAllMocks, so drop the previous test's text blob explicitly.
+        vi.mocked(useNoteBlob).mockReturnValue(null);
+
+        // PDF renders only when a note context is available to hand down.
+        mount("application/pdf", {});
+        expect(container.querySelector(".pdf-preview-stub")).not.toBeNull();
+
+        mount("video/mp4");
+        expect(container.querySelector(".media-preview-stub")).not.toBeNull();
+        mount("audio/mpeg");
+        expect(container.querySelector(".media-preview-stub")).not.toBeNull();
+
+        mount("application/octet-stream");
+        expect(container.querySelector(".media-preview-stub")).toBeNull();
+        expect(container.querySelector(".alert")).not.toBeNull();
+    });
 });
 
 describe("TextPreview", () => {

--- a/apps/client/src/widgets/type_widgets/File.tsx
+++ b/apps/client/src/widgets/type_widgets/File.tsx
@@ -40,7 +40,7 @@ export function TextPreview({ content, mime }: { content: string, mime?: string 
             <CodeBlock
                 className="file-preview-content"
                 code={trimmedContent}
-                mimeType={mime}
+                mimeType={resolveHighlightMime(mime)}
                 copyable={!isTooLarge}
             />
         </>
@@ -53,4 +53,19 @@ function NoPreview() {
             {t("file.file_preview_not_available")}
         </Alert>
     );
+}
+
+/**
+ * Resolves a MIME type to one the highlighter has a grammar for. Concrete types carrying an
+ * RFC 6839 structured-syntax suffix (e.g. `application/inkml+xml`, OneNote's ink debug source)
+ * are unknown to the registry as such, but highlight fine as their base syntax.
+ */
+function resolveHighlightMime(mime: string | undefined): string | undefined {
+    if (mime?.endsWith("+xml")) {
+        return "text/xml";
+    }
+    if (mime?.endsWith("+json")) {
+        return "application/json";
+    }
+    return mime;
 }

--- a/apps/client/src/widgets/type_widgets/File.tsx
+++ b/apps/client/src/widgets/type_widgets/File.tsx
@@ -2,6 +2,7 @@ import "./File.css";
 
 import { t } from "../../services/i18n";
 import Alert from "../react/Alert";
+import CodeBlock from "../react/CodeBlock";
 import { useNoteBlob } from "../react/hooks";
 import MediaPreview from "./file/MediaPreview";
 import PdfPreview from "./file/Pdf";
@@ -13,7 +14,7 @@ export default function FileTypeWidget({ note, parentComponent, noteContext, isV
     const blob = useNoteBlob(note, parentComponent?.componentId);
 
     if (blob?.content) {
-        return <TextPreview content={blob.content} />;
+        return <TextPreview content={blob.content} mime={note.mime} />;
     } else if (note.mime === "application/pdf") {
         return noteContext && <PdfPreview blob={blob} note={note} componentId={parentComponent?.componentId} noteContext={noteContext} />;
     } else if (note.mime.startsWith("video/") || note.mime.startsWith("audio/")) {
@@ -23,7 +24,7 @@ export default function FileTypeWidget({ note, parentComponent, noteContext, isV
 
 }
 
-export function TextPreview({ content }: { content: string }) {
+export function TextPreview({ content, mime }: { content: string, mime?: string }) {
     const trimmedContent = content.substring(0, TEXT_MAX_NUM_CHARS);
     const isTooLarge = trimmedContent.length !== content.length;
 
@@ -34,7 +35,14 @@ export function TextPreview({ content }: { content: string }) {
                     {t("file.too_big", { maxNumChars: TEXT_MAX_NUM_CHARS })}
                 </Alert>
             )}
-            <pre class="file-preview-content">{trimmedContent}</pre>
+            {/* The copy button is dropped for a truncated preview — it could only copy the visible
+                5000 characters, which reads as copying the whole file. */}
+            <CodeBlock
+                className="file-preview-content"
+                code={trimmedContent}
+                mimeType={mime}
+                copyable={!isTooLarge}
+            />
         </>
     );
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -72,6 +72,7 @@
     "cheerio": "1.2.0",
     "chokidar": "5.0.0",
     "cls-hooked": "4.2.2",
+    "color": "5.0.3",
     "compression": "1.8.1",
     "cookie-parser": "1.4.7",
     "csrf-csrf": "4.0.3",

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Promoted Attributes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Promoted Attributes.html
@@ -47,16 +47,16 @@
       <li>The list is not fixed, meaning that new options can be easily added from
         the promoted attribute.</li>
       <li>Renaming an option does not change the existing values since the value
-        is stored as text. Consider a <a href="#root/pOsGYCXsbNQG/tC7s2alapj8V/_help_ivYnonVFBxbQ">bulk rename</a>.</li>
+        is stored as text. Consider a <a href="#root/_help_ivYnonVFBxbQ">bulk rename</a>.</li>
       <li>The items do not have a custom color or icon. This is intentional as selects
         are meant to be light-weight. For a more customizable option, consider
-        using&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/zEY4DaJG4YT5/_help_Cq5X6iKQop6R">Relations</a>&nbsp;instead
+        using&nbsp;<a class="reference-link" href="#root/_help_Cq5X6iKQop6R">Relations</a>&nbsp;instead
         which use notes as items and those notes can be colorized and also carry
         an icon.</li>
     </ul>
   </li>
-  <li><em>Date, </em>which provides a date picker.</li>
-  <li><em>Date &amp; Time, </em>which provides a date &amp; time picker.</li>
+  <li><em>Date,</em> which provides a date picker.</li>
+  <li><em>Date &amp; Time,</em> which provides a date &amp; time picker.</li>
   <li><em>Time,</em> which provides a time picker.</li>
   <li><em>URL,</em> which provides a button to open the web address in a new
     window.</li>
@@ -67,8 +67,8 @@
   <li><em>Color</em>, which provides a color picker and a way to remove the
     value.</li>
   <li><em>Relation</em>, which points to another note and uses&nbsp;<a class="reference-link"
-    href="#root/pOsGYCXsbNQG/tC7s2alapj8V/zEY4DaJG4YT5/_help_Cq5X6iKQop6R">Relations</a>&nbsp;instead
-    of&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/tC7s2alapj8V/zEY4DaJG4YT5/_help_HI6GBBIduIgv">Labels</a>.</li>
+    href="#root/_help_Cq5X6iKQop6R">Relations</a>&nbsp;instead of&nbsp;<a class="reference-link"
+    href="#root/_help_HI6GBBIduIgv">Labels</a>.</li>
 </ul>
 <aside class="admonition note">
   <p>For label-based attributes, these types are not enforced by the attribute
@@ -106,8 +106,8 @@
   <table>
     <thead>
       <tr>
-        <th>&nbsp;</th>
-        <th>&nbsp;</th>
+        <th></th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -186,10 +186,8 @@
   inverse relation on the target note.</p>
 <h2>See also</h2>
 <ul>
-  <li>
-    <p>The&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/GTwFsgaA0lCt/_help_2FvYrpmOXm29">Table</a>&nbsp;collection
-      makes heavy use of promoted attributes to define the columns of the table,
-      since they already carry the type information. When made inheritable, it's
-      also easy to change those fields when the child notes are opened.</p>
-  </li>
+  <li>The&nbsp;<a class="reference-link" href="#root/_help_2FvYrpmOXm29">Table</a>&nbsp;collection
+    makes heavy use of promoted attributes to define the columns of the table,
+    since they already carry the type information. When made inheritable, it's
+    also easy to change those fields when the child notes are opened.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
@@ -24,10 +24,17 @@
 <p>The following features are preserved by Trilium during the import process:</p>
 <ul>
   <li>Basic formatting (bold, italic, underline, strikethrough, subscript, super
-    script, inline code, font sizes, headings, colors, highlights).
+    script, font sizes, headings, colors, highlights).
     <ul>
       <li>Black-colored text is intentionally stripped to allow it to work in dark
         themes.</li>
+    </ul>
+  </li>
+  <li>Inline code is automatically detected and formatted. Paragraphs that use
+    the Code style are also converted to&nbsp;<a class="reference-link" href="#root/pOsGYCXsbNQG/KSZ04uQ2D1St/iPIMuisry3hd/UYuUB1ZekNQU/_help_QxEyIjRBizuC">Code blocks</a>.
+    <ul>
+      <li>Unfortunately the indentation of the code might be lost because the information
+        is simply not present in the data from the Microsoft API.</li>
     </ul>
   </li>
   <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>&nbsp;with
@@ -151,7 +158,7 @@
   <li>The order of the sections (and section groups) is not available, the sections
     are ordered by creation date instead.</li>
   <li>Revision history.</li>
-  <li>Paragraph indentation.</li>
+  <li>Paragraph indentation, as well as code block indentation.</li>
   <li>Section colors.</li>
   <li>Drawings inside titles, the title might appear incomplete or “Untitled”.</li>
 </ul>

--- a/apps/server/src/services/import/onenote/color.spec.ts
+++ b/apps/server/src/services/import/onenote/color.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+
+describe("parseHexColor", () => {
+    it("parses #rrggbb and expands #rgb, tolerating case and whitespace", () => {
+        expect(parseHexColor("#1353BA")).toEqual([0x13, 0x53, 0xba]);
+        expect(parseHexColor("#333")).toEqual([0x33, 0x33, 0x33]);
+        expect(parseHexColor("  #ffffff  ")).toEqual([255, 255, 255]);
+    });
+
+    it("rejects anything that isn't a 3- or 6-digit hex color", () => {
+        for (const value of ["", "black", "333333", "#33", "#33333", "#3333333", "#33g333", "rgb(0,0,0)"]) {
+            expect(parseHexColor(value)).toBeNull();
+        }
+    });
+});
+
+describe("rgbToHsl / hslToHex", () => {
+    it("lightness-reflects grays exactly (the near-black ink correction)", () => {
+        // #333333 -> #cccccc is the OneNote near-black case; pure black reflects to pure white.
+        for (const [input, reflected] of [["#333333", "#cccccc"], ["#404040", "#bfbfbf"], ["#000000", "#ffffff"], ["#ffffff", "#000000"]]) {
+            const rgb = parseHexColor(input);
+            expect(rgb).not.toBeNull();
+            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
+            expect(saturation).toBe(0);
+            expect(hslToHex(hue, saturation, 1 - lightness)).toBe(reflected);
+        }
+    });
+
+    it("preserves hue and saturation when reflecting chromatic colors", () => {
+        // One color per hue sector of rgbToHsl, both lightness directions for hslToHex.
+        const cases: [string, string][] = [
+            ["#800000", "#ff7f7f"], // dark red (red-dominant sector)
+            ["#008000", "#7fff7f"], // dark green (green-dominant sector)
+            ["#000080", "#7f7fff"], // navy (blue-dominant sector)
+            ["#800080", "#ff7fff"], // dark magenta (hue wraps past the top of the wheel)
+            ["#ffe6e6", "#190000"] // near-white pink -> dark red (reflected lightness below 0.5)
+        ];
+        for (const [input, reflected] of cases) {
+            const rgb = parseHexColor(input);
+            expect(rgb).not.toBeNull();
+            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
+            expect(hslToHex(hue, saturation, 1 - lightness)).toBe(reflected);
+        }
+    });
+
+    it("round-trips a color through rgbToHsl and hslToHex unchanged", () => {
+        for (const input of ["#1353ba", "#faf320", "#c62938", "#808080", "#000000"]) {
+            const rgb = parseHexColor(input);
+            expect(rgb).not.toBeNull();
+            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
+            expect(hslToHex(hue, saturation, lightness)).toBe(input);
+        }
+    });
+});

--- a/apps/server/src/services/import/onenote/color.spec.ts
+++ b/apps/server/src/services/import/onenote/color.spec.ts
@@ -1,56 +1,43 @@
 import { describe, expect, it } from "vitest";
 
-import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+import { parseColor, reflectLightness } from "./color.js";
 
-describe("parseHexColor", () => {
-    it("parses #rrggbb and expands #rgb, tolerating case and whitespace", () => {
-        expect(parseHexColor("#1353BA")).toEqual([0x13, 0x53, 0xba]);
-        expect(parseHexColor("#333")).toEqual([0x33, 0x33, 0x33]);
-        expect(parseHexColor("  #ffffff  ")).toEqual([255, 255, 255]);
+/** reflectLightness on a raw CSS color string, for terser cases below. */
+function reflect(value: string): string | null {
+    const parsed = parseColor(value);
+    return parsed ? reflectLightness(parsed) : null;
+}
+
+describe("parseColor", () => {
+    it("parses the color forms OneNote emits: #rrggbb, #rgb, named and rgb()", () => {
+        expect(parseColor("#1353BA")?.hex()).toBe("#1353BA");
+        expect(parseColor("#333")?.hex()).toBe("#333333");
+        expect(parseColor("black")?.hex()).toBe("#000000");
+        expect(parseColor("rgb(54, 86, 35)")?.hex()).toBe("#365623");
     });
 
-    it("rejects anything that isn't a 3- or 6-digit hex color", () => {
-        for (const value of ["", "black", "333333", "#33", "#33333", "#3333333", "#33g333", "rgb(0,0,0)"]) {
-            expect(parseHexColor(value)).toBeNull();
+    it("returns null for anything that isn't a CSS color", () => {
+        for (const value of ["", "not-a-color", "#33", "#33g333", "url(x)"]) {
+            expect(parseColor(value)).toBeNull();
         }
     });
 });
 
-describe("rgbToHsl / hslToHex", () => {
+describe("reflectLightness", () => {
     it("lightness-reflects grays exactly (the near-black ink correction)", () => {
         // #333333 -> #cccccc is the OneNote near-black case; pure black reflects to pure white.
-        for (const [input, reflected] of [["#333333", "#cccccc"], ["#404040", "#bfbfbf"], ["#000000", "#ffffff"], ["#ffffff", "#000000"]]) {
-            const rgb = parseHexColor(input);
-            expect(rgb).not.toBeNull();
-            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
-            expect(saturation).toBe(0);
-            expect(hslToHex(hue, saturation, 1 - lightness)).toBe(reflected);
-        }
+        expect(reflect("#333333")).toBe("#cccccc");
+        expect(reflect("#404040")).toBe("#bfbfbf");
+        expect(reflect("#000000")).toBe("#ffffff");
+        expect(reflect("#ffffff")).toBe("#000000");
     });
 
     it("preserves hue and saturation when reflecting chromatic colors", () => {
-        // One color per hue sector of rgbToHsl, both lightness directions for hslToHex.
-        const cases: [string, string][] = [
-            ["#800000", "#ff7f7f"], // dark red (red-dominant sector)
-            ["#008000", "#7fff7f"], // dark green (green-dominant sector)
-            ["#000080", "#7f7fff"], // navy (blue-dominant sector)
-            ["#800080", "#ff7fff"], // dark magenta (hue wraps past the top of the wheel)
-            ["#ffe6e6", "#190000"] // near-white pink -> dark red (reflected lightness below 0.5)
-        ];
-        for (const [input, reflected] of cases) {
-            const rgb = parseHexColor(input);
-            expect(rgb).not.toBeNull();
-            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
-            expect(hslToHex(hue, saturation, 1 - lightness)).toBe(reflected);
-        }
-    });
-
-    it("round-trips a color through rgbToHsl and hslToHex unchanged", () => {
-        for (const input of ["#1353ba", "#faf320", "#c62938", "#808080", "#000000"]) {
-            const rgb = parseHexColor(input);
-            expect(rgb).not.toBeNull();
-            const [hue, saturation, lightness] = rgbToHsl(rgb ?? [0, 0, 0]);
-            expect(hslToHex(hue, saturation, lightness)).toBe(input);
-        }
+        // One color per hue region, both lightness directions.
+        expect(reflect("#800000")).toBe("#ff7f7f"); // dark red
+        expect(reflect("#008000")).toBe("#7fff7f"); // dark green
+        expect(reflect("#000080")).toBe("#7f7fff"); // navy
+        expect(reflect("#800080")).toBe("#ff7fff"); // dark magenta (hue wraps past the top of the wheel)
+        expect(reflect("#ffe6e6")).toBe("#190000"); // near-white pink -> dark red
     });
 });

--- a/apps/server/src/services/import/onenote/color.ts
+++ b/apps/server/src/services/import/onenote/color.ts
@@ -1,0 +1,73 @@
+/**
+ * Small color helpers shared by the OneNote importer's HTML converter (table-shading correction in
+ * converter.ts) and its InkML renderer (theme-adaptive ink in inkml.ts). Both correct the same
+ * OneNote quirk — colors exported for one canvas lightness rendered on the opposite one — by
+ * reflecting a color's HSL lightness (L → 1 − L) while leaving hue and saturation untouched.
+ */
+
+/** Parses a `#rgb` or `#rrggbb` colour to [r, g, b] (0-255), or null if it isn't a hex colour. */
+export function parseHexColor(value: string): [number, number, number] | null {
+    const match = value.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (!match) {
+        return null;
+    }
+    const hex = match[1].length === 3 ? match[1].replace(/(.)/g, "$1$1") : match[1];
+    return [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)];
+}
+
+/** Converts an [r, g, b] (0-255) colour to [h, s, l], each in [0, 1]. */
+export function rgbToHsl([r, g, b]: [number, number, number]): [number, number, number] {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const lightness = (max + min) / 2;
+    const delta = max - min;
+    if (delta === 0) {
+        return [0, 0, lightness];
+    }
+    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+    let hue: number;
+    switch (max) {
+        case r:
+            hue = (g - b) / delta + (g < b ? 6 : 0);
+            break;
+        case g:
+            hue = (b - r) / delta + 2;
+            break;
+        default:
+            hue = (r - g) / delta + 4;
+            break;
+    }
+    return [hue / 6, saturation, lightness];
+}
+
+/** Converts [h, s, l] (each in [0, 1]) back to a `#rrggbb` hex colour. */
+export function hslToHex(h: number, s: number, l: number): string {
+    const channel = (value: number) => Math.round(value * 255).toString(16).padStart(2, "0");
+    if (s === 0) {
+        return `#${channel(l).repeat(3)}`;
+    }
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const component = (t: number) => {
+        if (t < 0) {
+            t += 1;
+        }
+        if (t > 1) {
+            t -= 1;
+        }
+        if (t < 1 / 6) {
+            return p + (q - p) * 6 * t;
+        }
+        if (t < 1 / 2) {
+            return q;
+        }
+        if (t < 2 / 3) {
+            return p + (q - p) * (2 / 3 - t) * 6;
+        }
+        return p;
+    };
+    return `#${channel(component(h + 1 / 3))}${channel(component(h))}${channel(component(h - 1 / 3))}`;
+}

--- a/apps/server/src/services/import/onenote/color.ts
+++ b/apps/server/src/services/import/onenote/color.ts
@@ -1,73 +1,22 @@
 /**
- * Small color helpers shared by the OneNote importer's HTML converter (table-shading correction in
+ * Color helpers shared by the OneNote importer's HTML converter (table-shading correction in
  * converter.ts) and its InkML renderer (theme-adaptive ink in inkml.ts). Both correct the same
  * OneNote quirk — colors exported for one canvas lightness rendered on the opposite one — by
- * reflecting a color's HSL lightness (L → 1 − L) while leaving hue and saturation untouched.
+ * reflecting a color's HSL lightness (L → 100 − L) while leaving hue and saturation untouched.
  */
 
-/** Parses a `#rgb` or `#rrggbb` colour to [r, g, b] (0-255), or null if it isn't a hex colour. */
-export function parseHexColor(value: string): [number, number, number] | null {
-    const match = value.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
-    if (!match) {
+import Color, { type ColorInstance } from "color";
+
+/** Parses any CSS color (`#rgb`/`#rrggbb`, named, `rgb()`, …), or null if the value isn't one. */
+export function parseColor(value: string): ColorInstance | null {
+    try {
+        return Color(value);
+    } catch {
         return null;
     }
-    const hex = match[1].length === 3 ? match[1].replace(/(.)/g, "$1$1") : match[1];
-    return [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)];
 }
 
-/** Converts an [r, g, b] (0-255) colour to [h, s, l], each in [0, 1]. */
-export function rgbToHsl([r, g, b]: [number, number, number]): [number, number, number] {
-    r /= 255;
-    g /= 255;
-    b /= 255;
-    const max = Math.max(r, g, b);
-    const min = Math.min(r, g, b);
-    const lightness = (max + min) / 2;
-    const delta = max - min;
-    if (delta === 0) {
-        return [0, 0, lightness];
-    }
-    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
-    let hue: number;
-    switch (max) {
-        case r:
-            hue = (g - b) / delta + (g < b ? 6 : 0);
-            break;
-        case g:
-            hue = (b - r) / delta + 2;
-            break;
-        default:
-            hue = (r - g) / delta + 4;
-            break;
-    }
-    return [hue / 6, saturation, lightness];
-}
-
-/** Converts [h, s, l] (each in [0, 1]) back to a `#rrggbb` hex colour. */
-export function hslToHex(h: number, s: number, l: number): string {
-    const channel = (value: number) => Math.round(value * 255).toString(16).padStart(2, "0");
-    if (s === 0) {
-        return `#${channel(l).repeat(3)}`;
-    }
-    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-    const p = 2 * l - q;
-    const component = (t: number) => {
-        if (t < 0) {
-            t += 1;
-        }
-        if (t > 1) {
-            t -= 1;
-        }
-        if (t < 1 / 6) {
-            return p + (q - p) * 6 * t;
-        }
-        if (t < 1 / 2) {
-            return q;
-        }
-        if (t < 2 / 3) {
-            return p + (q - p) * (2 / 3 - t) * 6;
-        }
-        return p;
-    };
-    return `#${channel(component(h + 1 / 3))}${channel(component(h))}${channel(component(h - 1 / 3))}`;
+/** The `#rrggbb` hex of a color with its HSL lightness reflected (L → 100 − L), hue and saturation kept. */
+export function reflectLightness(color: ColorInstance): string {
+    return color.lightness(100 - color.lightness()).hex().toLowerCase();
 }

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -790,6 +790,61 @@ describe("convertPageHtml", () => {
         expect(out).toContain(`<span class="text-big">Title</span>`);
         expect(out).toContain("<code>Code</code>");
     });
+
+    it("merges a run of all-Consolas paragraphs into a code block, keeping true inline code", () => {
+        // Mirrors a real OneNote export: an inline Consolas span, a three-line code passage, and a
+        // trailing paragraph whose Consolas paragraph mark is dead styling (every text run
+        // overrides it back to Calibri) — the latter must not become code at all.
+        const sample = `<body data-absolute-enabled="true" style="font-family:Calibri;font-size:11pt">
+            <div style="position:absolute;left:48px;top:115px;width:720px">
+                <p style="margin-top:0pt;margin-bottom:0pt">This is normal text, with <span style="font-family:Consolas">monospace text</span>.</p>
+                <br />
+                <p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt">void main() {</p>
+                <p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt">printf(&quot;Hello world.&quot;);</p>
+                <p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt">}</p>
+                <br />
+                <p style="font-family:Consolas;margin-top:0pt;margin-bottom:0pt"><span style="font-family:Calibri">Back to normal text.</span></p>
+            </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        // The &quot; entities come out as literal quotes: decoded when the line text is extracted,
+        // and the sanitizer only re-escapes &<> in text content.
+        expect(out).toContain(`<pre><code class="language-text-x-trilium-auto">void main() {\nprintf("Hello world.");\n}</code></pre>`);
+        expect(out).toContain("<code>monospace text</code>");
+        // The dead-font paragraph stays plain text: exactly one block + one inline <code> overall.
+        expect(out).toContain("Back to normal text.");
+        expect(out.match(/<code/g) ?? []).toHaveLength(2);
+    });
+
+    it("bridges block-level <br> gaps inside a code run as blank lines, flattening formatting", () => {
+        // The bold span's formatting is dropped (code blocks are plain text), the <br> between the
+        // code lines becomes an empty line, and a paragraph that is all-Consolas only through its
+        // spans still joins the run.
+        const sample = `<body><div>
+            <p style="font-family:Consolas"><span style="font-weight:bold">let x</span> = 1;</p>
+            <br />
+            <p><span style="font-family:Consolas">return x;</span></p>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).toContain(`<pre><code class="language-text-x-trilium-auto">let x = 1;\n\nreturn x;</code></pre>`);
+        expect(out).not.toContain("<strong>");
+    });
+
+    it("leaves a lone all-Consolas paragraph as inline code and breaks runs on normal text", () => {
+        // A single code-styled line reads fine inline; the intervening normal paragraph keeps the
+        // two Consolas lines from merging across it.
+        const sample = `<body><div>
+            <p style="font-family:Consolas">npm install</p>
+            <p>Then run it:</p>
+            <p style="font-family:Consolas">npm start</p>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).not.toContain("<pre>");
+        expect(out).toContain("<code>npm install</code>");
+        expect(out).toContain("<code>npm start</code>");
+    });
 });
 
 describe("extractPageCreatedDate", () => {

--- a/apps/server/src/services/import/onenote/converter.spec.ts
+++ b/apps/server/src/services/import/onenote/converter.spec.ts
@@ -845,6 +845,36 @@ describe("convertPageHtml", () => {
         expect(out).toContain("<code>npm install</code>");
         expect(out).toContain("<code>npm start</code>");
     });
+
+    it("sees through formatting wrappers and whitespace when judging what renders in Consolas", () => {
+        // Text inside a formatting child with no font-family of its own still renders in the
+        // paragraph's Consolas, so the lone paragraph becomes inline code with the wrapper kept.
+        const wrapped = converter.convertPageHtml(
+            `<body><div><p style="font-family:Consolas"><strong>ls -la</strong></p></div></body>`
+        );
+        expect(wrapped).toContain("<code><strong>ls -la</strong></code>");
+
+        // Whitespace-only direct text is not "text rendering in Consolas": with the only real text
+        // overridden to Calibri, the paragraph is not code at all — neither block nor inline.
+        const whitespace = converter.convertPageHtml(
+            `<body><div><p style="font-family:Consolas"> <span style="font-family:Calibri">plain</span></p></div></body>`
+        );
+        expect(whitespace).toContain("plain");
+        expect(whitespace).not.toContain("<code>");
+    });
+
+    it("treats an empty Consolas paragraph inside a run as a blank code line", () => {
+        // The empty paragraph has no text to judge, so only its own Consolas paragraph mark lets it
+        // join the run — as an empty line between the two code lines.
+        const sample = `<body><div>
+            <p style="font-family:Consolas">a</p>
+            <p style="font-family:Consolas"></p>
+            <p style="font-family:Consolas">b</p>
+        </div></body>`;
+        const out = converter.convertPageHtml(sample);
+
+        expect(out).toContain(`<pre><code class="language-text-x-trilium-auto">a\n\nb</code></pre>`);
+    });
 });
 
 describe("extractPageCreatedDate", () => {

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -24,6 +24,8 @@
 import { sanitize, utils } from "@triliumnext/core";
 import { HTMLElement, parse } from "node-html-parser";
 
+import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+
 /**
  * The marker class the importer keys on to find OneNote file attachments (see importer.ts). The href
  * carries the Graph resource URL (a placeholder the importer swaps for a local attachment link) and
@@ -646,74 +648,6 @@ function correctTableShadingColors(scope: HTMLElement) {
         style.set("background-color", hslToHex(hue, saturation, 1 - lightness));
         cell.setAttribute("style", serializeStyle(style));
     }
-}
-
-/** Parses a `#rgb` or `#rrggbb` colour to [r, g, b] (0-255), or null if it isn't a hex colour. */
-function parseHexColor(value: string): [number, number, number] | null {
-    const match = value.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
-    if (!match) {
-        return null;
-    }
-    const hex = match[1].length === 3 ? match[1].replace(/(.)/g, "$1$1") : match[1];
-    return [parseInt(hex.slice(0, 2), 16), parseInt(hex.slice(2, 4), 16), parseInt(hex.slice(4, 6), 16)];
-}
-
-/** Converts an [r, g, b] (0-255) colour to [h, s, l], each in [0, 1]. */
-function rgbToHsl([r, g, b]: [number, number, number]): [number, number, number] {
-    r /= 255;
-    g /= 255;
-    b /= 255;
-    const max = Math.max(r, g, b);
-    const min = Math.min(r, g, b);
-    const lightness = (max + min) / 2;
-    const delta = max - min;
-    if (delta === 0) {
-        return [0, 0, lightness];
-    }
-    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
-    let hue: number;
-    switch (max) {
-        case r:
-            hue = (g - b) / delta + (g < b ? 6 : 0);
-            break;
-        case g:
-            hue = (b - r) / delta + 2;
-            break;
-        default:
-            hue = (r - g) / delta + 4;
-            break;
-    }
-    return [hue / 6, saturation, lightness];
-}
-
-/** Converts [h, s, l] (each in [0, 1]) back to a `#rrggbb` hex colour. */
-function hslToHex(h: number, s: number, l: number): string {
-    const channel = (value: number) => Math.round(value * 255).toString(16).padStart(2, "0");
-    if (s === 0) {
-        return `#${channel(l).repeat(3)}`;
-    }
-    /* v8 ignore next -- only called from correctTableShadingColors with l strictly above 0.5 */
-    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-    const p = 2 * l - q;
-    const component = (t: number) => {
-        if (t < 0) {
-            t += 1;
-        }
-        if (t > 1) {
-            t -= 1;
-        }
-        if (t < 1 / 6) {
-            return p + (q - p) * 6 * t;
-        }
-        if (t < 1 / 2) {
-            return q;
-        }
-        if (t < 2 / 3) {
-            return p + (q - p) * (2 / 3 - t) * 6;
-        }
-        return p;
-    };
-    return `#${channel(component(h + 1 / 3))}${channel(component(h))}${channel(component(h - 1 / 3))}`;
 }
 
 /** Drops list items that hold nothing but whitespace/<br> (OneNote's "exited the list" remnant). */

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -22,7 +22,7 @@
  */
 
 import { sanitize, utils } from "@triliumnext/core";
-import { HTMLElement, parse } from "node-html-parser";
+import { HTMLElement, NodeType, parse } from "node-html-parser";
 
 import { parseColor, reflectLightness } from "./color.js";
 
@@ -111,6 +111,7 @@ export function convertPageHtml(rawHtml: string): string {
     convertResourceReferences(scope);
     wrapFloatingImages(scope);
     convertTags(scope);
+    convertCodeBlocks(scope);
     convertInlineFormatting(scope);
     normalizeNamedColors(scope);
     removeDefaultTextColor(scope);
@@ -353,8 +354,11 @@ function convertInlineFormatting(scope: HTMLElement) {
         if (decorations.includes("line-through")) {
             wrap("del");
         }
-        // OneNote's "Code" style is just a Consolas font; map it to an inline <code> element.
-        if ((style.get("font-family") ?? "").includes("consolas")) {
+        // OneNote's "Code" style is just a Consolas font; map it to an inline <code> element — but
+        // only when some of the element's own text actually renders in it. After leaving the code
+        // style, OneNote keeps Consolas on the paragraph mark while every text run overrides it
+        // back to the body font, and that dead paragraph-level Consolas must not become <code>.
+        if ((style.get("font-family") ?? "").includes(MONOSPACE_FONT) && hasUnoverriddenText(el)) {
             wrap("code");
         }
         // OneNote carries explicit point sizes; map them onto CKEditor's tiny/small/big/huge scale.
@@ -368,6 +372,117 @@ function convertInlineFormatting(scope: HTMLElement) {
             el.set_content(`${open.join("")}${el.innerHTML}${close.join("")}`);
         }
     }
+}
+
+/** The font-family OneNote's community "Code" style applies; its only marker for code-styled text. */
+const MONOSPACE_FONT = "consolas";
+
+/**
+ * Whether any of the element's text actually renders in the element's own font — i.e. some
+ * non-empty text node is not inside a descendant that declares a font-family of its own. A
+ * descendant that declares one either overrides the font away (its text doesn't count) or restates
+ * a monospace font (and then gets its own <code> wrap on its own visit), so either way its subtree
+ * is skipped.
+ */
+function hasUnoverriddenText(el: HTMLElement): boolean {
+    for (const child of el.childNodes) {
+        if (child instanceof HTMLElement) {
+            if (!declaredFontFamily(child) && hasUnoverriddenText(child)) {
+                return true;
+            }
+        } else if (child.nodeType === NodeType.TEXT_NODE && child.text.trim().length > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * OneNote has no code-block construct: its community "Code" style is just Consolas-styled ordinary
+ * paragraphs. A run of two or more consecutive paragraphs whose entire text renders in Consolas is
+ * a code block in all but markup, so merge it into one <pre><code> (with the language-autodetect
+ * class the Markdown and ENEX importers use). Blank lines survive as OneNote's block-level <br>
+ * spacing between code paragraphs; lines are flattened to plain text, matching CKEditor's code
+ * blocks, so any inline formatting within them is dropped. A lone all-Consolas paragraph is left to
+ * convertInlineFormatting's inline <code> treatment — one line reads fine inline, and eagerly
+ * promoting every such paragraph to a block would catch code-styled asides like filenames. Runs
+ * before convertInlineFormatting so the merged lines aren't first wrapped as inline <code>.
+ */
+function convertCodeBlocks(scope: HTMLElement) {
+    const consumed = new Set<HTMLElement>();
+    for (const paragraph of scope.querySelectorAll("p")) {
+        if (consumed.has(paragraph) || !isCodeParagraph(paragraph)) {
+            continue;
+        }
+
+        // Gather the run: consecutive code paragraphs, bridging bare <br> gaps as blank lines.
+        // A trailing gap with no code paragraph after it is left in place, not consumed.
+        const members: HTMLElement[] = [paragraph];
+        const lines: string[] = [paragraph.text];
+        let paragraphCount = 1;
+        let cursor = paragraph.nextElementSibling;
+        while (cursor) {
+            const gap: HTMLElement[] = [];
+            while (cursor && cursor.tagName?.toLowerCase() === "br") {
+                gap.push(cursor);
+                cursor = cursor.nextElementSibling;
+            }
+            if (!cursor || cursor.tagName?.toLowerCase() !== "p" || !isCodeParagraph(cursor)) {
+                break;
+            }
+            members.push(...gap, cursor);
+            lines.push(...gap.map(() => ""), cursor.text);
+            paragraphCount++;
+            cursor = cursor.nextElementSibling;
+        }
+        if (paragraphCount < 2) {
+            continue;
+        }
+
+        for (const member of members) {
+            consumed.add(member);
+        }
+        const code = lines.map((line) => utils.escapeHtml(line)).join("\n");
+        paragraph.insertAdjacentHTML("beforebegin", `<pre><code class="language-text-x-trilium-auto">${code}</code></pre>`);
+        for (const member of members) {
+            member.remove();
+        }
+    }
+}
+
+/**
+ * Whether a paragraph is one line of code-styled text: every non-empty text node in it renders in
+ * Consolas — via the paragraph's own font or a wrapping span's — with descendant font-family
+ * declarations overriding the inherited state either way. A paragraph with no text at all only
+ * qualifies through its own Consolas paragraph mark (a blank line inside a code passage).
+ */
+function isCodeParagraph(paragraph: HTMLElement): boolean {
+    const base = (declaredFontFamily(paragraph) ?? "").includes(MONOSPACE_FONT);
+    if (paragraph.text.trim().length === 0) {
+        return base;
+    }
+    return allTextMonospace(paragraph, base);
+}
+
+/** Whether every non-empty text node under `el` renders in Consolas, given the inherited state. */
+function allTextMonospace(el: HTMLElement, inherited: boolean): boolean {
+    for (const child of el.childNodes) {
+        if (child instanceof HTMLElement) {
+            const family = declaredFontFamily(child);
+            const monospace = family ? family.includes(MONOSPACE_FONT) : inherited;
+            if (!allTextMonospace(child, monospace)) {
+                return false;
+            }
+        } else if (child.nodeType === NodeType.TEXT_NODE && child.text.trim().length > 0 && !inherited) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/** The element's own font-family declaration, if any. */
+function declaredFontFamily(el: HTMLElement): string | undefined {
+    return parseStyle(el.getAttribute("style") ?? "").get("font-family");
 }
 
 /**

--- a/apps/server/src/services/import/onenote/converter.ts
+++ b/apps/server/src/services/import/onenote/converter.ts
@@ -24,7 +24,7 @@
 import { sanitize, utils } from "@triliumnext/core";
 import { HTMLElement, parse } from "node-html-parser";
 
-import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+import { parseColor, reflectLightness } from "./color.js";
 
 /**
  * The marker class the importer keys on to find OneNote file attachments (see importer.ts). The href
@@ -629,23 +629,18 @@ function columnPercentages(widths: number[]): number[] {
  * OneNote's Graph API exports table cell shading as a dark *shade* of the colour OneNote actually
  * displays: it keeps the hue and saturation but inverts the lightness (e.g. a cell shown as #b6d9a1
  * comes back as #375623). Left as-is the cell imports far too dark — commonly dark-on-dark and
- * unreadable. So for a cell whose background is dark, reflect its lightness (L → 1 − L, hue/saturation
- * untouched) to recover the displayed light tint; light backgrounds (plausible shading as-is, and the
- * form correctly-exported colours arrive in) are left alone. Runs after normalizeNamedColors, so a
- * named background has already become the hex this keys on.
+ * unreadable. So for a cell whose background is dark, reflect its lightness (L → 100 − L,
+ * hue/saturation untouched) to recover the displayed light tint; light backgrounds (plausible shading
+ * as-is, and the form correctly-exported colours arrive in) are left alone.
  */
 function correctTableShadingColors(scope: HTMLElement) {
     for (const cell of scope.querySelectorAll("td, th")) {
         const style = parseStyle(cell.getAttribute("style") ?? "");
-        const rgb = parseHexColor(style.get("background-color") ?? "");
-        if (!rgb) {
+        const background = parseColor(style.get("background-color") ?? "");
+        if (!background || background.lightness() >= 50) {
             continue;
         }
-        const [hue, saturation, lightness] = rgbToHsl(rgb);
-        if (lightness >= 0.5) {
-            continue;
-        }
-        style.set("background-color", hslToHex(hue, saturation, 1 - lightness));
+        style.set("background-color", reflectLightness(background));
         cell.setAttribute("style", serializeStyle(style));
     }
 }

--- a/apps/server/src/services/import/onenote/graph.spec.ts
+++ b/apps/server/src/services/import/onenote/graph.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../safe_fetch.js", () => ({ safeFetch: vi.fn() }));
 
 import { safeFetch } from "../../safe_fetch.js";
-import { backoffDelayMs, ENCRYPTED_SECTION_ERROR_CODE, extractGraphErrorDetail, getAccount, getPageContent, getResource, getThrottleStats, GraphRequestError, isEncryptedSectionError, listPages, resetThrottleGate, resetThrottleStats, retryAfterMs, sanitizeGraphUrl } from "./graph.js";
+import { backoffDelayMs, ENCRYPTED_SECTION_ERROR_CODE, extractGraphErrorDetail, getAccount, getPageContent, getResource, getThrottleStats, GraphRequestError, isEncryptedSectionError, listPages, resetThrottleGate, resetThrottleStats, retryAfterMs, sanitizeGraphUrl, setThrottleListener } from "./graph.js";
 
 const safeFetchMock = vi.mocked(safeFetch);
 
@@ -68,8 +68,38 @@ describe("throttling retries", () => {
 
     afterEach(() => {
         resetThrottleGate();
+        setThrottleListener(null);
         vi.useRealTimers();
         safeFetchMock.mockReset();
+    });
+
+    it("notifies the registered throttle listener on each gate extension, and stops once cleared", async () => {
+        const listener = vi.fn();
+        setThrottleListener(listener);
+        let calls = 0;
+        safeFetchMock.mockImplementation(async () => {
+            calls++;
+            return calls <= 2 ? graphResponse(429, "", { "Retry-After": "30" }) : graphResponse(200, JSON.stringify({ displayName: "Ada" }));
+        });
+
+        const promise = getAccount(token);
+        await vi.runAllTimersAsync();
+        await expect(promise).resolves.toEqual({ name: "Ada", email: "" });
+
+        // One notification per throttled response, carrying the wait pushed onto the shared gate —
+        // this is what lets the importer flip its progress toast to "waiting out rate limiting".
+        expect(listener).toHaveBeenCalledTimes(2);
+        expect(listener).toHaveBeenCalledWith(30_000);
+
+        // After clearing (the importer does this when its run ends), later throttling must not reach
+        // the stale listener.
+        setThrottleListener(null);
+        calls = 0;
+        safeFetchMock.mockClear();
+        const second = getAccount(token);
+        await vi.runAllTimersAsync();
+        await second;
+        expect(listener).toHaveBeenCalledTimes(2);
     });
 
     it("keeps retrying well past eight attempts while the wait budget lasts", async () => {

--- a/apps/server/src/services/import/onenote/graph.ts
+++ b/apps/server/src/services/import/onenote/graph.ts
@@ -50,6 +50,18 @@ const MAX_GATEWAY_TIMEOUT_RETRIES = 5;
 // "don't send until" timestamp that ALL requests wait on, so the whole pool backs off together.
 let throttledUntilMs = 0;
 
+// Notified whenever the shared throttle gate is extended — i.e. Graph is actively throttling and every
+// request is now waiting. The importer uses this to flip its progress toast to a "waiting out rate
+// limiting" message: during a long throttle window no page completes, so the progress count sits still
+// for up to an hour and is otherwise indistinguishable from a hang (users have killed multi-hour
+// imports — losing all fetched work — over exactly that).
+let throttleListener: ((waitMs: number) => void) | null = null;
+
+/** Registers (or clears, with null) the single throttle-gate listener. */
+export function setThrottleListener(listener: ((waitMs: number) => void) | null): void {
+    throttleListener = listener;
+}
+
 // Aggregate throttle statistics for the current import, surfaced in the import report (they answer
 // "why did this take hours?"). `requestCount` counts throttled (429/503) responses; `waitMs`
 // accumulates net extensions of the shared gate — wall-clock time spent waiting out throttles —
@@ -126,6 +138,7 @@ async function graphFetch(getAccessToken: AccessTokenProvider, url: string): Pro
         throttledUntilMs = Math.max(throttledUntilMs, Date.now() + waitMs);
         throttleAttempt++;
         getLog().info(`OneNote import: Graph throttled (HTTP ${response.status}) on ${sanitizeGraphUrl(url)}; retry ${throttleAttempt} after ${waitMs}ms (${Math.round((giveUpAtMs - Date.now()) / 60_000)}min of wait budget left)`);
+        throttleListener?.(waitMs);
     }
 }
 
@@ -489,5 +502,6 @@ export default {
     getResource,
     getThrottleStats,
     resetThrottleStats,
+    setThrottleListener,
     isEncryptedSectionError
 };

--- a/apps/server/src/services/import/onenote/importer.spec.ts
+++ b/apps/server/src/services/import/onenote/importer.spec.ts
@@ -1,4 +1,4 @@
-import { becca, cls, date_utils, note_service as noteService } from "@triliumnext/core";
+import { becca, cls, date_utils, note_service as noteService, ws } from "@triliumnext/core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import sqlInit from "../../sql_init.js";
@@ -14,6 +14,7 @@ vi.mock("./graph.js", () => ({
         getResource: vi.fn(),
         getThrottleStats: vi.fn(() => ({ requestCount: 0, waitMs: 0 })),
         resetThrottleStats: vi.fn(),
+        setThrottleListener: vi.fn(),
         isEncryptedSectionError: vi.fn(() => false)
     }
 }));
@@ -118,6 +119,57 @@ describe("importSelection (real DB)", () => {
         // Container notes (section, notebook) are not OneNote pages and must not carry the label.
         const sectionNote = Object.values(becca.notes).find((note) => note.title === "Section");
         expect(sectionNote?.getOwnedLabelValue("oneNotePageId")).toBeNull();
+    });
+
+    it("reports a throttled phase while Graph rate limits and clears it once work resumes", async () => {
+        const sent: { type: string; taskId?: string; phase?: string; progressCount?: number }[] = [];
+        const wsSpy = vi.spyOn(ws, "sendMessageToAllClients").mockImplementation((message) => {
+            sent.push(message as (typeof sent)[number]);
+        });
+
+        // Capture the listener importSelection registers so the test can play the role of graphFetch's
+        // shared throttle gate.
+        let throttleListener: ((waitMs: number) => void) | null = null;
+        graphMock.setThrottleListener.mockImplementation((listener) => {
+            throttleListener = listener;
+        });
+
+        graphMock.listPages.mockResolvedValue([{ id: "1-thr", title: "Throttled Page", level: 0 }]);
+        graphMock.getPageContent.mockImplementation(async () => {
+            // Two gate extensions before the page finally arrives — a sustained throttle re-fires the
+            // listener on every retry, but the toast must only be flipped once.
+            throttleListener?.(30_000);
+            throttleListener?.(60_000);
+            return { html: "<p>hello</p>", inkml: "" };
+        });
+
+        try {
+            await cls.init(() => importSelection({
+                getAccessToken: () => Promise.resolve("token"),
+                parentNoteId: "root",
+                sections: [{ id: "sec-thr", title: "Throttled Section", groupPath: [], notebookId: "nb-thr", notebookTitle: "Notebook" }],
+                taskId: "task-throttled"
+            }));
+        } finally {
+            wsSpy.mockRestore();
+        }
+
+        const progress = sent.filter((message) => message.type === "taskProgressCount" && message.taskId === "task-throttled");
+        const throttledIndex = progress.findIndex((message) => message.phase === "throttled");
+
+        // The throttle flips the toast exactly once (repeat extensions are deduplicated)...
+        expect(throttledIndex).toBeGreaterThanOrEqual(0);
+        expect(progress.filter((message) => message.phase === "throttled")).toHaveLength(1);
+
+        // ...and the next completed unit of work sends promptly with the label gone, so the toast
+        // returns to the normal "Imported X out of N" message.
+        const after = progress.slice(throttledIndex + 1);
+        expect(after.length).toBeGreaterThan(0);
+        expect(after.every((message) => message.phase === undefined)).toBe(true);
+
+        // The run unregisters its listener so a stale one can't outlive the import.
+        expect(graph.setThrottleListener).toHaveBeenLastCalledWith(null);
+        graphMock.setThrottleListener.mockReset();
     });
 
     it("writes an import report as the root import note's content", async () => {

--- a/apps/server/src/services/import/onenote/importer.ts
+++ b/apps/server/src/services/import/onenote/importer.ts
@@ -122,6 +122,24 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
     const startedAtMs = Date.now();
     graph.resetThrottleStats();
 
+    // While Graph is throttling, no page completes and the progress count sits still — for up to an
+    // hour — which looks exactly like a hang; users have killed healthy multi-hour imports (losing all
+    // fetched work, since notes are only committed at the end) over it. So the first gate extension
+    // flips the toast to a "waiting out rate limiting" phase, and the next completed unit of work flips
+    // it back (clearThrottledPhase below). The extra flag keeps a sustained throttle — which re-fires
+    // the listener on every retry — from re-sending an identical message each time.
+    let throttleReported = false;
+    graph.setThrottleListener(() => {
+        if (!throttleReported) {
+            throttleReported = true;
+            taskContext.reportPhase("throttled");
+        }
+    });
+    const clearThrottledPhase = () => {
+        throttleReported = false;
+        taskContext.clearPhase();
+    };
+
     try {
         // Phase 1: pull everything over the network first, so note creation can run in a single
         // synchronous transaction afterwards.
@@ -138,6 +156,7 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
             try {
                 sectionPages.push({ section, pages: await graph.listPages(getAccessToken, section.id) });
                 consecutiveSectionFailures = 0;
+                clearThrottledPhase();
             } catch (e: unknown) {
                 const rawMessage = e instanceof Error ? e.message : String(e);
                 // A password-protected section is a user-fixable, expected case, so replace Graph's opaque
@@ -190,6 +209,7 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
                         throw new Error(`Aborting the OneNote import: ${consecutivePageFailures} pages in a row failed to fetch, which points to a systemic problem rather than individual broken pages. Last error: ${message}`);
                     }
                     fetchedPages.push(buildPlaceholderPage(page, message));
+                    clearThrottledPhase();
                     taskContext.increaseProgressCount();
                     continue;
                 }
@@ -203,6 +223,7 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
                     getLog().error(`OneNote import: fetched page '${page.title}' (${page.id}) but could not process its content; a placeholder note will be imported instead: ${message}`);
                     fetchedPages.push(buildPlaceholderPage(page, message));
                 }
+                clearThrottledPhase();
                 taskContext.increaseProgressCount();
             }
             fetched.push(toFetchedSection(section, fetchedPages));
@@ -215,6 +236,8 @@ export async function importSelection({ getAccessToken, parentNoteId, sections, 
     } catch (e: unknown) {
         getLog().error(`OneNote import failed: ${e instanceof Error ? (e.stack ?? e.message) : e}`);
         taskContext.reportError(e instanceof Error ? e.message : String(e));
+    } finally {
+        graph.setThrottleListener(null);
     }
 }
 

--- a/apps/server/src/services/import/onenote/inkml.spec.ts
+++ b/apps/server/src/services/import/onenote/inkml.spec.ts
@@ -136,7 +136,7 @@ describe("inkmlToSvg", () => {
         expect(svg).toContain(`style="stroke:light-dark(#190000, #ffe6e6)"`);
     });
 
-    it("adapts the named colors black and white through their hex equivalents", () => {
+    it("adapts named colors, keeping the original token on the as-sent side", () => {
         const named = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
             <inkml:definitions>
                 <inkml:brush xml:id="b0"><inkml:brushProperty name="color" value="Black"/></inkml:brush>
@@ -147,7 +147,8 @@ describe("inkmlToSvg", () => {
         </inkml:ink>`;
         const svg = inkmlToSvg(named) ?? "";
 
-        expect((svg.match(/style="stroke:light-dark\(#000000, #ffffff\)"/g) ?? [])).toHaveLength(2);
+        expect(svg).toContain(`style="stroke:light-dark(Black, #ffffff)"`);
+        expect(svg).toContain(`style="stroke:light-dark(#000000, white)"`);
     });
 
     it("leaves ink readable under both themes literal and omits the adaptive style", () => {

--- a/apps/server/src/services/import/onenote/inkml.spec.ts
+++ b/apps/server/src/services/import/onenote/inkml.spec.ts
@@ -49,12 +49,12 @@ describe("inkmlToSvg", () => {
         const svg = inkmlToSvg(dot) ?? "";
         expect(svg).toContain("<circle");
         expect(svg).not.toContain("<path");
-        // The default brush is OneNote's automatic ink, so the dot fills adaptively via the class.
-        expect(svg).toContain(`class="ink-auto"`);
-        expect(svg).toContain("circle.ink-auto{fill:light-dark(#000,#fff)}");
+        // The default brush is black ink, so the dot fills theme-adaptively via an inline style.
+        expect(svg).toContain(`style="fill:light-dark(#000000, #ffffff)"`);
+        expect(svg).toContain("<style>svg{color-scheme:light dark}</style>");
     });
 
-    it("renders a deliberately-colored single-point trace with a literal fill", () => {
+    it("renders a readable-colored single-point trace with a literal fill", () => {
         const dot = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
             <inkml:definitions>
                 <inkml:brush xml:id="br0"><inkml:brushProperty name="color" value="#FF0000"/></inkml:brush>
@@ -63,25 +63,24 @@ describe("inkmlToSvg", () => {
         </inkml:ink>`;
         const svg = inkmlToSvg(dot) ?? "";
 
-        // A chosen color is baked into the dot's fill; no adaptive class or style block is emitted.
+        // A color readable under both themes is baked into the dot's fill; no adaptive style is emitted.
         expect(svg).toContain("<circle");
         expect(svg).toContain(`fill="#FF0000"`);
-        expect(svg).not.toContain("ink-auto");
+        expect(svg).not.toContain("light-dark");
         expect(svg).not.toContain("<style>");
     });
 
-    it("works without namespace prefixes and falls back to a default (automatic) brush", () => {
+    it("works without namespace prefixes and falls back to a default (black) brush", () => {
         const plain = `<ink><trace>0 0, 10 10</trace></ink>`;
         const svg = inkmlToSvg(plain) ?? "";
         expect(svg).toContain("<path");
-        // The default brush is OneNote's automatic ink: rendered theme-adaptively, never hard black.
-        expect(svg).toContain(`class="ink-auto"`);
+        // The default brush is black ink: rendered theme-adaptively, never hard black.
+        expect(svg).toContain(`style="stroke:light-dark(#000000, #ffffff)"`);
         expect(svg).not.toContain(`stroke="#000000"`);
-        expect(svg).toContain("light-dark(#000,#fff)");
     });
 
-    it("renders OneNote's automatic ink (default black and its white inverse) theme-adaptively", () => {
-        const automatic = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+    it("renders black ink and its dark-canvas inverse (white) theme-adaptively", () => {
+        const blackAndWhite = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
             <inkml:definitions>
                 <inkml:brush xml:id="black"><inkml:brushProperty name="color" value="#000000"/></inkml:brush>
                 <inkml:brush xml:id="white"><inkml:brushProperty name="color" value="#FFFFFF"/></inkml:brush>
@@ -89,24 +88,88 @@ describe("inkmlToSvg", () => {
             <inkml:trace brushRef="#black">0 0, 10 10</inkml:trace>
             <inkml:trace brushRef="#white">20 20, 30 30</inkml:trace>
         </inkml:ink>`;
-        const svg = inkmlToSvg(automatic) ?? "";
+        const svg = inkmlToSvg(blackAndWhite) ?? "";
 
-        // Both default black and its dark-mode inverse (white) become the adaptive class, not a color.
-        expect((svg.match(/class="ink-auto"/g) ?? [])).toHaveLength(2);
+        // Lightness reflection maps black and white onto the same black-on-light/white-on-dark pair.
+        expect((svg.match(/style="stroke:light-dark\(#000000, #ffffff\)"/gi) ?? [])).toHaveLength(2);
         expect(svg).not.toContain(`stroke="#000000"`);
         expect(svg).not.toContain(`stroke="#FFFFFF"`);
 
         // The adaptive <style> is emitted once, keyed to the embedding context's color-scheme.
         expect((svg.match(/<style>/g) ?? [])).toHaveLength(1);
         expect(svg).toContain("svg{color-scheme:light dark}");
-        expect(svg).toContain("path.ink-auto{stroke:light-dark(#000,#fff)}");
     });
 
-    it("leaves deliberately-colored ink literal and omits the adaptive style", () => {
-        // #FF0000 is a chosen color — untouched — and with no automatic strokes there's no <style> block.
+    it("adapts palette near-blacks like #333333 for dark mode, keeping them literal in light mode", () => {
+        // The reported regression: OneNote's black-looking pens are per-client near-blacks
+        // (#333333, #404040, ...), not #000000. Reflected lightness lands within a rounding error
+        // of OneNote's own dark-mode rendering (#333333 -> #cbc8c8 in OneNote, #cccccc here).
+        const nearBlacks = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="b33"><inkml:brushProperty name="color" value="#333333"/></inkml:brush>
+                <inkml:brush xml:id="b40"><inkml:brushProperty name="color" value="#404040"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#b33">0 0, 10 10</inkml:trace>
+            <inkml:trace brushRef="#b40">20 20, 30 30</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(nearBlacks) ?? "";
+
+        expect(svg).toContain(`style="stroke:light-dark(#333333, #cccccc)"`);
+        expect(svg).toContain(`style="stroke:light-dark(#404040, #bfbfbf)"`);
+        expect(svg).not.toContain(`stroke="#333333"`);
+    });
+
+    it("keeps the hue when adapting saturated colors, in either direction", () => {
+        // A dark blue must lighten to a readable *blue*, not to gray; a near-white pink must darken
+        // to a red. The light-mode side always keeps the exact color OneNote sent.
+        const saturated = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="navy"><inkml:brushProperty name="color" value="#000080"/></inkml:brush>
+                <inkml:brush xml:id="pink"><inkml:brushProperty name="color" value="#ffe6e6"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#navy">0 0, 10 10</inkml:trace>
+            <inkml:trace brushRef="#pink">20 20, 30 30</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(saturated) ?? "";
+
+        expect(svg).toContain(`style="stroke:light-dark(#000080, #7f7fff)"`);
+        expect(svg).toContain(`style="stroke:light-dark(#190000, #ffe6e6)"`);
+    });
+
+    it("adapts the named colors black and white through their hex equivalents", () => {
+        const named = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="b0"><inkml:brushProperty name="color" value="Black"/></inkml:brush>
+                <inkml:brush xml:id="b1"><inkml:brushProperty name="color" value="white"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#b0">0 0, 10 10</inkml:trace>
+            <inkml:trace brushRef="#b1">20 20, 30 30</inkml:trace>
+        </inkml:ink>`;
+        const svg = inkmlToSvg(named) ?? "";
+
+        expect((svg.match(/style="stroke:light-dark\(#000000, #ffffff\)"/g) ?? [])).toHaveLength(2);
+    });
+
+    it("leaves ink readable under both themes literal and omits the adaptive style", () => {
+        // #FF0000 (lightness exactly 0.5) and a mid-light gray are untouched — including #cccccc,
+        // which is a dark-mode *target* but as source ink is readable on both canvases — and with no
+        // adapted strokes there's no <style> block. An unparseable color also stays literal.
+        const readable = `<inkml:ink xmlns:inkml="http://www.w3.org/2003/InkML">
+            <inkml:definitions>
+                <inkml:brush xml:id="gray"><inkml:brushProperty name="color" value="#cccccc"/></inkml:brush>
+                <inkml:brush xml:id="odd"><inkml:brushProperty name="color" value="not-a-color"/></inkml:brush>
+            </inkml:definitions>
+            <inkml:trace brushRef="#gray">0 0, 10 10</inkml:trace>
+            <inkml:trace brushRef="#odd">20 20, 30 30</inkml:trace>
+        </inkml:ink>`;
+        const graySvg = inkmlToSvg(readable) ?? "";
+        expect(graySvg).toContain(`stroke="#cccccc"`);
+        expect(graySvg).toContain(`stroke="not-a-color"`);
+        expect(graySvg).not.toContain("light-dark");
+        expect(graySvg).not.toContain("<style>");
+
         const svg = inkmlToSvg(INKML) ?? "";
         expect(svg).toContain(`stroke="#FF0000"`);
-        expect(svg).not.toContain("ink-auto");
         expect(svg).not.toContain("<style>");
     });
 
@@ -130,7 +193,7 @@ describe("inkmlToSvg", () => {
         const svg = inkmlToSvg(messy) ?? "";
 
         expect((svg.match(/<path/g) ?? [])).toHaveLength(1);
-        expect(svg).toContain(`stroke="#00AA00"`);
+        expect(svg).toContain(`style="stroke:light-dark(#00AA00, #55ff55)"`); // dark green, adapted
         expect(svg).toContain(`stroke-width="70"`); // default width kept over the unparseable one
         expect(svg).not.toContain("#123456"); // the id-less brush is never referenced
     });
@@ -152,13 +215,17 @@ describe("inkmlToSvg", () => {
         const svg = inkmlToSvg(readFileSync(join(FIXTURES_DIR, "sample.inkml"), "utf-8")) ?? "";
 
         // One <path> per <trace>, each resolving its brush color despite the `#{guid}{n}` brushRef ids.
+        // The pens are all dark colors (including the palette's near-black #404040 rather than
+        // #000000), so each adapts for dark mode while keeping its exact color in light mode.
         expect((svg.match(/<path/g) ?? []).length).toBe(42);
-        for (const color of ["#404040", "#1353BA", "#167D1D", "#C62938", "#904C15", "#FAF320"]) {
-            expect(svg).toContain(`stroke="${color}"`);
+        for (const color of ["#404040", "#1353BA", "#167D1D", "#C62938", "#904C15"]) {
+            expect(svg).toContain(`style="stroke:light-dark(${color}, #`);
         }
+        expect(svg).toContain(`style="stroke:light-dark(#404040, #bfbfbf)"`);
 
-        // Highlighter strokes (transparency 0.496, rectangle tip) render translucent and use the
-        // larger height as their thickness rather than the thin pen-style width.
+        // Highlighter strokes (transparency 0.496, rectangle tip) keep their literal mid-light
+        // yellow, render translucent, and use the larger height as their thickness rather than the
+        // thin pen-style width.
         expect(svg).toContain(`opacity="0.50"`);
         expect(svg).toContain(`stroke="#FAF320" stroke-width="1000"`);
 

--- a/apps/server/src/services/import/onenote/inkml.ts
+++ b/apps/server/src/services/import/onenote/inkml.ts
@@ -18,7 +18,7 @@
 
 import { HTMLElement, parse } from "node-html-parser";
 
-import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+import { parseColor, reflectLightness } from "./color.js";
 
 /** Padding around the rendered strokes, in coordinate units. */
 const PADDING = 10;
@@ -41,11 +41,11 @@ interface Trace {
 const DEFAULT_BRUSH: Brush = { color: "#000000", width: 70, height: 70, transparency: 0 };
 
 /**
- * Ink darker than this HSL lightness is unreadable against a dark canvas, so it gets a
+ * Ink darker than this HSL lightness (0-100) is unreadable against a dark canvas, so it gets a
  * lightness-reflected dark-mode variant. Matches the threshold correctTableShadingColors
  * (converter.ts) uses for the same judgement on cell backgrounds.
  */
-const DARK_INK_MAX_LIGHTNESS = 0.5;
+const DARK_INK_MAX_LIGHTNESS = 50;
 
 /**
  * Ink at least this light is unreadable against a light canvas (it's near-white ink laid down on
@@ -53,13 +53,7 @@ const DARK_INK_MAX_LIGHTNESS = 0.5;
  * light-mode variant. Deliberately high: mid-light colors like highlighter yellows and pastels are
  * chosen for a light canvas and read fine there, so only the near-white band is adapted.
  */
-const LIGHT_INK_MIN_LIGHTNESS = 0.9;
-
-/** The named colors ink brushes can carry, mapped to the hex used inside `light-dark()`. */
-const NAMED_INK_COLORS = new Map([
-    ["black", "#000000"],
-    ["white", "#ffffff"]
-]);
+const LIGHT_INK_MIN_LIGHTNESS = 90;
 
 /**
  * Enables the `light-dark()` function used by adapted strokes. The used scheme is inherited from the
@@ -94,17 +88,17 @@ function strokeWidth(brush: Brush): number {
  * dark color becomes a readable same-hue light one in dark mode instead of an invisible one.
  */
 function adaptInkColor(color: string): string | null {
-    const hex = NAMED_INK_COLORS.get(color.trim().toLowerCase()) ?? color;
-    const rgb = parseHexColor(hex);
-    if (!rgb) {
+    const literal = color.trim();
+    const parsed = parseColor(literal);
+    if (!parsed) {
         return null;
     }
-    const [hue, saturation, lightness] = rgbToHsl(rgb);
+    const lightness = parsed.lightness();
     if (lightness < DARK_INK_MAX_LIGHTNESS) {
-        return `light-dark(${hex}, ${hslToHex(hue, saturation, 1 - lightness)})`;
+        return `light-dark(${literal}, ${reflectLightness(parsed)})`;
     }
     if (lightness >= LIGHT_INK_MIN_LIGHTNESS) {
-        return `light-dark(${hslToHex(hue, saturation, 1 - lightness)}, ${hex})`;
+        return `light-dark(${reflectLightness(parsed)}, ${literal})`;
     }
     return null;
 }

--- a/apps/server/src/services/import/onenote/inkml.ts
+++ b/apps/server/src/services/import/onenote/inkml.ts
@@ -18,6 +18,8 @@
 
 import { HTMLElement, parse } from "node-html-parser";
 
+import { hslToHex, parseHexColor, rgbToHsl } from "./color.js";
+
 /** Padding around the rendered strokes, in coordinate units. */
 const PADDING = 10;
 
@@ -39,30 +41,33 @@ interface Trace {
 const DEFAULT_BRUSH: Brush = { color: "#000000", width: 70, height: 70, transparency: 0 };
 
 /**
- * OneNote's automatic ink colors. Like its automatic *text* color (see removeDefaultTextColor in
- * converter.ts), the default pen isn't a chosen color: it's black on OneNote's light canvas but
- * inverts to white in dark mode. These two are rendered theme-adaptively (see AUTO_INK_STYLE) rather
- * than baked as a hard color that would be unreadable under the opposite theme; every deliberately
- * picked color is left exactly as OneNote sent it.
+ * Ink darker than this HSL lightness is unreadable against a dark canvas, so it gets a
+ * lightness-reflected dark-mode variant. Matches the threshold correctTableShadingColors
+ * (converter.ts) uses for the same judgement on cell backgrounds.
  */
-const AUTOMATIC_INK_COLORS = new Set(["#000000", "#000", "black", "#ffffff", "#fff", "white"]);
-
-/** The class carried by an automatic-colored shape; the color itself comes from {@link AUTO_INK_STYLE}. */
-const AUTO_INK_CLASS = "ink-auto";
+const DARK_INK_MAX_LIGHTNESS = 0.5;
 
 /**
- * Theme-adaptive styling for automatic-colored strokes. `color-scheme: light dark` enables the
- * `light-dark()` function; the used scheme is inherited from the embedding `<img>` — Trilium sets
- * `color-scheme` from its active theme on `:root` (theme-next/base.css) and Chromium propagates it
- * into the referenced SVG — so the ink follows Trilium's light/dark toggle instead of rendering as
- * unreadable black-on-dark. Paths take the color on `stroke`, single-point dots on `fill`; qualifying
- * each rule by element keeps the fill rule from overriding a path's `fill="none"` and flooding it solid.
- * Emitted only when at least one automatic stroke is present.
+ * Ink at least this light is unreadable against a light canvas (it's near-white ink laid down on
+ * OneNote's dark canvas — most commonly the automatic pen's white inverse), so it gets a reflected
+ * light-mode variant. Deliberately high: mid-light colors like highlighter yellows and pastels are
+ * chosen for a light canvas and read fine there, so only the near-white band is adapted.
  */
-const AUTO_INK_STYLE =
-    `<style>svg{color-scheme:light dark}` +
-    `path.${AUTO_INK_CLASS}{stroke:light-dark(#000,#fff)}` +
-    `circle.${AUTO_INK_CLASS}{fill:light-dark(#000,#fff)}</style>`;
+const LIGHT_INK_MIN_LIGHTNESS = 0.9;
+
+/** The named colors ink brushes can carry, mapped to the hex used inside `light-dark()`. */
+const NAMED_INK_COLORS = new Map([
+    ["black", "#000000"],
+    ["white", "#ffffff"]
+]);
+
+/**
+ * Enables the `light-dark()` function used by adapted strokes. The used scheme is inherited from the
+ * embedding `<img>` — Trilium sets `color-scheme` from its active theme on `:root`
+ * (theme-next/base.css) and Chromium propagates it into the referenced SVG — so adapted ink follows
+ * Trilium's light/dark toggle. Emitted only when at least one adapted stroke is present.
+ */
+const COLOR_SCHEME_STYLE = `<style>svg{color-scheme:light dark}</style>`;
 
 /**
  * The on-screen stroke thickness. Pens carry equal width/height, but highlighters (rectangle tip)
@@ -73,9 +78,35 @@ function strokeWidth(brush: Brush): number {
     return Math.max(brush.width, brush.height);
 }
 
-/** Whether a brush color is OneNote's mode-adaptive automatic ink (default black / its white inverse). */
-function isAutomaticColor(color: string): boolean {
-    return AUTOMATIC_INK_COLORS.has(color.trim().toLowerCase());
+/**
+ * The theme-adaptive `light-dark()` paint for an ink color that would be unreadable under one theme,
+ * or null for a color readable under both (kept literal, exactly as OneNote sent it).
+ *
+ * Contrast — not provenance — is the rule, because InkML gives no way to tell the automatic pen from
+ * a chosen color, and "black" ink is rarely literal `#000000`: each OneNote client's palette has its
+ * own near-black (`#404040`, `#333333`, …). OneNote's own dark mode remaps a hard-coded lookup of
+ * exact swatch values (`#000000`→`#edebe9`, `#333333`→`#cbc8c8`) and renders everything else
+ * verbatim, unreadable included — a table not worth reproducing. Reflecting the HSL lightness
+ * (L → 1 − L, hue/saturation untouched — the same correction correctTableShadingColors applies to
+ * cell backgrounds) matches OneNote's sensible mappings to within a rounding error (`#333333` →
+ * `#cccccc` vs its `#cbc8c8`) and also covers the colors OneNote itself gets wrong. A false positive
+ * is cheap by construction: the light-mode rendering keeps the exact original, and a wrongly-adapted
+ * dark color becomes a readable same-hue light one in dark mode instead of an invisible one.
+ */
+function adaptInkColor(color: string): string | null {
+    const hex = NAMED_INK_COLORS.get(color.trim().toLowerCase()) ?? color;
+    const rgb = parseHexColor(hex);
+    if (!rgb) {
+        return null;
+    }
+    const [hue, saturation, lightness] = rgbToHsl(rgb);
+    if (lightness < DARK_INK_MAX_LIGHTNESS) {
+        return `light-dark(${hex}, ${hslToHex(hue, saturation, 1 - lightness)})`;
+    }
+    if (lightness >= LIGHT_INK_MIN_LIGHTNESS) {
+        return `light-dark(${hslToHex(hue, saturation, 1 - lightness)}, ${hex})`;
+    }
+    return null;
 }
 
 export function inkmlToSvg(inkml: string): string | null {
@@ -99,11 +130,11 @@ export function inkmlToSvg(inkml: string): string | null {
     const height = maxY - minY + PADDING * 2;
     const scale = Math.min(1, MAX_DISPLAY_SIZE / Math.max(width, height, 1));
 
-    const hasAutomaticInk = traces.some((trace) => isAutomaticColor(trace.brush.color));
+    const hasAdaptedInk = traces.some((trace) => adaptInkColor(trace.brush.color) !== null);
     const shapes = traces.flatMap((trace) => traceToSvg(trace, minX, minY)).join("");
     return (
         `<svg xmlns="http://www.w3.org/2000/svg" width="${Math.round(width * scale)}" height="${Math.round(height * scale)}" ` +
-        `viewBox="0 0 ${width} ${height}">${hasAutomaticInk ? AUTO_INK_STYLE : ""}${shapes}</svg>`
+        `viewBox="0 0 ${width} ${height}">${hasAdaptedInk ? COLOR_SCHEME_STYLE : ""}${shapes}</svg>`
     );
 }
 
@@ -202,16 +233,18 @@ function traceToSvg(trace: Trace, minX: number, minY: number): string[] {
     const opacity = 1 - transparency;
     const opacityAttr = opacity < 1 ? ` opacity="${opacity.toFixed(2)}"` : "";
     const point = (coord: number[]) => [coord[0] - minX + PADDING, coord[1] - minY + PADDING];
-    const automatic = isAutomaticColor(color);
+    // Adapted paints go through `style` because `light-dark()` needs CSS value resolution, which
+    // presentation attributes don't reliably get; literal colors stay plain attributes.
+    const adapted = adaptInkColor(color);
 
     if (trace.coords.length === 1) {
         const [x, y] = point(trace.coords[0]);
-        const fillAttr = automatic ? ` class="${AUTO_INK_CLASS}"` : ` fill="${color}"`;
+        const fillAttr = adapted ? ` style="fill:${adapted}"` : ` fill="${color}"`;
         return [`<circle cx="${x}" cy="${y}" r="${width / 2}"${fillAttr}${opacityAttr}/>`];
     }
 
     const path = trace.coords.map((coord, index) => `${index === 0 ? "M" : "L"} ${point(coord).join(" ")}`).join(" ");
-    const strokeAttr = automatic ? ` class="${AUTO_INK_CLASS}"` : ` stroke="${color}"`;
+    const strokeAttr = adapted ? ` style="stroke:${adapted}"` : ` stroke="${color}"`;
     return [`<path d="${path}"${strokeAttr} stroke-width="${width}" fill="none" stroke-linecap="round" stroke-linejoin="round"${opacityAttr}/>`];
 }
 

--- a/docs/User Guide/!!!meta.json
+++ b/docs/User Guide/!!!meta.json
@@ -7516,6 +7516,13 @@
                                                     "value": "bx bx-window-open",
                                                     "isInheritable": false,
                                                     "position": 20
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "QxEyIjRBizuC",
+                                                    "isInheritable": false,
+                                                    "position": 110
                                                 }
                                             ],
                                             "format": "markdown",
@@ -16010,37 +16017,65 @@
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "BlN9DFI679QC",
+                                            "value": "ivYnonVFBxbQ",
                                             "isInheritable": false,
                                             "position": 20
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "bwZpz2ajCEwO",
+                                            "value": "Cq5X6iKQop6R",
                                             "isInheritable": false,
                                             "position": 30
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "GTwFsgaA0lCt",
+                                            "value": "HI6GBBIduIgv",
                                             "isInheritable": false,
                                             "position": 40
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "zP3PMqaG71Ct",
+                                            "value": "BlN9DFI679QC",
                                             "isInheritable": false,
                                             "position": 50
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "R9pX4DGra2Vt",
+                                            "value": "bwZpz2ajCEwO",
                                             "isInheritable": false,
                                             "position": 60
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "GTwFsgaA0lCt",
+                                            "isInheritable": false,
+                                            "position": 70
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "zP3PMqaG71Ct",
+                                            "isInheritable": false,
+                                            "position": 80
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "R9pX4DGra2Vt",
+                                            "isInheritable": false,
+                                            "position": 90
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "2FvYrpmOXm29",
+                                            "isInheritable": false,
+                                            "position": 100
                                         },
                                         {
                                             "type": "label",
@@ -16055,34 +16090,6 @@
                                             "value": "bx bx-table",
                                             "isInheritable": false,
                                             "position": 20
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "Cq5X6iKQop6R",
-                                            "isInheritable": false,
-                                            "position": 70
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "HI6GBBIduIgv",
-                                            "isInheritable": false,
-                                            "position": 80
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "ivYnonVFBxbQ",
-                                            "isInheritable": false,
-                                            "position": 90
-                                        },
-                                        {
-                                            "type": "relation",
-                                            "name": "internalLink",
-                                            "value": "2FvYrpmOXm29",
-                                            "isInheritable": false,
-                                            "position": 100
                                         }
                                     ],
                                     "format": "markdown",

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.md
@@ -15,8 +15,10 @@ Trilium allows importing from OneNote. Currently the only mechanism supported is
 
 The following features are preserved by Trilium during the import process:
 
-*   Basic formatting (bold, italic, underline, strikethrough, subscript, super script, inline code, font sizes, headings, colors, highlights).
+*   Basic formatting (bold, italic, underline, strikethrough, subscript, super script, font sizes, headings, colors, highlights).
     *   Black-colored text is intentionally stripped to allow it to work in dark themes.
+*   Inline code is automatically detected and formatted. Paragraphs that use the Code style are also converted to <a class="reference-link" href="../../../Note%20Types/Text/Developer-specific%20formatting/Code%20blocks.md">Code blocks</a>.
+    *   Unfortunately the indentation of the code might be lost because the information is simply not present in the data from the Microsoft API.
 *   <a class="reference-link" href="../../../Note%20Types/Text/Lists.md">Lists</a> with different bullet types.
 *   <a class="reference-link" href="../../../Note%20Types/Text/Tables.md">Tables</a>
     *   Cell backgrounds are preserved, including a best-effort hue correction because the colors returned by the Graph API are sometimes incorrect.
@@ -87,7 +89,7 @@ The following are known limitations due to how the information comes from the im
 
 *   The order of the sections (and section groups) is not available, the sections are ordered by creation date instead.
 *   Revision history.
-*   Paragraph indentation.
+*   Paragraph indentation, as well as code block indentation.
 *   Section colors.
 *   Drawings inside titles, the title might appear incomplete or “Untitled”.
 

--- a/packages/commons/src/lib/ws_api.ts
+++ b/packages/commons/src/lib/ws_api.ts
@@ -69,8 +69,12 @@ export type TaskResult<T extends TaskType> = TaskResultDefinitions[T];
  * Identifies which phase of a multi-phase task a progress message belongs to, so the client can label
  * the bar accordingly (e.g. zip import counts archive entries while "extracting", then notes while
  * "processing"). Single-phase tasks omit it and the client falls back to a generic message.
+ *
+ * "throttled" is a transient state rather than a pipeline stage: the task is alive but deliberately
+ * waiting out an external service's rate limiting (e.g. the OneNote importer under Graph throttling),
+ * so the count will not move for a while and the client should say why instead of looking hung.
  */
-export type ProgressPhase = "extracting" | "processing";
+export type ProgressPhase = "extracting" | "processing" | "throttled";
 
 type TaskDefinition<T extends TaskType> = {
     type: "taskProgressCount",

--- a/packages/trilium-core/package.json
+++ b/packages/trilium-core/package.json
@@ -12,6 +12,7 @@
     "@triliumnext/turndown-plugin-gfm": "workspace:*",
     "async-mutex": "0.5.0",
     "chardet": "2.2.0",
+    "color": "5.0.3",
     "escape-html": "1.0.3",
     "i18next": "26.3.6",
     "js-yaml": "5.2.2",

--- a/packages/trilium-core/src/services/task_context.spec.ts
+++ b/packages/trilium-core/src/services/task_context.spec.ts
@@ -135,6 +135,45 @@ describe("TaskContext", () => {
         });
     });
 
+    describe("reportPhase and clearPhase", () => {
+        it("pushes the phase immediately and drops it from the next flushed count", () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(1_000);
+            const ctx = new TaskContext("phase-2", "importNotes", importData);
+            ctx.setTotalCount(10);
+            sendMessageToAllClients.mockClear();
+
+            // reportPhase must not wait for the next unit of work — its whole point is signalling a
+            // stall (e.g. Graph throttling) while no counts are flowing, so it sends even inside the
+            // 300ms coalescing window and without an increment.
+            vi.setSystemTime(1_100);
+            ctx.reportPhase("throttled");
+            expect(sendMessageToAllClients).toHaveBeenCalledTimes(1);
+            expect(sendMessageToAllClients).toHaveBeenLastCalledWith(expect.objectContaining({ phase: "throttled", progressCount: 0, totalCount: 10 }));
+
+            // clearPhase alone sends nothing, but forces the next increment out immediately (still
+            // inside the window) — one message carrying the corrected label and count together.
+            vi.setSystemTime(1_200);
+            ctx.clearPhase();
+            expect(sendMessageToAllClients).toHaveBeenCalledTimes(1);
+            ctx.increaseProgressCount();
+            expect(sendMessageToAllClients).toHaveBeenCalledTimes(2);
+            expect(sendMessageToAllClients).toHaveBeenLastCalledWith(expect.not.objectContaining({ phase: expect.anything() }));
+
+            // With no phase set, clearPhase is inert — it must not defeat the coalescing window.
+            ctx.clearPhase();
+            vi.setSystemTime(1_300);
+            ctx.increaseProgressCount();
+            expect(sendMessageToAllClients).toHaveBeenCalledTimes(2);
+        });
+
+        it("stays silent for the reserved no-progress-reporting id", () => {
+            const ctx = new TaskContext("no-progress-reporting", "importNotes", importData);
+            ctx.reportPhase("throttled");
+            expect(sendMessageToAllClients).not.toHaveBeenCalled();
+        });
+    });
+
     describe("reportError", () => {
         it("broadcasts a taskError message with the failure text and task metadata", () => {
             const ctx = new TaskContext("err-1", "importNotes", importData);

--- a/packages/trilium-core/src/services/task_context.ts
+++ b/packages/trilium-core/src/services/task_context.ts
@@ -72,22 +72,52 @@ class TaskContext<T extends TaskType> {
         this.progressCount = 0;
     }
 
+    /**
+     * Sets the phase and pushes the current progress immediately, without waiting for the next unit of
+     * work. For phases entered while no counts are flowing — e.g. the OneNote importer waiting out Graph
+     * throttling, where the next increaseProgressCount() may be an hour away — setPhase() alone would
+     * leave the client showing the previous label (and a seemingly hung count) the whole time.
+     */
+    reportPhase(phase: ProgressPhase) {
+        this.phase = phase;
+        this.sendProgressMessage();
+    }
+
+    /**
+     * Clears the phase so subsequent progress messages drop the label. Does not send by itself: callers
+     * clear right before counting the unit of work that ended the phase, and the forced flush here makes
+     * that very next increaseProgressCount() deliver the corrected label and count in one message.
+     */
+    clearPhase() {
+        if (this.phase !== null) {
+            this.phase = null;
+            this.lastSentCountTs = 0;
+        }
+    }
+
     increaseProgressCount() {
         this.progressCount++;
 
-        if (Date.now() - this.lastSentCountTs >= 300 && this.taskId !== "no-progress-reporting") {
-            this.lastSentCountTs = Date.now();
-
-            ws.sendMessageToAllClients({
-                type: "taskProgressCount",
-                taskId: this.taskId,
-                taskType: this.taskType,
-                data: this.data,
-                progressCount: this.progressCount,
-                ...(this.totalCount !== null ? { totalCount: this.totalCount } : {}),
-                ...(this.phase !== null ? { phase: this.phase } : {})
-            } as WebSocketMessage);
+        if (Date.now() - this.lastSentCountTs >= 300) {
+            this.sendProgressMessage();
         }
+    }
+
+    private sendProgressMessage() {
+        if (this.taskId === "no-progress-reporting") {
+            return;
+        }
+        this.lastSentCountTs = Date.now();
+
+        ws.sendMessageToAllClients({
+            type: "taskProgressCount",
+            taskId: this.taskId,
+            taskType: this.taskType,
+            data: this.data,
+            progressCount: this.progressCount,
+            ...(this.totalCount !== null ? { totalCount: this.totalCount } : {}),
+            ...(this.phase !== null ? { phase: this.phase } : {})
+        } as WebSocketMessage);
     }
 
     reportError(message: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,6 +719,9 @@ importers:
       cls-hooked:
         specifier: 4.2.2
         version: 4.2.2
+      color:
+        specifier: 5.0.3
+        version: 5.0.3
       compression:
         specifier: 1.8.1
         version: 1.8.1(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1665,6 +1665,9 @@ importers:
       chardet:
         specifier: 2.2.0
         version: 2.2.0
+      color:
+        specifier: 5.0.3
+        version: 5.0.3
       escape-html:
         specifier: 1.0.3
         version: 1.0.3


### PR DESCRIPTION
## Summary

A batch of OneNote import refinements plus syntax highlighting for text file/attachment previews.

### OneNote import
- **Ink colors**: near-black ink is adapted for dark mode by contrast rather than a color lookup, with the lightness reflection reworked on top of the `color` library (now properly declared as a `trilium-core` dependency).
- **Graph throttling feedback**: when Microsoft Graph rate-limits the import, the progress toast now says so instead of appearing stalled.
- **Section picker**: added a refresh button to reload the notebook list without reconnecting, and notebook-loading failures are now shown inline instead of masquerading as an empty account.
- **Code blocks**: OneNote code blocks are detected and imported as proper code blocks, fixing the previously dead paragraph-font inline-code path; user guide updated accordingly.

### File & attachment previews
- Text previews of file notes and attachments now render through the shared `CodeBlock` component, gaining syntax highlighting (respecting the code-block theme settings) and a copy-to-clipboard affordance.
- MIME types with RFC 6839 structured-syntax suffixes (e.g. the `application/inkml+xml` ink debug source attached by the OneNote import) highlight as their base syntax (`+xml` → XML, `+json` → JSON).

### Theme
- Spinning button icons (e.g. the refresh button) now rotate about their center instead of their padding box.

## Test plan
- [x] New/extended unit tests: OneNote converter/inkml/color/graph/importer, client `onenote_import`, `server` service, `TextPreview` (`File.spec.tsx`), `task_context`
- [x] Client + affected server suites pass locally; lint clean on touched files
- [x] Manual: run a OneNote import with "attach source" enabled and verify the HTML/InkML attachments render highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)