### PR TITLE
fix(oauth): accept ID tokens signed with an algorithm other than RS256

### DIFF
--- a/apps/server/src/assets/config-sample.ini
+++ b/apps/server/src/assets/config-sample.ini
@@ -75,6 +75,12 @@ oauthIssuerIcon=
 # e.g. on a self-hosted GitLab. Must match the method your client is registered with.
 oauthClientAuthMethod=
 
+# The algorithm the provider signs ID tokens with, e.g. RS256, EdDSA or ES256. Leave empty to
+# detect it from the provider's discovery document (RS256 is used whenever the provider offers it).
+# Set this only if sign-in fails with "unexpected JWT alg received", which means the provider signs
+# with an algorithm other than the one it advertises first.
+oauthIdTokenSigningAlg=
+
 [Security]
 # Enable backend script execution. WARNING: Backend scripts have full server access including
 # filesystem, network, and OS commands via require('child_process'). Only enable if you trust

--- a/apps/server/src/services/config.spec.ts
+++ b/apps/server/src/services/config.spec.ts
@@ -397,6 +397,9 @@ corsAllowOrigin=https://ini-cors.com
             expect(config.MultiFactorAuthentication.oauthIssuerBaseUrl).toBe("https://accounts.google.com");
             expect(config.MultiFactorAuthentication.oauthIssuerName).toBe("Google");
             expect(config.MultiFactorAuthentication.oauthIssuerIcon).toBe("");
+            // Empty means "detect from the provider's discovery document" for both of these.
+            expect(config.MultiFactorAuthentication.oauthClientAuthMethod).toBe("");
+            expect(config.MultiFactorAuthentication.oauthIdTokenSigningAlg).toBe("");
 
             // Logging defaults
             expect(config.Logging.retentionDays).toBe(90);

--- a/apps/server/src/services/config.ts
+++ b/apps/server/src/services/config.ts
@@ -139,6 +139,11 @@ export interface TriliumConfig {
          * 'client_secret_post'. Leave empty to auto-detect from the issuer.
          */
         oauthClientAuthMethod: string;
+        /**
+         * The JWS algorithm the provider signs ID tokens with (e.g. 'RS256', 'EdDSA', 'ES256').
+         * Leave empty to auto-detect from the issuer's discovery document.
+         */
+        oauthIdTokenSigningAlg: string;
     };
     /** Logging configuration */
     Logging: {
@@ -495,6 +500,13 @@ const configMapping = {
             aliasEnvVars: ['TRILIUM_OAUTH_CLIENT_AUTH_METHOD'],
             iniGetter: () => getIniSection("MultiFactorAuthentication")?.oauthClientAuthMethod,
             defaultValue: ''
+        },
+        oauthIdTokenSigningAlg: {
+            standardEnvVar: 'TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHIDTOKENSIGNINGALG',
+            // alternative format
+            aliasEnvVars: ['TRILIUM_OAUTH_ID_TOKEN_SIGNING_ALG'],
+            iniGetter: () => getIniSection("MultiFactorAuthentication")?.oauthIdTokenSigningAlg,
+            defaultValue: ''
         }
     },
     Logging: {
@@ -579,7 +591,8 @@ const config: TriliumConfig = {
         oauthIssuerBaseUrl: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerBaseUrl),
         oauthIssuerName: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerName),
         oauthIssuerIcon: getConfigValue(configMapping.MultiFactorAuthentication.oauthIssuerIcon),
-        oauthClientAuthMethod: getConfigValue(configMapping.MultiFactorAuthentication.oauthClientAuthMethod)
+        oauthClientAuthMethod: getConfigValue(configMapping.MultiFactorAuthentication.oauthClientAuthMethod),
+        oauthIdTokenSigningAlg: getConfigValue(configMapping.MultiFactorAuthentication.oauthIdTokenSigningAlg)
     },
     Logging: {
         retentionDays: getConfigValue(configMapping.Logging.retentionDays)

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -1,11 +1,13 @@
 import { cls, getLog, options } from "@triliumnext/core";
 import type { NextFunction, Request as ExpressRequest, RequestHandler, Response as ExpressResponse } from "express";
-import { ClientSecretBasic, ClientSecretPost, type CustomFetch, customFetch, discovery } from "openid-client";
+import { generateKeyPairSync, type KeyObject, sign } from "node:crypto";
+import { authorizationCodeGrant, ClientSecretBasic, ClientSecretPost, type CustomFetch, customFetch, discovery } from "openid-client";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { describeError } from "../routes/error_handlers.js";
 import config from "./config.js";
 import openIDEncryption from "./encryption/open_id_encryption.js";
-import openID, { createReactiveOidcMiddleware, reconcileIssuerBaseUrl, resolveClientAuthMethod, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
+import openID, { createReactiveOidcMiddleware, DEFAULT_ID_TOKEN_SIGNING_ALG, reconcileIssuerBaseUrl, resolveClientAuthMethod, resolveIdTokenSigningAlg, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
 import sql from "./sql.js";
 import sqlInit from "./sql_init.js";
 
@@ -20,6 +22,7 @@ function setOauthConfig(complete: boolean) {
     mfa.oauthIssuerName = "Acme";
     mfa.oauthIssuerIcon = "icon.png";
     mfa.oauthClientAuthMethod = "";
+    mfa.oauthIdTokenSigningAlg = "";
 }
 
 describe("open_id", () => {
@@ -488,7 +491,8 @@ describe("open_id", () => {
 
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: true,
-                issuerBaseUrl: "https://issuer.example.com"
+                issuerBaseUrl: "https://issuer.example.com",
+                idTokenSigningAlg: "RS256"
             });
             expect(fetchSpy).toHaveBeenCalledWith(wellKnownUrl, expect.anything());
         });
@@ -520,13 +524,15 @@ describe("open_id", () => {
             mockFetch(() => ({ ok: false, status: 404, json: () => Promise.resolve({}) }));
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: false,
-                issuerBaseUrl: "https://issuer.example.com"
+                issuerBaseUrl: "https://issuer.example.com",
+                idTokenSigningAlg: "RS256"
             });
 
             vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: false,
-                issuerBaseUrl: "https://issuer.example.com"
+                issuerBaseUrl: "https://issuer.example.com",
+                idTokenSigningAlg: "RS256"
             });
         });
 
