### PR TITLE
Backup import: standalone support and other improvements

### DIFF
--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -145,9 +145,6 @@ function SetupOptions({ setState }: { setState: (state: State) => void }) {
                     icon="bx bx-archive-in"
                     title={t("setup.restore-from-backup")}
                     description={t("setup.restore-from-backup-description")}
-                    // The backup has to be unwrapped and opened by a real database engine, which the
-                    // standalone build does not have: its database lives in the browser's own storage.
-                    disabled={glob.isStandalone}
                     onClick={() => setState("restoreFromBackup")}
                 />
 

--- a/apps/client/src/setup_restore.spec.tsx
+++ b/apps/client/src/setup_restore.spec.tsx
@@ -167,6 +167,94 @@ describe("picking a backup", () => {
     });
 });
 
+describe("restoring on standalone", () => {
+    const importBackup = vi.fn();
+
+    /** Drives the file input, which is the only way in on standalone: there is nothing to upload. */
+    async function chooseFile(file: File) {
+        const input = container.querySelector<HTMLInputElement>(".restore-file-input");
+        Object.defineProperty(input, "files", { value: [ file ], configurable: true });
+        input?.dispatchEvent(new Event("change", { bubbles: true }));
+        await flushEffects();
+    }
+
+    beforeEach(() => {
+        window.standaloneApi = { restore: { importBackup } } as unknown as typeof window.standaloneApi;
+    });
+
+    afterEach(() => {
+        window.standaloneApi = undefined;
+    });
+
+    it("hands the file to the worker that owns the database, rather than uploading it", async () => {
+        importBackup.mockResolvedValue({ status: "restored" });
+        const onRestored = vi.fn();
+        renderRestore({ onRestored });
+        await flushEffects();
+
+        const backup = new File([ "database bytes" ], "backup.db");
+        await chooseFile(backup);
+
+        // The file itself goes across, not a copy of its bytes and not a request.
+        expect(importBackup).toHaveBeenCalledWith(expect.objectContaining({ backup }));
+        expect(uploadMock.uploadInChunks).not.toHaveBeenCalled();
+        expect(serverMock.post).not.toHaveBeenCalled();
+        expect(onRestored).toHaveBeenCalled();
+    });
+
+    it("asks for the passphrase when the worker says it needs one, and retries with the same file", async () => {
+        importBackup.mockResolvedValueOnce({ status: "needs-passphrase" });
+        renderRestore();
+        await flushEffects();
+
+        const backup = new File([ "container bytes" ], "backup.tnbackup");
+        await chooseFile(backup);
+
+        const input = container.querySelector<HTMLInputElement>("input[type=password]");
+        expect(input).toBeTruthy();
+
+        importBackup.mockResolvedValueOnce({ status: "restored" });
+        if (input) {
+            input.value = "hunter2";
+            input.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        await flushEffects();
+        container.querySelector("form")?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+        await flushEffects();
+
+        // The same file, kept as a reference: nothing was picked again and nothing was re-read.
+        expect(importBackup).toHaveBeenLastCalledWith(expect.objectContaining({ backup, passphrase: "hunter2" }));
+    });
+
+    it("shows the step the worker reports, since there is nothing to poll", async () => {
+        importBackup.mockImplementation(async ({ onProgress }: { onProgress: (p: unknown) => void }) => {
+            onProgress({ stage: "validating" });
+
+            return new Promise(() => {});
+        });
+        renderRestore();
+        await flushEffects();
+
+        await chooseFile(new File([ "database bytes" ], "backup.db"));
+
+        expect(container.querySelector(".restore-step-name")?.textContent).toBe("setup.restore-stage-validating");
+        expect(serverMock.get).not.toHaveBeenCalledWith("setup/restore/status");
+    });
+
+    it("reports a refusal in the same words every other platform uses", async () => {
+        importBackup.mockResolvedValue({
+            status: "error", reason: "database-too-new", message: "The database is version 999."
+        });
+        renderRestore();
+        await flushEffects();
+
+        await chooseFile(new File([ "database bytes" ], "backup.db"));
+
+        expect(container.querySelector(".restore-error-headline")?.textContent).toBe("setup.restore-error-too-new");
+        expect(container.querySelector(".restore-error-detail")?.textContent).toBe("The database is version 999.");
+    });
+});
+
 describe("going back", () => {
     it("leaves the restore altogether from the first step, since there is nothing before it", async () => {
         const onBack = vi.fn();

--- a/apps/client/src/setup_restore.spec.tsx
+++ b/apps/client/src/setup_restore.spec.tsx
@@ -241,6 +241,16 @@ describe("restoring on standalone", () => {
         expect(serverMock.get).not.toHaveBeenCalledWith("setup/restore/status");
     });
 
+    it("offers no list of existing backups, since there are none to offer", async () => {
+        renderRestore();
+        await flushEffects();
+
+        expect(serverMock.get).not.toHaveBeenCalledWith("database/backups");
+        expect(container.textContent).not.toContain("setup.restore-existing-backups");
+        // The way in from a file is the whole screen here.
+        expect(container.querySelector(".restore-choose-file")).toBeTruthy();
+    });
+
     it("reports a refusal in the same words every other platform uses", async () => {
         importBackup.mockResolvedValue({
             status: "error", reason: "database-too-new", message: "The database is version 999."

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -57,6 +57,13 @@ export default function RestoreFromBackup({ onBack, onRestored }: { onBack: () =
     /** Stops the upload in flight, for the one thing that can interrupt it: the user going back. */
     const uploadCancellation = useRef<AbortController | null>(null);
     /**
+     * The file a standalone restore is working from, kept so a wrong passphrase can be answered
+     * without picking it again. It is a reference to bytes the browser already has, not a copy.
+     */
+    const localBackup = useRef<File | null>(null);
+    /** Where a standalone restore has got to, which it reports rather than being polled for. */
+    const [ localProgress, setLocalProgress ] = useState<RestoreStatus | null>(null);
+    /**
      * Fetched here rather than by the step that lists them, which is mounted afresh every time it is
      * returned to: asking again would show "looking for backups" for the length of each slide back.
      */
@@ -96,7 +103,38 @@ export default function RestoreFromBackup({ onBack, onRestored }: { onBack: () =
         }
     }, [ raiseError ]);
 
+    /**
+     * Restores a picked file through the standalone build's own way to the worker that owns the
+     * database, which is already on this device: there is nothing to upload, and the request path
+     * would serialise the whole database and give up on it besides.
+     */
+    async function restoreLocally(file: File, passphrase?: string) {
+        setSelection({ source: "pending", fileName: file.name });
+        localBackup.current = file;
+        setStep("restoring");
+
+        const result = await window.standaloneApi?.restore.importBackup({
+            backup: file,
+            passphrase,
+            onProgress: ({ stage, fraction }) => setLocalProgress({ stage, fraction })
+        });
+
+        if (result?.status === "restored") {
+            onRestored();
+        } else if (result?.status === "needs-passphrase") {
+            setStep("passphrase");
+        } else {
+            setStep("picking");
+            raiseError(headlineFor(result?.reason), result?.message);
+        }
+    }
+
     async function uploadAndRestore(file: File) {
+        if (window.standaloneApi) {
+            await restoreLocally(file);
+            return;
+        }
+
         const cancellation = new AbortController();
         uploadCancellation.current = cancellation;
 
@@ -183,12 +221,20 @@ export default function RestoreFromBackup({ onBack, onRestored }: { onBack: () =
                                 wrong={wrongPassphrase}
                                 onSubmit={(passphrase) => {
                                     setWrongPassphrase(false);
-                                    void restore(selection, passphrase);
+
+                                    // Standalone still has the file it was given, so answering the
+                                    // prompt starts again from it rather than from a server's copy.
+                                    const backup = localBackup.current;
+                                    void (backup ? restoreLocally(backup, passphrase) : restore(selection, passphrase));
                                 }}
                             />
                         )}
                         {shown === "restoring" && (
-                            <RestoreProgress onRestored={onRestored} onFailed={onRestoreFailed} />
+                            <RestoreProgress
+                                reported={localProgress}
+                                onRestored={onRestored}
+                                onFailed={onRestoreFailed}
+                            />
                         )}
                     </>
                 )}
@@ -450,11 +496,23 @@ interface RestoreStatus {
     reason?: string;
 }
 
-function RestoreProgress({ onRestored, onFailed }: { onRestored: () => void; onFailed: (failure: { error?: string; reason?: string }) => void }) {
+function RestoreProgress({ reported, onRestored, onFailed }: {
+    /** Where the restore has got to, where it says so itself; polled when it does not. */
+    reported?: RestoreStatus | null;
+    onRestored: () => void;
+    onFailed: (failure: { error?: string; reason?: string }) => void;
+}) {
     const [ stage, setStage ] = useState<string>("staging");
     const [ fraction, setFraction ] = useState<number | null>(null);
+    const polled = !reported;
 
     useEffect(() => {
+        // A restore that reports itself is already telling this component everything it knows, and
+        // there is nothing on the other end to ask besides.
+        if (!polled) {
+            return;
+        }
+
         const interval = setInterval(async () => {
             let restore;
             try {
@@ -484,21 +542,24 @@ function RestoreProgress({ onRestored, onFailed }: { onRestored: () => void; onF
         }, 1000);
 
         return () => clearInterval(interval);
-    }, [ onRestored, onFailed ]);
+    }, [ polled, onRestored, onFailed ]);
+
+    const shownStage = reported?.stage ?? stage;
+    const shownFraction = (reported ? reported.fraction : fraction) ?? null;
 
     // Only what is happening now, rather than the four steps as a list. Preparing the backup is the
     // one that takes any time; the rest go by too quickly to be read, so a list of them mostly shows
     // the user three things they will never see happen.
     return (
         <div class="restore-current-step">
-            <div class="restore-step-name">{t(`setup.restore-stage-${stage}`)}</div>
+            <div class="restore-step-name">{t(`setup.restore-stage-${shownStage}`)}</div>
 
             {/* Only where the step can say how far it has got. The ones that cannot show nothing,
                 rather than an empty bar that never moves. */}
-            {fraction !== null && (
+            {shownFraction !== null && (
                 <div class="restore-stage-progress">
-                    <progress value={fraction} max={1} />
-                    <span>{Math.floor(fraction * 100)}%</span>
+                    <progress value={shownFraction} max={1} />
+                    <span>{Math.floor(shownFraction * 100)}%</span>
                 </div>
             )}
 

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -70,6 +70,13 @@ export default function RestoreFromBackup({ onBack, onRestored }: { onBack: () =
     const [ backups, setBackups ] = useState<DatabaseBackup[] | null>(null);
 
     useEffect(() => {
+        // Standalone keeps no backups worth offering: nothing takes them on a schedule there, and a
+        // copy kept beside the database in the browser's own storage is cleared along with it.
+        if (window.standaloneApi) {
+            setBackups([]);
+            return;
+        }
+
         server.get<ExistingBackupsResponse>("database/backups")
             .then((response) => setBackups(response.backups))
             // An unreadable backup directory is not a reason to lose the way in from a file.

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -290,6 +290,7 @@ function headlineFor(reason: string | undefined): string {
         case "swap-failed": return t("setup.restore-error-swap-failed");
         case "migration-failed": return t("setup.restore-error-would-not-open");
         case "restore-refused": return t("setup.restore-error-refused");
+        case "already-initialized": return t("setup.restore-error-already-initialized");
         default: return t("setup.restore-error-unusable");
     }
 }

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3699,6 +3699,7 @@
     "restore-error-swap-failed": "The database could not be replaced. Your previous database is back in place.",
     "restore-error-would-not-open": "The restored database could not be opened. Your previous database is back in place.",
     "restore-error-refused": "Another setup step is already running.",
+    "restore-error-already-initialized": "This instance already has a knowledge base, so it cannot be restored over. Reload the page.",
     "restore-error-could-not-start": "The restore could not be started.",
     "restore-error-upload-failed": "The backup could not be uploaded.",
     "restore-passphrase": "Encryption password",

--- a/apps/client/src/types.d.ts
+++ b/apps/client/src/types.d.ts
@@ -1,4 +1,4 @@
-import { BootstrapDefinition, ElectronApi, ElectronContextMenuParams } from "@triliumnext/commons";
+import { BootstrapDefinition, ElectronApi, ElectronContextMenuParams, StandaloneApi } from "@triliumnext/commons";
 
 import appContext, { AppContext } from "./components/app_context";
 import type FNote from "./entities/fnote";
@@ -58,6 +58,8 @@ declare global {
         };
 
         electronApi?: ElectronApi;
+        /** Present only in the standalone build, where the stack runs in this browser. */
+        standaloneApi?: StandaloneApi;
     }
 
 

--- a/apps/server/src/services/database_restore.ts
+++ b/apps/server/src/services/database_restore.ts
@@ -8,6 +8,7 @@ import {
 } from "@triliumnext/backup-container";
 import {
     cls,
+    type DatabaseRejection,
     events as eventService,
     getLog,
     getSql,
@@ -19,7 +20,7 @@ import path from "path";
 
 import config from "./config.js";
 import dataDir from "./data_dir.js";
-import { type DatabaseRejection, validateDatabaseFile } from "./database_validation.js";
+import { validateDatabaseFile } from "./database_validation.js";
 
 /**
  * Puts a backup in place of this instance's database.

--- a/apps/server/src/services/database_validation.spec.ts
+++ b/apps/server/src/services/database_validation.spec.ts
@@ -1,11 +1,17 @@
-import { app_info as appInfo } from "@triliumnext/core";
+import { app_info as appInfo, OLDEST_SUPPORTED_DB_VERSION } from "@triliumnext/core";
 import Database from "better-sqlite3";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterAll, describe, expect, it } from "vitest";
 
-import { OLDEST_SUPPORTED_DB_VERSION, validateDatabaseFile } from "./database_validation.js";
+import { validateDatabaseFile } from "./database_validation.js";
+
+/*
+ * What the checks decide is covered against a stand-in candidate in core, where it belongs and where
+ * no file is needed. These cover the opening: that a real database on disk answers those checks
+ * correctly through this platform's driver, and that files which are not one are turned away.
+ */
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trilium-db-validation-spec-"));
 let counter = 0;
@@ -48,8 +54,8 @@ function fileWith(content: Buffer | string) {
 
 const CURRENT = { initialized: "true", dbVersion: String(appInfo.dbVersion) };
 
-describe("validating a database file", () => {
-    it("accepts a database from this version, and one that only needs migrating", () => {
+describe("opening a candidate database on this platform", () => {
+    it("reads a real database's integrity, tables and options, and accepts it", () => {
         expect(validateDatabaseFile(triliumDatabase(CURRENT))).toEqual({
             valid: true, dbVersion: appInfo.dbVersion, needsMigration: false
         });
@@ -57,6 +63,16 @@ describe("validating a database file", () => {
         const older = triliumDatabase({ initialized: "true", dbVersion: String(OLDEST_SUPPORTED_DB_VERSION) });
         expect(validateDatabaseFile(older)).toEqual({
             valid: true, dbVersion: OLDEST_SUPPORTED_DB_VERSION, needsMigration: true
+        });
+    });
+
+    it("carries a rejection back from the checks, with the driver's own answers behind it", () => {
+        const notOurs = databaseWith((db) => db.exec("CREATE TABLE recipes (name TEXT)"));
+
+        expect(validateDatabaseFile(notOurs)).toMatchObject({
+            valid: false,
+            rejection: "not-a-trilium-database",
+            message: expect.stringContaining("options, notes, branches, blobs")
         });
     });
 
@@ -68,45 +84,6 @@ describe("validating a database file", () => {
         expect(validateDatabaseFile(fileWith("SQLite"))).toMatchObject({ valid: false, rejection: "not-a-database" });
         expect(validateDatabaseFile(path.join(tempRoot, "nothing-here.db"))).toMatchObject({
             valid: false, rejection: "not-a-database"
-        });
-    });
-
-    it("refuses a SQLite database that is not one of ours, naming what is missing", () => {
-        const empty = databaseWith((db) => db.exec("CREATE TABLE recipes (name TEXT)"));
-        expect(validateDatabaseFile(empty)).toMatchObject({
-            valid: false, rejection: "not-a-trilium-database", message: expect.stringContaining("options, notes, branches, blobs")
-        });
-
-        const partial = triliumDatabase(CURRENT, [ "options", "notes" ]);
-        expect(validateDatabaseFile(partial)).toMatchObject({
-            valid: false, rejection: "not-a-trilium-database", message: expect.stringContaining("branches, blobs")
-        });
-    });
-
-    it("refuses a database left behind by a setup that never finished", () => {
-        const unfinished = triliumDatabase({ dbVersion: String(appInfo.dbVersion) });
-
-        expect(validateDatabaseFile(unfinished)).toMatchObject({
-            valid: false, rejection: "database-not-initialized"
-        });
-    });
-
-    it("refuses a database from a version this one cannot migrate, in either direction", () => {
-        const tooOld = triliumDatabase({ initialized: "true", dbVersion: String(OLDEST_SUPPORTED_DB_VERSION - 1) });
-        expect(validateDatabaseFile(tooOld)).toMatchObject({ valid: false, rejection: "database-too-old" });
-
-        const tooNew = triliumDatabase({ initialized: "true", dbVersion: String(appInfo.dbVersion + 1) });
-        expect(validateDatabaseFile(tooNew)).toMatchObject({
-            valid: false, rejection: "database-too-new", message: expect.stringContaining(String(appInfo.dbVersion))
-        });
-    });
-
-    it("refuses a database that does not say which version it is from", () => {
-        expect(validateDatabaseFile(triliumDatabase({ initialized: "true" }))).toMatchObject({
-            valid: false, rejection: "not-a-trilium-database"
-        });
-        expect(validateDatabaseFile(triliumDatabase({ initialized: "true", dbVersion: "recent" }))).toMatchObject({
-            valid: false, rejection: "not-a-trilium-database"
         });
     });
 

--- a/apps/server/src/services/database_validation.ts
+++ b/apps/server/src/services/database_validation.ts
@@ -1,60 +1,31 @@
-import { app_info as appInfo } from "@triliumnext/core";
+import {
+    type CandidateDatabase,
+    type DatabaseValidation,
+    looksLikeSqlite,
+    validateDatabase
+} from "@triliumnext/core";
 import Database from "better-sqlite3";
 import fs from "fs";
 
 /**
- * Decides whether a file is a Trilium database this version can open, before anything is done that
- * depends on the answer.
+ * Opens a candidate database on this platform and puts it through the shared checks.
  *
- * A restore replaces the document the whole application is about, and the file it replaces it with
- * arrived from outside: an upload, a directory listing, a file the user picked. "It has a .db
- * extension" says nothing, and finding out later is not an option, because the code that would find
- * out is the migration, and a migration that cannot proceed calls `crash()` — which on the server is
- * `process.exit(1)`. By then the original database has already been moved aside.
- *
- * So every reason the database could turn out to be unusable is checked here, on a copy nothing is
- * attached to yet, and turned into an answer the user can act on.
+ * Only the opening is here. What makes a database ours is decided in core, so that a platform which
+ * keeps its databases somewhere other than a filesystem answers the same questions the same way.
  *
  * @module
  */
-
-/** The oldest database the migrations can still take, from `migration.migrate`. */
-export const OLDEST_SUPPORTED_DB_VERSION = 214;
-
-const REQUIRED_TABLES = [ "options", "notes", "branches", "blobs" ];
-const SQLITE_MAGIC = Buffer.from("SQLite format 3\0", "latin1");
-
-export type DatabaseRejection =
-    /** Not a SQLite database at all. */
-    | "not-a-database"
-    /** SQLite, but corrupt. */
-    | "damaged-database"
-    /** A SQLite database, but not one of ours. */
-    | "not-a-trilium-database"
-    /** Ours, but from a setup that never finished, so there is nothing to restore. */
-    | "database-not-initialized"
-    /** From a version so old the migrations no longer reach back to it. */
-    | "database-too-old"
-    /** From a newer version, which this one cannot read. */
-    | "database-too-new";
-
-export type DatabaseValidation =
-    | { valid: true; dbVersion: number; needsMigration: boolean }
-    | { valid: false; rejection: DatabaseRejection; message: string };
 
 /**
  * Reads `filePath` and reports whether it can become this instance's database.
  *
  * The file is opened read-only through its own connection, so nothing here touches the database the
- * application is currently attached to.
- *
- * `PRAGMA quick_check` reads the whole file, which for a large database is not instant. It is worth
- * it: a restore that succeeds and leaves the user with a corrupt document is worse than one that
- * takes another minute to say no.
+ * application is currently attached to, and pages are read as they are needed rather than the whole
+ * file at once.
  */
 export function validateDatabaseFile(filePath: string): DatabaseValidation {
     if (!hasSqliteHeader(filePath)) {
-        return reject("not-a-database", "The file is not a SQLite database.");
+        return { valid: false, rejection: "not-a-database", message: "The file is not a SQLite database." };
     }
 
     let db: Database.Database;
@@ -65,61 +36,35 @@ export function validateDatabaseFile(filePath: string): DatabaseValidation {
             nativeBinding: process.env.BETTERSQLITE3_NATIVE_PATH || undefined
         });
     } catch (e) {
-        return reject("not-a-database", `The database could not be opened: ${messageOf(e)}`);
+        return {
+            valid: false,
+            rejection: "not-a-database",
+            message: `The database could not be opened: ${messageOf(e)}`
+        };
     }
 
     try {
-        return inspect(db);
+        return validateDatabase(candidateOf(db));
     } catch (e) {
-        return reject("damaged-database", `The database could not be read: ${messageOf(e)}`);
+        // What a database too damaged to query throws is this driver's business, not the checks'.
+        return {
+            valid: false,
+            rejection: "damaged-database",
+            message: `The database could not be read: ${messageOf(e)}`
+        };
     } finally {
         db.close();
     }
 }
 
-function inspect(db: Database.Database): DatabaseValidation {
-    const integrity = db.pragma("quick_check", { simple: true });
-    if (integrity !== "ok") {
-        return reject("damaged-database", `The database failed its integrity check: ${integrity}`);
-    }
-
-    const tables = new Set(
-        db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").pluck().all() as string[]
-    );
-    const missing = REQUIRED_TABLES.filter((table) => !tables.has(table));
-    if (missing.length > 0) {
-        return reject(
-            "not-a-trilium-database",
-            `The database is missing the ${missing.join(", ")} table${missing.length > 1 ? "s" : ""}.`
-        );
-    }
-
-    const readOption = db.prepare("SELECT value FROM options WHERE name = ?").pluck();
-    if (readOption.get("initialized") !== "true") {
-        return reject(
-            "database-not-initialized",
-            "The database is from a setup that never finished, so it holds nothing to restore."
-        );
-    }
-
-    const dbVersion = Number(readOption.get("dbVersion"));
-    if (!Number.isInteger(dbVersion)) {
-        return reject("not-a-trilium-database", "The database does not state which version it is from.");
-    }
-    if (dbVersion < OLDEST_SUPPORTED_DB_VERSION) {
-        return reject(
-            "database-too-old",
-            `The database is version ${dbVersion}; the oldest that can still be migrated is ${OLDEST_SUPPORTED_DB_VERSION}.`
-        );
-    }
-    if (dbVersion > appInfo.dbVersion) {
-        return reject(
-            "database-too-new",
-            `The database is version ${dbVersion}, which is newer than this application's ${appInfo.dbVersion}.`
-        );
-    }
-
-    return { valid: true, dbVersion, needsMigration: dbVersion < appInfo.dbVersion };
+/** The three questions the checks ask, answered by a better-sqlite3 connection. */
+function candidateOf(db: Database.Database): CandidateDatabase {
+    return {
+        integrityCheck: () => String(db.pragma("quick_check", { simple: true })),
+        tableNames: () => db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").pluck().all() as string[],
+        option: (name: string) =>
+            db.prepare("SELECT value FROM options WHERE name = ?").pluck().get(name) as string | undefined
+    };
 }
 
 /**
@@ -127,14 +72,14 @@ function inspect(db: Database.Database): DatabaseValidation {
  * user an error about a malformed database when what they picked was a photograph.
  */
 function hasSqliteHeader(filePath: string): boolean {
-    const head = Buffer.alloc(SQLITE_MAGIC.length);
+    const head = Buffer.alloc(16);
     let descriptor: number | undefined;
 
     try {
         descriptor = fs.openSync(filePath, "r");
         const read = fs.readSync(descriptor, head, 0, head.length, 0);
 
-        return read === head.length && head.equals(SQLITE_MAGIC);
+        return looksLikeSqlite(head.subarray(0, read));
     } catch {
         return false;
     } finally {
@@ -142,10 +87,6 @@ function hasSqliteHeader(filePath: string): boolean {
             fs.closeSync(descriptor);
         }
     }
-}
-
-function reject(rejection: DatabaseRejection, message: string): DatabaseValidation {
-    return { valid: false, rejection, message };
 }
 
 function messageOf(e: unknown): string {

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -19,6 +19,7 @@
     "@popperjs/core": "2.11.8",
     "@preact/signals": "2.10.1",
     "@sqlite.org/sqlite-wasm": "3.51.1-build2",
+    "@triliumnext/backup-container": "workspace:*",
     "@triliumnext/ckeditor5": "workspace:*",
     "@triliumnext/codemirror": "workspace:*",
     "@triliumnext/commons": "workspace:*",

--- a/apps/standalone/src/lightweight/backup_provider.spec.ts
+++ b/apps/standalone/src/lightweight/backup_provider.spec.ts
@@ -1,4 +1,4 @@
-import { options } from "@triliumnext/core";
+import { getSql, options } from "@triliumnext/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import StandaloneBackupService from "./backup_provider.js";
@@ -115,6 +115,23 @@ describe("StandaloneBackupService with OPFS", () => {
         const path = await service.backupNow("daily");
         expect(path).toBe("/backups/backup-daily.db");
         expect(fs.files.get("backup-daily.db")?.data.byteLength).toBeGreaterThan(0);
+    });
+
+    it("leaves a database too large to hold in memory unbacked-up", async () => {
+        const fs = makeOpfs();
+        installOpfs(async () => fs.root);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        // Serializing builds the whole database in the WebAssembly heap twice over, so past a size
+        // the attempt takes the tab down rather than failing. Nothing is written instead.
+        vi.spyOn(getSql(), "getValue").mockReturnValue(4 * 1024 * 1024 * 1024);
+        const serialize = vi.spyOn(getSql(), "serialize");
+
+        expect(await new StandaloneBackupService(options).backupNow("before-migration"))
+            .toBe("/backups/backup-before-migration.db");
+
+        expect(serialize).not.toHaveBeenCalled();
+        expect(fs.files.size).toBe(0);
+        expect(warn).toHaveBeenCalled();
     });
 
     it("lists matching backups newest-first and ignores non-backup entries", async () => {

--- a/apps/standalone/src/lightweight/backup_provider.ts
+++ b/apps/standalone/src/lightweight/backup_provider.ts
@@ -5,6 +5,19 @@ const BACKUP_DIR_NAME = "backups";
 const BACKUP_FILE_PATTERN = /^backup-.*\.db$/;
 
 /**
+ * How large a database may be and still be backed up here.
+ *
+ * A backup on this platform is a `serialize()`, which builds the whole database as one array inside
+ * the WebAssembly heap and then copies it out to JavaScript: two copies of it in memory at once, in
+ * an address space a fraction of what a native process has. Past a certain size that allocation does
+ * not fail, it takes the tab down with it, so anything larger is left unbacked-up instead.
+ *
+ * The size that matters is the one a restore can bring in: a database restored from a large backup
+ * migrates on the next start, and the migration asks for a backup first.
+ */
+const MAX_SERIALIZABLE_BYTES = 256 * 1024 * 1024;
+
+/**
  * Standalone backup service using OPFS (Origin Private File System).
  * Stores database backups as serialized byte arrays in OPFS.
  * Falls back to no-op behavior when OPFS is not available (e.g., in tests).
@@ -58,6 +71,12 @@ export default class StandaloneBackupService extends BackupService {
                 return `/${BACKUP_DIR_NAME}/${fileName}`;
             }
 
+            const size = this.databaseSize();
+            if (size > MAX_SERIALIZABLE_BYTES) {
+                console.warn(`[Backup] Database is too large to back up in the browser (${size} bytes), skipping: ${fileName}`);
+                return `/${BACKUP_DIR_NAME}/${fileName}`;
+            }
+
             // Serialize the database
             const data = getSql().serialize();
 
@@ -74,6 +93,15 @@ export default class StandaloneBackupService extends BackupService {
             // Don't throw - backup failure shouldn't block operations
             return `/${BACKUP_DIR_NAME}/${fileName}`;
         }
+    }
+
+    /** How many bytes the live database occupies, asked of the database rather than of a copy of it. */
+    private databaseSize(): number {
+        const size = getSql().getValue<number>(
+            "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()"
+        );
+
+        return typeof size === "number" ? size : 0;
     }
 
     override async getExistingBackups(): Promise<DatabaseBackup[]> {

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -1,0 +1,276 @@
+import { writeBackupContainer } from "@triliumnext/backup-container";
+import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
+import fs from "fs";
+import fsp from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+    DEFAULT_DATABASE_NAME,
+    readCurrentDatabaseName,
+    type RestoreProgress,
+    restoreDatabase,
+    type RestoreTarget
+} from "./database_restore.js";
+
+const CANDIDATE_NAME = "/trilium.candidate.db";
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trilium-standalone-restore-"));
+
+/**
+ * Bytes that start the way SQLite does, page size and all: the reader checks the header of what it
+ * unwraps, and the service checks the header of what it is given.
+ */
+function databaseBytes(size = 8192): Uint8Array {
+    const bytes = new Uint8Array(size);
+    bytes.set(Uint8Array.from("SQLite format 3\0", (c) => c.charCodeAt(0)));
+    // Page size, big-endian: 4096.
+    bytes[16] = 0x10;
+    bytes[17] = 0x00;
+    bytes.fill(0x42, 100);
+
+    return bytes;
+}
+
+/** Wraps `payload` the way a backup does, using the writer the backup service itself uses. */
+async function containerOf(payload: Uint8Array, options: { passphrase?: string; compress?: boolean } = {}) {
+    const filePath = path.join(tempRoot, `backup-${Math.random().toString(36).slice(2)}.tnbackup`);
+    fs.writeFileSync(filePath, "");
+
+    await writeBackupContainer(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- a Node stream over the bytes.
+        (await import("stream")).Readable.from([ Buffer.from(payload) ]) as any,
+        fs.createWriteStream(filePath),
+        {
+            compress: options.compress ?? false,
+            passphrase: options.passphrase,
+            plaintextSize: payload.length,
+            patchHeader: async (offset, data) => {
+                const handle = await fsp.open(filePath, "r+");
+                try {
+                    await handle.write(data, 0, data.length, offset);
+                } finally {
+                    await handle.close();
+                }
+            }
+        }
+    );
+
+    return new Blob([ fs.readFileSync(filePath) ]);
+}
+
+/** A pool that keeps its databases in memory and answers the checks however the test says. */
+function fakePool() {
+    const files = new Map<string, Uint8Array>();
+    const answers = {
+        integrity: "ok",
+        tables: [ "options", "notes", "branches", "blobs" ],
+        options: { initialized: "true", dbVersion: "240" } as Record<string, string | undefined>
+    };
+
+    class FakeDb {
+        constructor(readonly name: string) {
+            if (!files.has(name)) {
+                throw new Error(`no such database: ${name}`);
+            }
+        }
+        selectValue(sql: string, params?: unknown[]) {
+            if (sql.includes("quick_check")) return answers.integrity;
+            return answers.options[String((params ?? [])[0])];
+        }
+        selectValues() {
+            return answers.tables;
+        }
+        close() { /* nothing to release */ }
+    }
+
+    const pool = {
+        OpfsSAHPoolDb: FakeDb,
+        getCapacity: () => 6,
+        getFileCount: () => files.size,
+        addCapacity: async () => 1,
+        unlink: (name: string) => files.delete(name),
+        importDb: async (name: string, pull: () => Promise<Uint8Array | undefined>) => {
+            const chunks: Uint8Array[] = [];
+            for (let chunk = await pull(); chunk; chunk = await pull()) {
+                chunks.push(chunk);
+            }
+            files.set(name, concat(chunks));
+
+            return files.get(name)?.length ?? 0;
+        }
+    };
+
+    return { files, answers, pool: pool as unknown as SAHPoolUtil };
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+    const total = chunks.reduce((size, chunk) => size + chunk.length, 0);
+    const joined = new Uint8Array(total);
+    let at = 0;
+    for (const chunk of chunks) {
+        joined.set(chunk, at);
+        at += chunk.length;
+    }
+
+    return joined;
+}
+
+/** The database the restore acts on, recording what it was asked to do and in what order. */
+function fakeTarget(pool: SAHPoolUtil, options: { failToOpen?: string } = {}) {
+    const acted: string[] = [];
+    const target: RestoreTarget = {
+        pool,
+        close: () => { acted.push("close"); },
+        open: (dbName) => {
+            if (dbName === options.failToOpen) {
+                acted.push(`open-failed:${dbName}`);
+                throw new Error("database is locked");
+            }
+            acted.push(`open:${dbName}`);
+        }
+    };
+
+    return { target, acted };
+}
+
+/** Stands in for the origin's private filesystem, which is where the pointer lives. */
+let pointer: string | undefined;
+
+beforeEach(() => {
+    pointer = undefined;
+    vi.stubGlobal("navigator", {
+        storage: {
+            getDirectory: async () => ({
+                getFileHandle: async (_name: string, opts?: { create?: boolean }) => {
+                    if (pointer === undefined && !opts?.create) {
+                        throw new Error("NotFoundError");
+                    }
+
+                    return {
+                        getFile: async () => ({ text: async () => pointer ?? "" }),
+                        createWritable: async () => ({
+                            write: async (text: string) => { pointer = text; },
+                            close: async () => {}
+                        })
+                    };
+                }
+            })
+        }
+    });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("which database is the live one", () => {
+    it("is the original name until a restore says otherwise", async () => {
+        await expect(readCurrentDatabaseName()).resolves.toBe(DEFAULT_DATABASE_NAME);
+    });
+
+    it("is whatever the last restore wrote down", async () => {
+        const { pool } = fakePool();
+        const { target } = fakeTarget(pool);
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]));
+
+        await expect(readCurrentDatabaseName()).resolves.toBe(CANDIDATE_NAME);
+    });
+});
+
+describe("restoring from a picked backup", () => {
+    it("streams a plain database into the pool and makes it live", async () => {
+        const { files, pool } = fakePool();
+        const { target, acted } = fakeTarget(pool);
+        const original = databaseBytes();
+
+        await restoreDatabase(target, new Blob([ original ]));
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
+        // Closed, then written down, then opened: the pointer is what makes the swap, and nothing
+        // opens until it has been made.
+        expect(acted).toEqual([ "close", `open:${CANDIDATE_NAME}` ]);
+        expect(pointer).toBe(CANDIDATE_NAME);
+    });
+
+    it("unwraps a container back into the database it was made from", async () => {
+        const { files, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const original = databaseBytes();
+
+        await restoreDatabase(target, await containerOf(original, { compress: true }));
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
+    });
+
+    it("unwraps an encrypted one when it is given the passphrase", async () => {
+        const { files, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const original = databaseBytes();
+        const backup = await containerOf(original, { passphrase: "hunter2" });
+
+        await restoreDatabase(target, backup, { passphrase: "hunter2" });
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
+    });
+
+    it("says what it is doing as it goes", async () => {
+        const { pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const seen: RestoreProgress[] = [];
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]), { report: (p) => seen.push(p) });
+
+        expect(seen.map((p) => p.stage)).toEqual(
+            expect.arrayContaining([ "staging", "validating", "swapping", "done" ])
+        );
+    });
+});
+
+describe("a backup that cannot be restored", () => {
+    it("asks for a passphrase before reading an encrypted container, and imports nothing", async () => {
+        const { files, pool } = fakePool();
+        const { target, acted } = fakeTarget(pool);
+
+        await expect(restoreDatabase(target, await containerOf(databaseBytes(), { passphrase: "hunter2" })))
+            .rejects.toMatchObject({ reason: "passphrase-required" });
+
+        expect(files.size).toBe(0);
+        expect(acted).toEqual([]);
+        expect(pointer).toBeUndefined();
+    });
+
+    it("refuses a file that is neither a database nor a backup", async () => {
+        const { pool } = fakePool();
+        const { target } = fakeTarget(pool);
+
+        await expect(restoreDatabase(target, new Blob([ "a holiday photograph" ])))
+            .rejects.toMatchObject({ reason: "not-a-database" });
+
+        expect(pointer).toBeUndefined();
+    });
+
+    it("carries the checks' verdict back, and drops the candidate it had imported", async () => {
+        const { files, answers, pool } = fakePool();
+        const { target, acted } = fakeTarget(pool);
+        answers.options.dbVersion = "99999";
+
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ reason: "database-too-new" });
+
+        expect(files.has(CANDIDATE_NAME)).toBe(false);
+        // Never swapped: the live database is untouched and still the one to open.
+        expect(acted).toEqual([]);
+        expect(pointer).toBeUndefined();
+    });
+
+    it("puts the previous database back when the restored one will not open", async () => {
+        const { pool } = fakePool();
+        const { target, acted } = fakeTarget(pool, { failToOpen: CANDIDATE_NAME });
+
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ reason: "swap-failed" });
+
+        expect(acted).toEqual([ "close", `open-failed:${CANDIDATE_NAME}`, `open:${DEFAULT_DATABASE_NAME}` ]);
+        expect(pointer).toBe(DEFAULT_DATABASE_NAME);
+    });
+});

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -63,6 +63,8 @@ async function containerOf(payload: Uint8Array, options: { passphrase?: string; 
 /** A pool that keeps its databases in memory and answers the checks however the test says. */
 function fakePool() {
     const files = new Map<string, Uint8Array>();
+    /** Every statement the checks put to the candidate, so a test can say what was not asked. */
+    const asked: string[] = [];
     const answers = {
         integrity: "ok",
         tables: [ "options", "notes", "branches", "blobs" ],
@@ -76,10 +78,12 @@ function fakePool() {
             }
         }
         selectValue(sql: string, params?: unknown[]) {
+            asked.push(sql);
             if (sql.includes("quick_check")) return answers.integrity;
             return answers.options[String((params ?? [])[0])];
         }
-        selectValues() {
+        selectValues(sql: string) {
+            asked.push(sql);
             return answers.tables;
         }
         close() { /* nothing to release */ }
@@ -102,7 +106,7 @@ function fakePool() {
         }
     };
 
-    return { files, answers, pool: pool as unknown as SAHPoolUtil };
+    return { asked, files, answers, pool: pool as unknown as SAHPoolUtil };
 }
 
 function concat(chunks: Uint8Array[]): Uint8Array {
@@ -227,6 +231,20 @@ describe("restoring from a picked backup", () => {
         await restoreDatabase(target, backup, { passphrase: "hunter2" });
 
         expect(files.get(CANDIDATE_NAME)).toEqual(original);
+    });
+
+    it("checks the database without reading all of it", async () => {
+        const { asked, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]));
+
+        // The one check whose cost grows with the database is left out here, where every page would
+        // come back through the pool into a WebAssembly engine.
+        expect(asked.some((sql) => sql.includes("quick_check"))).toBe(false);
+        // The rest is still asked: the schema and the version are what accept a database.
+        expect(asked.some((sql) => sql.includes("sqlite_master"))).toBe(true);
+        expect(asked.some((sql) => sql.includes("options"))).toBe(true);
     });
 
     it("says what it is doing as it goes", async () => {

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -45,6 +45,11 @@ async function containerOf(payload: Uint8Array, options: { passphrase?: string; 
         {
             compress: options.compress ?? false,
             passphrase: options.passphrase,
+            // The production cost takes seconds through pure-JS scrypt under coverage
+            // instrumentation, which is a test timeout and then a stray swap polluting the next
+            // test. The reader derives with whatever the header records, so a cheap cost changes
+            // nothing about what is being tested.
+            scrypt: { log2N: 10, r: 8, p: 1 },
             plaintextSize: payload.length,
             patchHeader: async (offset, data) => {
                 const handle = await fsp.open(filePath, "r+");

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -1,5 +1,5 @@
-import { writeBackupContainer } from "@triliumnext/backup-container";
 import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
+import { writeBackupContainer } from "@triliumnext/backup-container";
 import fs from "fs";
 import fsp from "fs/promises";
 import os from "os";
@@ -9,12 +9,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     DEFAULT_DATABASE_NAME,
     readCurrentDatabaseName,
-    type RestoreProgress,
     restoreDatabase,
+    type RestoreProgress,
     type RestoreTarget
 } from "./database_restore.js";
 
-const CANDIDATE_NAME = "/trilium.candidate.db";
+/** The name a restore writes to while the default one is live: the two alternate. */
+const CANDIDATE_NAME = "/trilium.alt.db";
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "trilium-standalone-restore-"));
 
 /**
@@ -174,6 +175,21 @@ describe("which database is the live one", () => {
         await restoreDatabase(target, new Blob([ databaseBytes() ]));
 
         await expect(readCurrentDatabaseName()).resolves.toBe(CANDIDATE_NAME);
+    });
+
+    it("alternates between the two names, so a restore never prepares over the live database", async () => {
+        const { files, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const second = databaseBytes(12288);
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]));
+        await restoreDatabase(target, new Blob([ second ]));
+
+        await expect(readCurrentDatabaseName()).resolves.toBe(DEFAULT_DATABASE_NAME);
+        // Only ever the one database: the name it went back to holds the newer backup, and the one
+        // it came from was dropped once the swap was through.
+        expect([ ...files.keys() ]).toEqual([ DEFAULT_DATABASE_NAME ]);
+        expect(files.get(DEFAULT_DATABASE_NAME)).toEqual(second);
     });
 });
 

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -180,12 +180,23 @@ async function stageCandidate(
     await Promise.all([ unwrapped, imported ]);
 }
 
-/** Opens the candidate and puts it through the checks every platform shares. */
+/**
+ * Opens the candidate and puts it through the checks every platform shares, minus the scan.
+ *
+ * `PRAGMA quick_check` reads every page, and here every page comes back through the pool's
+ * synchronous access handles into a WebAssembly database engine, which is the slowest reader of the
+ * three platforms and the one with a user watching a setup screen that cannot say how far along it
+ * is. What it would find is largely accounted for already: a container's payload is checked against
+ * a SHA-256 recorded when the backup was written, and any file is opened, its schema parsed and its
+ * options read before it is accepted. The remaining case, a plain `.db` damaged somewhere no schema
+ * read reaches, surfaces the way it would in any other Trilium, which never scans its database
+ * either except when asked to from the options screen.
+ */
 function validate(pool: SAHPoolUtil, candidate: string): DatabaseValidation {
     const db = new pool.OpfsSAHPoolDb(candidate);
 
     try {
-        return validateDatabase(candidateOf(db));
+        return validateDatabase(candidateOf(db), { skipIntegrityCheck: true });
     } catch (e) {
         // What a database too damaged to query throws is this driver's business, not the checks'.
         return {

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -1,3 +1,4 @@
+import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
 import {
     FIXED_HEADER_BYTES,
     isBackupContainerError,
@@ -11,7 +12,6 @@ import {
     looksLikeSqlite,
     validateDatabase
 } from "@triliumnext/core";
-import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
 
 /**
  * Puts a backup in place of this instance's database, in the browser.
@@ -34,11 +34,22 @@ import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
 /** Where the pointer to the live database is kept, in the origin's private filesystem. */
 const POINTER_FILE = "trilium-current-database";
 
-/** The database opened when nothing has ever been restored. */
-export const DEFAULT_DATABASE_NAME = "/trilium.db";
+/**
+ * The two names a database is ever kept under.
+ *
+ * A restore writes the new database in beside the old one and then points at it, so the name it
+ * writes to has to be the one that is *not* live. Alternating between two settles that: whichever is
+ * live, the other is free, and a restore can never be preparing over the database it is replacing.
+ */
+const DATABASE_NAMES = [ "/trilium.db", "/trilium.alt.db" ] as const;
 
-/** Where a backup is written while it is being checked, before it is anything to anyone. */
-const CANDIDATE_NAME = "/trilium.candidate.db";
+/** The database opened when nothing has ever been restored. */
+export const DEFAULT_DATABASE_NAME = DATABASE_NAMES[0];
+
+/** Where a backup is written while it is being checked, which is wherever the live one is not. */
+function candidateNameFor(live: string): string {
+    return DATABASE_NAMES.find((name) => name !== live) ?? DATABASE_NAMES[1];
+}
 
 /** What the restore is doing, in the order it does it. Mirrors the server's own steps. */
 export type RestoreStage = "staging" | "validating" | "swapping" | "done" | "failed";
@@ -90,26 +101,28 @@ export async function restoreDatabase(
     options: { passphrase?: string; report?: (progress: RestoreProgress) => void } = {}
 ): Promise<void> {
     const report = options.report ?? (() => {});
+    const live = await readCurrentDatabaseName();
+    const candidate = candidateNameFor(live);
 
     try {
         report({ stage: "staging" });
-        await stageCandidate(target.pool, backup, options.passphrase, (fraction) =>
+        await stageCandidate(target.pool, candidate, backup, options.passphrase, (fraction) =>
             report({ stage: "staging", fraction }));
 
         report({ stage: "validating" });
-        const validation = validate(target.pool);
+        const validation = validate(target.pool, candidate);
         if (!validation.valid) {
             throw new RestoreFailure(validation.rejection, validation.message);
         }
 
         report({ stage: "swapping" });
-        await swapIn(target);
+        await swapIn(target, live, candidate);
 
         report({ stage: "done" });
     } catch (e) {
         const failure = asFailure(e);
         // The candidate is no use to anyone now, and the pool's slots are finite.
-        await removeQuietly(target.pool, CANDIDATE_NAME);
+        await removeQuietly(target.pool, candidate);
         report({ stage: "failed", error: failure.message, reason: failure.reason });
 
         throw failure;
@@ -134,12 +147,13 @@ export class RestoreFailure extends Error {
  */
 async function stageCandidate(
     pool: SAHPoolUtil,
+    candidate: string,
     backup: Blob,
     passphrase: string | undefined,
     onProgress: ProgressCallback
 ): Promise<void> {
     await makeRoomFor(pool);
-    await removeQuietly(pool, CANDIDATE_NAME);
+    await removeQuietly(pool, candidate);
 
     const format = await readBackupFormat(backup);
     if (!format) {
@@ -147,7 +161,7 @@ async function stageCandidate(
     }
 
     if (!format.container) {
-        await pool.importDb(CANDIDATE_NAME, pullFrom(backup.stream()));
+        await pool.importDb(candidate, pullFrom(backup.stream()));
         onProgress(1);
         return;
     }
@@ -160,15 +174,15 @@ async function stageCandidate(
 
     const relay = new TransformStream<Uint8Array, Uint8Array>();
     const unwrapped = readBackupContainer(backup.stream(), relay.writable, { passphrase, onProgress });
-    const imported = pool.importDb(CANDIDATE_NAME, pullFrom(relay.readable));
+    const imported = pool.importDb(candidate, pullFrom(relay.readable));
 
     // Awaited together: either failing has to stop the other, which is what a rejected pipe does.
     await Promise.all([ unwrapped, imported ]);
 }
 
 /** Opens the candidate and puts it through the checks every platform shares. */
-function validate(pool: SAHPoolUtil): DatabaseValidation {
-    const db = new pool.OpfsSAHPoolDb(CANDIDATE_NAME);
+function validate(pool: SAHPoolUtil, candidate: string): DatabaseValidation {
+    const db = new pool.OpfsSAHPoolDb(candidate);
 
     try {
         return validateDatabase(candidateOf(db));
@@ -200,14 +214,12 @@ function candidateOf(db: InstanceType<SAHPoolUtil["OpfsSAHPoolDb"]>): CandidateD
  * changes, an interrupted restore leaves the old one live with an unused entry beside it, which the
  * next attempt overwrites.
  */
-async function swapIn(target: RestoreTarget): Promise<void> {
-    const previous = await readCurrentDatabaseName();
-
+async function swapIn(target: RestoreTarget, previous: string, candidate: string): Promise<void> {
     target.close();
-    await writeCurrentDatabaseName(CANDIDATE_NAME);
+    await writeCurrentDatabaseName(candidate);
 
     try {
-        target.open(CANDIDATE_NAME);
+        target.open(candidate);
     } catch (e) {
         // Put back what was live, so a candidate that will not open costs nothing.
         await writeCurrentDatabaseName(previous);
@@ -217,9 +229,7 @@ async function swapIn(target: RestoreTarget): Promise<void> {
     }
 
     // Only once the restored database is open: until then the old one is what a restart needs.
-    if (previous !== CANDIDATE_NAME) {
-        await removeQuietly(target.pool, previous);
-    }
+    await removeQuietly(target.pool, previous);
 }
 
 async function writeCurrentDatabaseName(dbName: string): Promise<void> {

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -1,0 +1,292 @@
+import {
+    FIXED_HEADER_BYTES,
+    isBackupContainerError,
+    peekBackupContainer,
+    type ProgressCallback,
+    readBackupContainer
+} from "@triliumnext/backup-container/web";
+import {
+    type CandidateDatabase,
+    type DatabaseValidation,
+    looksLikeSqlite,
+    validateDatabase
+} from "@triliumnext/core";
+import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
+
+/**
+ * Puts a backup in place of this instance's database, in the browser.
+ *
+ * The server exchanges two files on a disk. Here the databases live as entries in the SAH pool,
+ * which has no rename, so a restore is done by writing the new database in beside the old one and
+ * then changing which name the next start opens. That single small write is the whole of the swap:
+ * before it the old database is live, after it the new one is, and there is no moment in between
+ * where neither is.
+ *
+ * Nothing is ever held whole. The backup arrives as a stream and is fed to `importDb` chunk by
+ * chunk, and the checks read the imported database page by page through the VFS, so a restore costs
+ * the size of the backup on disk and almost nothing in memory. That matters more here than on a
+ * server: this database engine is compiled to WebAssembly, whose address space is a fraction of what
+ * a native process has.
+ *
+ * @module
+ */
+
+/** Where the pointer to the live database is kept, in the origin's private filesystem. */
+const POINTER_FILE = "trilium-current-database";
+
+/** The database opened when nothing has ever been restored. */
+export const DEFAULT_DATABASE_NAME = "/trilium.db";
+
+/** Where a backup is written while it is being checked, before it is anything to anyone. */
+const CANDIDATE_NAME = "/trilium.candidate.db";
+
+/** What the restore is doing, in the order it does it. Mirrors the server's own steps. */
+export type RestoreStage = "staging" | "validating" | "swapping" | "done" | "failed";
+
+export interface RestoreProgress {
+    stage: RestoreStage;
+    /** How far through the current step, from 0 to 1, for the step that can say. */
+    fraction?: number;
+    error?: string;
+    reason?: string;
+}
+
+/** The database the restore acts on, reduced to what it needs and no more. */
+export interface RestoreTarget {
+    pool: SAHPoolUtil;
+    /** Closes whatever is open. */
+    close(): void;
+    /** Opens the named pool entry as the live database. */
+    open(dbName: string): void;
+}
+
+/**
+ * Reads which pool entry holds the live database.
+ *
+ * Falls back to the original name, which is what every instance that has never restored anything is
+ * still using, and what a browser that has lost the pointer should reach for.
+ */
+export async function readCurrentDatabaseName(): Promise<string> {
+    try {
+        const root = await navigator.storage.getDirectory();
+        const handle = await root.getFileHandle(POINTER_FILE);
+        const name = (await (await handle.getFile()).text()).trim();
+
+        return name || DEFAULT_DATABASE_NAME;
+    } catch {
+        return DEFAULT_DATABASE_NAME;
+    }
+}
+
+/**
+ * Restores `backup` over the live database, reporting each step through `report`.
+ *
+ * @param backup the file the user chose, read where it lies rather than copied anywhere first.
+ * @throws Error carrying a `reason` the setup screen maps to something the user can act on.
+ */
+export async function restoreDatabase(
+    target: RestoreTarget,
+    backup: Blob,
+    options: { passphrase?: string; report?: (progress: RestoreProgress) => void } = {}
+): Promise<void> {
+    const report = options.report ?? (() => {});
+
+    try {
+        report({ stage: "staging" });
+        await stageCandidate(target.pool, backup, options.passphrase, (fraction) =>
+            report({ stage: "staging", fraction }));
+
+        report({ stage: "validating" });
+        const validation = validate(target.pool);
+        if (!validation.valid) {
+            throw new RestoreFailure(validation.rejection, validation.message);
+        }
+
+        report({ stage: "swapping" });
+        await swapIn(target);
+
+        report({ stage: "done" });
+    } catch (e) {
+        const failure = asFailure(e);
+        // The candidate is no use to anyone now, and the pool's slots are finite.
+        await removeQuietly(target.pool, CANDIDATE_NAME);
+        report({ stage: "failed", error: failure.message, reason: failure.reason });
+
+        throw failure;
+    }
+}
+
+/** A failure with a reason attached, so the setup screen can tell the cases apart. */
+export class RestoreFailure extends Error {
+    constructor(readonly reason: string, message: string) {
+        super(message);
+        this.name = "RestoreFailure";
+    }
+}
+
+/**
+ * Writes the backup into the pool as the candidate, unwrapping it on the way where it is a
+ * container.
+ *
+ * The unwrap writes into one end of a pipe while the import pulls from the other, so the database
+ * passes through in chunks and the pipe's own backpressure keeps the two in step. Neither end ever
+ * holds more than a chunk.
+ */
+async function stageCandidate(
+    pool: SAHPoolUtil,
+    backup: Blob,
+    passphrase: string | undefined,
+    onProgress: ProgressCallback
+): Promise<void> {
+    await makeRoomFor(pool);
+    await removeQuietly(pool, CANDIDATE_NAME);
+
+    const format = await readBackupFormat(backup);
+    if (!format) {
+        throw new RestoreFailure("not-a-database", "The backup could not be read.");
+    }
+
+    if (!format.container) {
+        await pool.importDb(CANDIDATE_NAME, pullFrom(backup.stream()));
+        onProgress(1);
+        return;
+    }
+
+    // Asked before the file is read rather than after: an encrypted container without a passphrase
+    // fails the same way either way, but only one of them takes minutes to get there.
+    if (format.encrypted && !passphrase) {
+        throw new RestoreFailure("passphrase-required", "The backup is encrypted.");
+    }
+
+    const relay = new TransformStream<Uint8Array, Uint8Array>();
+    const unwrapped = readBackupContainer(backup.stream(), relay.writable, { passphrase, onProgress });
+    const imported = pool.importDb(CANDIDATE_NAME, pullFrom(relay.readable));
+
+    // Awaited together: either failing has to stop the other, which is what a rejected pipe does.
+    await Promise.all([ unwrapped, imported ]);
+}
+
+/** Opens the candidate and puts it through the checks every platform shares. */
+function validate(pool: SAHPoolUtil): DatabaseValidation {
+    const db = new pool.OpfsSAHPoolDb(CANDIDATE_NAME);
+
+    try {
+        return validateDatabase(candidateOf(db));
+    } catch (e) {
+        // What a database too damaged to query throws is this driver's business, not the checks'.
+        return {
+            valid: false,
+            rejection: "damaged-database",
+            message: `The database could not be read: ${messageOf(e)}`
+        };
+    } finally {
+        db.close();
+    }
+}
+
+/** The three questions the checks ask, answered by a database opened from the pool. */
+function candidateOf(db: InstanceType<SAHPoolUtil["OpfsSAHPoolDb"]>): CandidateDatabase {
+    return {
+        integrityCheck: () => String(db.selectValue("PRAGMA quick_check")),
+        tableNames: () => db.selectValues("SELECT name FROM sqlite_master WHERE type = 'table'") as string[],
+        option: (name) => db.selectValue("SELECT value FROM options WHERE name = ?", [ name ]) as string | undefined
+    };
+}
+
+/**
+ * Makes the candidate the live database.
+ *
+ * The pointer is written last, and is the only thing that decides which database is opened: until it
+ * changes, an interrupted restore leaves the old one live with an unused entry beside it, which the
+ * next attempt overwrites.
+ */
+async function swapIn(target: RestoreTarget): Promise<void> {
+    const previous = await readCurrentDatabaseName();
+
+    target.close();
+    await writeCurrentDatabaseName(CANDIDATE_NAME);
+
+    try {
+        target.open(CANDIDATE_NAME);
+    } catch (e) {
+        // Put back what was live, so a candidate that will not open costs nothing.
+        await writeCurrentDatabaseName(previous);
+        target.open(previous);
+
+        throw new RestoreFailure("swap-failed", messageOf(e));
+    }
+
+    // Only once the restored database is open: until then the old one is what a restart needs.
+    if (previous !== CANDIDATE_NAME) {
+        await removeQuietly(target.pool, previous);
+    }
+}
+
+async function writeCurrentDatabaseName(dbName: string): Promise<void> {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle(POINTER_FILE, { create: true });
+    const writable = await handle.createWritable();
+
+    try {
+        await writable.write(dbName);
+    } finally {
+        await writable.close();
+    }
+}
+
+/**
+ * Identifies a backup from its first bytes: a container states what it is in the clear, and anything
+ * else has to be a database already.
+ */
+async function readBackupFormat(backup: Blob): Promise<{ container: boolean; encrypted: boolean } | null> {
+    const head = new Uint8Array(await backup.slice(0, FIXED_HEADER_BYTES).arrayBuffer());
+    const container = peekBackupContainer(head);
+
+    if (container) {
+        return { container: true, encrypted: container.encrypted };
+    }
+
+    return looksLikeSqlite(head) ? { container: false, encrypted: false } : null;
+}
+
+/** Turns a stream into the pull `importDb` asks for: a chunk each call, nothing at the end. */
+function pullFrom(stream: ReadableStream<Uint8Array>): () => Promise<Uint8Array | undefined> {
+    const reader = stream.getReader();
+
+    return async () => {
+        const { done, value } = await reader.read();
+
+        return done ? undefined : value;
+    };
+}
+
+/** Adds a slot if every one the pool has is spoken for, since a restore needs one for the candidate. */
+async function makeRoomFor(pool: SAHPoolUtil): Promise<void> {
+    if (pool.getFileCount() >= pool.getCapacity()) {
+        await pool.addCapacity(1);
+    }
+}
+
+/** Removes a pool entry, if it is there at all. Never the reason a restore fails. */
+async function removeQuietly(pool: SAHPoolUtil, dbName: string): Promise<void> {
+    try {
+        pool.unlink(dbName);
+    } catch {
+        // A leftover entry costs a slot, which is not worth losing the answer over.
+    }
+}
+
+function asFailure(e: unknown): RestoreFailure {
+    if (e instanceof RestoreFailure) {
+        return e;
+    }
+    if (isBackupContainerError(e)) {
+        return new RestoreFailure(e.reason, e.message);
+    }
+
+    return new RestoreFailure("swap-failed", messageOf(e));
+}
+
+function messageOf(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+}

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -350,3 +350,66 @@ describe("isLocalApiRequest", () => {
         expect(bridge.isLocalApiRequest(new URL("http://x/"))).toBe(false);
     });
 });
+
+describe("restoreBackup", () => {
+    /** The message the bridge sent to the worker to start a restore. */
+    function restoreMessage(worker: MockWorker) {
+        const sent = worker.postMessage.mock.calls
+            .map(([ message ]) => message as { type: string; id: string; backup?: File; passphrase?: string })
+            .find((message) => message.type === "RESTORE_BACKUP");
+        if (!sent) {
+            throw new Error("no restore was started");
+        }
+
+        return sent;
+    }
+
+    it("hands the file itself to the worker, rather than anything read out of it", async () => {
+        const bridge = await freshBridge();
+        const backup = new File([ "database bytes" ], "backup.db");
+
+        void bridge.restoreBackup({ backup, passphrase: "hunter2" });
+
+        const sent = restoreMessage(lastWorker());
+        // The same File, not a copy: structured cloning passes it by reference, which is the whole
+        // reason this does not go through the request path.
+        expect(sent.backup).toBe(backup);
+        expect(sent.passphrase).toBe("hunter2");
+        // No transfer list, since a File is not transferable and must not be treated as one.
+        expect(lastWorker().postMessage).toHaveBeenLastCalledWith(sent);
+    });
+
+    it("relays what the worker reports, and settles on the outcome", async () => {
+        const bridge = await freshBridge();
+        const seen: unknown[] = [];
+        const restoring = bridge.restoreBackup({
+            backup: new File([ "bytes" ], "backup.db"),
+            onProgress: (progress) => seen.push(progress)
+        });
+        const worker = lastWorker();
+        const { id } = restoreMessage(worker);
+
+        worker.onmessage?.({ data: { type: "RESTORE_PROGRESS", id, progress: { stage: "staging", fraction: 0.5 } } });
+        worker.onmessage?.({ data: { type: "RESTORE_RESULT", id, result: { status: "restored" } } });
+
+        await expect(restoring).resolves.toEqual({ status: "restored" });
+        expect(seen).toEqual([ { stage: "staging", fraction: 0.5 } ]);
+    });
+
+    it("keeps two restores apart, and stops listening once one has answered", async () => {
+        const bridge = await freshBridge();
+        const first = bridge.restoreBackup({ backup: new File([ "one" ], "one.db") });
+        const worker = lastWorker();
+        const { id } = restoreMessage(worker);
+
+        worker.onmessage?.({ data: { type: "RESTORE_RESULT", id, result: { status: "restored" } } });
+        await expect(first).resolves.toEqual({ status: "restored" });
+
+        // A late or repeated answer for a restore that is over has nobody to tell, and must not throw.
+        expect(() => worker.onmessage?.({ data: { type: "RESTORE_RESULT", id, result: { status: "error" } } }))
+            .not.toThrow();
+        // Nor does a message for a restore that was never started.
+        expect(() => worker.onmessage?.({ data: { type: "RESTORE_PROGRESS", id: "other", progress: {} } }))
+            .not.toThrow();
+    });
+});

--- a/apps/standalone/src/local-bridge.ts
+++ b/apps/standalone/src/local-bridge.ts
@@ -1,8 +1,45 @@
+import type { StandaloneRestoreProgress, StandaloneRestoreResult } from "@triliumnext/commons";
+
 import LocalServerWorker from "./local-server-worker?worker";
 let localWorker: Worker | null = null;
 const pending = new Map();
+/** Restores in flight, by id, each with the progress callback that stays on this side. */
+const restores = new Map<string, {
+    resolve: (result: StandaloneRestoreResult) => void;
+    reject: (reason: unknown) => void;
+    onProgress?: (progress: StandaloneRestoreProgress) => void;
+}>();
 
 const LOCAL_API_PREFIXES = ["/bootstrap", "/api/", "/sync/", "/search/"];
+
+/**
+ * Restores the database from a backup, on the worker that owns it.
+ *
+ * The file goes across as a `File`, which structured cloning passes by reference, so nothing is
+ * copied and nothing is read into memory here. It deliberately avoids the request path: that
+ * serialises bodies whole and gives up after thirty seconds, neither of which a database survives.
+ *
+ * Progress is relayed from the worker to `onProgress`, which stays on this side of the boundary.
+ */
+export function restoreBackup(opts: {
+    backup: File;
+    passphrase?: string;
+    onProgress?: (progress: StandaloneRestoreProgress) => void;
+}): Promise<StandaloneRestoreResult> {
+    startLocalServerWorker();
+
+    const id = Math.random().toString(36).slice(2);
+
+    return new Promise((resolve, reject) => {
+        restores.set(id, { resolve, reject, onProgress: opts.onProgress });
+        localWorker!.postMessage({
+            type: "RESTORE_BACKUP",
+            id,
+            backup: opts.backup,
+            passphrase: opts.passphrase
+        });
+    });
+}
 
 export function isLocalApiRequest(url: URL): boolean {
     return LOCAL_API_PREFIXES.some(p => url.pathname.startsWith(p));
@@ -98,6 +135,18 @@ export function startLocalServerWorker() {
 
     localWorker.onmessage = (event) => {
         const msg = event.data;
+
+        // Restore progress and outcome, which travel on their own channel rather than as a response
+        // to a request: the backup that started them never went through one.
+        if (msg?.type === "RESTORE_PROGRESS") {
+            restores.get(msg.id)?.onProgress?.(msg.progress);
+            return;
+        }
+        if (msg?.type === "RESTORE_RESULT") {
+            restores.get(msg.id)?.resolve(msg.result);
+            restores.delete(msg.id);
+            return;
+        }
 
         // Handle fatal platform crashes (shown as a dialog to the user)
         if (msg?.type === "FATAL_ERROR") {

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -372,17 +372,40 @@ async function dispatch(request: LocalRequest) {
  * question, so it is reported as one and the same file can be offered again with an answer.
  */
 async function handleRestoreBackup(id: string, backup: File, passphrase?: string): Promise<void> {
-    const report = (progress: StandaloneRestoreProgress) =>
-        (self as unknown as Worker).postMessage({ type: "RESTORE_PROGRESS", id, progress });
     const answer = (result: StandaloneRestoreResult) =>
         (self as unknown as Worker).postMessage({ type: "RESTORE_RESULT", id, result });
+    const report = (progress: StandaloneRestoreProgress) =>
+        (self as unknown as Worker).postMessage({ type: "RESTORE_PROGRESS", id, progress });
+
+    const core = coreModule;
+    const pool = sqlProvider?.sahPool;
+    if (!core || !sqlProvider || !pool) {
+        answer({ status: "error", reason: "swap-failed", message: "The database is not ready yet." });
+        return;
+    }
+
+    // What `checkAppNotInitialized` is to the server's routes. A restore replaces the database
+    // wholesale, so it is only ever offered by the setup screen; a tab left open on that screen
+    // after another one finished setting up must not act on it.
+    if (core.sql_init.isDbInitialized()) {
+        answer({ status: "error", reason: "already-initialized", message: "The database is already set up." });
+        return;
+    }
+
+    // Two restores would prepare over each other, since they write the same candidate.
+    if (restoreInProgress) {
+        answer({ status: "error", reason: "restore-refused", message: "A restore is already running." });
+        return;
+    }
+
+    restoreInProgress = true;
 
     try {
         await restoreDatabase(
             {
-                pool: sqlProvider!.sahPool!,
-                close: () => sqlProvider!.close(),
-                open: (dbName) => sqlProvider!.loadFromSahPool(dbName)
+                pool,
+                close: () => sqlProvider?.close(),
+                open: (dbName) => sqlProvider?.loadFromSahPool(dbName)
             },
             backup,
             { passphrase, report: ({ stage, fraction }) => report({ stage, fraction }) }
@@ -390,8 +413,8 @@ async function handleRestoreBackup(id: string, backup: File, passphrase?: string
 
         // What the "create new document" path announces for the same reason: everything that waits
         // on a database being there starts from here.
-        await coreModule!.sql_init.initDbConnection();
-        coreModule!.events.emit(coreModule!.events.DB_INITIALIZED);
+        await core.sql_init.initDbConnection();
+        core.events.emit(core.events.DB_INITIALIZED);
 
         answer({ status: "restored" });
     } catch (e) {
@@ -401,8 +424,13 @@ async function handleRestoreBackup(id: string, backup: File, passphrase?: string
         answer(reason === "passphrase-required"
             ? { status: "needs-passphrase" }
             : { status: "error", reason, message });
+    } finally {
+        restoreInProgress = false;
     }
 }
+
+/** Whether a restore is running, since a second one would prepare over the first one's work. */
+let restoreInProgress = false;
 
 // Wait for the INIT message before initializing so that queryString
 // (which may contain ?integrationTest=memory for e2e) is available.

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -47,6 +47,9 @@ console.log("[Worker] Error handlers installed, loading modules...");
 // TYPE-ONLY IMPORTS (erased at runtime, safe as static imports)
 // =============================================================================
 import type { BrowserRouter } from './lightweight/browser_router';
+import type { StandaloneRestoreProgress, StandaloneRestoreResult } from "@triliumnext/commons";
+
+import { readCurrentDatabaseName, RestoreFailure, restoreDatabase } from './lightweight/database_restore';
 
 // Build-time constant injected by Vite (see `define` in vite.config.mts).
 declare const __TRILIUM_INTEGRATION_TEST__: string;
@@ -222,7 +225,10 @@ async function initialize(): Promise<void> {
             // __TRILIUM_INTEGRATION_TEST__ Vite define (derived from the
             // TRILIUM_INTEGRATION_TEST env var when the bundle was built).
             const integrationTestMode = __TRILIUM_INTEGRATION_TEST__;
-            const dbName = "/trilium.db";
+            // Which pool entry holds the database is a stored answer rather than a constant: a
+            // restore cannot rename an entry, so it writes the new database in beside the old one
+            // and changes this. Unrestored instances read the name they have always used.
+            const dbName = await readCurrentDatabaseName();
 
             if (integrationTestMode === "memory") {
                 // Use OPFS for the DB in integration test mode so option changes
@@ -358,6 +364,46 @@ async function dispatch(request: LocalRequest) {
     return appRouter.dispatch(request.method, request.url, request.body, request.headers);
 }
 
+/**
+ * Restores the database from a backup handed straight to this worker.
+ *
+ * Answers rather than throws: the caller is a page waiting on a message, and every way this can end
+ * is something the setup screen has to say to the user. A missing passphrase is not a failure but a
+ * question, so it is reported as one and the same file can be offered again with an answer.
+ */
+async function handleRestoreBackup(id: string, backup: File, passphrase?: string): Promise<void> {
+    const report = (progress: StandaloneRestoreProgress) =>
+        (self as unknown as Worker).postMessage({ type: "RESTORE_PROGRESS", id, progress });
+    const answer = (result: StandaloneRestoreResult) =>
+        (self as unknown as Worker).postMessage({ type: "RESTORE_RESULT", id, result });
+
+    try {
+        await restoreDatabase(
+            {
+                pool: sqlProvider!.sahPool!,
+                close: () => sqlProvider!.close(),
+                open: (dbName) => sqlProvider!.loadFromSahPool(dbName)
+            },
+            backup,
+            { passphrase, report: ({ stage, fraction }) => report({ stage, fraction }) }
+        );
+
+        // What the "create new document" path announces for the same reason: everything that waits
+        // on a database being there starts from here.
+        await coreModule!.sql_init.initDbConnection();
+        coreModule!.events.emit(coreModule!.events.DB_INITIALIZED);
+
+        answer({ status: "restored" });
+    } catch (e) {
+        const reason = e instanceof RestoreFailure ? e.reason : "swap-failed";
+        const message = e instanceof Error ? e.message : String(e);
+
+        answer(reason === "passphrase-required"
+            ? { status: "needs-passphrase" }
+            : { status: "error", reason, message });
+    }
+}
+
 // Wait for the INIT message before initializing so that queryString
 // (which may contain ?integrationTest=memory for e2e) is available.
 let initReceived = false;
@@ -383,6 +429,11 @@ self.onmessage = async (event) => {
                 });
             });
         }
+        return;
+    }
+
+    if (msg.type === "RESTORE_BACKUP") {
+        await handleRestoreBackup(msg.id, msg.backup, msg.passphrase);
         return;
     }
 

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -4,13 +4,15 @@ const mocks = vi.hoisted(() => ({
     startLocalServerWorker: vi.fn(),
     attachServiceWorkerBridge: vi.fn(),
     registerNativeHttpHandler: vi.fn(),
+    restoreBackup: vi.fn(),
     capacitorHttpHandler: vi.fn()
 }));
 
 vi.mock("./local-bridge.js", () => ({
     startLocalServerWorker: mocks.startLocalServerWorker,
     attachServiceWorkerBridge: mocks.attachServiceWorkerBridge,
-    registerNativeHttpHandler: mocks.registerNativeHttpHandler
+    registerNativeHttpHandler: mocks.registerNativeHttpHandler,
+    restoreBackup: mocks.restoreBackup
 }));
 vi.mock("./services/capacitor_http_handler.js", () => ({ capacitorHttpHandler: mocks.capacitorHttpHandler }));
 // Avoid pulling the entire client bundle when loadScripts() runs.

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -1,5 +1,5 @@
 import { installIosInterceptors } from "./ios-interceptors.js";
-import { attachServiceWorkerBridge, registerNativeHttpHandler, startLocalServerWorker } from "./local-bridge.js";
+import { attachServiceWorkerBridge, registerNativeHttpHandler, restoreBackup, startLocalServerWorker } from "./local-bridge.js";
 
 async function waitForServiceWorkerControl(): Promise<void> {
     if (!("serviceWorker" in navigator) || !navigator.serviceWorker) {
@@ -43,6 +43,10 @@ async function waitForServiceWorkerControl(): Promise<void> {
 async function bootstrap() {
     /* fixes https://github.com/webpack/webpack/issues/10035 */
     window.global = globalThis;
+
+    // The client's way to the worker for the few things that carry a file, which the request path
+    // would serialise whole and time out on. The desktop's `window.electronApi` is the same idea.
+    window.standaloneApi = { restore: { importBackup: restoreBackup } };
 
     try {
         // When running inside a Capacitor WebView, register the native HTTP

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -28,6 +28,7 @@ export { default as BUILTIN_ATTRIBUTES } from "./lib/builtin_attributes.js";
 // barrel is imported by virtually every client module. Import them via their subpath instead,
 // e.g. "@triliumnext/commons/src/lib/spreadsheet/render_to_html".
 export * from "./lib/electron_api_interface.js";
+export * from "./lib/standalone_api_interface.js";
 export * from "./lib/favicon_contrast.js";
 export * from "./lib/link_embed.js";
 export * from "./lib/llm_api.js";

--- a/packages/commons/src/lib/standalone_api_interface.ts
+++ b/packages/commons/src/lib/standalone_api_interface.ts
@@ -1,0 +1,48 @@
+/**
+ * What the standalone build exposes to the client as `window.standaloneApi`.
+ *
+ * Standalone runs the whole stack in the browser: the database lives in a worker's private
+ * filesystem, and the client talks to it over an intercepted `fetch`. That path serialises every
+ * request body twice on its way through, and gives up after thirty seconds, which is fine for the
+ * JSON everything else exchanges and impossible for a database.
+ *
+ * So the few things that carry a file get their own way through, the same way the desktop's
+ * `window.electronApi` does. A `File` handed across is a reference to bytes the browser already has;
+ * nothing is copied, nothing is uploaded, and the worker reads it as a stream.
+ */
+
+/** How far a restore has got, reported as it goes. */
+export interface StandaloneRestoreProgress {
+    /** Which step is running: preparing the backup, checking it, or putting it in place. */
+    stage: "staging" | "validating" | "swapping" | "done" | "failed";
+    /** How far through that step, from 0 to 1, for the step that can say. */
+    fraction?: number;
+}
+
+/** How a restore ended. */
+export interface StandaloneRestoreResult {
+    status: "restored" | "needs-passphrase" | "error";
+    /** Machine-readable cause when `status` is `error`, which the screen turns into a sentence. */
+    reason?: string;
+    /** The technical detail behind that cause. */
+    message?: string;
+}
+
+export interface StandaloneRestoreApi {
+    /**
+     * Restores the database from a backup the user picked, reading it where it lies.
+     *
+     * Answers `needs-passphrase` for an encrypted backup given none, which is an invitation to ask
+     * for one and call again with the same file rather than a failure.
+     */
+    importBackup(opts: {
+        backup: File;
+        passphrase?: string;
+        onProgress?: (progress: StandaloneRestoreProgress) => void;
+    }): Promise<StandaloneRestoreResult>;
+}
+
+/** The complete surface the standalone build exposes to the client. */
+export interface StandaloneApi {
+    restore: StandaloneRestoreApi;
+}

--- a/packages/trilium-core/src/index.ts
+++ b/packages/trilium-core/src/index.ts
@@ -23,6 +23,14 @@ export type * from "./services/sql/types";
 export * from "./services/sql/index";
 export { default as sql_init } from "./services/sql_init";
 export { getRunningSetupOperation, holdSetup, withSetupLock } from "./services/setup_lock";
+export {
+    type CandidateDatabase,
+    type DatabaseRejection,
+    type DatabaseValidation,
+    looksLikeSqlite,
+    OLDEST_SUPPORTED_DB_VERSION,
+    validateDatabase
+} from "./services/database_validation";
 export * as protected_session from "./services/protected_session";
 export { default as data_encryption } from "./services/encryption/data_encryption";
 export { default as scrypt } from "./services/encryption/scrypt";

--- a/packages/trilium-core/src/index.ts
+++ b/packages/trilium-core/src/index.ts
@@ -29,7 +29,8 @@ export {
     type DatabaseValidation,
     looksLikeSqlite,
     OLDEST_SUPPORTED_DB_VERSION,
-    validateDatabase
+    validateDatabase,
+    type ValidationOptions
 } from "./services/database_validation";
 export * as protected_session from "./services/protected_session";
 export { default as data_encryption } from "./services/encryption/data_encryption";

--- a/packages/trilium-core/src/services/database_validation.spec.ts
+++ b/packages/trilium-core/src/services/database_validation.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import appInfo from "./app_info.js";
+import {
+    type CandidateDatabase,
+    looksLikeSqlite,
+    OLDEST_SUPPORTED_DB_VERSION,
+    validateDatabase
+} from "./database_validation.js";
+
+const TRILIUM_TABLES = [ "options", "notes", "branches", "blobs" ];
+
+/** A candidate that answers whatever the test says it does, without a database engine involved. */
+function candidate(answers: {
+    integrity?: string;
+    tables?: string[];
+    options?: Record<string, string>;
+} = {}): CandidateDatabase {
+    const options = answers.options ?? { initialized: "true", dbVersion: String(appInfo.dbVersion) };
+
+    return {
+        integrityCheck: () => answers.integrity ?? "ok",
+        tableNames: () => answers.tables ?? TRILIUM_TABLES,
+        option: (name) => options[name]
+    };
+}
+
+function bytesOf(text: string): Uint8Array {
+    return Uint8Array.from(text, (character) => character.charCodeAt(0));
+}
+
+describe("recognising a SQLite database by its first bytes", () => {
+    it("accepts the header every SQLite database begins with", () => {
+        expect(looksLikeSqlite(bytesOf("SQLite format 3\0"))).toBe(true);
+        // Whatever follows it is the database's business, not this check's.
+        expect(looksLikeSqlite(bytesOf("SQLite format 3\0and then some"))).toBe(true);
+    });
+
+    it("refuses anything else, including too little to tell", () => {
+        expect(looksLikeSqlite(bytesOf("this is a text file"))).toBe(false);
+        expect(looksLikeSqlite(bytesOf("SQLite"))).toBe(false);
+        expect(looksLikeSqlite(new Uint8Array())).toBe(false);
+        // Right length, one byte wrong.
+        expect(looksLikeSqlite(bytesOf("SQLite format 4\0"))).toBe(false);
+    });
+});
+
+describe("validating a candidate database", () => {
+    it("accepts one from this version, and one that only needs migrating", () => {
+        expect(validateDatabase(candidate())).toEqual({
+            valid: true, dbVersion: appInfo.dbVersion, needsMigration: false
+        });
+
+        const older = candidate({
+            options: { initialized: "true", dbVersion: String(OLDEST_SUPPORTED_DB_VERSION) }
+        });
+        expect(validateDatabase(older)).toEqual({
+            valid: true, dbVersion: OLDEST_SUPPORTED_DB_VERSION, needsMigration: true
+        });
+    });
+
+    it("refuses one that does not pass its own integrity check", () => {
+        expect(validateDatabase(candidate({ integrity: "row 3 missing from index sqlite_autoindex_notes_1" })))
+            .toMatchObject({ valid: false, rejection: "damaged-database" });
+    });
+
+    it("refuses a database that is not one of ours, naming what is missing", () => {
+        expect(validateDatabase(candidate({ tables: [ "recipes" ] }))).toMatchObject({
+            valid: false,
+            rejection: "not-a-trilium-database",
+            message: expect.stringContaining("options, notes, branches, blobs")
+        });
+
+        expect(validateDatabase(candidate({ tables: [ "options", "notes" ] }))).toMatchObject({
+            valid: false, rejection: "not-a-trilium-database", message: expect.stringContaining("branches, blobs")
+        });
+    });
+
+    it("refuses one left behind by a setup that never finished", () => {
+        const unfinished = candidate({ options: { dbVersion: String(appInfo.dbVersion) } });
+
+        expect(validateDatabase(unfinished)).toMatchObject({
+            valid: false, rejection: "database-not-initialized"
+        });
+    });
+
+    it("refuses one from a version this cannot migrate, in either direction", () => {
+        const tooOld = candidate({
+            options: { initialized: "true", dbVersion: String(OLDEST_SUPPORTED_DB_VERSION - 1) }
+        });
+        expect(validateDatabase(tooOld)).toMatchObject({ valid: false, rejection: "database-too-old" });
+
+        const tooNew = candidate({
+            options: { initialized: "true", dbVersion: String(appInfo.dbVersion + 1) }
+        });
+        expect(validateDatabase(tooNew)).toMatchObject({
+            valid: false, rejection: "database-too-new", message: expect.stringContaining(String(appInfo.dbVersion))
+        });
+    });
+
+    it("refuses one that does not say which version it is from", () => {
+        expect(validateDatabase(candidate({ options: { initialized: "true" } }))).toMatchObject({
+            valid: false, rejection: "not-a-trilium-database"
+        });
+
+        expect(validateDatabase(candidate({ options: { initialized: "true", dbVersion: "recent" } })))
+            .toMatchObject({ valid: false, rejection: "not-a-trilium-database" });
+    });
+
+    it("asks the cheapest questions first, so a damaged database is not read for its options", () => {
+        const asked: string[] = [];
+        const damaged: CandidateDatabase = {
+            integrityCheck: () => { asked.push("integrity"); return "malformed database schema"; },
+            tableNames: () => { asked.push("tables"); return TRILIUM_TABLES; },
+            option: (name) => { asked.push(`option:${name}`); return undefined; }
+        };
+
+        expect(validateDatabase(damaged)).toMatchObject({ rejection: "damaged-database" });
+        expect(asked).toEqual([ "integrity" ]);
+    });
+});

--- a/packages/trilium-core/src/services/database_validation.spec.ts
+++ b/packages/trilium-core/src/services/database_validation.spec.ts
@@ -107,6 +107,27 @@ describe("validating a candidate database", () => {
             .toMatchObject({ valid: false, rejection: "not-a-trilium-database" });
     });
 
+    it("leaves the scan out when asked to, and keeps every other check", () => {
+        const asked: string[] = [];
+        const watched: CandidateDatabase = {
+            integrityCheck: () => { asked.push("integrity"); return "malformed database schema"; },
+            tableNames: () => { asked.push("tables"); return TRILIUM_TABLES; },
+            option: (name) => {
+                asked.push(`option:${name}`);
+                return name === "initialized" ? "true" : String(appInfo.dbVersion);
+            }
+        };
+
+        // Accepted despite an integrity check that would have failed, because it is never put.
+        expect(validateDatabase(watched, { skipIntegrityCheck: true }))
+            .toMatchObject({ valid: true, dbVersion: appInfo.dbVersion });
+        expect(asked).toEqual([ "tables", "option:initialized", "option:dbVersion" ]);
+
+        // Nothing else is waived: a database that is not ours is still refused.
+        expect(validateDatabase(candidate({ tables: [ "recipes" ] }), { skipIntegrityCheck: true }))
+            .toMatchObject({ valid: false, rejection: "not-a-trilium-database" });
+    });
+
     it("asks the cheapest questions first, so a damaged database is not read for its options", () => {
         const asked: string[] = [];
         const damaged: CandidateDatabase = {

--- a/packages/trilium-core/src/services/database_validation.ts
+++ b/packages/trilium-core/src/services/database_validation.ts
@@ -1,0 +1,136 @@
+import appInfo from "./app_info.js";
+
+/**
+ * Decides whether a database can become this instance's, before anything depends on the answer.
+ *
+ * A restore replaces the document the whole application is about, and the file it replaces it with
+ * arrived from outside: an upload, a directory listing, a file the user picked. "It has a .db
+ * extension" says nothing, and finding out later is not an option, because the code that would find
+ * out is the migration, and a migration that cannot proceed calls `crash()`.
+ *
+ * The checks live here, apart from the opening: what makes a database ours is the same everywhere,
+ * while opening one is not. A platform supplies a {@link CandidateDatabase}, which is the whole of
+ * what these checks need and is deliberately small enough that any driver can offer it — a second
+ * connection on the server, an entry read out of the browser's own storage, page by page in both
+ * cases rather than in memory.
+ *
+ * @module
+ */
+
+/** The oldest database the migrations still reach back to; below this one, there is no upgrade path. */
+export const OLDEST_SUPPORTED_DB_VERSION = 214;
+
+/** What every SQLite database begins with, in the encoding the bytes are read as. */
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+const REQUIRED_TABLES = [ "options", "notes", "branches", "blobs" ];
+
+export type DatabaseRejection =
+    /** Not a SQLite database at all. */
+    | "not-a-database"
+    /** SQLite, but corrupt. */
+    | "damaged-database"
+    /** A SQLite database, but not one of ours. */
+    | "not-a-trilium-database"
+    /** Ours, but from a setup that never finished, so there is nothing to restore. */
+    | "database-not-initialized"
+    /** From a version so old the migrations no longer reach back to it. */
+    | "database-too-old"
+    /** From a newer version, which this one cannot read. */
+    | "database-too-new";
+
+export type DatabaseValidation =
+    | { valid: true; dbVersion: number; needsMigration: boolean }
+    | { valid: false; rejection: DatabaseRejection; message: string };
+
+/**
+ * A candidate database, open and readable, reduced to the three questions validation asks of it.
+ *
+ * Each is a plain read: nothing here writes, and nothing needs the whole database at once.
+ */
+export interface CandidateDatabase {
+    /** What `PRAGMA quick_check` answers, which is `"ok"` and nothing else when all is well. */
+    integrityCheck(): string;
+    /** The names of the tables it has. */
+    tableNames(): string[];
+    /** A value from the `options` table, or `undefined` where there is no such row. */
+    option(name: string): string | undefined;
+}
+
+/**
+ * Reports whether `head` starts the way a SQLite database does.
+ *
+ * Sixteen bytes, asked before a database engine is involved at all, so that a photograph gets an
+ * answer about what it is rather than one about a malformed database.
+ *
+ * @param head the first bytes of the file; anything shorter than the magic is not one.
+ */
+export function looksLikeSqlite(head: Uint8Array): boolean {
+    if (head.length < SQLITE_MAGIC.length) {
+        return false;
+    }
+
+    for (let i = 0; i < SQLITE_MAGIC.length; i++) {
+        if (head[i] !== SQLITE_MAGIC.charCodeAt(i)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Puts an open candidate through every check, in the order that answers most cheaply first.
+ *
+ * `PRAGMA quick_check` reads the whole database, which for a large one is not instant. It is worth
+ * it: a restore that succeeds and leaves the user with a corrupt document is worse than one that
+ * takes another minute to say no.
+ *
+ * @throws whatever the driver throws on a database too damaged to query; the caller knows its own
+ *         driver's failures and turns them into {@link DatabaseRejection}.
+ */
+export function validateDatabase(db: CandidateDatabase): DatabaseValidation {
+    const integrity = db.integrityCheck();
+    if (integrity !== "ok") {
+        return reject("damaged-database", `The database failed its integrity check: ${integrity}`);
+    }
+
+    const tables = new Set(db.tableNames());
+    const missing = REQUIRED_TABLES.filter((table) => !tables.has(table));
+    if (missing.length > 0) {
+        return reject(
+            "not-a-trilium-database",
+            `The database is missing the ${missing.join(", ")} table${missing.length > 1 ? "s" : ""}.`
+        );
+    }
+
+    if (db.option("initialized") !== "true") {
+        return reject(
+            "database-not-initialized",
+            "The database is from a setup that never finished, so it holds nothing to restore."
+        );
+    }
+
+    const dbVersion = Number(db.option("dbVersion"));
+    if (!Number.isInteger(dbVersion)) {
+        return reject("not-a-trilium-database", "The database does not state which version it is from.");
+    }
+    if (dbVersion < OLDEST_SUPPORTED_DB_VERSION) {
+        return reject(
+            "database-too-old",
+            `The database is version ${dbVersion}; the oldest that can still be migrated is ${OLDEST_SUPPORTED_DB_VERSION}.`
+        );
+    }
+    if (dbVersion > appInfo.dbVersion) {
+        return reject(
+            "database-too-new",
+            `The database is version ${dbVersion}, which is newer than this application's ${appInfo.dbVersion}.`
+        );
+    }
+
+    return { valid: true, dbVersion, needsMigration: dbVersion < appInfo.dbVersion };
+}
+
+function reject(rejection: DatabaseRejection, message: string): DatabaseValidation {
+    return { valid: false, rejection, message };
+}

--- a/packages/trilium-core/src/services/database_validation.ts
+++ b/packages/trilium-core/src/services/database_validation.ts
@@ -49,7 +49,10 @@ export type DatabaseValidation =
  * Each is a plain read: nothing here writes, and nothing needs the whole database at once.
  */
 export interface CandidateDatabase {
-    /** What `PRAGMA quick_check` answers, which is `"ok"` and nothing else when all is well. */
+    /**
+     * What `PRAGMA quick_check` answers, which is `"ok"` and nothing else when all is well. Not
+     * asked at all when {@link ValidationOptions.skipIntegrityCheck} is set.
+     */
     integrityCheck(): string;
     /** The names of the tables it has. */
     tableNames(): string[];
@@ -79,18 +82,30 @@ export function looksLikeSqlite(head: Uint8Array): boolean {
     return true;
 }
 
+/** What a platform may leave out of the checks, and why it is allowed to. */
+export interface ValidationOptions {
+    /**
+     * Leaves out `PRAGMA quick_check`, which is the only check whose cost grows with the database.
+     *
+     * For a platform where that scan is prohibitive, and where the bytes have already been accounted
+     * for by other means. Everything else here is a handful of small reads and is always done.
+     */
+    skipIntegrityCheck?: boolean;
+}
+
 /**
  * Puts an open candidate through every check, in the order that answers most cheaply first.
  *
  * `PRAGMA quick_check` reads the whole database, which for a large one is not instant. It is worth
  * it: a restore that succeeds and leaves the user with a corrupt document is worse than one that
- * takes another minute to say no.
+ * takes another minute to say no. Where it is not worth it, see
+ * {@link ValidationOptions.skipIntegrityCheck}.
  *
  * @throws whatever the driver throws on a database too damaged to query; the caller knows its own
  *         driver's failures and turns them into {@link DatabaseRejection}.
  */
-export function validateDatabase(db: CandidateDatabase): DatabaseValidation {
-    const integrity = db.integrityCheck();
+export function validateDatabase(db: CandidateDatabase, options: ValidationOptions = {}): DatabaseValidation {
+    const integrity = options.skipIntegrityCheck ? "ok" : db.integrityCheck();
     if (integrity !== "ok") {
         return reject("damaged-database", `The database failed its integrity check: ${integrity}`);
     }

--- a/packages/trilium-core/src/services/migration.ts
+++ b/packages/trilium-core/src/services/migration.ts
@@ -1,4 +1,5 @@
 import { getBackup } from "./backup.js";
+import { OLDEST_SUPPORTED_DB_VERSION } from "./database_validation.js";
 import { getSql } from "./sql/index.js";
 import { getLog } from "./log.js";
 import { getPlatform } from "./platform.js";
@@ -20,7 +21,7 @@ interface MigrationInfo {
 async function migrate() {
     const currentDbVersion = getDbVersion();
 
-    if (currentDbVersion < 214) {
+    if (currentDbVersion < OLDEST_SUPPORTED_DB_VERSION) {
         getPlatform().crash(t("migration.old_version"));
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,9 @@ importers:
       '@sqlite.org/sqlite-wasm':
         specifier: 3.51.1-build2
         version: 3.51.1-build2
+      '@triliumnext/backup-container':
+        specifier: workspace:*
+        version: link:../../packages/trilium-backup-container
       '@triliumnext/ckeditor5':
         specifier: workspace:*
         version: link:../../packages/ckeditor5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   '@lezer/common': 1.5.2
   '@lezer/highlight': 1.2.3
   '@lezer/lr': 1.4.10
+  '@ai-sdk/provider-utils': 5.0.19
   mermaid: 11.16.0
   preact: 10.29.8
   roughjs: 4.6.6
@@ -1525,12 +1526,6 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.19':
     resolution: {integrity: sha512-7GJ9TkXXr3RLUK5tvOjqejH/eozVkiV7i0B/AcOrcVjE2l2iJNKNe022ZAr8uUHUesWRyBj0ZkUe9wIk4OqgSw==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: '>=4.0.0'
-
-  '@ai-sdk/provider-utils@5.0.20':
-    resolution: {integrity: sha512-9W8c2mXiGgbo9sBBT4ybEWF8znxla2CO8VTim8t5oCCLP4aDH4o6RvkHfwL/iLC6mEbO4a6LpS2FBbQHccU+ig==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: '>=4.0.0'
@@ -12526,7 +12521,7 @@ snapshots:
   '@ai-sdk/anthropic@4.0.29(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
-      '@ai-sdk/provider-utils': 5.0.20(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.19(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/gateway@4.0.39(zod@4.4.3)':
@@ -12549,15 +12544,6 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.19(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.5
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      undici: 7.28.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@5.0.20(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.5
       '@standard-schema/spec': 1.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,12 @@ overrides:
   "@lezer/common": "1.5.2"
   "@lezer/highlight": "1.2.3"
   "@lezer/lr": "1.4.10"
+  # The AI SDK packages each pin @ai-sdk/provider-utils to an exact patch, and they do not move in
+  # step: `ai` and the OpenAI/Google providers ask for one, the Anthropic provider for another. Two
+  # copies in the tree mean two declarations of the `unique symbol` that marks a `Schema`, so a tool
+  # built by one provider stops being assignable to the ToolSet `ai` expects (TS2322 on the Anthropic
+  # web-search tool). Pin the version `ai` itself is built against, and raise it with the next bump.
+  "@ai-sdk/provider-utils": "5.0.19"
   "mermaid": "11.16.0"
   "preact": "10.29.8"
   "roughjs": "4.6.6"


### PR DESCRIPTION
Trilium's browser-only build can now restore from a backup at setup, the same as the server and desktop apps can. Pick a backup file and it is read straight from where it sits on your device: nothing is uploaded, nothing is copied first, and a multi-gigabyte backup works as well as a small one. Compressed and encrypted `.tnbackup` files are unwrapped in the browser, with the password asked for before the file is read rather than after. The backup is checked before anything is replaced, and if it turns out to be unusable your existing knowledge base is left exactly as it was.

## Restoring a backup in the browser

- Enable "Restore from backup" on the setup screen of the standalone build, which was previously disabled there.
- Stream the picked file into the browser's database storage chunk by chunk, so a large backup is never held whole in memory.
- Unwrap `.tnbackup` containers in the browser, compressed and encrypted alike, by piping the reader into the import so neither end holds more than a chunk.
- Ask for the encryption password from the container header before the file is read, and restart from the same file once it is given.
- Pass the picked file to the worker by reference through a new `window.standaloneApi`, bypassing the request path that serialises bodies whole and times out after thirty seconds.
- Relay restore progress from the worker to the setup screen, instead of polling a server that is not there.
- Read which database the worker opens from a pointer file at start, falling back to the original name for an instance that has never restored anything.
- Make the swap by writing that pointer file, since the browser's storage pool cannot rename an entry.
- Alternate the database between two names, so a restore never stages over the database it is replacing.
- Remove the previous database only once the restored one has opened, and put it back if it will not.
- Report each step and its progress: preparing the backup, checking it, putting it in place.

## Refusing a restore that would do harm

- Refuse a restore when the database is already set up, which is what `checkAppNotInitialized` does for the server's routes, and say so on the setup screen.
- Refuse a second restore while one is running, since both would stage over each other.
- Skip the pre-migration backup in the browser when the database is over 256 MB, where serialising it would take the tab down rather than fail.

## Database validation

- Move the checks that decide whether a database can be restored into core, behind a `CandidateDatabase` interface a platform implements with three small reads.
- Reduce the server's validation to opening a read-only connection and handing it over.
- Validate a candidate in the browser by opening it from the storage pool, page by page through the VFS, without loading it into memory.
- Add a `skipIntegrityCheck` option that leaves out `PRAGMA quick_check`, the one check whose cost grows with the size of the database.
- Skip that scan for browser imports, where every page would come back through WebAssembly and the setup screen cannot report progress on it.
- Take the oldest supported database version from a single constant, which the migration now reads as well.

## Setup screen

- Hide the existing-backups list in the browser build, where nothing takes backups on a schedule and one kept beside the database would be cleared along with it.
- Show progress as the restore reports it, and keep polling for it where it does not report.
- Add an error message for restoring over an instance that already has a knowledge base.

## Tests

- Cover the browser restore end to end against an in-memory storage pool: plain databases, compressed and encrypted containers, the passphrase prompt, every rejection, the name alternation, and the rollback when the restored database will not open.
- Assert that the integrity scan is never put to a candidate while the schema and version reads still are.
- Cover the worker message relay, the setup screen's browser branch, and the size ceiling on the pre-migration backup.
