### PR TITLE
Customizable database backup location

### DIFF
--- a/apps/build-docs/src/build-docs.ts
+++ b/apps/build-docs/src/build-docs.ts
@@ -17,6 +17,7 @@ class StubBackupService extends BackupService {
     constructor() {
         super({
             getOption: () => "",
+            getOptionOrNull: () => null,
             getOptionBool: () => false,
             setOption: () => {}
         });

--- a/apps/client/src/services/open.spec.ts
+++ b/apps/client/src/services/open.spec.ts
@@ -4,6 +4,7 @@ import { buildNote } from "../test/easy-froca";
 import open, { checkType, downloadFileNote, getUrlForDownload, openNoteExternally } from "./open.js";
 import options from "./options.js";
 import server from "./server.js";
+import toast from "./toast.js";
 import utils from "./utils.js";
 
 const realWindow = window as any;
@@ -242,22 +243,30 @@ describe("open service", () => {
             expect(errSpy).not.toHaveBeenCalled();
         });
 
-        it("logs an error under Electron when openPath returns an error string", async () => {
+        it("reports to the user, not only the console, when openPath returns an error string", async () => {
             const shell = installElectronApi();
             vi.spyOn(utils, "isElectron").mockReturnValue(true);
             shell.openPath.mockResolvedValue("ENOENT"); // failure
             const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+            const toastSpy = vi.spyOn(toast, "showError").mockImplementation(() => {});
+
             await open.openDirectory("/bad/dir");
-            expect(errSpy).toHaveBeenCalledWith("Failed to open directory:", "ENOENT");
+
+            expect(errSpy).toHaveBeenCalledWith("Failed to open directory:", "/bad/dir", "ENOENT");
+            expect(toastSpy).toHaveBeenCalled();
         });
 
-        it("catches and logs filesystem errors thrown by openPath", async () => {
+        it("reports filesystem errors thrown by openPath the same way", async () => {
             const shell = installElectronApi();
             vi.spyOn(utils, "isElectron").mockReturnValue(true);
             shell.openPath.mockRejectedValue(new Error("boom"));
             const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+            const toastSpy = vi.spyOn(toast, "showError").mockImplementation(() => {});
+
             await open.openDirectory("/throws");
-            expect(errSpy).toHaveBeenCalledWith("Error:", "boom");
+
+            expect(errSpy).toHaveBeenCalledWith("Failed to open directory:", "/throws", "boom");
+            expect(toastSpy).toHaveBeenCalled();
         });
     });
 });

--- a/apps/client/src/services/open.ts
+++ b/apps/client/src/services/open.ts
@@ -1,7 +1,9 @@
 import Component from "../components/component.js";
 import FNote from "../entities/fnote.js";
+import { t } from "./i18n.js";
 import options from "./options.js";
 import server from "./server.js";
+import toast from "./toast.js";
 import utils from "./utils.js";
 
 
@@ -137,19 +139,27 @@ async function openNoteOnServer(noteId: string) {
 }
 
 async function openDirectory(directory: string) {
-    try {
-        if (utils.isElectron()) {
-            const res = await window.electronApi?.shell.openPath(directory);
-            if (res) {
-                console.error("Failed to open directory:", res);
-            }
-        } else {
-            console.error("Not running in an Electron environment.");
-        }
-    } catch (err: any) {
-        // Handle file system errors (e.g. path does not exist or is inaccessible)
-        console.error("Error:", err.message);
+    if (!utils.isElectron()) {
+        console.error("Not running in an Electron environment.");
+        return;
     }
+
+    try {
+        // Resolves to an empty string once the file manager is up, or to the reason it is not.
+        const failure = await window.electronApi?.shell.openPath(directory);
+        if (failure) {
+            reportDirectoryFailure(directory, failure);
+        }
+    } catch (e) {
+        // File system errors, e.g. the path no longer exists or is inaccessible.
+        reportDirectoryFailure(directory, e instanceof Error ? e.message : String(e));
+    }
+}
+
+/** Reported to the user, not only the console: a silent failure reads as the link doing nothing at all. */
+function reportDirectoryFailure(directory: string, reason: string) {
+    console.error("Failed to open directory:", directory, reason);
+    toast.showError(t("open.directory_failed", { directory, reason }));
 }
 
 export default {

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1990,16 +1990,25 @@
     "enable_daily_backup": "Daily backup",
     "enable_weekly_backup": "Weekly backup",
     "enable_monthly_backup": "Monthly backup",
+    "location_title": "Backup location",
+    "saved_in": "Backups are saved in",
+    "select_location": "Select location",
+    "select_location_desktop_only": "Choosing a backup location is available only in the desktop application.",
+    "reset_location": "Reset to default",
+    "reset_location_confirmation": "Would you like to reset the database backup location to default?",
+    "default_location": "Default location",
     "backup_recommendation": "It's recommended to keep the backup turned on, but this can make application startup slow with large databases and/or slow storage devices.",
     "backup_now": "Backup now",
     "backup_database_now": "Backup database now",
     "existing_backups": "Existing backups",
-    "backup_location_description": "Backups are stored in {{- backupFolder}}.",
     "date-and-time": "Date & time",
     "path": "Path",
     "database_backed_up_to": "Database has been backed up to {{- backupFilePath}}",
     "no_backup_yet": "no backup yet",
     "download": "Download"
+  },
+  "open": {
+    "directory_failed": "Could not open {{- directory}}: {{- reason}}"
   },
   "etapi": {
     "description": "ETAPI is a REST API used to access Trilium instance programmatically, without UI.",

--- a/apps/client/src/widgets/dialogs/about.tsx
+++ b/apps/client/src/widgets/dialogs/about.tsx
@@ -11,10 +11,10 @@ import { Trans } from "react-i18next";
 
 import contributors from "../../../../../contributors.json";
 import { t } from "../../services/i18n.js";
-import openService from "../../services/open.js";
 import server from "../../services/server.js";
-import utils, { isStandalone } from "../../services/utils.js";
+import { isStandalone } from "../../services/utils.js";
 import { formatDateTime } from "../../utils/formatters.js";
+import DirectoryLink from "../react/DirectoryLink.js";
 import { useTooltip, useTriliumEvent } from "../react/hooks.jsx";
 import Modal from "../react/Modal.js";
 import { PropertySheet, PropertySheetItem } from "../react/PropertySheet.js";
@@ -225,14 +225,3 @@ function ContributorListItem({data, onHover}: {data: Contributor, onHover?: Hove
     </>;
 }
 
-function DirectoryLink({ directory }: { directory: string}) {
-    if (utils.isElectron()) {
-        const onClick = (e: MouseEvent) => {
-            e.preventDefault();
-            openService.openDirectory(directory);
-        };
-
-        return <a className="tn-link selectable-text" href="#" onClick={onClick}>{directory}</a>;
-    }
-    return <span className="selectable-text">{directory}</span>;
-}

--- a/apps/client/src/widgets/react/Button.css
+++ b/apps/client/src/widgets/react/Button.css
@@ -1,0 +1,5 @@
+/* Takes the button's place in the layout rather than adding a box of its own, but still has one for
+   the pointer to reach — a disabled button emits no events for the tooltip to hang off. */
+.tn-disabled-reason {
+    display: inline-flex;
+}

--- a/apps/client/src/widgets/react/Button.tsx
+++ b/apps/client/src/widgets/react/Button.tsx
@@ -1,9 +1,13 @@
+import "./Button.css";
+
+import type { Tooltip } from "bootstrap";
 import type { ComponentChildren, CSSProperties, RefObject } from "preact";
-import { useMemo } from "preact/hooks";
+import { useMemo, useRef } from "preact/hooks";
 
 import { CommandNames } from "../../components/app_context";
 import { isDesktop, isMobile } from "../../services/utils";
 import ActionButton from "./ActionButton";
+import { useStaticTooltip } from "./hooks";
 import Icon from "./Icon";
 import { renderShortcutKbds } from "./shortcut_kbd";
 
@@ -25,9 +29,11 @@ export interface ButtonProps {
     style?: CSSProperties;
     triggerCommand?: CommandNames;
     title?: string;
+    /** Why the button is off, shown on hover while `disabled`. Ignored otherwise. */
+    disabledTooltip?: string;
 }
 
-function Button({ name, buttonRef, className, text, onClick, keyboardShortcut, icon, kind, disabled, size, style, triggerCommand, ...restProps }: ButtonProps) {
+function Button({ name, buttonRef, className, text, onClick, keyboardShortcut, icon, kind, disabled, disabledTooltip, size, style, triggerCommand, ...restProps }: ButtonProps) {
     // Memoize classes array to prevent recreation
     const classes = useMemo(() => {
         const classList: string[] = ["btn"];
@@ -67,7 +73,7 @@ function Button({ name, buttonRef, className, text, onClick, keyboardShortcut, i
         return renderShortcutKbds(keyboardShortcut);
     }, [keyboardShortcut]);
 
-    return (
+    const button = (
         <button
             name={name}
             className={classes}
@@ -83,6 +89,27 @@ function Button({ name, buttonRef, className, text, onClick, keyboardShortcut, i
             {text} {shortcutElements}
         </button>
     );
+
+    if (disabled && disabledTooltip) {
+        return <DisabledReason reason={disabledTooltip}>{button}</DisabledReason>;
+    }
+
+    return button;
+}
+
+/**
+ * Carries the tooltip for a disabled control. A disabled `<button>` emits no pointer events, so the
+ * explanation for why it is off has to hang off a wrapper the pointer can still reach.
+ */
+function DisabledReason({ reason, children }: { reason: string; children: ComponentChildren }) {
+    const ref = useRef<HTMLSpanElement>(null);
+
+    useStaticTooltip(ref, useMemo<Partial<Tooltip.Options>>(() => ({
+        title: reason,
+        placement: "top"
+    }), [reason]));
+
+    return <span ref={ref} class="tn-disabled-reason">{children}</span>;
 }
 
 export function ButtonGroup({ size, className, children }: { size?: "sm" | "lg"; className?: string; children: ComponentChildren }) {

--- a/apps/client/src/widgets/react/DirectoryLink.tsx
+++ b/apps/client/src/widgets/react/DirectoryLink.tsx
@@ -1,0 +1,18 @@
+import openService from "../../services/open.js";
+import { isElectron } from "../../services/utils.js";
+
+/**
+ * A filesystem location, opened in the OS file manager on click. Only the desktop application can
+ * open anything, so everywhere else the path is shown as plain (selectable) text.
+ */
+export default function DirectoryLink({ directory }: { directory: string }) {
+    if (isElectron()) {
+        const onClick = (e: MouseEvent) => {
+            e.preventDefault();
+            openService.openDirectory(directory);
+        };
+
+        return <a className="tn-link selectable-text" href="#" onClick={onClick}>{directory}</a>;
+    }
+    return <span className="selectable-text">{directory}</span>;
+}

--- a/apps/client/src/widgets/type_widgets/options/backup.css
+++ b/apps/client/src/widgets/type_widgets/options/backup.css
@@ -1,0 +1,35 @@
+.backup-location .tn-card-section {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto auto;
+    align-items: center;
+    column-gap: 16px;
+
+    .backup-location-icon {
+        grid-row: 1 / span 2;
+        font-size: 2.2em;
+        opacity: .6;
+    }
+
+    .backup-location-label {
+        grid-column: 2;
+        font-size: .85em;
+        opacity: .7;
+    }
+
+    .backup-location-path {
+        grid-column: 2;
+        overflow-wrap: anywhere;
+    }
+
+    .backup-location-actions {
+        display: flex;
+        grid-column: 3;
+        grid-row: 1 / span 2;
+        gap: 8px;
+
+        .btn {
+            white-space: nowrap;
+        }
+    }
+}

--- a/apps/client/src/widgets/type_widgets/options/backup.location.spec.tsx
+++ b/apps/client/src/widgets/type_widgets/options/backup.location.spec.tsx
@@ -1,0 +1,190 @@
+import { render, VNode } from "preact";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    setCustomDir: vi.fn(),
+    confirm: vi.fn<() => Promise<boolean>>(),
+    isElectron: vi.fn(() => true),
+    customDir: ""
+}));
+
+// Partial-mock so sibling components (e.g. `useUniqueName` in OptionsRow) keep their real implementation.
+vi.mock("../../react/hooks", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../react/hooks")>()),
+    useTriliumOption: () => [mocks.customDir, mocks.setCustomDir]
+}));
+
+vi.mock("../../../services/utils", async (importActual) => ({
+    ...(await importActual<typeof import("../../../services/utils")>()),
+    isElectron: () => mocks.isElectron()
+}));
+
+vi.mock("../../../services/dialog", () => ({ default: { confirm: mocks.confirm } }));
+
+// i18next is never initialized in the client tests, so its `t` returns undefined; echo the key instead.
+vi.mock("../../../services/i18n", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/i18n")>()),
+    t: (key: string) => key
+}));
+
+// Import AFTER the mocks (vi.mock is hoisted, but the component import must resolve the mocked deps).
+import { BackupList, BackupLocation } from "./backup";
+
+const DEFAULT_DIR = "/data/backup";
+const CUSTOM_DIR = "/mnt/usb/trilium";
+
+let container: HTMLDivElement | undefined;
+const refreshCallback = vi.fn();
+
+function renderInto(vnode: VNode) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    render(vnode, container);
+    return container;
+}
+
+function renderLocation(folderPath = DEFAULT_DIR) {
+    return renderInto(<BackupLocation backupFolderPath={folderPath} refreshCallback={refreshCallback} />);
+}
+
+function button(name: string) {
+    return container?.querySelector<HTMLButtonElement>(`button[name="${name}"]`);
+}
+
+function setPickDirectory(pickDirectory: unknown) {
+    (window as unknown as { electronApi?: unknown }).electronApi = pickDirectory ? { dialog: { pickDirectory } } : undefined;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.customDir = "";
+    mocks.isElectron.mockReturnValue(true);
+    setPickDirectory(vi.fn(async () => ({ status: "selected", path: CUSTOM_DIR })));
+});
+
+function cleanup() {
+    if (container) {
+        render(null, container);
+        container.remove();
+        container = undefined;
+    }
+}
+
+/** Lets the click handler's awaited continuation run, so "nothing happened" is a real assertion. */
+function settle() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(cleanup);
+
+describe("BackupLocation", () => {
+    it("shows the effective location, offering a reset only once a custom one is in use", () => {
+        renderLocation();
+        expect(container?.querySelector(".backup-location-path")?.textContent).toBe(DEFAULT_DIR);
+        // On the desktop the location opens in the OS file manager, as in the About dialog.
+        expect(container?.querySelector(".backup-location-path a.tn-link")).not.toBeNull();
+        expect(button("select-backup-location-button")?.disabled).toBe(false);
+        expect(button("reset-backup-location-button")).toBeNull();
+
+        cleanup();
+        mocks.customDir = CUSTOM_DIR;
+        renderLocation(CUSTOM_DIR);
+        expect(container?.querySelector(".backup-location-path")?.textContent).toBe(CUSTOM_DIR);
+        expect(button("reset-backup-location-button")).not.toBeNull();
+    });
+
+    it("disables the picker outside Electron, explaining why", () => {
+        mocks.isElectron.mockReturnValue(false);
+
+        renderLocation();
+
+        expect(button("select-backup-location-button")?.disabled).toBe(true);
+        // The explanation hangs off a wrapper, since a disabled button emits no pointer events.
+        expect(container?.querySelector(".tn-disabled-reason button")).not.toBeNull();
+        // Nothing can open a file manager here, so the location stays plain text.
+        expect(container?.querySelector(".backup-location-path a")).toBeNull();
+        expect(container?.querySelector(".backup-location-path")?.textContent).toBe(DEFAULT_DIR);
+    });
+
+    it("stores the chosen directory and refreshes, opening the picker at the current location", async () => {
+        const pickDirectory = vi.fn(async () => ({ status: "selected", path: CUSTOM_DIR }));
+        setPickDirectory(pickDirectory);
+
+        renderLocation();
+        button("select-backup-location-button")?.click();
+
+        expect(pickDirectory).toHaveBeenCalledWith({ defaultPath: DEFAULT_DIR });
+        await vi.waitFor(() => expect(mocks.setCustomDir).toHaveBeenCalledWith(CUSTOM_DIR));
+        await vi.waitFor(() => expect(refreshCallback).toHaveBeenCalled());
+    });
+
+    it("leaves the option alone when the picker is dismissed", async () => {
+        const pickDirectory = vi.fn(async () => ({ status: "cancelled" }));
+        setPickDirectory(pickDirectory);
+
+        renderLocation();
+        button("select-backup-location-button")?.click();
+        await settle();
+
+        expect(pickDirectory).toHaveBeenCalled();
+        expect(mocks.setCustomDir).not.toHaveBeenCalled();
+        expect(refreshCallback).not.toHaveBeenCalled();
+    });
+
+    it("clears the option on a confirmed reset, and only then", async () => {
+        mocks.customDir = CUSTOM_DIR;
+        mocks.confirm.mockResolvedValue(false);
+
+        renderLocation(CUSTOM_DIR);
+        button("reset-backup-location-button")?.click();
+        await settle();
+
+        expect(mocks.confirm).toHaveBeenCalled();
+        expect(mocks.setCustomDir).not.toHaveBeenCalled();
+
+        mocks.confirm.mockResolvedValue(true);
+        button("reset-backup-location-button")?.click();
+        await vi.waitFor(() => expect(mocks.setCustomDir).toHaveBeenCalledWith(""));
+        await vi.waitFor(() => expect(refreshCallback).toHaveBeenCalled());
+    });
+});
+
+describe("BackupList: telling the two locations apart", () => {
+    const backup = (filePath: string) => ({ fileName: filePath.split(/[/\\]/).pop() ?? "", filePath, mtime: new Date(0), fileSize: 1 });
+
+    function renderList(folderPath: string, files: string[]) {
+        return renderInto(
+            <BackupList
+                backups={files.map(backup)}
+                backupFolderPath={folderPath}
+                refreshCallback={refreshCallback}
+            />
+        );
+    }
+
+    function badges() {
+        return [...(container?.querySelectorAll(".database-file-badge") ?? [])].map((el) => el.textContent);
+    }
+
+    it("badges only the backups left outside a custom location", () => {
+        mocks.customDir = CUSTOM_DIR;
+
+        renderList(CUSTOM_DIR, [`${CUSTOM_DIR}/backup-daily.db`, `${DEFAULT_DIR}/backup-weekly.db`]);
+
+        expect(badges()).toEqual(["backup.default_location"]);
+    });
+
+    it("badges nothing while the default location is the one in use", () => {
+        renderList(DEFAULT_DIR, [`${DEFAULT_DIR}/backup-daily.db`, `${DEFAULT_DIR}/backup-weekly.db`]);
+
+        expect(badges()).toEqual([]);
+    });
+
+    it("does not mistake a sibling directory sharing the location's name for the location itself", () => {
+        mocks.customDir = CUSTOM_DIR;
+
+        renderList(CUSTOM_DIR, [`${CUSTOM_DIR}-old/backup-daily.db`]);
+
+        expect(badges()).toEqual(["backup.default_location"]);
+    });
+});

--- a/apps/client/src/widgets/type_widgets/options/backup.tsx
+++ b/apps/client/src/widgets/type_widgets/options/backup.tsx
@@ -1,12 +1,19 @@
+import "./backup.css";
+
 import { BackupDatabaseNowResponse, DatabaseBackup, ExistingBackupsResponse } from "@triliumnext/commons";
 import { useCallback, useEffect, useState } from "preact/hooks";
 
+import dialogService from "../../../services/dialog";
 import { t } from "../../../services/i18n";
 import server from "../../../services/server";
 import toast from "../../../services/toast";
+import { isElectron } from "../../../services/utils";
 import Button from "../../react/Button";
-import { useTriliumOptionBool } from "../../react/hooks";
-import DatabaseFileList from "./components/DatabaseFileList";
+import { Card, CardSection } from "../../react/Card";
+import DirectoryLink from "../../react/DirectoryLink";
+import { useTriliumOption, useTriliumOptionBool } from "../../react/hooks";
+import Icon from "../../react/Icon";
+import DatabaseFileList, { type DatabaseFile } from "./components/DatabaseFileList";
 import OptionsPageHeader from "./components/OptionsPageHeader";
 import OptionsRow, { OptionsRowWithToggle } from "./components/OptionsRow";
 import OptionsSection from "./components/OptionsSection";
@@ -28,6 +35,8 @@ export default function BackupSettings() {
         <>
             <OptionsPageHeader />
             <BackupConfiguration />
+            {/* Absent where there is no user-accessible location at all, e.g. backups kept in OPFS. */}
+            {backupFolderPath && <BackupLocation backupFolderPath={backupFolderPath} refreshCallback={refreshBackups} />}
             <BackupList backups={backups} backupFolderPath={backupFolderPath} refreshCallback={refreshBackups} />
         </>
     );
@@ -67,14 +76,85 @@ export function BackupConfiguration() {
     );
 }
 
-export function BackupList({ backups, backupFolderPath, refreshCallback }: { backups: DatabaseBackup[]; backupFolderPath: string | null; refreshCallback: () => void }) {
-    const [backupInProgress, setBackupInProgress] = useState(false);
+/**
+ * Where the backups go. The location can only be moved on the desktop application, which is the only
+ * one with a directory picker to offer; a server is pointed elsewhere through `TRILIUM_BACKUP_DIR`.
+ */
+export function BackupLocation({ backupFolderPath, refreshCallback }: { backupFolderPath: string; refreshCallback: () => void }) {
+    const [customDir, setCustomDir] = useTriliumOption("customDbBackupDir");
+    const canSelect = isElectron();
+
+    async function selectLocation() {
+        const result = await window.electronApi?.dialog.pickDirectory({ defaultPath: backupFolderPath });
+        if (result?.status !== "selected" || !result.path) {
+            return;
+        }
+
+        await setCustomDir(result.path);
+        refreshCallback();
+    }
+
+    async function resetToDefault() {
+        if (!await dialogService.confirm(t("backup.reset_location_confirmation"))) {
+            return;
+        }
+
+        await setCustomDir("");
+        refreshCallback();
+    }
 
     return (
+        <div className="options-section backup-location">
+            <Card heading={t("backup.location_title")}>
+                <CardSection>
+                    <Icon icon="bx bx-folder" className="backup-location-icon" />
+
+                    <div className="backup-location-label">{t("backup.saved_in")}</div>
+                    <div className="backup-location-path"><DirectoryLink directory={backupFolderPath} /></div>
+
+                    <div className="backup-location-actions">
+                        <Button
+                            name="select-backup-location-button"
+                            text={t("backup.select_location")}
+                            size="micro"
+                            disabled={!canSelect}
+                            disabledTooltip={t("backup.select_location_desktop_only")}
+                            onClick={selectLocation}
+                        />
+
+                        {customDir && (
+                            <Button
+                                name="reset-backup-location-button"
+                                text={t("backup.reset_location")}
+                                size="micro"
+                                onClick={resetToDefault}
+                            />
+                        )}
+                    </div>
+                </CardSection>
+            </Card>
+        </div>
+    );
+}
+
+export function BackupList({ backups, backupFolderPath, refreshCallback }: { backups: DatabaseBackup[]; backupFolderPath: string | null; refreshCallback: () => void }) {
+    const [backupInProgress, setBackupInProgress] = useState(false);
+    const [customDir] = useTriliumOption("customDbBackupDir");
+
+    // With a custom location in use the list also carries whatever stayed in — or was redirected to —
+    // the default one, and a row shows only a file name, so those need telling apart.
+    const fileBadge = useCallback((file: DatabaseFile) => (
+        customDir && backupFolderPath && !isInsideDirectory(backupFolderPath, file.filePath)
+            ? t("backup.default_location")
+            : undefined
+    ), [customDir, backupFolderPath]);
+
+    return (
+        // Where the backups live is stated by the "Backup location" card above, not repeated here.
         <DatabaseFileList
             title={t("backup.existing_backups")}
-            locationDescription={backupFolderPath && t("backup.backup_location_description", { backupFolder: backupFolderPath })}
             files={backups}
+            fileBadge={fileBadge}
             downloadEndpoint="api/database/backup/download"
             rowName="existing-backup"
             downloadText={t("backup.download")}
@@ -101,4 +181,11 @@ export function BackupList({ backups, backupFolderPath, refreshCallback }: { bac
             </OptionsRow>
         </DatabaseFileList>
     );
+}
+
+/** Both paths come already resolved from the server, so a prefix test settles containment on either platform. */
+function isInsideDirectory(directory: string, filePath: string) {
+    const rest = filePath.slice(directory.length);
+
+    return filePath.startsWith(directory) && (rest.startsWith("/") || rest.startsWith("\\"));
 }

--- a/apps/client/src/widgets/type_widgets/options/components/DatabaseFileList.css
+++ b/apps/client/src/widgets/type_widgets/options/components/DatabaseFileList.css
@@ -1,0 +1,10 @@
+.database-file-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.database-file-badge {
+    --color: var(--muted-text-color);
+    flex-shrink: 0;
+}

--- a/apps/client/src/widgets/type_widgets/options/components/DatabaseFileList.tsx
+++ b/apps/client/src/widgets/type_widgets/options/components/DatabaseFileList.tsx
@@ -1,3 +1,5 @@
+import "./DatabaseFileList.css";
+
 import { ComponentChildren } from "preact";
 import { useMemo } from "preact/hooks";
 
@@ -5,6 +7,7 @@ import open from "../../../../services/open";
 import { formatSize } from "../../../../services/utils";
 import { formatDateTime } from "../../../../utils/formatters";
 import ActionButton from "../../../react/ActionButton";
+import { Badge } from "../../../react/Badge";
 import NoItems from "../../../react/NoItems";
 import OptionsRow from "./OptionsRow";
 import OptionsSection from "./OptionsSection";
@@ -29,11 +32,13 @@ interface DatabaseFileListProps {
     downloadText: string;
     emptyIcon: string;
     emptyText: string;
+    /** Labels individual files, for the ones that need telling apart — e.g. one kept somewhere else. */
+    fileBadge?: (file: DatabaseFile) => string | undefined;
     /** Extra content rendered below the list (e.g. an action button). */
     children?: ComponentChildren;
 }
 
-export default function DatabaseFileList({ title, locationDescription, files, downloadEndpoint, rowName, downloadText, emptyIcon, emptyText, children }: DatabaseFileListProps) {
+export default function DatabaseFileList({ title, locationDescription, files, downloadEndpoint, rowName, downloadText, emptyIcon, emptyText, fileBadge, children }: DatabaseFileListProps) {
     const sortedFiles = useMemo(() => [...files].sort((a, b) => {
         if (a.mtime < b.mtime) return 1;
         if (a.mtime > b.mtime) return -1;
@@ -48,17 +53,22 @@ export default function DatabaseFileList({ title, locationDescription, files, do
             )}
         >
             {sortedFiles.length > 0 ? (
-                sortedFiles.map(({ fileName, filePath, mtime, fileSize }) => (
+                sortedFiles.map((file) => (
                     <OptionsRow
-                        key={filePath}
+                        key={file.filePath}
                         name={rowName}
-                        label={<span className="selectable-text">{fileName}</span>}
-                        description={`${mtime ? formatDateTime(mtime) : "-"} • ${formatSize(fileSize)}`}
+                        label={
+                            <span className="database-file-label">
+                                <span className="selectable-text">{file.fileName}</span>
+                                {fileBadge?.(file) && <Badge className="database-file-badge" text={fileBadge(file)} outline />}
+                            </span>
+                        }
+                        description={`${file.mtime ? formatDateTime(file.mtime) : "-"} • ${formatSize(file.fileSize)}`}
                     >
                         <ActionButton
                             icon="bx bx-download"
                             text={downloadText}
-                            onClick={() => open.download(open.getUrlForDownload(`${downloadEndpoint}?filePath=${encodeURIComponent(filePath)}`))}
+                            onClick={() => open.download(open.getUrlForDownload(`${downloadEndpoint}?filePath=${encodeURIComponent(file.filePath)}`))}
                         />
                     </OptionsRow>
                 ))

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -257,7 +257,8 @@ export async function main() {
         getDemoArchive: async () => fs.readFileSync(path.join(RESOURCE_DIR, "db", "demo.zip")),
         inAppHelp: new NodejsInAppHelpProvider(),
         log: new ServerLogService(),
-        backup: new ServerBackupService(options),
+        // Only the desktop lets the user pick where backups go; the server uses TRILIUM_BACKUP_DIR.
+        backup: new ServerBackupService(options, { allowCustomDirectory: true }),
         image: (await import("@triliumnext/server/src/services/image_provider.js")).serverImageProvider,
         config,
         extraAppInfo: {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,7 @@ import { registerTriliumAppScheme, setupTriliumAppProtocol } from "./protocol";
 import { applyLaunchOnStartup, setupAutoLaunch, wasLaunchedHidden } from "./services/auto_launch";
 import { setupCustomDictionary } from "./services/custom_dictionary";
 import { setupReferer } from "./services/referer";
+import { setupDialogHandlers } from "./services/dialog";
 import { setupExportHandlers } from "./services/export";
 import { setupImportHandlers } from "./services/import";
 import { setupOneNoteHandlers } from "./services/onenote";
@@ -129,6 +130,7 @@ export async function main() {
     setupPrintingHandlers();
     setupExportHandlers();
     setupImportHandlers();
+    setupDialogHandlers();
     registerSecurityIpcHandlers();
     setupStartupMetricsIpc();
 

--- a/apps/desktop/src/preload.spec.ts
+++ b/apps/desktop/src/preload.spec.ts
@@ -651,4 +651,18 @@ describe("preload script", () => {
             expect(ipcRendererInvoked).toContainEqual({ channel: "import-grant-dropped", args: [["/data/a.zip"]] });
         });
     });
+
+    describe("dialog", () => {
+        const dialog = () => getGroup("dialog");
+
+        it("pickDirectory forwards the starting location to its IPC channel", async () => {
+            await dialog().pickDirectory({ defaultPath: "/data/backup" });
+            expect(ipcRendererInvoked).toContainEqual({ channel: "dialog-pick-directory", args: [{ defaultPath: "/data/backup" }] });
+        });
+
+        it("pickDirectory may be called without a starting location", async () => {
+            await dialog().pickDirectory();
+            expect(ipcRendererInvoked).toContainEqual({ channel: "dialog-pick-directory", args: [undefined] });
+        });
+    });
 });

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -227,6 +227,12 @@ contextBridge.exposeInMainWorld("electronApi", {
         }
     },
 
+    dialog: {
+        pickDirectory(opts?: { defaultPath?: string }) {
+            return ipcRenderer.invoke("dialog-pick-directory", opts);
+        }
+    },
+
     ws: {
         // Renderer → main process. Mirror channel name with the server-side
         // IpcMessagingProvider constants.

--- a/apps/desktop/src/services/dialog.spec.ts
+++ b/apps/desktop/src/services/dialog.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- electron mock: capture the IPC handlers and drive the dialog/window from the test ---
+const electronMock = vi.hoisted(() => ({
+    handlers: new Map<string, (...args: unknown[]) => unknown>(),
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => electronMock.handlers.set(channel, handler)),
+    showOpenDialog: vi.fn<(...args: unknown[]) => Promise<{ canceled: boolean; filePaths: string[] }>>(),
+    getFocusedWindow: vi.fn<() => object | null>(() => ({}))
+}));
+
+vi.mock("electron", () => ({
+    default: {
+        ipcMain: { handle: electronMock.handle },
+        dialog: { showOpenDialog: electronMock.showOpenDialog },
+        BrowserWindow: { getFocusedWindow: electronMock.getFocusedWindow }
+    }
+}));
+
+vi.mock("i18next", () => ({ t: (key: string) => key }));
+
+const { setupDialogHandlers } = await import("./dialog.js");
+
+function pickDirectory(opts?: { defaultPath?: string }) {
+    return electronMock.handlers.get("dialog-pick-directory")?.({}, opts) as Promise<{ status: string; path?: string }>;
+}
+
+describe("desktop native directory picker", () => {
+    beforeEach(() => {
+        electronMock.handlers.clear();
+        vi.clearAllMocks();
+        electronMock.getFocusedWindow.mockReturnValue({});
+        electronMock.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: ["/data/backup"] });
+        setupDialogHandlers();
+    });
+
+    it("returns the chosen directory, opening the picker at the given location", async () => {
+        expect(await pickDirectory({ defaultPath: "/data/old" })).toEqual({ status: "selected", path: "/data/backup" });
+
+        const [, options] = electronMock.showOpenDialog.mock.calls[0] as [unknown, { defaultPath?: string; properties: string[] }];
+        expect(options.defaultPath).toBe("/data/old");
+        expect(options.properties).toEqual(["openDirectory", "createDirectory"]);
+    });
+
+    it("works without a starting location", async () => {
+        expect(await pickDirectory()).toEqual({ status: "selected", path: "/data/backup" });
+
+        const [, options] = electronMock.showOpenDialog.mock.calls[0] as [unknown, { defaultPath?: string }];
+        expect(options.defaultPath).toBeUndefined();
+    });
+
+    it("reports a cancelled dialog", async () => {
+        electronMock.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+        expect(await pickDirectory()).toEqual({ status: "cancelled" });
+    });
+
+    it("reports a cancel when the dialog comes back empty despite not being cancelled", async () => {
+        electronMock.showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [] });
+        expect(await pickDirectory()).toEqual({ status: "cancelled" });
+    });
+
+    it("does not open a picker when there is no window to own it", async () => {
+        electronMock.getFocusedWindow.mockReturnValue(null);
+
+        expect(await pickDirectory()).toEqual({ status: "cancelled" });
+        expect(electronMock.showOpenDialog).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/src/services/dialog.ts
+++ b/apps/desktop/src/services/dialog.ts
@@ -1,0 +1,32 @@
+import type { NativeDirectoryPickResult } from "@triliumnext/commons";
+import { default as electron } from "electron";
+import { t } from "i18next";
+
+/**
+ * Registers the native picker IPC handlers.
+ *
+ * The renderer never supplies the answer: the OS dialog runs here in the main process and a path
+ * only comes back once the user has accepted it, so a note script can at most pop the dialog.
+ */
+export function setupDialogHandlers() {
+    electron.ipcMain.handle("dialog-pick-directory", async (_e, opts?: { defaultPath?: string }): Promise<NativeDirectoryPickResult> => {
+        const focusedWindow = electron.BrowserWindow.getFocusedWindow();
+        if (!focusedWindow) {
+            return { status: "cancelled" };
+        }
+
+        // Async dialog: showOpenDialogSync blocks the main process event loop (freezing the UI, WebSockets
+        // and background tasks) for as long as the picker is open.
+        const { canceled, filePaths } = await electron.dialog.showOpenDialog(focusedWindow, {
+            title: t("dialog.select_directory"),
+            defaultPath: opts?.defaultPath,
+            properties: ["openDirectory", "createDirectory"]
+        });
+
+        if (canceled || filePaths.length === 0) {
+            return { status: "cancelled" };
+        }
+
+        return { status: "selected", path: filePaths[0] };
+    });
+}

--- a/apps/desktop/src/services/shell.spec.ts
+++ b/apps/desktop/src/services/shell.spec.ts
@@ -178,6 +178,33 @@ describe("validateOpenPath", () => {
         expect(validateOpenPath(dataDir, dataDir, tmpDir)).toBe(path.resolve(dataDir));
     });
 
+    describe("backup directory root", () => {
+        let backupDir: string;
+
+        beforeAll(() => {
+            backupDir = fs.mkdtempSync(path.join(os.tmpdir(), "trilium-open-path-backup-"));
+            fs.writeFileSync(path.join(backupDir, "backup-daily.db"), "");
+        });
+
+        afterAll(() => fs.rmSync(backupDir, { recursive: true, force: true }));
+
+        it("accepts a backup directory outside the data directory, and what it holds", () => {
+            expect(validateOpenPath(backupDir, dataDir, tmpDir, backupDir)).toBe(path.resolve(backupDir));
+            expect(validateOpenPath(path.join(backupDir, "backup-daily.db"), dataDir, tmpDir, backupDir))
+                .toBe(path.resolve(backupDir, "backup-daily.db"));
+        });
+
+        it("rejects that same directory when it is not the configured one", () => {
+            expect(() => validateOpenPath(backupDir, dataDir, tmpDir)).toThrow(/outside data dir/);
+            expect(() => validateOpenPath(backupDir, dataDir, tmpDir, null)).toThrow(/outside data dir/);
+        });
+
+        it("does not widen the sandbox beyond the backup directory", () => {
+            const outside = path.join(backupDir, "..", "elsewhere.txt");
+            expect(() => validateOpenPath(outside, dataDir, tmpDir, backupDir)).toThrow(/outside data dir/);
+        });
+    });
+
     it("accepts files under the data directory", () => {
         expect(validateOpenPath(dataFile, dataDir, tmpDir)).toBe(path.resolve(dataFile));
     });

--- a/apps/desktop/src/services/shell.ts
+++ b/apps/desktop/src/services/shell.ts
@@ -1,5 +1,5 @@
 import { SHELL_OPEN_EXTERNAL_PROTOCOLS } from "@triliumnext/commons";
-import { getLog, utils as coreUtils } from "@triliumnext/core";
+import { getBackup, getLog, utils as coreUtils } from "@triliumnext/core";
 import dataDirs from "@triliumnext/server/src/services/data_dir.js";
 import { execFile } from "child_process";
 import electron from "electron";
@@ -63,25 +63,31 @@ export function validateOpenCustomPath(filePath: unknown, tmpDir: string): strin
 
 //#endregion
 
-//#region open-path — sandbox to Trilium's data dir ∪ tmp dir + existence check
+//#region open-path — sandbox to Trilium's data dir ∪ tmp dir ∪ backup dir + existence check
 
 /**
  * Validates a path for the "open-path" IPC channel (Open Note Externally,
- * Open Attachment Externally, and the "open data directory" link in the
- * About dialog). The legit callers only ever pass server-generated paths
- * either inside the tmp dir or equal to the data dir itself.
+ * Open Attachment Externally, and the "open data directory" / "open backup
+ * directory" links in the About dialog and the backup settings). The legit
+ * callers only ever pass server-generated paths either inside the tmp dir or
+ * equal to one of the directories themselves.
+ *
+ * `backupDir` is a root of its own because the user may have moved backups
+ * outside the data directory. It is resolved from the app's own configuration
+ * rather than taken from the renderer, so the sandbox still bounds the caller.
  *
  * UNC paths are blocked implicitly — they cannot normalise to a descendant
- * of the data/tmp dirs, so the sandbox check rejects them. This closes the
+ * of those roots, so the sandbox check rejects them. This closes the
  * NTLM-hash-leak vector that affects file:// and smb:// URLs.
  */
-export function validateOpenPath(input: unknown, dataDir: string, tmpDir: string): string {
+export function validateOpenPath(input: unknown, dataDir: string, tmpDir: string, backupDir?: string | null): string {
     if (typeof input !== "string" || input.length === 0 || input.includes("\0")) {
         throw new Error("open-path: invalid filePath");
     }
 
+    const roots = backupDir ? [dataDir, tmpDir, backupDir] : [dataDir, tmpDir];
     const resolved = path.resolve(input);
-    if (!isUnderOrEquals(resolved, dataDir) && !isUnderOrEquals(resolved, tmpDir)) {
+    if (!roots.some((root) => isUnderOrEquals(resolved, root))) {
         throw new Error(`open-path: refusing path outside data dir: ${resolved}`);
     }
 
@@ -242,7 +248,7 @@ export function setupShellHandlers() {
 
     electron.ipcMain.handle("open-path", (_event, filePath: string) => {
         try {
-            const resolved = validateOpenPath(filePath, dataDirs.TRILIUM_DATA_DIR, dataDirs.TMP_DIR);
+            const resolved = validateOpenPath(filePath, dataDirs.TRILIUM_DATA_DIR, dataDirs.TMP_DIR, getConfiguredBackupDir());
             return electron.shell.openPath(resolved);
         } catch (e) {
             getLog().error(`open-path failed: ${coreUtils.safeExtractMessageAndStackFromError(e)}`);
@@ -325,6 +331,19 @@ export function setupShellHandlers() {
             getLog().error(`open-custom failed: ${coreUtils.safeExtractMessageAndStackFromError(e)}`);
         }
     });
+}
+
+/**
+ * The directory backups currently go to, which the user may have moved outside the data directory.
+ * Read from the backup service rather than accepted from the renderer, so it stays the app's own
+ * notion of where backups live. Null before core is initialized, leaving the other roots to apply.
+ */
+function getConfiguredBackupDir(): string | null {
+    try {
+        return getBackup().getBackupFolderPath();
+    } catch {
+        return null;
+    }
 }
 
 //#endregion

--- a/apps/edit-docs/src/utils.ts
+++ b/apps/edit-docs/src/utils.ts
@@ -24,7 +24,7 @@ registerTriliumAppScheme();
 // Stub backup service (not used in edit-docs, but required by initializeCore)
 class StubBackupService extends BackupService {
     constructor() {
-        super({ getOption: () => "", getOptionBool: () => false, setOption: () => {} });
+        super({ getOption: () => "", getOptionOrNull: () => null, getOptionBool: () => false, setOption: () => {} });
     }
     scheduleBackups(): void {}
     async backupNow(_name: string): Promise<string> {

--- a/apps/server/src/assets/translations/en/server.json
+++ b/apps/server/src/assets/translations/en/server.json
@@ -400,6 +400,9 @@
     "show-windows": "Show windows",
     "open_new_window": "Open new window"
   },
+  "backup": {
+    "custom_directory_unwritable": "Database backup failed: unable to write to {{- location}}. Backing up to the default location instead."
+  },
   "migration": {
     "old_version": "Direct migration from your current version is not supported. Please upgrade to the latest v0.60.4 first and only then to this version.",
     "error_message": "Error during migration to version {{version}}: {{stack}}",

--- a/apps/server/src/assets/translations/en/server.json
+++ b/apps/server/src/assets/translations/en/server.json
@@ -403,6 +403,9 @@
   "backup": {
     "custom_directory_unwritable": "Database backup failed: unable to write to {{- location}}. Backing up to the default location instead."
   },
+  "dialog": {
+    "select_directory": "Select folder"
+  },
   "migration": {
     "old_version": "Direct migration from your current version is not supported. Please upgrade to the latest v0.60.4 first and only then to this version.",
     "error_message": "Error during migration to version {{version}}: {{stack}}",

--- a/apps/server/src/backup_provider.spec.ts
+++ b/apps/server/src/backup_provider.spec.ts
@@ -1,5 +1,5 @@
 import type { OptionNames } from "@triliumnext/commons";
-import { getSql, ws } from "@triliumnext/core";
+import { getLog, getSql, ws } from "@triliumnext/core";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -153,6 +153,54 @@ describe("ServerBackupService: fallback when the custom directory cannot be writ
 
         await expect(desktopService("").backupNow("now")).rejects.toThrow("EACCES");
         expect(ws.sendMessageToAllClients).not.toHaveBeenCalled();
+    });
+});
+
+describe("ServerBackupService: what reaches the backend log", () => {
+    /** The log is meant to be postable for diagnostics as-is, so no backup path may appear in it. */
+    function loggedBy(method: "info" | "error") {
+        return vi.spyOn(getLog(), method).mockImplementation(() => {});
+    }
+
+    function linesFrom(spy: ReturnType<typeof loggedBy>) {
+        return spy.mock.calls.flat().join("\n");
+    }
+
+    it("names the backup relative to its directory, never the directory itself", async () => {
+        const info = loggedBy("info");
+
+        await desktopService("").backupNow("daily");
+
+        expect(linesFrom(info)).toContain(`Created backup .${path.sep}backup-daily.db`);
+        expect(linesFrom(info)).not.toContain(DEFAULT_DIR);
+    });
+
+    it("says a backup went to the custom location without saying where that is", async () => {
+        const info = loggedBy("info");
+
+        await desktopService(CUSTOM_DIR).backupNow("daily");
+
+        expect(linesFrom(info)).toContain(`Created backup .${path.sep}backup-daily.db in the custom backup location.`);
+        expect(linesFrom(info)).not.toContain(CUSTOM_DIR);
+    });
+
+    it("keeps the reason for a fallback but strips the location the error quotes back", async () => {
+        const error = loggedBy("error");
+        copyDatabase.mockRejectedValueOnce(new Error(`EACCES: permission denied, open '${CUSTOM_DIR}\\backup-daily.db'`));
+
+        await desktopService(CUSTOM_DIR).backupNow("daily");
+
+        expect(linesFrom(error)).toContain("EACCES: permission denied");
+        expect(linesFrom(error)).not.toContain(CUSTOM_DIR);
+    });
+
+    it("strips the location from the failure it propagates when there is nowhere left to fall back to", async () => {
+        copyDatabase.mockRejectedValue(new Error(`ENOSPC: no space left on device, open '${DEFAULT_DIR}\\backup-now.db'`));
+
+        const failure = await desktopService("").backupNow("now").catch((e: Error) => e.message);
+
+        expect(failure).toContain("ENOSPC: no space left on device");
+        expect(failure).not.toContain(DEFAULT_DIR);
     });
 });
 

--- a/apps/server/src/backup_provider.spec.ts
+++ b/apps/server/src/backup_provider.spec.ts
@@ -1,42 +1,241 @@
+import type { OptionNames } from "@triliumnext/commons";
+import { getSql, ws } from "@triliumnext/core";
 import fs from "fs";
+import os from "os";
 import path from "path";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 
 import ServerBackupService from "./backup_provider.js";
 import dataDir from "./services/data_dir.js";
 
-const service = new ServerBackupService({
-    getOption: () => "",
-    getOptionBool: () => false,
-    setOption: () => {}
+const DEFAULT_DIR = path.resolve(dataDir.BACKUP_DIR);
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trilium-backup-spec-"));
+const CUSTOM_DIR = path.join(tempRoot, "custom");
+
+/** Stands in for the real online backup: writes a small file at the destination. */
+let copyDatabase: MockInstance<(target: string) => Promise<void>>;
+
+async function writeStubDatabase(target: string) {
+    fs.writeFileSync(target, "db-bytes");
+}
+
+/** A desktop service (custom directory honoured) reading the given option value. */
+function desktopService(customDbBackupDir: string | null) {
+    return new ServerBackupService(optionsWith(customDbBackupDir), { allowCustomDirectory: true });
+}
+
+/** A server service, which ignores the option entirely. */
+function serverService(customDbBackupDir: string | null) {
+    return new ServerBackupService(optionsWith(customDbBackupDir));
+}
+
+function optionsWith(customDbBackupDir: string | null) {
+    return {
+        getOption: (name: OptionNames) => (name === "customDbBackupDir" ? customDbBackupDir ?? "" : ""),
+        getOptionOrNull: (name: OptionNames) => (name === "customDbBackupDir" ? customDbBackupDir : null),
+        getOptionBool: () => false,
+        setOption: () => {}
+    };
+}
+
+function backupNamesIn(directory: string) {
+    return fs.existsSync(directory) ? fs.readdirSync(directory).sort() : [];
+}
+
+beforeEach(() => {
+    copyDatabase = vi.spyOn(getSql(), "copyDatabase").mockImplementation(writeStubDatabase);
+    vi.spyOn(ws, "sendMessageToAllClients").mockImplementation(() => {});
+
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.mkdirSync(tempRoot, { recursive: true });
+    fs.rmSync(DEFAULT_DIR, { recursive: true, force: true });
 });
 
-const dbFile = path.join(dataDir.BACKUP_DIR, "backup-spec-list.db");
-const journalFile = path.join(dataDir.BACKUP_DIR, "backup-spec-list.db-journal");
+afterEach(() => vi.restoreAllMocks());
 
-describe("ServerBackupService", () => {
-    afterAll(() => {
-        fs.rmSync(dbFile, { force: true });
-        fs.rmSync(journalFile, { force: true });
+afterAll(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    fs.rmSync(DEFAULT_DIR, { recursive: true, force: true });
+});
+
+describe("ServerBackupService: backup location", () => {
+    it("uses the default directory when no custom one is configured", async () => {
+        const service = desktopService("");
+
+        expect(service.getBackupFolderPath()).toBe(DEFAULT_DIR);
+        expect(await service.backupNow("now")).toBe(path.join(DEFAULT_DIR, "backup-now.db"));
     });
 
+    it("uses the custom directory on the desktop, creating it if needed", async () => {
+        const service = desktopService(CUSTOM_DIR);
+
+        expect(service.getBackupFolderPath()).toBe(CUSTOM_DIR);
+        expect(await service.backupNow("daily")).toBe(path.join(CUSTOM_DIR, "backup-daily.db"));
+        expect(backupNamesIn(CUSTOM_DIR)).toEqual(["backup-daily.db"]);
+        expect(backupNamesIn(DEFAULT_DIR)).toEqual([]);
+    });
+
+    it("ignores the custom directory on the server, which is configured via TRILIUM_BACKUP_DIR", async () => {
+        const service = serverService(CUSTOM_DIR);
+
+        expect(service.getBackupFolderPath()).toBe(DEFAULT_DIR);
+        expect(await service.backupNow("daily")).toBe(path.join(DEFAULT_DIR, "backup-daily.db"));
+        expect(backupNamesIn(CUSTOM_DIR)).toEqual([]);
+    });
+
+    it("falls back to the default directory for a blank, whitespace-only or missing option", () => {
+        expect(desktopService("").getBackupFolderPath()).toBe(DEFAULT_DIR);
+        expect(desktopService("   ").getBackupFolderPath()).toBe(DEFAULT_DIR);
+        // The option row does not exist yet, e.g. the pre-migration backup of an older database.
+        expect(desktopService(null).getBackupFolderPath()).toBe(DEFAULT_DIR);
+    });
+
+    it("resolves a relative custom directory against the working directory", () => {
+        expect(desktopService("./my-backups").getBackupFolderPath()).toBe(path.resolve("./my-backups"));
+    });
+
+    it("treats a custom directory equal to the default one as no custom directory", async () => {
+        const service = desktopService(DEFAULT_DIR);
+
+        expect(service.getBackupFolderPath()).toBe(DEFAULT_DIR);
+        await service.backupNow("now");
+        // Listed once, not once per configured directory.
+        expect((await service.getExistingBackups()).map((b) => b.fileName)).toEqual(["backup-now.db"]);
+    });
+});
+
+describe("ServerBackupService: fallback when the custom directory cannot be written to", () => {
+    it("backs up to the default directory and notifies the user", async () => {
+        copyDatabase.mockRejectedValueOnce(new Error("ENOSPC: no space left on device"));
+
+        expect(await desktopService(CUSTOM_DIR).backupNow("daily")).toBe(path.join(DEFAULT_DIR, "backup-daily.db"));
+        expect(backupNamesIn(DEFAULT_DIR)).toEqual(["backup-daily.db"]);
+
+        expect(ws.sendMessageToAllClients).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "toast",
+                message: `Database backup failed: unable to write to ${CUSTOM_DIR}. Backing up to the default location instead.`
+            })
+        );
+    });
+
+    it("falls back when the custom directory itself cannot be created", async () => {
+        // A file where the directory should be: mkdir fails on every platform.
+        const blocked = path.join(tempRoot, "blocked");
+        fs.writeFileSync(blocked, "not-a-directory");
+
+        const service = desktopService(path.join(blocked, "backups"));
+
+        expect(await service.backupNow("now")).toBe(path.join(DEFAULT_DIR, "backup-now.db"));
+        expect(ws.sendMessageToAllClients).toHaveBeenCalledOnce();
+    });
+
+    it("leaves no half-written file behind in the custom directory", async () => {
+        copyDatabase.mockImplementationOnce(async (target: string) => {
+            fs.writeFileSync(target, "partial");
+            throw new Error("EIO: i/o error");
+        });
+
+        await desktopService(CUSTOM_DIR).backupNow("daily");
+
+        expect(backupNamesIn(CUSTOM_DIR)).toEqual([]);
+        expect(backupNamesIn(DEFAULT_DIR)).toEqual(["backup-daily.db"]);
+    });
+
+    it("propagates the failure when the default directory fails too", async () => {
+        copyDatabase.mockRejectedValue(new Error("EACCES: permission denied"));
+
+        await expect(desktopService(CUSTOM_DIR).backupNow("now")).rejects.toThrow("EACCES");
+    });
+
+    it("does not notify when there is no custom directory to fall back from", async () => {
+        copyDatabase.mockRejectedValue(new Error("EACCES: permission denied"));
+
+        await expect(desktopService("").backupNow("now")).rejects.toThrow("EACCES");
+        expect(ws.sendMessageToAllClients).not.toHaveBeenCalled();
+    });
+});
+
+describe("ServerBackupService.backupNow: naming", () => {
+    it("rejects a name with no usable characters", async () => {
+        await expect(desktopService("").backupNow("../..")).rejects.toThrow("Invalid backup name");
+    });
+
+    it("strips path traversal from the name", async () => {
+        expect(await desktopService(CUSTOM_DIR).backupNow("../../evil")).toBe(path.join(CUSTOM_DIR, "backup-evil.db"));
+    });
+});
+
+describe("ServerBackupService.getExistingBackups", () => {
     it("lists .db backups with their size, excluding intermediate SQLite files", async () => {
-        fs.mkdirSync(dataDir.BACKUP_DIR, { recursive: true });
-        fs.writeFileSync(dbFile, "backup-bytes");
-        fs.writeFileSync(journalFile, "journal-bytes");
+        fs.mkdirSync(DEFAULT_DIR, { recursive: true });
+        fs.writeFileSync(path.join(DEFAULT_DIR, "backup-spec-list.db"), "backup-bytes");
+        fs.writeFileSync(path.join(DEFAULT_DIR, "backup-spec-list.db-journal"), "journal-bytes");
 
-        const backups = await service.getExistingBackups();
-        const names = backups.map((b) => b.fileName);
-        expect(names).toContain("backup-spec-list.db");
-        expect(names).not.toContain("backup-spec-list.db-journal");
+        const backups = await desktopService("").getExistingBackups();
 
-        const entry = backups.find((b) => b.fileName === "backup-spec-list.db");
-        expect(entry?.fileSize).toBe("backup-bytes".length);
-        expect(entry?.filePath).toBe(path.resolve(dataDir.BACKUP_DIR, "backup-spec-list.db"));
-        expect(entry?.mtime).toBeInstanceOf(Date);
+        expect(backups.map((b) => b.fileName)).toEqual(["backup-spec-list.db"]);
+        expect(backups[0].fileSize).toBe("backup-bytes".length);
+        expect(backups[0].filePath).toBe(path.join(DEFAULT_DIR, "backup-spec-list.db"));
+        expect(backups[0].mtime).toBeInstanceOf(Date);
     });
 
-    it("reports the backup folder path", () => {
-        expect(service.getBackupFolderPath()).toBe(path.resolve(dataDir.BACKUP_DIR));
+    it("merges the custom and the default directory, so redirected backups stay reachable", async () => {
+        fs.mkdirSync(CUSTOM_DIR, { recursive: true });
+        fs.mkdirSync(DEFAULT_DIR, { recursive: true });
+        fs.writeFileSync(path.join(CUSTOM_DIR, "backup-daily.db"), "a");
+        fs.writeFileSync(path.join(DEFAULT_DIR, "backup-weekly.db"), "b");
+
+        const backups = await desktopService(CUSTOM_DIR).getExistingBackups();
+
+        expect(backups.map((b) => b.filePath).sort()).toEqual(
+            [path.join(CUSTOM_DIR, "backup-daily.db"), path.join(DEFAULT_DIR, "backup-weekly.db")].sort()
+        );
+    });
+
+    it("tolerates a custom directory that does not exist", async () => {
+        await expect(desktopService(path.join(tempRoot, "gone")).getExistingBackups()).resolves.toEqual([]);
+    });
+});
+
+describe("ServerBackupService.getBackupContent", () => {
+    it("reads a backup from the default directory", async () => {
+        fs.mkdirSync(DEFAULT_DIR, { recursive: true });
+        const file = path.join(DEFAULT_DIR, "backup-now.db");
+        fs.writeFileSync(file, "db-bytes");
+
+        expect(await desktopService("").getBackupContent(file)).toEqual(Buffer.from("db-bytes"));
+    });
+
+    it("reads a backup from the custom directory", async () => {
+        fs.mkdirSync(CUSTOM_DIR, { recursive: true });
+        const file = path.join(CUSTOM_DIR, "backup-now.db");
+        fs.writeFileSync(file, "db-bytes");
+
+        expect(await desktopService(CUSTOM_DIR).getBackupContent(file)).toEqual(Buffer.from("db-bytes"));
+    });
+
+    it("refuses a path outside the backup directories", async () => {
+        const outside = path.join(tempRoot, "secret.db");
+        fs.writeFileSync(outside, "secret");
+
+        expect(await desktopService(CUSTOM_DIR).getBackupContent(outside)).toBeNull();
+        expect(await desktopService(CUSTOM_DIR).getBackupContent(path.join(DEFAULT_DIR, "..", "document.db"))).toBeNull();
+        // The directory itself is not a backup.
+        expect(await desktopService(CUSTOM_DIR).getBackupContent(CUSTOM_DIR)).toBeNull();
+        // The custom directory is only allowed while it is the configured one.
+        expect(await desktopService("").getBackupContent(path.join(CUSTOM_DIR, "backup-now.db"))).toBeNull();
+    });
+
+    it("accepts a custom directory given with a trailing separator", async () => {
+        fs.mkdirSync(CUSTOM_DIR, { recursive: true });
+        const file = path.join(CUSTOM_DIR, "backup-now.db");
+        fs.writeFileSync(file, "db-bytes");
+
+        expect(await desktopService(CUSTOM_DIR + path.sep).getBackupContent(file)).toEqual(Buffer.from("db-bytes"));
+    });
+
+    it("returns null for a missing file inside the backup directory", async () => {
+        expect(await desktopService("").getBackupContent(path.join(DEFAULT_DIR, "backup-absent.db"))).toBeNull();
     });
 });

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -1,5 +1,5 @@
 import type { DatabaseBackup } from "@triliumnext/commons";
-import { BackupOptionsService, BackupService, getLog, sync_mutex as syncMutexService, ws } from "@triliumnext/core";
+import { BackupOptionsService, BackupService, utils as coreUtils, getLog, sync_mutex as syncMutexService, ws } from "@triliumnext/core";
 import fs from "fs";
 import { t } from "i18next";
 import path from "path";
@@ -53,11 +53,12 @@ export default class ServerBackupService extends BackupService {
 
             if (customDir) {
                 try {
-                    return await writeBackup(customDir, fileName);
+                    return await writeBackup(customDir, fileName, "custom");
                 } catch (e) {
                     // A backup that cannot reach the chosen location is still worth having, so the
-                    // default one takes over instead of the backup being lost altogether.
-                    getLog().error(`Could not back up to '${customDir}', falling back to the default directory: ${e}`);
+                    // default one takes over instead of the backup being lost altogether. The reason
+                    // reaches the log; where it was headed reaches only the user, in the toast.
+                    getLog().error(`Could not back up to the custom backup location, using the default one instead: ${e}`);
                     ws.sendMessageToAllClients({
                         type: "toast",
                         message: t("backup.custom_directory_unwritable", { location: customDir }),
@@ -66,7 +67,7 @@ export default class ServerBackupService extends BackupService {
                 }
             }
 
-            return await writeBackup(getDefaultBackupDir(), fileName);
+            return await writeBackup(getDefaultBackupDir(), fileName, "default");
         });
     }
 
@@ -147,7 +148,7 @@ function listBackupsIn(directory: string): DatabaseBackup[] {
         });
 }
 
-async function writeBackup(directory: string, fileName: string): Promise<string> {
+async function writeBackup(directory: string, fileName: string, location: "default" | "custom"): Promise<string> {
     const backupFile = path.resolve(directory, fileName);
 
     fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -159,9 +160,20 @@ async function writeBackup(directory: string, fileName: string): Promise<string>
         // Whatever was written before the failure is not a usable database, and would otherwise be
         // listed and offered for download as if it were one.
         fs.rmSync(backupFile, { force: true });
-        throw e;
+        throw new Error(withoutDirectory(e, directory));
     }
-    getLog().info(`Created backup at ${backupFile}`);
+    getLog().info(`Created backup .${path.sep}${fileName}${location === "custom" ? " in the custom backup location." : ""}`);
 
     return backupFile;
+}
+
+/**
+ * Keeps the backup directory out of anything that reaches the log. It carries the user's name on most
+ * platforms, and the backend log is meant to be shareable for diagnostics without having to be censored
+ * first — so the reason for a failure is kept and the location filesystem errors quote back is not.
+ */
+function withoutDirectory(error: unknown, directory: string): string {
+    const message = error instanceof Error ? error.message : String(error);
+
+    return coreUtils.replaceAll(message, directory, "<backup location>");
 }

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -1,35 +1,32 @@
 import type { DatabaseBackup } from "@triliumnext/commons";
-import { BackupOptionsService, BackupService, getLog, sync_mutex as syncMutexService } from "@triliumnext/core";
+import { BackupOptionsService, BackupService, getLog, sync_mutex as syncMutexService, ws } from "@triliumnext/core";
 import fs from "fs";
+import { t } from "i18next";
 import path from "path";
 
 import dataDir from "./services/data_dir.js";
 import sql from "./services/sql.js";
 
+export interface ServerBackupConfig {
+    /**
+     * Whether the `customDbBackupDir` option is honoured. Set by the desktop application, where the user
+     * picks the directory themselves; on the server the backup location is part of the deployment and is
+     * configured through the `TRILIUM_BACKUP_DIR` environment variable instead.
+     */
+    allowCustomDirectory?: boolean;
+}
+
 export default class ServerBackupService extends BackupService {
-    constructor(options: BackupOptionsService) {
+    constructor(options: BackupOptionsService, private readonly config: ServerBackupConfig = {}) {
         super(options);
     }
 
     override async getExistingBackups(): Promise<DatabaseBackup[]> {
-        if (!fs.existsSync(dataDir.BACKUP_DIR)) {
-            return [];
-        }
-
-        return fs
-            .readdirSync(dataDir.BACKUP_DIR)
-            // The .db check excludes intermediate SQLite files (e.g. *.db-journal) created while a backup is in progress.
-            .filter((fileName) => fileName.includes("backup") && fileName.endsWith(".db"))
-            .map((fileName) => {
-                const filePath = path.resolve(dataDir.BACKUP_DIR, fileName);
-                const stat = fs.statSync(filePath);
-
-                return { fileName, filePath, mtime: stat.mtime, fileSize: stat.size };
-            });
+        return this.getBackupDirectories().flatMap(listBackupsIn);
     }
 
     override getBackupFolderPath(): string {
-        return path.resolve(dataDir.BACKUP_DIR);
+        return this.getCustomBackupDir() ?? getDefaultBackupDir();
     }
 
     override scheduleBackups(): void {
@@ -48,28 +45,36 @@ export default class ServerBackupService extends BackupService {
             throw new Error("Invalid backup name: must contain at least one alphanumeric character, hyphen, or underscore.");
         }
 
+        const fileName = `backup-${sanitizedName}.db`;
+
         // we don't want to back up DB in the middle of sync with potentially inconsistent DB state
         return await syncMutexService.doExclusively(async () => {
-            const backupFile = path.resolve(`${dataDir.BACKUP_DIR}/backup-${sanitizedName}.db`);
+            const customDir = this.getCustomBackupDir();
 
-            if (!fs.existsSync(dataDir.BACKUP_DIR)) {
-                fs.mkdirSync(dataDir.BACKUP_DIR, 0o700);
+            if (customDir) {
+                try {
+                    return await writeBackup(customDir, fileName);
+                } catch (e) {
+                    // A backup that cannot reach the chosen location is still worth having, so the
+                    // default one takes over instead of the backup being lost altogether.
+                    getLog().error(`Could not back up to '${customDir}', falling back to the default directory: ${e}`);
+                    ws.sendMessageToAllClients({
+                        type: "toast",
+                        message: t("backup.custom_directory_unwritable", { location: customDir }),
+                        timeout: 15000
+                    });
+                }
             }
 
-            getLog().info("Creating backup...");
-            await sql.copyDatabase(backupFile);
-            getLog().info(`Created backup at ${backupFile}`);
-
-            return backupFile;
+            return await writeBackup(getDefaultBackupDir(), fileName);
         });
     }
 
     override async getBackupContent(filePath: string): Promise<Uint8Array | null> {
         const resolvedPath = path.resolve(filePath);
-        const backupDir = path.resolve(dataDir.BACKUP_DIR);
 
-        // Security check: ensure the path is within the backup directory
-        if (!resolvedPath.startsWith(backupDir + path.sep)) {
+        // Security check: ensure the path is within one of the backup directories
+        if (!this.getBackupDirectories().some((dir) => isInsideDirectory(dir, resolvedPath))) {
             return null;
         }
 
@@ -79,4 +84,84 @@ export default class ServerBackupService extends BackupService {
 
         return fs.readFileSync(resolvedPath);
     }
+
+    /** The directory the user chose to back up to, or `null` when the default one applies. */
+    private getCustomBackupDir(): string | null {
+        if (!this.config.allowCustomDirectory) {
+            return null;
+        }
+
+        const customDir = this.options.getOptionOrNull("customDbBackupDir")?.trim();
+        if (!customDir) {
+            return null;
+        }
+
+        const resolved = path.resolve(customDir);
+        return resolved !== getDefaultBackupDir() ? resolved : null;
+    }
+
+    /**
+     * Every directory that may hold backups. The default one stays in the list next to a custom
+     * directory, since it still holds the backups taken before the custom one was chosen, as well as
+     * the ones redirected there after a failed write.
+     */
+    private getBackupDirectories(): string[] {
+        const customDir = this.getCustomBackupDir();
+        const defaultDir = getDefaultBackupDir();
+
+        return customDir ? [customDir, defaultDir] : [defaultDir];
+    }
+}
+
+function getDefaultBackupDir(): string {
+    return path.resolve(dataDir.BACKUP_DIR);
+}
+
+/** Both paths must already be resolved. Unlike a prefix comparison, this also holds at a drive root. */
+function isInsideDirectory(directory: string, filePath: string): boolean {
+    const relative = path.relative(directory, filePath);
+
+    return !!relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function listBackupsIn(directory: string): DatabaseBackup[] {
+    let fileNames: string[];
+    try {
+        fileNames = fs.readdirSync(directory);
+    } catch {
+        // Missing or unreadable, e.g. a custom directory on a drive that is no longer plugged in.
+        return [];
+    }
+
+    return fileNames
+        // The .db check excludes intermediate SQLite files (e.g. *.db-journal) created while a backup is in progress.
+        .filter((fileName) => fileName.includes("backup") && fileName.endsWith(".db"))
+        .flatMap((fileName) => {
+            const filePath = path.resolve(directory, fileName);
+            const stat = fs.statSync(filePath, { throwIfNoEntry: false });
+            if (!stat) {
+                return [];
+            }
+
+            return [{ fileName, filePath, mtime: stat.mtime, fileSize: stat.size }];
+        });
+}
+
+async function writeBackup(directory: string, fileName: string): Promise<string> {
+    const backupFile = path.resolve(directory, fileName);
+
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+
+    getLog().info("Creating backup...");
+    try {
+        await sql.copyDatabase(backupFile);
+    } catch (e) {
+        // Whatever was written before the failure is not a usable database, and would otherwise be
+        // listed and offered for download as if it were one.
+        fs.rmSync(backupFile, { force: true });
+        throw e;
+    }
+    getLog().info(`Created backup at ${backupFile}`);
+
+    return backupFile;
 }

--- a/packages/commons/src/lib/electron_api_interface.ts
+++ b/packages/commons/src/lib/electron_api_interface.ts
@@ -596,6 +596,23 @@ export interface ElectronNativeImportApi {
     importFromToken(opts: { token: string; parentNoteId: string; taskId: string; options: NativeImportOptions; last: boolean; format?: string }): Promise<NativeImportResult>;
 }
 
+/** Outcome of {@link ElectronDialogApi.pickDirectory}. */
+export interface NativeDirectoryPickResult {
+    status: "selected" | "cancelled";
+    /** Absolute path of the chosen directory (when `status === "selected"`). */
+    path?: string;
+}
+
+/** Native OS pickers that hand the renderer a location the user chose themselves. */
+export interface ElectronDialogApi {
+    /**
+     * Prompts a native "select folder" dialog, starting at `defaultPath` when it is given. The renderer
+     * cannot supply the answer: a script can at most pop the dialog, which the user still has to accept
+     * before any path comes back.
+     */
+    pickDirectory(opts?: { defaultPath?: string }): Promise<NativeDirectoryPickResult>;
+}
+
 /**
  * The complete surface exposed to the renderer as `window.electronApi` via
  * `contextBridge`. The renderer must access Electron-only functionality through
@@ -634,4 +651,6 @@ export interface ElectronApi {
     nativeExport: ElectronNativeExportApi;
     /** Desktop-native large-`.zip` import that reads the user's file in place via a capability token. */
     nativeImport: ElectronNativeImportApi;
+    /** Native OS pickers that hand the renderer a location the user chose themselves. */
+    dialog: ElectronDialogApi;
 }

--- a/packages/commons/src/lib/options_interface.ts
+++ b/packages/commons/src/lib/options_interface.ts
@@ -55,6 +55,12 @@ export interface OptionDefinitions extends KeyboardShortcutsOptions<KeyboardActi
     lastDailyBackupDate: string;
     lastWeeklyBackupDate: string;
     lastMonthlyBackupDate: string;
+    /**
+     * Directory the database backups are written to, replacing the default one inside the data
+     * directory. Empty means "use the default". Honoured on the desktop application only; the server
+     * is configured through the `TRILIUM_BACKUP_DIR` environment variable instead.
+     */
+    customDbBackupDir: string;
     dbVersion: string;
     theme: string;
     syncServerHost: string;

--- a/packages/trilium-core/src/routes/api/options.ts
+++ b/packages/trilium-core/src/routes/api/options.ts
@@ -90,6 +90,7 @@ const ALLOWED_OPTIONS = new Set<OptionNames>([
     "dailyBackupEnabled",
     "weeklyBackupEnabled",
     "monthlyBackupEnabled",
+    "customDbBackupDir",
     "motionEnabled",
     "shadowsEnabled",
     "smoothScrollEnabled",

--- a/packages/trilium-core/src/services/backup.spec.ts
+++ b/packages/trilium-core/src/services/backup.spec.ts
@@ -7,7 +7,7 @@ import dateUtils from "./utils/date.js";
 
 /**
  * A simple in-memory options service used to drive the abstract backup logic.
- * Mirrors the three methods the real BackupOptionsService exposes.
+ * Mirrors the methods the real BackupOptionsService exposes.
  */
 class FakeOptions implements BackupOptionsService {
     private readonly store: Record<string, string>;
@@ -18,6 +18,10 @@ class FakeOptions implements BackupOptionsService {
 
     getOption(name: OptionNames): string {
         return this.store[name] ?? "";
+    }
+
+    getOptionOrNull(name: OptionNames): string | null {
+        return this.store[name] ?? null;
     }
 
     getOptionBool(name: FilterOptionsByType<boolean>): boolean {

--- a/packages/trilium-core/src/services/backup.ts
+++ b/packages/trilium-core/src/services/backup.ts
@@ -6,6 +6,11 @@ type BackupType = "daily" | "weekly" | "monthly";
 
 export interface BackupOptionsService {
     getOption(name: OptionNames): string;
+    /**
+     * Reads an option without throwing when it does not exist yet — the pre-migration backup runs
+     * before {@link options_init.initStartupOptions} has filled in the options added by newer versions.
+     */
+    getOptionOrNull(name: OptionNames): string | null;
     getOptionBool(name: FilterOptionsByType<boolean>): boolean;
     setOption(name: OptionNames, value: string): void;
 }

--- a/packages/trilium-core/src/services/options_init.ts
+++ b/packages/trilium-core/src/services/options_init.ts
@@ -210,6 +210,7 @@ const defaultOptions: DefaultOption[] = [
     { name: "dailyBackupEnabled", value: "true", isSynced: false },
     { name: "weeklyBackupEnabled", value: "true", isSynced: false },
     { name: "monthlyBackupEnabled", value: "true", isSynced: false },
+    { name: "customDbBackupDir", value: "", isSynced: false },
     { name: "maxContentWidth", value: "1200", isSynced: false },
     { name: "centerContent", value: "false", isSynced: false },
     { name: "compressImages", value: "true", isSynced: true },


### PR DESCRIPTION
The desktop application can now back up to a folder of your choosing instead of the one inside the data
directory. Options → Backup gains a "Backup location" card where you pick that folder, open it in your file
manager, and reset it. If the chosen folder ever cannot be written to, the backup goes to the default
location rather than being lost, and you are told. Servers are unaffected and keep using `TRILIUM_BACKUP_DIR`.

### Backup location
* Adds `customDbBackupDir`, a non-synced option holding the chosen folder; empty means the default one.
* Honoured by the desktop application only; the server is still configured through `TRILIUM_BACKUP_DIR`.
* A backup that cannot reach the chosen folder is written to the default one, with a toast naming the folder that failed.
* A backup that fails part-way is deleted, so a half-written file is never listed or offered for download.
* The backup list and its downloads cover both folders, so a redirected backup stays reachable.
* Fixes downloads being refused for a backup folder at a drive root, or one given with a trailing separator.

### Options → Backup
* Adds a "Backup location" card stating where backups go, with "Select location" and "Reset to default".
* "Select location" opens the native folder picker, and is disabled outside the desktop application with a tooltip saying why.
* "Reset to default" appears only while a custom folder is in use, and asks for confirmation first.
* The location opens in the file manager on click, as the data directory does in the About dialog.
* Backups left in the default folder are badged "Default location" while a custom one is in use.
* Drops the location line from "Existing backups", now that the card states it.

### Backend log
* Backup lines name the file relative to its folder and never the folder itself: `Created backup .\backup-daily.db`, or `Created backup .\backup-daily.db in the custom backup location.`
* Filesystem errors have the folder stripped before they are logged or rethrown, keeping the log postable for diagnostics without censoring.
* A directory that fails to open now reports to the user instead of only to the console.

### Internal
* Adds `electronApi.dialog.pickDirectory()`, a generic native folder picker.
* Widens the `open-path` sandbox to the configured backup folder, resolved in the main process rather than supplied by the renderer.
* Extracts `DirectoryLink` out of the About dialog into `widgets/react`, and adds `disabledTooltip` to `Button`.
* Adds `getOptionOrNull` to `BackupOptionsService`, so the pre-migration backup does not throw on a database predating the option.