@@ -535,8 +541,125 @@ describe("open_id", () => {
             mfa.oauthIssuerBaseUrl = "";
             const fetchSpy = mockFetch(() => ({ ok: true, json: () => Promise.resolve({}) }));
 
-            expect(await openID.probeDiscovery()).toEqual({ endSessionSupported: false, issuerBaseUrl: "" });
+            expect(await openID.probeDiscovery()).toEqual({
+                endSessionSupported: false,
+                issuerBaseUrl: "",
+                idTokenSigningAlg: "RS256"
+            });
             expect(fetchSpy).not.toHaveBeenCalled();
+        });
+
+        it("reports the signing algorithm the issuer advertises", async () => {
+            // Pocket ID with an Ed25519 key (discussion 6318): RS256 is not on offer at all, so expecting it is
+            // what produced "unexpected JWT alg received, expected RS256, got: EdDSA".
+            setOauthConfig(true);
+            mockFetch(() => ({
+                ok: true,
+                json: () => Promise.resolve({
+                    issuer: "https://issuer.example.com",
+                    id_token_signing_alg_values_supported: ["EdDSA"]
+                })
+            }));
+
+            expect((await openID.probeDiscovery()).idTokenSigningAlg).toBe("EdDSA");
+        });
+    });
+
+    /**
+     * Cover for https://github.com/orgs/TriliumNext/discussions/6318: express-openid-connect defaults
+     * `idTokenSigningAlg` to RS256 and hands it to openid-client as the client's registered
+     * `id_token_signed_response_alg`, which is then enforced on every ID token. Trilium never set it, so
+     * any provider signing with something else — Pocket ID and Kanidm sign Ed25519 by default — failed
+     * the round-trip outright.
+     */
+    describe("resolveIdTokenSigningAlg", () => {
+        it("keeps RS256 unless the issuer rules it out", () => {
+            setOauthConfig(true);
+
+            // No document, an unusable one, or one that says nothing about signing: the OIDC Core
+            // default stands, so nothing changes for a deployment that works today.
+            expect(resolveIdTokenSigningAlg(null)).toBe("RS256");
+            expect(resolveIdTokenSigningAlg("not an object")).toBe("RS256");
+            expect(resolveIdTokenSigningAlg({})).toBe("RS256");
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: "RS256" })).toBe("RS256");
+
+            // Advertised alongside others, in any position — RS256 is preferred whenever it is on offer,
+            // so a provider that supports both keeps signing exactly as it does today.
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["RS256", "EdDSA"] })).toBe("RS256");
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["EdDSA", "ES256", "RS256"] })).toBe("RS256");
+        });
+
+        it("adopts the issuer's algorithm when RS256 is not offered", () => {
+            setOauthConfig(true);
+            const logSpy = vi.spyOn(getLog(), "info").mockImplementation(() => {});
+
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["EdDSA"] })).toBe("EdDSA");
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("EdDSA"));
+            // First advertised wins among several; providers list their own preference first.
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["ES256", "EdDSA"] })).toBe("ES256");
+
+            // "none" would leave ID tokens unsigned, and express-openid-connect's schema rejects it —
+            // passing it through would take the whole OIDC round-trip down at build time.
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["none"] })).toBe("RS256");
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["none", "EdDSA"] })).toBe("EdDSA");
+            // Junk entries are ignored rather than handed on as an algorithm.
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: [null, "", 256, "EdDSA"] })).toBe("EdDSA");
+        });
+
+        it("lets an explicit oauthIdTokenSigningAlg override discovery", () => {
+            setOauthConfig(true);
+
+            // The escape hatch for a provider that misadvertises, in both directions.
+            mfa.oauthIdTokenSigningAlg = "  EdDSA  ";
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["RS256"] })).toBe("EdDSA");
+            mfa.oauthIdTokenSigningAlg = "RS512";
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["EdDSA"] })).toBe("RS512");
+
+            // ...but not into accepting unsigned ID tokens: that is logged and ignored, leaving
+            // discovery to answer, rather than reaching express-openid-connect's schema (which rejects
+            // "none" and would take the OIDC round-trip down at build time).
+            const logSpy = vi.spyOn(getLog(), "error").mockImplementation(() => {});
+            mfa.oauthIdTokenSigningAlg = "none";
+            expect(resolveIdTokenSigningAlg({ id_token_signing_alg_values_supported: ["EdDSA"] })).toBe("EdDSA");
+            expect(resolveIdTokenSigningAlg(null)).toBe("RS256");
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("none"));
+        });
+
+        /**
+         * The other half of the loop. The cases above pin what Trilium *resolves*; these pin that the
+         * resolved value is what openid-client then accepts, by running a real authorization-code
+         * exchange against a provider that genuinely signs Ed25519 — the Pocket ID shape from the report.
+         */
+        describe("against a real Ed25519-signing provider", () => {
+            it("rejects the ID token while the client expects RS256", async () => {
+                // The reported failure, reproduced end to end: the token is validly signed and the
+                // signature verifies, but the client is registered as expecting an algorithm the issuer
+                // does not use, so the exchange is refused before any claim is read.
+                expect(await eddsaIdTokenOutcome(DEFAULT_ID_TOKEN_SIGNING_ALG))
+                    .toContain('unexpected JWT "alg" header parameter');
+            });
+
+            it("accepts it once the expected algorithm is the issuer's", async () => {
+                expect(await eddsaIdTokenOutcome("EdDSA")).toBe("accepted");
+            });
+
+            it("resolves, from that provider's own discovery document, an algorithm that is accepted", async () => {
+                setOauthConfig(true);
+                const pocketId = { id_token_signing_alg_values_supported: ["EdDSA"] };
+                expect(await eddsaIdTokenOutcome(resolveIdTokenSigningAlg(pocketId))).toBe("accepted");
+            });
+        });
+
+        it("closes the loop: the resolved algorithm is what reaches express-openid-connect", () => {
+            setOauthConfig(true);
+
+            // Unset, the library would silently apply its RS256 default — the bug.
+            expect(openID.generateOAuthConfig().idTokenSigningAlg).toBe("RS256");
+            expect(openID.generateOAuthConfig(false, mfa.oauthIssuerBaseUrl, "EdDSA").idTokenSigningAlg).toBe("EdDSA");
+
+            // A configured value applies even to callers that never probed discovery.
+            mfa.oauthIdTokenSigningAlg = "ES256";
+            expect(openID.generateOAuthConfig().idTokenSigningAlg).toBe("ES256");
         });
     });
 
