### PR TITLE
fix(notes): don't let an inherited ~template suppress child:template

### DIFF
--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -187,6 +187,23 @@ describe("notes service (real DB)", () => {
             expect(applied).toEqual([chosen.note.noteId]);
         });
 
+        it("applies child:template even when the parent also has an inheritable ~template", () => {
+            const template = createNote("root", { title: "spec-inh-tmpl", content: "<p>tmpl</p>" });
+            const parent = createNote("root", {
+                title: "spec-inh-tmpl-parent",
+                attributes: [
+                    { type: "relation", name: "child:template", value: template.note.noteId },
+                    { type: "relation", name: "template", value: template.note.noteId, isInheritable: true }
+                ]
+            });
+
+            const { note } = createNote(parent.note.noteId, { title: "spec-inh-tmpl-child", content: "" });
+
+            // the relation must be owned, not merely inherited, so the template's content is copied
+            expect(note.getOwnedRelations("template").map((r) => r.value)).toEqual([template.note.noteId]);
+            expect(note.getContent()).toBe("<p>tmpl</p>");
+        });
+
         it("does not inherit the parent's child:template when the new note's type differs (#3015)", () => {
             const template = createNote("root", { title: "spec-child-tmpl-mismatch", content: "<p>day template</p>" });
             const parent = createNote("root", {

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -108,9 +108,10 @@ function deriveMime(type: string, mime?: string) {
 }
 
 function copyChildAttributes(parentNote: BNote, childNote: BNote, isTypeDefaulted = false) {
-    // A template already present at this point was chosen by the user explicitly in the menu, and
-    // suppresses the `child:template` defaults (#3628). Deliberately read once, before the loop.
-    const hasUserChosenTemplate = childNote.hasRelation("template");
+    // A template *owned* at this point was chosen by the user explicitly in the menu, and suppresses
+    // the `child:template` defaults (#3628). Deliberately read once, before the loop, and owned-only
+    // so an inherited `~template` on the parent doesn't count as a choice.
+    const hasUserChosenTemplate = childNote.hasOwnedRelation("template");
 
     for (const attr of parentNote.getAttributes()) {
         if (attr.name.startsWith("child:")) {


### PR DESCRIPTION
## Problem

A parent carrying **both** `~child:template=ABC` and `~template(inheritable)=ABC` passes no `~template` down to new children. The child ends up with the relation only implicitly, through inheritance, and never as an attribute of its own:

```
owned ~template:     []      <- nothing written
effective ~template: [ABC]   <- inheritance only
content:             ""      <- template content NOT copied
```

## Cause

`copyChildAttributes()` guards the `child:template` copy with a snapshot of whether the child already has a template:

```ts
const hasUserChosenTemplate = childNote.hasRelation("template");
```

That guard exists so a template picked explicitly in the "new note" submenu overrides the `child:template` defaults (#3628). But `hasRelation()` resolves through `getAttributes()`, which walks the parents' inheritable attributes; `hasOwnedRelation()` is the non-inherited variant.

Ordering makes it fire: `createNewNote()` saves the branch *before* it calls `copyChildAttributes()`, so by then the child is already parented and already inherits `~template=ABC`. The guard reads that as "the user chose a template" and skips the copy.

## Why it is more than cosmetic

Attribute resolution still works — `BNote.__getAttributes()` expands `template`/`inherit` relations found in `parentAttributes`, which includes inherited ones. But the `ENTITY_CREATED` handler in `handlers.ts` keys off an attribute row actually being created, so with no owned relation:

1. the template's **content is not copied** into the new note;
2. the template's **child subtree is not duplicated**.

The inherited link also vanishes if the note is later moved out of that parent, and it never shows as the note's own relation in the UI.

## Fix

Narrow the guard to the owned relation. This is exact rather than a heuristic: an explicitly chosen template always arrives as an *owned* relation, either via `note.addRelation("template", …)` on the `templateNoteId` path or through the atomic `params.attributes`. Neither is affected.

## Testing

Added a regression test to `notes.spec.ts` asserting the relation is **owned** (not merely inherited) and that the template's content lands in the child. Verified it fails on the old code (`expected [] to deeply equal [ 'zWPh…' ]`) and passes with the fix; all 36 tests in the file pass.

## Notes

Pre-existing — the guard has read `hasRelation` since `ec8ed65feb` introduced it; `e78fda1d2f` only hoisted the snapshot out of the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)