### PR TITLE
fix(standalone): content-hash built chunks so a deploy switches over atomically

### DIFF
--- a/apps/standalone/public/_headers
+++ b/apps/standalone/public/_headers
@@ -1,2 +1,13 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
+
+# Everything under src/ is content-hashed by the build (see vite.config.mts), so a given
+# URL never changes meaning and may be cached indefinitely. index.html is left on the
+# host's default (revalidate-always) so a deployment is picked up immediately.
+/src/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# The service worker keeps a stable URL, so it must never be served stale: a cached copy
+# would keep an outdated worker in control of the page after a deployment.
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/apps/standalone/vite.config.mts
+++ b/apps/standalone/vite.config.mts
@@ -337,15 +337,22 @@ export default defineConfig(() => ({
                 'local-bridge': join(__dirname, 'src', 'local-bridge.ts'),
             },
             output: {
+                // Everything below `src/` carries a content hash so a deployment switches over
+                // atomically: `index.html` is served uncached and can only ever reference chunks
+                // from its own build. Without the hash, a browser holding a still-fresh copy of
+                // one chunk mixes it with newly fetched ones — and since the minifier reassigns
+                // single-letter export names every build, a cross-build import silently binds to
+                // the wrong value ("X is not a function") until the cache expires.
                 entryFileNames: (chunkInfo) => {
-                    // Service worker and other workers should be at root level
-                    if (chunkInfo.name === 'sw') {
-                        return '[name].js';
+                    // The service worker must keep a stable URL: `main.ts` registers it as
+                    // `./sw.js`, and a hash would orphan the previously registered worker.
+                    if (chunkInfo.name === "sw") {
+                        return "[name].js";
                     }
-                    return 'src/[name].js';
+                    return "src/[name]-[hash].js";
                 },
-                chunkFileNames: "src/[name].js",
-                assetFileNames: "src/[name].[ext]"
+                chunkFileNames: "src/[name]-[hash].js",
+                assetFileNames: "src/[name]-[hash].[ext]"
             }
         }
     },


### PR DESCRIPTION
## Problem

Users of app.triliumnotes.org hit recurring `TypeError: 1 is not a function`, reported from `src/image_upload.js`. Tracing the deployed bundle, the failing call is inside floating-ui's `useFloating` — the `flushSync(() => setData(...))` that runs on every popover/tooltip reposition. `flushSync` is imported from `./compat.module.js`, where it is a genuine function in the current build. So on a consistent build the crash is impossible.

The cause is a **mixed-build module graph**. The standalone build emits every chunk and asset under `src/` at a stable, unhashed name:

```js
chunkFileNames: "src/[name].js",
assetFileNames: "src/[name].[ext]"
```

`index.html` is served uncached (`max-age=0, must-revalidate`), but the chunks it references are served `public, must-revalidate, max-age=14400`. A returning user therefore always gets fresh HTML while their browser keeps serving JS from its own cache — each of the ~1200 chunks on an independent 4-hour clock started whenever that file happened to be fetched. After a deploy, the page runs an arbitrary mix of old and new chunks for up to four hours.

Since the minifier reassigns single-letter export names on every build, a cross-build import binds to whatever value now occupies that letter — here, the number `1`.

Collision-numbered names made it sharper still: the old output contained `dist.js`, `dist10.js`, `dist17.js` …, numbered by module discovery order, so the same URL routinely denoted an unrelated module in the next build.

## Fix

Content-hash everything under `src/`, so the uncached `index.html` can only ever reference chunks from its own build and the switchover is atomic. `sw.js` deliberately keeps its stable root-level URL — `main.ts` registers it as `./sw.js`, and a hash there would orphan the previously registered worker.

`_headers` gains the matching cache policy: hashed assets become `immutable` (a performance win now that the URLs are safe to pin), and the service worker is marked revalidate-always so a stale copy cannot stay in control of the page.

## Verification

A full `pnpm --filter @triliumnext/standalone build` was run against the change:

- every one of the 1231 files under `dist/src/` now carries a content hash; none are unhashed
- `index.html` references `./src/main-BCOyjFD-.js`, `./src/local-bridge-BaSRU9ky.js`, `./src/preload-helper-HclGiUj8.js`
- `sw.js` remains at the root, unhashed
- `assets/sqlite3.wasm` and `assets/sqlite3-opfs-async-proxy.js` keep their stable names — they are placed by `viteStaticCopy`, which bypasses `assetFileNames`, and the sqlite-wasm library resolves them by convention inside the worker
- the collision-numbered `dist*.js` names are gone
- `apps/standalone` unit tests pass (`sw.spec.ts`, `main.spec.ts`: 24 tests)

Nothing downstream references a built filename: `apps/mobile/capacitor.config.json` points `webDir` at the whole `dist` directory, and the deploy workflow uploads `apps/standalone/dist` wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