@@ -677,7 +800,8 @@ describe("createReactiveOidcMiddleware", () => {
         const buildAuth = vi.fn(() => oidcHandler);
         const probeDiscovery = vi.fn().mockResolvedValue({
             endSessionSupported: false,
-            issuerBaseUrl: PROBED_ISSUER
+            issuerBaseUrl: PROBED_ISSUER,
+            idTokenSigningAlg: "RS256"
         });
         const generateOAuthConfig = vi.fn((endSessionSupported: boolean) => ({ endSessionSupported }) as never);
         const isConfigured = vi.fn(() => configured);
@@ -731,7 +855,7 @@ describe("createReactiveOidcMiddleware", () => {
         const { req, res, next } = await run(t.middleware);
 
         expect(t.probeDiscovery).toHaveBeenCalledOnce();
-        expect(t.generateOAuthConfig).toHaveBeenCalledWith(false, PROBED_ISSUER);
+        expect(t.generateOAuthConfig).toHaveBeenCalledWith(false, PROBED_ISSUER, "RS256");
         expect(t.buildAuth).toHaveBeenCalledOnce();
         expect(t.oidcHandler).toHaveBeenCalledWith(req, res, expect.any(Function));
         // The wrapper must hand off to the OIDC handler and NOT call next() itself — calling it again
@@ -752,19 +876,21 @@ describe("createReactiveOidcMiddleware", () => {
         expect(t.oidcHandler).toHaveBeenCalledTimes(2);
     });
 
-    it("passes both discovery-probe results into the OAuth config", async () => {
+    it("passes every discovery-probe result into the OAuth config", async () => {
         const t = setup();
         // The issuer reaching express-openid-connect is the probe's, not whatever sits in config — that
-        // indirection is what lets a trailing-slash difference be reconciled (#10695).
+        // indirection is what lets a trailing-slash difference be reconciled (#10695). The signing
+        // algorithm travels the same way, so a non-RS256 provider is honoured (discussion 6318).
         t.probeDiscovery.mockResolvedValue({
             endSessionSupported: true,
-            issuerBaseUrl: "https://sso.example.com/application/o/trilium-app/"
+            issuerBaseUrl: "https://sso.example.com/application/o/trilium-app/",
+            idTokenSigningAlg: "EdDSA"
         });
         t.setConfigured(true);
 
         await run(t.middleware);
 
-        expect(t.generateOAuthConfig).toHaveBeenCalledWith(true, "https://sso.example.com/application/o/trilium-app/");
+        expect(t.generateOAuthConfig).toHaveBeenCalledWith(true, "https://sso.example.com/application/o/trilium-app/", "EdDSA");
     });
 
     // This is the regression the whole change exists to fix: with the old startup-only mount, flipping
@@ -805,13 +931,13 @@ describe("createReactiveOidcMiddleware", () => {
 
         // A deferred discovery probe keeps the first build in flight while a second request arrives,
         // exercising the in-flight-init guard (otherwise both requests would each build a handler).
-        type Probe = { endSessionSupported: boolean; issuerBaseUrl: string };
+        type Probe = { endSessionSupported: boolean; issuerBaseUrl: string; idTokenSigningAlg: string };
         let resolveProbe: (value: Probe) => void = () => {};
         t.probeDiscovery.mockReturnValue(new Promise<Probe>((resolve) => { resolveProbe = resolve; }));
 
         const first = run(t.middleware);
         const second = run(t.middleware);
-        resolveProbe({ endSessionSupported: false, issuerBaseUrl: PROBED_ISSUER });
+        resolveProbe({ endSessionSupported: false, issuerBaseUrl: PROBED_ISSUER, idTokenSigningAlg: "RS256" });
         await Promise.all([first, second]);
 
         expect(t.buildAuth).toHaveBeenCalledOnce();
@@ -1031,4 +1157,84 @@ async function discoveryOutcome(configuredIssuer: string, advertisedIssuer: stri
     } catch (error) {
         return (error as { code?: string })?.code ?? String(error);
     }
+}
+
+/** The issuer the {@link eddsaIdTokenOutcome} stub provider answers as. */
+const EDDSA_ISSUER = "https://issuer.example.com";
+const EDDSA_CLIENT_ID = "client-id";
+
+/**
+ * Runs a full authorization-code exchange against a stub provider that signs its ID token with Ed25519,
+ * with the client registered as expecting `expectedAlg` — which is precisely what express-openid-connect
+ * hands openid-client as `id_token_signed_response_alg`. Returns `"accepted"`, or the error message a
+ * user would see in the log.
+ *
+ * Like {@link discoveryOutcome} this drives the real openid-client over a `customFetch` transport, so the
+ * assertions are about the library's actual behaviour rather than a re-implementation of it — but here
+ * the token is genuinely signed and genuinely verified against the served JWKS, so a wrong `expectedAlg`
+ * fails for the real reason instead of a stubbed one. Ed25519 comes from node's own crypto, so no
+ * dependency (and no Pocket ID container) is needed to reproduce the report.
+ */
+async function eddsaIdTokenOutcome(expectedAlg: string) {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const jwks = { keys: [{ ...publicKey.export({ format: "jwk" }), kid: "ed25519-1", alg: "EdDSA", use: "sig" }] };
+
+    const now = Math.floor(Date.now() / 1000);
+    const idToken = signEdDsaJwt(privateKey, {
+        iss: EDDSA_ISSUER,
+        aud: EDDSA_CLIENT_ID,
+        sub: "user-1",
+        iat: now,
+        exp: now + 300
+    });
+
+    const json = (body: unknown) => new Response(
+        JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } }
+    );
+    // One transport serves all three legs of the exchange: discovery, the JWKS the signature is verified
+    // against, and the token endpoint that returns the signed ID token.
+    const serveProvider: CustomFetch = async (url) => {
+        const path = new URL(url.toString()).pathname;
+        if (path.endsWith("/jwks")) {
+            return json(jwks);
+        }
+        if (path.endsWith("/token")) {
+            return json({ access_token: "access-token", token_type: "bearer", id_token: idToken });
+        }
+        return json({
+            issuer: EDDSA_ISSUER,
+            authorization_endpoint: `${EDDSA_ISSUER}/authorize`,
+            token_endpoint: `${EDDSA_ISSUER}/token`,
+            jwks_uri: `${EDDSA_ISSUER}/jwks`,
+            response_types_supported: ["code"],
+            // The Pocket ID shape once its key has been rotated to Ed25519: RS256 is not on offer at all.
+            id_token_signing_alg_values_supported: ["EdDSA"]
+        });
+    };
+
+    const configuration = await discovery(
+        new URL(EDDSA_ISSUER),
+        EDDSA_CLIENT_ID,
+        { id_token_signed_response_alg: expectedAlg },
+        ClientSecretPost("client-secret"),
+        { [customFetch]: serveProvider }
+    );
+
+    try {
+        await authorizationCodeGrant(configuration, new URL("https://app.example.com/callback?code=auth-code"), {});
+        return "accepted";
+    } catch (error) {
+        // openid-client reports this as a bare "invalid response encountered" and puts the actual reason
+        // on `.cause`. describeError is what unwraps that chain for the log line and the toast the user
+        // gets (see failRoundTrip), so asserting on its output pins the message they would actually see.
+        return describeError(error) ?? String(error);
+    }
+}
+
+/** Signs `claims` as a compact EdDSA JWS. Node signs Ed25519 with a null digest (RFC 8032). */
+function signEdDsaJwt(privateKey: KeyObject, claims: Record<string, unknown>) {
+    const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+    const signingInput = `${encode({ alg: "EdDSA", typ: "JWT", kid: "ed25519-1" })}.${encode(claims)}`;
+    const signature = sign(null, Buffer.from(signingInput), privateKey).toString("base64url");
+    return `${signingInput}.${signature}`;
 }

--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -492,7 +492,8 @@ describe("open_id", () => {
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: true,
                 issuerBaseUrl: "https://issuer.example.com",
-                idTokenSigningAlg: "RS256"
+                idTokenSigningAlg: "RS256",
+                metadataAvailable: true
             });
             expect(fetchSpy).toHaveBeenCalledWith(wellKnownUrl, expect.anything());
         });
@@ -525,14 +526,16 @@ describe("open_id", () => {
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: false,
                 issuerBaseUrl: "https://issuer.example.com",
-                idTokenSigningAlg: "RS256"
+                idTokenSigningAlg: "RS256",
+                metadataAvailable: false
             });
 
             vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: false,
                 issuerBaseUrl: "https://issuer.example.com",
-                idTokenSigningAlg: "RS256"
+                idTokenSigningAlg: "RS256",
+                metadataAvailable: false
             });
         });
 
