### PR TITLE
fix(oauth): honour an OIDC issuer configured as an explicit .well-known URL

### DIFF
--- a/apps/server/src/services/open_id.spec.ts
+++ b/apps/server/src/services/open_id.spec.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { describeError } from "../routes/error_handlers.js";
 import config from "./config.js";
 import openIDEncryption from "./encryption/open_id_encryption.js";
-import openID, { createReactiveOidcMiddleware, DEFAULT_ID_TOKEN_SIGNING_ALG, reconcileIssuerBaseUrl, resolveClientAuthMethod, resolveIdTokenSigningAlg, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
+import openID, { createReactiveOidcMiddleware, DEFAULT_ID_TOKEN_SIGNING_ALG, discoveryUrlFor, reconcileIssuerBaseUrl, resolveClientAuthMethod, resolveIdTokenSigningAlg, resolveOAuthIdentity, supportsRpInitiatedLogout } from "./open_id.js";
 import sql from "./sql.js";
 import sqlInit from "./sql_init.js";
 
@@ -553,6 +553,40 @@ describe("open_id", () => {
             expect(fetchSpy).not.toHaveBeenCalled();
         });
 
+        /**
+         * An issuer configured as an explicit `.well-known` URL — the documented way out of Authentik's
+         * "global" issuer mode (see reconcileIssuerBaseUrl), and what a user reported having to undo.
+         *
+         * openid-client uses such a URL as-is, so sign-in worked while the probe was advisory: appending
+         * a second `.well-known` 404'd, and the only casualty was RP-Initiated Logout. Once the signing
+         * algorithm came from the probe that blind spot stopped being harmless — a non-RS256 provider
+         * would fall back to RS256 and reject every token — and it also costs the handler its cache,
+         * since a probe that reads nothing is deliberately never cached.
+         */
+        it("uses an issuer that already points at a discovery document as-is", async () => {
+            setOauthConfig(true);
+            mfa.oauthIssuerBaseUrl = "https://sso.example.com/application/o/trilium/.well-known/openid-configuration";
+            const fetchSpy = mockFetch(() => ({
+                ok: true,
+                json: () => Promise.resolve({
+                    issuer: "https://sso.example.com/",
+                    id_token_signing_alg_values_supported: ["ES256"]
+                })
+            }));
+
+            const probe = await openID.probeDiscovery();
+
+            // Fetched exactly as configured — not with a second `.well-known` bolted on.
+            expect(fetchSpy).toHaveBeenCalledWith(mfa.oauthIssuerBaseUrl, expect.anything());
+            expect(probe.idTokenSigningAlg).toBe("ES256");
+            // Read, so the handler built from it is cacheable rather than rebuilt on every request.
+            expect(probe.metadataAvailable).toBe(true);
+            // The `.well-known` URL itself must reach express-openid-connect: the advertised issuer
+            // differs by more than a trailing slash (that is the whole point of this mode), and
+            // openid-client skips its equality check for such URLs.
+            expect(probe.issuerBaseUrl).toBe(mfa.oauthIssuerBaseUrl);
+        });
+
         it("reports the signing algorithm the issuer advertises", async () => {
             // Pocket ID with an Ed25519 key (discussion 6318): RS256 is not on offer at all, so expecting it is
             // what produced "unexpected JWT alg received, expected RS256, got: EdDSA".
@@ -664,6 +698,27 @@ describe("open_id", () => {
             // A configured value applies even to callers that never probed discovery.
             mfa.oauthIdTokenSigningAlg = "ES256";
             expect(openID.generateOAuthConfig().idTokenSigningAlg).toBe("ES256");
+        });
+    });
+
+    describe("discoveryUrlFor", () => {
+        it("appends the well-known path, or leaves an already-complete discovery URL alone", () => {
+            // The ordinary case, including a path-bearing issuer (Keycloak realms, Authentik apps).
+            expect(discoveryUrlFor("https://issuer.example.com"))
+                .toBe("https://issuer.example.com/.well-known/openid-configuration");
+            expect(discoveryUrlFor("https://sso.example.com/realms/trilium"))
+                .toBe("https://sso.example.com/realms/trilium/.well-known/openid-configuration");
+
+            // Already a discovery endpoint — appending again would 404. Matches openid-client's own
+            // test (`!href.includes('/.well-known/')`), so both agree on what is already an endpoint.
+            const wellKnown = "https://sso.example.com/application/o/trilium/.well-known/openid-configuration";
+            expect(discoveryUrlFor(wellKnown)).toBe(wellKnown);
+            // Any `/.well-known/` path counts, not just openid-configuration — again mirroring the library.
+            expect(discoveryUrlFor("https://sso.example.com/.well-known/oauth-authorization-server"))
+                .toBe("https://sso.example.com/.well-known/oauth-authorization-server");
+            // A bare `/.well-known` (no trailing segment) is not one, and the library agrees.
+            expect(discoveryUrlFor("https://sso.example.com/.well-known"))
+                .toBe("https://sso.example.com/.well-known/.well-known/openid-configuration");
         });
     });
 

--- a/apps/server/src/services/open_id.ts
+++ b/apps/server/src/services/open_id.ts
@@ -495,10 +495,7 @@ async function fetchDiscoveryMetadata(configuredIssuer: string): Promise<unknown
         return null;
     }
 
