### PR TITLE
docs: add Zenith Hosting as a third-party cloud hosting option

### DIFF
--- a/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
@@ -8,6 +8,16 @@ As an alternative to [hosting your own Trilium instance](1.%20Installing%20the%2
 
 ## Cloud instance providers
 
+### Zenith Hosting
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/trilium-notes)
+
+1.  Go to [zenith.hosting/host/trilium-notes](https://zenith.hosting/host/trilium-notes) and sign up.
+2.  Click deploy and pick a name for your instance.
+3.  Trilium comes up at your own subdomain, ready to sync with the desktop and mobile clients.
+
+One-click managed Trilium: storage, backups, email and a free subdomain included. A share of every subscription goes back to Trilium.
+
 ### PikaPods
 
 1.  Go to [pikapods.com](https://www.pikapods.com)  and sign up.

--- a/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
@@ -10,8 +10,6 @@ As an alternative to [hosting your own Trilium instance](1.%20Installing%20the%2
 
 ### Zenith Hosting
 
-[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/trilium-notes)
-
 1.  Go to [zenith.hosting/host/trilium-notes](https://zenith.hosting/host/trilium-notes) and sign up.
 2.  Click deploy and pick a name for your instance.
 3.  Trilium comes up at your own subdomain, ready to sync with the desktop and mobile clients.


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Trilium Notes to our marketplace, so this PR adds a small "Deploy with Zenith" badge and a three step entry under Third-party cloud hosting (links to https://zenith.hosting/host/trilium-notes).

one file, docs only, additions only. a couple of notes so nothing is a surprise:

- i put the section above PikaPods, happy to move it below if you'd rather keep them in the order they arrived.
- i only touched the markdown under `docs/`, since `apps/server/src/assets/doc_notes` is marked `exportOnly` in `edit-docs-config.yaml`. say the word if you want the in-app help re-exported too.
- glad to reword it or drop the badge image if you'd prefer the page stay plain text.

we share a cut of revenue with the projects we host, so a share of every Trilium subscription goes back to Trilium. happy to explain if you're curious: hello@zenith.hosting
