### PR TITLE
fix(notes): apply all of a parent's child:template relations, not just the first

### DIFF
--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -141,6 +141,51 @@ describe("notes service (real DB)", () => {
             expect(note.getContent()).toBe("<p>day template</p>");
         });
 
+        it("inherits every one of the parent's child:template relations, not just one", () => {
+            const t1 = createNote("root", { title: "spec-multi-tmpl-1", content: "<p>one</p>" });
+            const t2 = createNote("root", { title: "spec-multi-tmpl-2", content: "<p>two</p>" });
+            const parent = createNote("root", {
+                title: "spec-multi-tmpl-parent",
+                attributes: [
+                    { type: "relation", name: "child:template", value: t1.note.noteId },
+                    { type: "relation", name: "child:template", value: t2.note.noteId }
+                ]
+            });
+
+            const { note } = createNote(parent.note.noteId, {
+                title: "spec-multi-tmpl-child",
+                content: ""
+            });
+
+            const applied = note.getRelations("template").map((r) => r.value);
+            expect(applied).toEqual([t1.note.noteId, t2.note.noteId]);
+        });
+
+        it("lets an explicitly chosen template suppress the child:template defaults", () => {
+            const chosen = createNote("root", {
+                title: "spec-multi-tmpl-chosen",
+                content: "<p>chosen</p>"
+            });
+            const t1 = createNote("root", { title: "spec-mt-def-1", content: "<p>one</p>" });
+            const t2 = createNote("root", { title: "spec-mt-def-2", content: "<p>two</p>" });
+            const parent = createNote("root", {
+                title: "spec-multi-tmpl-parent-chosen",
+                attributes: [
+                    { type: "relation", name: "child:template", value: t1.note.noteId },
+                    { type: "relation", name: "child:template", value: t2.note.noteId }
+                ]
+            });
+
+            const { note } = createNote(parent.note.noteId, {
+                title: "spec-multi-tmpl-child-chosen",
+                content: "",
+                templateNoteId: chosen.note.noteId
+            });
+
+            const applied = note.getRelations("template").map((r) => r.value);
+            expect(applied).toEqual([chosen.note.noteId]);
+        });
+
         it("does not inherit the parent's child:template when the new note's type differs (#3015)", () => {
             const template = createNote("root", { title: "spec-child-tmpl-mismatch", content: "<p>day template</p>" });
             const parent = createNote("root", {

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -108,14 +108,16 @@ function deriveMime(type: string, mime?: string) {
 }
 
 function copyChildAttributes(parentNote: BNote, childNote: BNote, isTypeDefaulted = false) {
+    // A template already present at this point was chosen by the user explicitly in the menu, and
+    // suppresses the `child:template` defaults (#3628). Deliberately read once, before the loop.
+    const hasUserChosenTemplate = childNote.hasRelation("template");
+
     for (const attr of parentNote.getAttributes()) {
         if (attr.name.startsWith("child:")) {
             const name = attr.name.substring(6);
 
             if (attr.type === "relation" && name === "template") {
-                if (childNote.hasRelation("template")) {
-                    // if the note already has a template, it means the template was chosen by the user explicitly
-                    // in the menu. In that case, we should override the default templates defined in the child: attrs
+                if (hasUserChosenTemplate) {
                     continue;
                 }
 


### PR DESCRIPTION
## Problem

A note with two `child:template` relations only passes the **first** one to new children:

```
~child:template=template1
~child:template=template2
```

Creating a child yields `~template=template1` only; `template2` is silently dropped.

Reported by a user; reproduced with a failing test before fixing.

## Cause

`copyChildAttributes()` re-read `childNote.hasRelation("template")` **inside** the loop over the parent's attributes:

```ts
for (const attr of parentNote.getAttributes()) {
    if (attr.type === "relation" && name === "template") {
        if (childNote.hasRelation("template")) {
            continue;
        }
```

That guard exists so a template chosen explicitly in the "new note" submenu overrides the `child:template` defaults (#3628). But reading it live meant the first template *the loop itself just copied* flipped the check to true, so every subsequent `child:template` hit the `continue`.

## Regression, not longstanding behaviour

The guard was added in ec8ed65feb (2023, #3628) as a snapshot taken **before** the loop, which handled multiple templates correctly:

```js
function copyChildAttributes(parentNote, childNote) {
    const hasAlreadyTemplate = childNote.hasRelation('template');   // ← once, outside
    for (const attr of parentNote.getAttributes()) { ... }
```

5508b505c8 (`chore(core): port notes service partially`) moved that line inside the loop while porting the notes service to `trilium-core`; 1666c5ebdf (the #3015 type-mismatch fix) refactored around it but kept the placement.

**Shipped in v0.104.0 and v0.104.1.**

## Fix

Hoist the check back out of the loop, restoring the original semantics.

Multiple templates are fully supported downstream — `BNote.__getAttributes()` already iterates every `template`/`inherit` relation and merges each one's attributes — so this copy step was the only defect.

## Tests

Two tests added to `notes.spec.ts`:

- all `child:template` relations propagate to the child (fails without the fix: `expected [ 'Jenmmtu9SdCE' ] to deeply equal [ 'Jenmmtu9SdCE', 'k8ZSHZ81JYPC' ]`)
- an explicitly chosen `templateNoteId` still suppresses **all** of the parent's defaults — guarding the #3628 behaviour the snapshot exists to protect

`notes.spec.ts` 35/35 pass, plus `attributes.spec.ts` and `hidden_subtree_templates.spec.ts`. The existing #3015 and #3628 tests are unaffected.

## Note for reviewers

The per-attribute type-mismatch guard from #3015 is intentionally left as-is, so templates whose note type differs from an explicitly chosen child type are still skipped individually. With same-type templates — the reported case — all now apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)