-    // The discovery document lives at `{issuer}/.well-known/openid-configuration` — appended to the full
-    // issuer (which may carry a path, e.g. Keycloak realms) rather than resolved against the origin root.
-    // Trailing slashes are stripped first so both spellings of a path-bearing issuer reach the same URL.
-    const metadataUrl = `${issuer}/.well-known/openid-configuration`;
+    const metadataUrl = discoveryUrlFor(issuer);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), DISCOVERY_TIMEOUT_MS);
     try {
@@ -514,6 +511,26 @@ async function fetchDiscoveryMetadata(configuredIssuer: string): Promise<unknown
     } finally {
         clearTimeout(timeout);
     }
+}
+
+/**
+ * Where an issuer's discovery document lives.
+ *
+ * Normally `{issuer}/.well-known/openid-configuration`, appended to the *full* issuer (which may carry a
+ * path, e.g. Keycloak realms) rather than resolved against the origin root. Callers strip trailing
+ * slashes first, so both spellings of a path-bearing issuer reach the same URL.
+ *
+ * An issuer that already points *at* a discovery document is used as-is. openid-client does exactly the
+ * same — `performDiscovery` skips resolution for any URL containing `/.well-known/`, and skips the
+ * issuer equality check along with it — which is what makes an explicit `.well-known` URL the documented
+ * way out of Authentik's "global" issuer mode (see {@link reconcileIssuerBaseUrl}). Appending a second
+ * `.well-known` there 404s, so the probe would come back blind on a configuration the library itself
+ * handles perfectly well, and everything derived from the document — the signing algorithm above all —
+ * would silently fall back. The `/.well-known/` test is the library's, character for character, so the
+ * two cannot disagree about which URLs are already discovery endpoints.
+ */
+export function discoveryUrlFor(issuer: string) {
+    return issuer.includes("/.well-known/") ? issuer : `${issuer}/.well-known/openid-configuration`;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #10876, from user testing on the merged branch. Kanidm (ES256) now works — both account linking and login — but the reporter had to **strip `.well-known/openid-configuration` from an issuer URL that previously worked**. That regression is real and this fixes it.

## Cause

`fetchDiscoveryMetadata` appended the well-known path unconditionally:

```ts
const metadataUrl = `${issuer}/.well-known/openid-configuration`;
```

So an issuer already pointing at a discovery document was fetched with a **second** `.well-known` bolted on, and 404'd.

openid-client does not do that — `performDiscovery`:

```js
const resolve = !server.href.includes('/.well-known/');
```

Any URL containing `/.well-known/` is used as-is, and the issuer equality check is skipped for it. That is exactly what makes an explicit `.well-known` URL the documented escape hatch for Authentik's "global" issuer mode — `reconcileIssuerBaseUrl`'s own comment points at it.

## Why it only surfaced now

While the probe's output was advisory, the 404 was harmless: sign-in went through openid-client, which handles the URL fine, and the only casualty was RP-Initiated Logout. Nobody noticed.

Sourcing the ID token signing algorithm from that probe ended that. With a `.well-known` issuer:

1. the algorithm falls back to RS256, so a non-RS256 provider rejects every token — the failure #10876 exists to fix, on a configuration we document; and
2. `metadataAvailable` is permanently false, so the handler is **never cached** and gets rebuilt on every request.

Point 2 is a regression I introduced in b9a09b1 while addressing Greptile's caching finding — worth flagging, since it turned a benign blind spot into per-request work.

## Fix

`discoveryUrlFor()` applies the library's own `/.well-known/` test, so the two cannot disagree about which URLs are already discovery endpoints. The reconciled issuer still passes the `.well-known` URL through unchanged, which is what openid-client needs.

## Testing

- `discoveryUrlFor` unit cases: plain issuer, path-bearing issuer (Keycloak realm), an already-complete discovery URL, a non-`openid-configuration` `.well-known` path, and a bare `/.well-known` (not an endpoint — matching the library).
- A `probeDiscovery` case pinning the whole reported scenario: fetched exactly as configured, ES256 detected, `metadataAvailable: true` (so the handler caches again), and the `.well-known` URL preserved as the issuer. Verified red against the blind-append behaviour first.
- `pnpm typecheck`: No errors found. Full `server` suite: 4912 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