@@ -544,7 +547,8 @@ describe("open_id", () => {
             expect(await openID.probeDiscovery()).toEqual({
                 endSessionSupported: false,
                 issuerBaseUrl: "",
-                idTokenSigningAlg: "RS256"
+                idTokenSigningAlg: "RS256",
+                metadataAvailable: false
             });
             expect(fetchSpy).not.toHaveBeenCalled();
         });
@@ -801,7 +805,8 @@ describe("createReactiveOidcMiddleware", () => {
         const probeDiscovery = vi.fn().mockResolvedValue({
             endSessionSupported: false,
             issuerBaseUrl: PROBED_ISSUER,
-            idTokenSigningAlg: "RS256"
+            idTokenSigningAlg: "RS256",
+            metadataAvailable: true
         });
         const generateOAuthConfig = vi.fn((endSessionSupported: boolean) => ({ endSessionSupported }) as never);
         const isConfigured = vi.fn(() => configured);
@@ -864,6 +869,47 @@ describe("createReactiveOidcMiddleware", () => {
         expect(next).toHaveBeenCalledOnce();
     });
 
+    /**
+     * A probe that couldn't reach the issuer returns fallbacks, not answers — and `auth()` performs no
+     * discovery of its own (it only validates config and builds a router), so the build succeeds and
+     * nothing downstream notices. Caching that would freeze the RS256 fallback into the config object
+     * for the life of the process: a provider signing EdDSA would then reject every valid ID token until
+     * a restart, re-creating the very failure this resolution exists to prevent. The library recovers
+     * from the same blip by itself, so the handler must be rebuilt rather than pinned.
+     */
+    it("does not cache a handler built without the provider's discovery document", async () => {
+        const t = setup();
+        t.probeDiscovery.mockResolvedValueOnce({
+            endSessionSupported: false,
+            issuerBaseUrl: PROBED_ISSUER,
+            idTokenSigningAlg: "RS256",
+            metadataAvailable: false
+        });
+        t.probeDiscovery.mockResolvedValue({
+            endSessionSupported: true,
+            issuerBaseUrl: PROBED_ISSUER,
+            idTokenSigningAlg: "EdDSA",
+            metadataAvailable: true
+        });
+        t.setConfigured(true);
+
+        // The degraded build still serves its own request rather than failing it — a blip must not break
+        // a sign-in the library itself may well complete.
+        await run(t.middleware);
+        expect(t.oidcHandler).toHaveBeenCalledOnce();
+        expect(t.generateOAuthConfig).toHaveBeenLastCalledWith(false, PROBED_ISSUER, "RS256");
+
+        // Once discovery recovers, the real algorithm takes effect without a restart...
+        await run(t.middleware);
+        expect(t.probeDiscovery).toHaveBeenCalledTimes(2);
+        expect(t.generateOAuthConfig).toHaveBeenLastCalledWith(true, PROBED_ISSUER, "EdDSA");
+
+        // ...and that build, made from a document that was actually read, is the one that gets cached.
+        await run(t.middleware);
+        expect(t.probeDiscovery).toHaveBeenCalledTimes(2);
+        expect(t.buildAuth).toHaveBeenCalledTimes(2);
+    });
+
     it("builds the underlying handler only once across requests (cached)", async () => {
         const t = setup();
         t.setConfigured(true);
@@ -884,7 +930,8 @@ describe("createReactiveOidcMiddleware", () => {
         t.probeDiscovery.mockResolvedValue({
             endSessionSupported: true,
             issuerBaseUrl: "https://sso.example.com/application/o/trilium-app/",
-            idTokenSigningAlg: "EdDSA"
+            idTokenSigningAlg: "EdDSA",
+            metadataAvailable: true
         });
         t.setConfigured(true);
 
@@ -931,13 +978,23 @@ describe("createReactiveOidcMiddleware", () => {
 
         // A deferred discovery probe keeps the first build in flight while a second request arrives,
         // exercising the in-flight-init guard (otherwise both requests would each build a handler).
-        type Probe = { endSessionSupported: boolean; issuerBaseUrl: string; idTokenSigningAlg: string };
+        type Probe = {
+            endSessionSupported: boolean;
+            issuerBaseUrl: string;
+            idTokenSigningAlg: string;
+            metadataAvailable: boolean;
+        };
         let resolveProbe: (value: Probe) => void = () => {};
         t.probeDiscovery.mockReturnValue(new Promise<Probe>((resolve) => { resolveProbe = resolve; }));
 
         const first = run(t.middleware);
         const second = run(t.middleware);
-        resolveProbe({ endSessionSupported: false, issuerBaseUrl: PROBED_ISSUER, idTokenSigningAlg: "RS256" });
+        resolveProbe({
+            endSessionSupported: false,
+            issuerBaseUrl: PROBED_ISSUER,
+            idTokenSigningAlg: "RS256",
+            metadataAvailable: true
+        });
         await Promise.all([first, second]);
 
         expect(t.buildAuth).toHaveBeenCalledOnce();

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -146,7 +146,8 @@ const OIDC_ROUTES = {
 
 function generateOAuthConfig(
     endSessionSupported = false,
-    issuerBaseUrl = config.MultiFactorAuthentication.oauthIssuerBaseUrl
+    issuerBaseUrl = config.MultiFactorAuthentication.oauthIssuerBaseUrl,
+    idTokenSigningAlg = resolveIdTokenSigningAlg(null)
 ) {
     const logoutParams = {
     };
@@ -163,6 +164,10 @@ function generateOAuthConfig(
         secret: config.MultiFactorAuthentication.oauthClientSecret,
         clientSecret: config.MultiFactorAuthentication.oauthClientSecret,
         clientAuthMethod: resolveClientAuthMethod(),
+        // Also not read straight from config: express-openid-connect hardcodes RS256 unless told
+        // otherwise, so this comes from the discovery probe via resolveIdTokenSigningAlg. Defaulted for
+        // callers that don't probe.
+        idTokenSigningAlg,
         authorizationParams: {
             response_type: "code",
             scope: "openid profile email",
@@ -265,7 +270,7 @@ interface ReactiveOidcDeps {
     /** Discovery probe supplying the issuer identifier and RP-Initiated Logout support. */
     probeDiscovery: () => Promise<DiscoveryProbe>;
     /** Builds the express-openid-connect config for the current provider settings. */
-    generateOAuthConfig: (endSessionSupported: boolean, issuerBaseUrl: string) => Parameters<AuthBuilder>[0];
+    generateOAuthConfig: (endSessionSupported: boolean, issuerBaseUrl: string, idTokenSigningAlg: string) => Parameters<AuthBuilder>[0];
     /** The express-openid-connect `auth()` factory (injectable so the middleware is unit-testable). */
     buildAuth: AuthBuilder;
 }
@@ -308,8 +313,8 @@ export function createReactiveOidcMiddleware(deps: Partial<ReactiveOidcDeps> = {
                 // OAuth unselected. The sole static reference to the package is the erased `Session` type
                 // import, so the bundler keeps it out of the eager-init graph (see scripts/build-utils.ts).
                 const authFactory = buildAuth ?? (await import("express-openid-connect")).auth;
-                const { endSessionSupported, issuerBaseUrl } = await probe();
-                oidcMiddleware = authFactory(buildOAuthConfig(endSessionSupported, issuerBaseUrl));
+                const { endSessionSupported, issuerBaseUrl, idTokenSigningAlg } = await probe();
+                oidcMiddleware = authFactory(buildOAuthConfig(endSessionSupported, issuerBaseUrl, idTokenSigningAlg));
             })();
             try {
                 await oidcInit;
@@ -421,17 +426,21 @@ interface DiscoveryProbe {
     endSessionSupported: boolean;
     /** The issuer to hand express-openid-connect — see {@link reconcileIssuerBaseUrl}. */
     issuerBaseUrl: string;
+    /** The ID token signature algorithm to expect — see {@link resolveIdTokenSigningAlg}. */
+    idTokenSigningAlg: string;
 }
 
 /**
- * Probes the configured OIDC issuer's discovery document for the two facts that must be settled before
- * express-openid-connect can be built: whether RP-Initiated Logout is available, and which spelling of
- * the issuer identifier the provider actually advertises. The issuer is fixed in config.ini/env and only
- * changes on restart, so this is resolved once at first use rather than per request.
+ * Probes the configured OIDC issuer's discovery document for the facts that must be settled before
+ * express-openid-connect can be built: whether RP-Initiated Logout is available, which spelling of the
+ * issuer identifier the provider actually advertises, and which algorithm it signs ID tokens with. The
+ * issuer is fixed in config.ini/env and only changes on restart, so this is resolved once at first use
+ * rather than per request.
  *
- * Any fetch/parse failure degrades to the configured issuer with logout support off, leaving a transient
- * network blip to break neither sign-in (express-openid-connect runs its own discovery, which either
- * succeeds or reports the real error) nor logout (which falls back to clearing the local session).
+ * Any fetch/parse failure degrades to the configured issuer with logout support off and the RS256
+ * default, leaving a transient network blip to break neither sign-in (express-openid-connect runs its
+ * own discovery, which either succeeds or reports the real error) nor logout (which falls back to
+ * clearing the local session).
  */
 async function probeDiscovery(): Promise<DiscoveryProbe> {
     const configuredIssuer = config.MultiFactorAuthentication.oauthIssuerBaseUrl;
@@ -439,7 +448,8 @@ async function probeDiscovery(): Promise<DiscoveryProbe> {
 
     return {
         endSessionSupported: supportsRpInitiatedLogout(metadata),
-        issuerBaseUrl: reconcileIssuerBaseUrl(configuredIssuer, readAdvertisedIssuer(metadata))
+        issuerBaseUrl: reconcileIssuerBaseUrl(configuredIssuer, readAdvertisedIssuer(metadata)),
+        idTokenSigningAlg: resolveIdTokenSigningAlg(metadata)
     };
 }
 
@@ -479,6 +489,7 @@ async function fetchDiscoveryMetadata(configuredIssuer: string): Promise<unknown
 interface OidcDiscoveryMetadata {
     end_session_endpoint?: string;
     issuer?: string;
+    id_token_signing_alg_values_supported?: unknown;
 }
 
 function readAdvertisedIssuer(metadata: unknown) {
@@ -546,6 +557,63 @@ export function supportsRpInitiatedLogout(metadata: unknown) {
     }
     const { end_session_endpoint } = metadata as OidcDiscoveryMetadata;
     return typeof end_session_endpoint === "string" && end_session_endpoint.length > 0;
+}
+
+/**
+ * What express-openid-connect assumes when `idTokenSigningAlg` is left unset, and what OIDC Core
+ * requires every provider to support — so it stays the fallback whenever discovery can't tell us better.
+ */
+export const DEFAULT_ID_TOKEN_SIGNING_ALG = "RS256";
+
+/**
+ * Picks the JWS algorithm to expect on ID tokens.
+ *
+ * express-openid-connect defaults `idTokenSigningAlg` to RS256 and passes it to openid-client as the
+ * client's registered `id_token_signed_response_alg`, which is then enforced on every ID token. Trilium
+ * never set it, so a provider signing with anything else failed the round-trip with
+ * "unexpected JWT alg received, expected RS256, got: EdDSA"
+ * (https://github.com/orgs/TriliumNext/discussions/6318). RS256 is merely the *legacy* default: Pocket
+ * ID and Kanidm sign with Ed25519 by default, and others offer ES256.
+ *
+ * The provider already publishes the answer as `id_token_signing_alg_values_supported`, so it is read
+ * from the discovery probe rather than demanded from the user. RS256 wins whenever it's advertised —
+ * that keeps every currently-working deployment on exactly the algorithm it uses today, and the fallback
+ * only engages for the providers that don't offer RS256 at all, which are precisely the broken ones.
+ * `none` is skipped: unsigned ID tokens are not acceptable here (and express-openid-connect's own schema
+ * rejects the value outright, which would take the OIDC round-trip down at build time).
+ *
+ * `oauthIdTokenSigningAlg` overrides all of it, for a provider that misadvertises or signs with an
+ * algorithm we'd rank differently.
+ */
+export function resolveIdTokenSigningAlg(metadata: unknown): string {
+    const configured = config.MultiFactorAuthentication.oauthIdTokenSigningAlg.trim();
+    if (configured) {
+        if (configured.toLowerCase() !== "none") {
+            return configured;
+        }
+        getLog().error(`OAuth: ignoring oauthIdTokenSigningAlg '${configured}' — unsigned ID tokens are not supported.`);
+    }
+
+    const advertised = readAdvertisedSigningAlgs(metadata);
+    if (advertised.length === 0 || advertised.includes(DEFAULT_ID_TOKEN_SIGNING_ALG)) {
+        return DEFAULT_ID_TOKEN_SIGNING_ALG;
+    }
+
+    const [preferred] = advertised;
+    getLog().info(`OAuth: the issuer does not sign ID tokens with ${DEFAULT_ID_TOKEN_SIGNING_ALG}; expecting ${preferred} (advertised: ${advertised.join(", ")}).`);
+    return preferred;
+}
+
+/** The usable entries of `id_token_signing_alg_values_supported`, or an empty list if there are none. */
+function readAdvertisedSigningAlgs(metadata: unknown): string[] {
+    if (typeof metadata !== "object" || metadata === null) {
+        return [];
+    }
+    const advertised = (metadata as OidcDiscoveryMetadata).id_token_signing_alg_values_supported;
+    if (!Array.isArray(advertised)) {
+        return [];
+    }
+    return advertised.filter((alg): alg is string => typeof alg === "string" && alg !== "" && alg.toLowerCase() !== "none");
 }
 
 export const CLIENT_AUTH_METHODS = ["client_secret_basic", "client_secret_post"] as const;

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -298,7 +298,7 @@ export function createReactiveOidcMiddleware(deps: Partial<ReactiveOidcDeps> = {
     } = deps;
 
     let oidcMiddleware: RequestHandler | null = null;
-    let oidcInit: Promise<void> | null = null;
+    let oidcInit: Promise<RequestHandler> | null = null;
 
     return async (req: Request, res: Response, next: NextFunction) => {
         // OAuth not selected as the sign-in method → behave as if the middleware were never mounted.
@@ -306,24 +306,51 @@ export function createReactiveOidcMiddleware(deps: Partial<ReactiveOidcDeps> = {
             return next();
         }
 
-        if (!oidcMiddleware) {
-            oidcInit ??= (async () => {
+        let handler = oidcMiddleware;
+        if (!handler) {
+            const init = (oidcInit ??= (async () => {
                 // Load express-openid-connect lazily so the (heavy) library and its transitive deps are
                 // only evaluated the first time OAuth is actually used, never on a server that runs with
                 // OAuth unselected. The sole static reference to the package is the erased `Session` type
                 // import, so the bundler keeps it out of the eager-init graph (see scripts/build-utils.ts).
                 const authFactory = buildAuth ?? (await import("express-openid-connect")).auth;
-                const { endSessionSupported, issuerBaseUrl, idTokenSigningAlg } = await probe();
-                oidcMiddleware = authFactory(buildOAuthConfig(endSessionSupported, issuerBaseUrl, idTokenSigningAlg));
-            })();
+                const { endSessionSupported, issuerBaseUrl, idTokenSigningAlg, metadataAvailable } = await probe();
+                const built = authFactory(buildOAuthConfig(endSessionSupported, issuerBaseUrl, idTokenSigningAlg));
+
+                // Only commit to the handler when the probe actually read the provider's document.
+                //
+                // A probe that couldn't reach the issuer degrades to fallbacks rather than throwing (see
+                // probeDiscovery), and `auth()` does not itself perform discovery — it only validates
+                // config and builds a router — so the build succeeds and nothing here would notice. The
+                // library recovers from the same blip on its own (it discovers per request, behind a
+                // cache it drops on failure), but these values are frozen into the config object handed
+                // to `auth()`. Caching them would outlive the blip: a provider that signs EdDSA would be
+                // pinned to the RS256 fallback and reject every valid ID token until a restart — exactly
+                // the failure this resolution exists to prevent.
+                if (metadataAvailable) {
+                    oidcMiddleware = built;
+                }
+                return built;
+            })());
+
             try {
-                await oidcInit;
+                handler = await init;
             } catch (error) {
-                // Reset so the next request can retry — otherwise a single failed init (transient
-                // discovery-probe failure, malformed config, etc.) would leave the rejected promise
+                // Reset so the next request can retry — otherwise a single failed init (a malformed
+                // config `auth()` rejects, an import failure, etc.) would leave the rejected promise
                 // cached and break every subsequent OAuth request until a server restart.
-                oidcInit = null;
+                if (oidcInit === init) {
+                    oidcInit = null;
+                }
                 return failRoundTrip(req, res, next, error);
+            }
+
+            // Settled, so drop the in-flight guard — its only job is to make concurrent first requests
+            // share one build. When the probe read the document `oidcMiddleware` now holds the handler
+            // and this is never consulted again; when it didn't, the next request re-probes. The identity
+            // check keeps a request from clearing a *newer* build's guard.
+            if (oidcInit === init) {
+                oidcInit = null;
             }
         }
 
@@ -331,14 +358,14 @@ export function createReactiveOidcMiddleware(deps: Partial<ReactiveOidcDeps> = {
         // (sends a response/redirect or calls next() itself) and returns undefined. We must NOT call
         // next() ourselves afterwards — doing so double-invokes the downstream pipeline and triggers
         // "Cannot set headers after they are sent". The guard only covers a failed build.
-        if (!oidcMiddleware) {
+        if (!handler) {
             return next();
         }
 
         // The library reports a broken round-trip by calling next(err) rather than by rejecting, so the
         // interception has to happen on `next` — a try/catch around this call would never see it. A bare
         // next() (the pass-through for non-OIDC routes) must still propagate untouched.
-        return oidcMiddleware(req, res, (error?: unknown) => {
+        return handler(req, res, (error?: unknown) => {
             if (!error) {
                 return next();
             }
@@ -428,6 +455,12 @@ interface DiscoveryProbe {
     issuerBaseUrl: string;
     /** The ID token signature algorithm to expect — see {@link resolveIdTokenSigningAlg}. */
     idTokenSigningAlg: string;
+    /**
+     * Whether the provider's discovery document was actually read. False means every field above is a
+     * fallback rather than an answer, which is what stops {@link createReactiveOidcMiddleware} from
+     * caching a handler built from it.
+     */
+    metadataAvailable: boolean;
 }
 
 /**
@@ -440,7 +473,8 @@ interface DiscoveryProbe {
  * Any fetch/parse failure degrades to the configured issuer with logout support off and the RS256
  * default, leaving a transient network blip to break neither sign-in (express-openid-connect runs its
  * own discovery, which either succeeds or reports the real error) nor logout (which falls back to
- * clearing the local session).
+ * clearing the local session). Such a result is flagged `metadataAvailable: false` so the caller can
+ * tell a fallback from an answer and decline to cache it — see {@link createReactiveOidcMiddleware}.
  */
 async function probeDiscovery(): Promise<DiscoveryProbe> {
     const configuredIssuer = config.MultiFactorAuthentication.oauthIssuerBaseUrl;
@@ -449,7 +483,8 @@ async function probeDiscovery(): Promise<DiscoveryProbe> {
     return {
         endSessionSupported: supportsRpInitiatedLogout(metadata),
         issuerBaseUrl: reconcileIssuerBaseUrl(configuredIssuer, readAdvertisedIssuer(metadata)),
-        idTokenSigningAlg: resolveIdTokenSigningAlg(metadata)
+        idTokenSigningAlg: resolveIdTokenSigningAlg(metadata),
+        metadataAvailable: metadata !== null
     };
 }
 


### PR DESCRIPTION
## Problem

OIDC sign-in fails outright against any provider that does not sign ID tokens with **RS256**. Reported by several users in [discussion #6318](https://github.com/orgs/TriliumNext/discussions/6318):

```
unexpected JWT alg received, expected RS256, got: EdDSA
```

`express-openid-connect` defaults `idTokenSigningAlg` to RS256 and hands it to openid-client as the client's registered `id_token_signed_response_alg`, which is then enforced on every ID token. Trilium never set the option, so it hardcoded RS256 by omission.

RS256 is only the *legacy* default — **Pocket ID** signs Ed25519 once its key is rotated, and **Kanidm** signs ES256 by default (its `warning-enable-legacy-crypto` switch exists precisely to fall back to RS256 for clients like ours).

There was no provider-side workaround. `checkSigningAlgorithm` in oauth4webapi tries three things in order: the client's registered algorithm, then the issuer's advertised list, then an RS256 fallback. Because express-openid-connect's schema *always* populates the first, the permissive middle path is unreachable.

> Note the message has moved on: `unexpected JWT alg received, expected RS256, got: EdDSA` is openid-client **v5** phrasing. On current Trilium (express-openid-connect 3.3.0 → openid-client 6.8.4) the same defect reads `unexpected JWT "alg" header parameter`. Reports under both strings are the same bug.

## Fix

The provider already publishes the answer, so read it rather than demand it. `id_token_signing_alg_values_supported` now comes off the **same discovery probe** that already reconciles the issuer (#10695) and detects `end_session_endpoint`.

- **RS256 wins whenever the issuer advertises it**, so every deployment that works today keeps the exact algorithm it uses now. The fallback only engages for providers that don't offer RS256 at all — precisely the broken ones.
- `none` is filtered out: unsigned ID tokens aren't acceptable, and the value fails express-openid-connect's own schema, which would take the round-trip down at build time.
- Escape hatch for a provider that misadvertises: **`oauthIdTokenSigningAlg`** / `TRILIUM_OAUTH_ID_TOKEN_SIGNING_ALG`, documented in `config-sample.ini`.

This is the third casualty of the express-openid-connect 2.20.2 → 3.2.0 bump, after #10585 (GitLab, client auth method) and #10695 (Authentik, issuer trailing slash), and follows the same shape as both fixes.

## Testing

Written test-first, and verified red → green: with the resolver forced back to its pre-fix behaviour the new test fails with the reported symptom, surfaced through the same `describeError` path the user's log uses:

```
invalid response encountered [OAUTH_INVALID_RESPONSE]
  ← caused by: unexpected JWT "alg" header parameter [OAUTH_INVALID_RESPONSE]
```

The tests drive the **real openid-client** through a full authorization-code exchange against a stub provider that **genuinely signs Ed25519** — node's own `crypto`, so no new dependency and no container is needed to reproduce the report. One `customFetch` serves discovery, the JWKS the signature is verified against, and the token endpoint. Three cases pin the contract end to end:

- expecting RS256 against an EdDSA-signed token reproduces the failure,
- expecting EdDSA accepts it,
- the algorithm Trilium resolves *from that provider's own discovery document* is one openid-client accepts.

Plus unit cover for the resolver itself (RS256 preference in any list position, `none` and junk entries, the config override) and for the value reaching express-openid-connect.

Full `server` suite green (4909 passed), `tsc --noEmit` clean on both the app and spec projects.

> ESLint could not be run: `eslint.config.mjs` imports `@stylistic/eslint-plugin`, which is declared neither in `package.json` nor in the lockfile, so `pnpm dev:linter-check` fails on a clean install of `main` too. Pre-existing and unrelated to this change.

## Follow-up (not in this PR)

The User Guide page on OpenID Connect should mention the new setting — it's edited via `pnpm edit-docs:edit-docs` rather than by hand, so it's left out here deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
