### PR TITLE
feat(share): allow slashes in shareAlias

### DIFF
--- a/apps/server/src/share/content_renderer.ts
+++ b/apps/server/src/share/content_renderer.ts
@@ -98,6 +98,7 @@ export function renderNoteForExport(note: BNote, parentBranch: BBranch, basePath
     return renderNoteContentInternal(note, {
         subRoot,
         rootNoteId: parentBranch.noteId,
+        relativeBasePath: './',
         cssToLoad: [
             `${basePath}assets/styles.css`,
             `${basePath}assets/scripts.css`,
@@ -120,6 +121,12 @@ export function renderNoteForExport(note: BNote, parentBranch: BBranch, basePath
 export function renderNoteContent(note: SNote) {
     const subRoot = getSharedSubTreeRoot(note);
 
+    // Get the relative URL to the share root. This is required for links to
+    // other notes, assets, etc.
+    const shareAlias = note.getLabelValue("shareAlias") ?? note.noteId;
+    const shareAliasSlashCount = (shareAlias.match(/\//g)||[]).length
+    const relativeBasePath = shareAliasSlashCount > 0 ? "../".repeat(shareAliasSlashCount) : "./";
+
     const ancestors: string[] = [];
     let notePointer = note;
     while (notePointer.parents[0]?.noteId !== subRoot.note?.noteId) {
@@ -134,38 +141,39 @@ export function renderNoteContent(note: SNote) {
     // Determine CSS to load.
     const cssToLoad: string[] = [];
     if (!note.isLabelTruthy("shareOmitDefaultCss")) {
-        cssToLoad.push(`assets/styles.css`);
-        cssToLoad.push(`assets/scripts.css`);
+        cssToLoad.push(`${relativeBasePath}assets/styles.css`);
+        cssToLoad.push(`${relativeBasePath}assets/scripts.css`);
     }
     for (const cssRelation of note.getRelations("shareCss")) {
-        cssToLoad.push(`api/notes/${cssRelation.value}/download`);
+        cssToLoad.push(`${relativeBasePath}api/notes/${cssRelation.value}/download`);
     }
 
     // Determine JS to load.
     const jsToLoad: string[] = [
-        "assets/scripts.js"
+        `${relativeBasePath}assets/scripts.js`
     ];
     for (const jsRelation of note.getRelations("shareJs")) {
-        jsToLoad.push(`api/notes/${jsRelation.value}/download`);
+        jsToLoad.push(`${relativeBasePath}api/notes/${jsRelation.value}/download`);
     }
 
     const customLogoId = note.getRelation("shareLogo")?.value;
-    const logoUrl = customLogoId ? `api/images/${customLogoId}/image.png` : `../${assetUrlFragment}/images/icon-color.svg`;
+    const logoUrl = customLogoId ? `${relativeBasePath}api/images/${customLogoId}/image.png` : `${relativeBasePath}../${assetUrlFragment}/images/icon-color.svg`;
     const iconPacks = iconPackService.getIconPacks().filter(p => p.builtin || !!shaca.notes[p.manifestNoteId]);
 
     return renderNoteContentInternal(note, {
         subRoot,
         rootNoteId: "_share",
+        relativeBasePath,
         cssToLoad,
         jsToLoad,
         logoUrl,
         ancestors,
         isStatic: false,
-        faviconUrl: note.hasRelation("shareFavicon") ? `api/notes/${note.getRelationValue("shareFavicon")}/download` : `../favicon.ico`,
+        faviconUrl: note.hasRelation("shareFavicon") ? `${relativeBasePath}api/notes/${note.getRelationValue("shareFavicon")}/download` : `../favicon.ico`,
         iconPackCss: [
             ...iconPacks.map(p => iconPackService.generateCss(p, p.builtin
-                ? `assets/fonts/${p.fontAttachmentId}.${iconPackService.MIME_TO_EXTENSION_MAPPINGS[p.fontMime]}`
-                : `api/attachments/${p.fontAttachmentId}/download`
+                ? `${relativeBasePath}assets/fonts/${p.fontAttachmentId}.${iconPackService.MIME_TO_EXTENSION_MAPPINGS[p.fontMime]}`
+                : `${relativeBasePath}api/attachments/${p.fontAttachmentId}/download`
             )),
             task_states.generateTaskStateCss()
         ]
@@ -178,6 +186,7 @@ export function renderNoteContent(note: SNote) {
 interface RenderArgs {
     subRoot: Subroot;
     rootNoteId: string;
+    relativeBasePath: string;
     cssToLoad: string[];
     jsToLoad: string[];
     logoUrl: string;

--- a/apps/server/src/share/routes.ts
+++ b/apps/server/src/share/routes.ts
@@ -259,10 +259,10 @@ function register(router: Router) {
         renderNote(shaca.shareRootNote, req, res);
     });
 
-    router.get("/share/:shareId", (req, res) => {
+    router.get("/share/*shareId", (req, res) => {
         shacaLoader.ensureLoad();
 
-        const { shareId } = req.params;
+        const shareId = req.params.shareId.join('/');
 
         const note = shaca.aliasToNote[shareId] || shaca.notes[shareId];
 

--- a/docs/User Guide/User Guide/Advanced Usage/Sharing.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Sharing.md
@@ -190,7 +190,7 @@ Shared notes typically have URLs like `http://domain.tld/share/knvU8aJy4dJ7`, wh
 **Important**:
 
 1.  Ensure that aliases are unique.
-2.  Using slashes (`/`) within aliases to create subpaths is not supported.
+2.  You can use slashes (`/`) within aliases to create subpaths (e.g. `#shareAlias=a/b/c` changes the URL to `/share/a/b/c`).
 
 > [!TIP]
 > *   To easily identify pages that don't have a share alias, run a <a class="reference-link" href="../Basic%20Concepts%20and%20Features/Navigation/Search.md">Search</a> with `#!shareAlias`.

--- a/packages/share-theme/src/templates/page.ejs
+++ b/packages/share-theme/src/templates/page.ejs
@@ -100,7 +100,7 @@
 const logoWidth = subRoot.note.getLabelValue("shareLogoWidth") ?? 53;
 const logoHeight = subRoot.note.getLabelValue("shareLogoHeight") ?? 40;
 const mobileLogoHeight = logoHeight && logoWidth ? 32 / (logoWidth / logoHeight) : "";
-const shareRootLink = subRoot.note.hasLabel("shareRootLink") ? sanitizeUrl(subRoot.note.getLabelValue("shareRootLink") ?? "") : `./${subRoot.note.noteId}`;
+const shareRootLink = subRoot.note.hasLabel("shareRootLink") ? sanitizeUrl(subRoot.note.getLabelValue("shareRootLink") ?? "") : `${relativeBasePath}${subRoot.note.noteId}`;
 const headingRe = /(<h[1-6]>)(.+?)(<\/h[1-6]>)/g;
 const headingMatches = [...content.matchAll(headingRe)];
 // Unique slug per heading (in document order) so duplicate titles get distinct
@@ -153,7 +153,7 @@ content = content.replaceAll(headingRe, (...match) => {
             </div>
         <% if (hasTree) { %>
             <nav id="menu">
-                <%- include("tree_item", {note: subRoot.note, activeNote: note, subRoot: subRoot, ancestors}) %>
+                <%- include("tree_item", {note: subRoot.note, activeNote: note, subRoot: subRoot, relativeBasePath: relativeBasePath, ancestors}) %>
             </nav>
         <% } %>   
         </div>
@@ -185,7 +185,7 @@ content = content.replaceAll(headingRe, (...match) => {
                         const action = note.type === "book" ? "getChildNotes" : "getVisibleChildNotes";
                         for (const childNote of note[action]()) {
                             const isExternalLink = childNote.hasLabel("shareExternal") || childNote.hasLabel("shareExternalLink");
-                            const rawHref = isExternalLink ? childNote.getLabelValue("shareExternal") ?? childNote.getLabelValue("shareExternalLink") : `./${childNote.shareId}`;
+                            const rawHref = isExternalLink ? childNote.getLabelValue("shareExternal") ?? childNote.getLabelValue("shareExternalLink") : `${relativeBasePath}${childNote.shareId}`;
                             const linkHref = isExternalLink ? sanitizeUrl(rawHref ?? "") : rawHref;
                             const target = isExternalLink ? ` target="_blank" rel="noopener noreferrer"` : "";
                         %>
@@ -206,12 +206,12 @@ content = content.replaceAll(headingRe, (...match) => {
                 <% } %>
 
                 <% if (hasTree) { %>
-                    <%- include("prev_next", { note: note, subRoot: subRoot }) %>
+                    <%- include("prev_next", { note: note, subRoot: subRoot, relativeBasePath: relativeBasePath }) %>
                 <% } %>
 
                 <% if (showLoginInShareTheme && !isStatic) { %>
                     <div class="login">
-                        <a href="../login" class="login-link"><%= t("share_theme.login") %></a>
+                        <a href="${relativeBasePath}../login" class="login-link"><%= t("share_theme.login") %></a>
                     </div>
                 <% } %>
             </footer>

--- a/packages/share-theme/src/templates/prev_next.ejs
+++ b/packages/share-theme/src/templates/prev_next.ejs
@@ -57,6 +57,6 @@
 %>
 
 <div class="navigation">
-    <% if (previousNote) { %><a class="previous" href="./<%= previousNote.shareId %>"><%= previousNote.title %></a><% } %>
-    <% if (nextNote) { %><a class="next" href="./<%= nextNote.shareId %>"><%= nextNote.title %></a><% } %>
+    <% if (previousNote) { %><a class="previous" href="<%= relativeBasePath + previousNote.shareId %>"><%= previousNote.title %></a><% } %>
+    <% if (nextNote) { %><a class="next" href="<%= relativeBasePath + nextNote.shareId %>"><%= nextNote.title %></a><% } %>
 </div>

--- a/packages/share-theme/src/templates/tree_item.ejs
+++ b/packages/share-theme/src/templates/tree_item.ejs
@@ -6,7 +6,7 @@ let linkHref;
 if (isExternalLink) {
     linkHref = sanitizeUrl(note.getLabelValue("shareExternal") ?? "");
 } else if (note.shareId) {
-    linkHref = `./${note.shareId}`;
+    linkHref = `${relativeBasePath}${note.shareId}`;
 }
 
 const target = isExternalLink ? ` target="_blank" rel="noopener noreferrer"` : "";


### PR DESCRIPTION
Two changes are made to accomodate this:

- The /share route is adapted to allow for share aliases with slashes in them (previously if a slash was found, it would be treated as a different, nonexistent route).
- The share theme gains a new variable, "relativeBasePath", which contains the relative path to the base /share endpoint from the current note (e.g. for /share/a this will be "./", for /share/a/b/c this will be "../../../", etc.). (We keep using relative paths for assets, note downloads, etc. rather than hardcoding the /share prefix to avoid breaking non-standard setups that serve the shared notes under a custom URL (I do this with a rule in my reverse proxy, for example - my share is at notes.(domain)/, rather than notes.(domain)/share).)

This can be used for creating "subpaths" in shares, e.g. you can have a note with a shareAlias of /a, /a/b, /a/b/c, ... (or skip in-between paths entirely, or use nesting unrelated to how the notes are nested - this change allows for using slashes anywhere in the share alias).

Note that this only applies to shared notes. Exports are unaffected and behave the exact same way as they did before this change - they have their own folder structure, and all slashes in share aliases will simply be deleted from the final note HTML filenames.

---

Not sure if this isn't too much of a hack. I guess having full support for auto-generated subpaths based on node roots would achieve the exact same goal, at least for my use case (something like what exports already do, but for shares); even then, it would probably be a toggleable option (with a label like `#shareAutoPath` or something more obvious?), and would require similar base changes as what I've done here.