### PR TITLE
fix(standalone): restore iOS startup broken by a static worker import

### DIFF
--- a/apps/standalone/src/error-overlay.css
+++ b/apps/standalone/src/error-overlay.css
@@ -1,27 +1,11 @@
 /*
- * Styles for the fatal-error overlay (see error-overlay.ts).
- *
- * Every colour is `var(--trilium-token, fallback)`: the token wins when the Next
- * theme CSS loaded, so the overlay adopts the user's actual theme; the fallback
- * (the theme's own light value, or its dark value under prefers-color-scheme)
- * covers the case where it never did. Selectors are kept flat rather than nested
- * so the one screen whose job is to render when things are broken needs no CSS
- * nesting support.
+ * Styles for the fatal-error overlay (see error-overlay.ts). Each colour reads a
+ * Next theme variable so the overlay matches the user's theme when that CSS
+ * loaded, behind a fallback for when it didn't. Selectors are flat (no nesting)
+ * so this screen renders even on an old engine.
  */
 
 #trilium-error-overlay {
-    --tn-eo-bg: var(--main-background-color, #fff);
-    --tn-eo-text: var(--main-text-color, #1a1a1a);
-    --tn-eo-muted: var(--muted-text-color, #666);
-    --tn-eo-border: var(--main-border-color, #dbdbdb);
-    --tn-eo-surface: var(--left-pane-background-color, #f2f2f2);
-    --tn-eo-accent: var(--admonition-caution-accent-color, #ff2e2e);
-    --tn-eo-detail-bg: var(--card-background-color, #0000000d);
-    --tn-eo-btn-bg: var(--cmd-button-background-color, #0000000f);
-    --tn-eo-btn-text: var(--cmd-button-text-color, #000000ad);
-    --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #00000016);
-    --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000040);
-
     position: fixed;
     inset: 0;
     z-index: 2147483647;
@@ -31,13 +15,13 @@
     box-sizing: border-box;
     padding: calc(1.5rem + env(safe-area-inset-top)) calc(1.5rem + env(safe-area-inset-right))
              calc(1.5rem + env(safe-area-inset-bottom)) calc(1.5rem + env(safe-area-inset-left));
-    font-family: var(--main-font-family, "Inter", system-ui, -apple-system, sans-serif);
-    color: var(--tn-eo-text);
+    font-family: var(--main-font-family, "Inter", system-ui, sans-serif);
+    color: var(--main-text-color, #1a1a1a);
     background:
-        radial-gradient(ellipse at 20% 50%, rgba(99, 102, 241, 0.3) 0%, transparent 50%),
-        radial-gradient(ellipse at 80% 20%, rgba(168, 85, 247, 0.25) 0%, transparent 50%),
-        radial-gradient(ellipse at 60% 80%, rgba(59, 130, 246, 0.25) 0%, transparent 50%),
-        var(--tn-eo-surface);
+        radial-gradient(ellipse at 20% 50%, rgba(99, 102, 241, 0.3), transparent 50%),
+        radial-gradient(ellipse at 80% 20%, rgba(168, 85, 247, 0.25), transparent 50%),
+        radial-gradient(ellipse at 60% 80%, rgba(59, 130, 246, 0.25), transparent 50%),
+        var(--left-pane-background-color, #f2f2f2);
 }
 
 #trilium-error-overlay .tn-eo-card {
@@ -52,15 +36,14 @@
     text-align: center;
     gap: 0.75rem;
     padding: 2.25rem 2rem;
-    background: var(--tn-eo-bg);
+    background: var(--main-background-color, #fff);
     border-radius: 16px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
 }
 
 #trilium-error-overlay .tn-eo-illustration {
-    color: var(--tn-eo-accent);
+    color: var(--admonition-caution-accent-color, #ff2e2e);
     line-height: 0;
-    margin-bottom: 0.25rem;
 }
 
 #trilium-error-overlay .tn-eo-title {
@@ -71,20 +54,17 @@
 
 #trilium-error-overlay .tn-eo-message {
     margin: 0;
-    font-size: 0.95rem;
+    color: var(--muted-text-color, #666);
     line-height: 1.5;
-    color: var(--tn-eo-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
 }
 
 #trilium-error-overlay .tn-eo-detail {
     align-self: stretch;
-    margin: 0.5rem 0 0;
+    margin-top: 0.5rem;
     padding: 0.75rem 0.85rem;
     text-align: start;
-    background: var(--tn-eo-detail-bg);
-    border: 1px solid var(--tn-eo-border);
+    background: var(--card-background-color, #0000000d);
+    border: 1px solid var(--main-border-color, #dbdbdb);
     border-radius: 8px;
     font-size: 0.75rem;
     line-height: 1.45;
@@ -92,52 +72,27 @@
     overflow: auto;
     white-space: pre-wrap;
     word-break: break-word;
-    /* The message is meant to be copied into bug reports — opt back out of the
-       app-wide user-select: none. */
-    user-select: text;
-}
-
-#trilium-error-overlay .tn-eo-actions {
-    margin-top: 1rem;
+    user-select: text; /* meant to be copied into a bug report */
 }
 
 #trilium-error-overlay .tn-eo-button {
+    margin-top: 1rem;
     min-width: 120px;
     padding: 7px 18px;
     border: none;
     border-radius: 6px;
-    background: var(--tn-eo-btn-bg);
-    color: var(--tn-eo-btn-text);
-    box-shadow: 1px 1px 1px var(--tn-eo-btn-shadow);
+    background: var(--cmd-button-background-color, #0000000f);
+    color: var(--cmd-button-text-color, #000000ad);
+    box-shadow: 1px 1px 1px var(--cmd-button-shadow-color, #00000040);
     font-family: inherit;
     font-size: 0.95rem;
     cursor: pointer;
 }
 
 #trilium-error-overlay .tn-eo-button:hover {
-    background: var(--tn-eo-btn-hover);
+    background: var(--cmd-button-hover-background-color, #00000016);
 }
 
 #trilium-error-overlay .tn-eo-button:focus-visible {
     outline: 2px solid var(--input-focus-outline-color, #00000063);
-    outline-offset: 1px;
-}
-
-@media (prefers-color-scheme: dark) {
-    #trilium-error-overlay {
-        --tn-eo-bg: var(--main-background-color, #242424);
-        --tn-eo-text: var(--main-text-color, #ccc);
-        --tn-eo-muted: var(--muted-text-color, #bbb);
-        --tn-eo-border: var(--main-border-color, #454545);
-        --tn-eo-surface: var(--left-pane-background-color, #1f1f1f);
-        --tn-eo-detail-bg: var(--card-background-color, #ffffff12);
-        --tn-eo-btn-bg: var(--cmd-button-background-color, #ffffff28);
-        --tn-eo-btn-text: var(--cmd-button-text-color, #ffffffc2);
-        --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #ffffff37);
-        --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000080);
-    }
-
-    #trilium-error-overlay .tn-eo-card {
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-    }
 }

--- a/apps/standalone/src/error-overlay.css
+++ b/apps/standalone/src/error-overlay.css
@@ -55,7 +55,6 @@
     background: var(--tn-eo-bg);
     border-radius: 16px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
-    animation: tn-eo-in 0.18s ease-out;
 }
 
 #trilium-error-overlay .tn-eo-illustration {
@@ -113,33 +112,15 @@
     font-family: inherit;
     font-size: 0.95rem;
     cursor: pointer;
-    transition: background 0.15s ease-out;
 }
 
 #trilium-error-overlay .tn-eo-button:hover {
     background: var(--tn-eo-btn-hover);
 }
 
-#trilium-error-overlay .tn-eo-button:active {
-    opacity: 0.85;
-    box-shadow: none;
-    transform: scale(0.96);
-}
-
 #trilium-error-overlay .tn-eo-button:focus-visible {
     outline: 2px solid var(--input-focus-outline-color, #00000063);
     outline-offset: 1px;
-}
-
-@keyframes tn-eo-in {
-    from { opacity: 0; transform: translateY(8px) scale(0.98); }
-    to   { opacity: 1; transform: none; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    #trilium-error-overlay .tn-eo-card {
-        animation: none;
-    }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/apps/standalone/src/error-overlay.css
+++ b/apps/standalone/src/error-overlay.css
@@ -1,0 +1,162 @@
+/*
+ * Styles for the fatal-error overlay (see error-overlay.ts).
+ *
+ * Every colour is `var(--trilium-token, fallback)`: the token wins when the Next
+ * theme CSS loaded, so the overlay adopts the user's actual theme; the fallback
+ * (the theme's own light value, or its dark value under prefers-color-scheme)
+ * covers the case where it never did. Selectors are kept flat rather than nested
+ * so the one screen whose job is to render when things are broken needs no CSS
+ * nesting support.
+ */
+
+#trilium-error-overlay {
+    --tn-eo-bg: var(--main-background-color, #fff);
+    --tn-eo-text: var(--main-text-color, #1a1a1a);
+    --tn-eo-muted: var(--muted-text-color, #666);
+    --tn-eo-border: var(--main-border-color, #dbdbdb);
+    --tn-eo-surface: var(--left-pane-background-color, #f2f2f2);
+    --tn-eo-accent: var(--admonition-caution-accent-color, #ff2e2e);
+    --tn-eo-detail-bg: var(--card-background-color, #0000000d);
+    --tn-eo-btn-bg: var(--cmd-button-background-color, #0000000f);
+    --tn-eo-btn-text: var(--cmd-button-text-color, #000000ad);
+    --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #00000016);
+    --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000040);
+
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: calc(1.5rem + env(safe-area-inset-top)) calc(1.5rem + env(safe-area-inset-right))
+             calc(1.5rem + env(safe-area-inset-bottom)) calc(1.5rem + env(safe-area-inset-left));
+    font-family: var(--main-font-family, "Inter", system-ui, -apple-system, sans-serif);
+    color: var(--tn-eo-text);
+    background:
+        radial-gradient(ellipse at 20% 50%, rgba(99, 102, 241, 0.3) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 20%, rgba(168, 85, 247, 0.25) 0%, transparent 50%),
+        radial-gradient(ellipse at 60% 80%, rgba(59, 130, 246, 0.25) 0%, transparent 50%),
+        var(--tn-eo-surface);
+}
+
+#trilium-error-overlay .tn-eo-card {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 460px;
+    max-height: 100%;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 2.25rem 2rem;
+    background: var(--tn-eo-bg);
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
+    animation: tn-eo-in 0.18s ease-out;
+}
+
+#trilium-error-overlay .tn-eo-illustration {
+    color: var(--tn-eo-accent);
+    line-height: 0;
+    margin-bottom: 0.25rem;
+}
+
+#trilium-error-overlay .tn-eo-title {
+    margin: 0;
+    font-size: 1.4em;
+    font-weight: 600;
+}
+
+#trilium-error-overlay .tn-eo-message {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--tn-eo-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+#trilium-error-overlay .tn-eo-detail {
+    align-self: stretch;
+    margin: 0.5rem 0 0;
+    padding: 0.75rem 0.85rem;
+    text-align: start;
+    background: var(--tn-eo-detail-bg);
+    border: 1px solid var(--tn-eo-border);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    /* The message is meant to be copied into bug reports — opt back out of the
+       app-wide user-select: none. */
+    user-select: text;
+}
+
+#trilium-error-overlay .tn-eo-actions {
+    margin-top: 1rem;
+}
+
+#trilium-error-overlay .tn-eo-button {
+    min-width: 120px;
+    padding: 7px 18px;
+    border: none;
+    border-radius: 6px;
+    background: var(--tn-eo-btn-bg);
+    color: var(--tn-eo-btn-text);
+    box-shadow: 1px 1px 1px var(--tn-eo-btn-shadow);
+    font-family: inherit;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: background 0.15s ease-out;
+}
+
+#trilium-error-overlay .tn-eo-button:hover {
+    background: var(--tn-eo-btn-hover);
+}
+
+#trilium-error-overlay .tn-eo-button:active {
+    opacity: 0.85;
+    box-shadow: none;
+    transform: scale(0.96);
+}
+
+#trilium-error-overlay .tn-eo-button:focus-visible {
+    outline: 2px solid var(--input-focus-outline-color, #00000063);
+    outline-offset: 1px;
+}
+
+@keyframes tn-eo-in {
+    from { opacity: 0; transform: translateY(8px) scale(0.98); }
+    to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #trilium-error-overlay .tn-eo-card {
+        animation: none;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    #trilium-error-overlay {
+        --tn-eo-bg: var(--main-background-color, #242424);
+        --tn-eo-text: var(--main-text-color, #ccc);
+        --tn-eo-muted: var(--muted-text-color, #bbb);
+        --tn-eo-border: var(--main-border-color, #454545);
+        --tn-eo-surface: var(--left-pane-background-color, #1f1f1f);
+        --tn-eo-detail-bg: var(--card-background-color, #ffffff12);
+        --tn-eo-btn-bg: var(--cmd-button-background-color, #ffffff28);
+        --tn-eo-btn-text: var(--cmd-button-text-color, #ffffffc2);
+        --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #ffffff37);
+        --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000080);
+    }
+
+    #trilium-error-overlay .tn-eo-card {
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    }
+}

--- a/apps/standalone/src/error-overlay.spec.ts
+++ b/apps/standalone/src/error-overlay.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function freshOverlay(): Promise<typeof import("./error-overlay.js")> {
+    // The module carries a "first failure wins" flag, so each test needs a
+    // fresh copy to start from a clean slate.
+    vi.resetModules();
+    return import("./error-overlay.js");
+}
+
+beforeEach(() => {
+    document.body.innerHTML = "";
+    document.body.style.display = "";
+});
+
+afterEach(() => {
+    document.getElementById("trilium-error-overlay")?.remove();
+});
+
+describe("showErrorOverlay", () => {
+    it("renders the title, message, detail and a reload button, and reveals the body", async () => {
+        const { showErrorOverlay } = await freshOverlay();
+        document.body.style.display = "none";
+
+        showErrorOverlay("Trilium couldn't start", "MIME type wrong", "at worker.js:1");
+
+        const overlay = document.getElementById("trilium-error-overlay");
+        expect(overlay).not.toBeNull();
+        expect(overlay?.textContent).toContain("Trilium couldn't start");
+        expect(overlay?.textContent).toContain("MIME type wrong");
+        expect(overlay?.querySelector("pre")?.textContent).toBe("at worker.js:1");
+        expect(overlay?.querySelector("button")?.textContent).toBe("Reload");
+        // The pre-client shell may hide the body; the overlay must un-hide it.
+        expect(document.body.style.display).toBe("block");
+    });
+
+    it("omits the detail block when no detail is given", async () => {
+        const { showErrorOverlay } = await freshOverlay();
+        showErrorOverlay("Title", "Message");
+        expect(document.getElementById("trilium-error-overlay")?.querySelector("pre")).toBeNull();
+    });
+
+    it("shows only the first failure — a hung worker can report twice", async () => {
+        const { showErrorOverlay } = await freshOverlay();
+        showErrorOverlay("First", "the informative one");
+        showErrorOverlay("Second", "the noise after");
+
+        const overlays = document.querySelectorAll("#trilium-error-overlay");
+        expect(overlays).toHaveLength(1);
+        expect(overlays[0]?.textContent).toContain("the informative one");
+        expect(overlays[0]?.textContent).not.toContain("the noise after");
+    });
+
+    it("inserts message text rather than interpreting it as markup", async () => {
+        const { showErrorOverlay } = await freshOverlay();
+        showErrorOverlay("Title", "<img src=x onerror=alert(1)>");
+        const overlay = document.getElementById("trilium-error-overlay");
+        expect(overlay?.querySelector("img")).toBeNull();
+        expect(overlay?.textContent).toContain("<img src=x onerror=alert(1)>");
+    });
+
+    it("reloads the page when the button is clicked", async () => {
+        const { showErrorOverlay } = await freshOverlay();
+        const reload = vi.fn();
+        // happy-dom's location.reload is not configurable to spy directly, so
+        // replace the whole accessor for the duration of the test.
+        const original = window.location;
+        Object.defineProperty(window, "location", {
+            value: { ...original, reload },
+            configurable: true
+        });
+
+        showErrorOverlay("Title", "Message");
+        document.getElementById("trilium-error-overlay")?.querySelector("button")?.click();
+        expect(reload).toHaveBeenCalled();
+
+        Object.defineProperty(window, "location", { value: original, configurable: true });
+    });
+});

--- a/apps/standalone/src/error-overlay.spec.ts
+++ b/apps/standalone/src/error-overlay.spec.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
 
 afterEach(() => {
     document.getElementById("trilium-error-overlay")?.remove();
+    document.getElementById("trilium-error-overlay-style")?.remove();
 });
 
 describe("showErrorOverlay", () => {
@@ -31,6 +32,9 @@ describe("showErrorOverlay", () => {
         expect(overlay?.querySelector("button")?.textContent).toBe("Reload");
         // The pre-client shell may hide the body; the overlay must un-hide it.
         expect(document.body.style.display).toBe("block");
+        // Styles ship as an injected stylesheet so the overlay renders even when
+        // no bundled CSS came up.
+        expect(document.getElementById("trilium-error-overlay-style")).not.toBeNull();
     });
 
     it("omits the detail block when no detail is given", async () => {

--- a/apps/standalone/src/error-overlay.spec.ts
+++ b/apps/standalone/src/error-overlay.spec.ts
@@ -14,7 +14,6 @@ beforeEach(() => {
 
 afterEach(() => {
     document.getElementById("trilium-error-overlay")?.remove();
-    document.getElementById("trilium-error-overlay-style")?.remove();
 });
 
 describe("showErrorOverlay", () => {
@@ -32,9 +31,6 @@ describe("showErrorOverlay", () => {
         expect(overlay?.querySelector("button")?.textContent).toBe("Reload");
         // The pre-client shell may hide the body; the overlay must un-hide it.
         expect(document.body.style.display).toBe("block");
-        // Styles ship as an injected stylesheet so the overlay renders even when
-        // no bundled CSS came up.
-        expect(document.getElementById("trilium-error-overlay-style")).not.toBeNull();
     });
 
     it("omits the detail block when no detail is given", async () => {

--- a/apps/standalone/src/error-overlay.ts
+++ b/apps/standalone/src/error-overlay.ts
@@ -7,18 +7,19 @@
  * just sits on a blank white screen. This renders the failure straight into the
  * DOM from wherever it is caught instead.
  *
- * Deliberately framework-free and self-contained: it has to render in exactly
- * the cases where the client bundle never came up, so it depends on nothing the
- * failure might have taken down with it — the styles ship as an injected
- * stylesheet rather than a bundled `.css`, and every colour reads a Trilium Next
- * theme variable (so it matches the user's actual theme when that CSS did load)
- * behind a hard-coded fallback (so it still looks right when it didn't). The
- * card, gradient backdrop and caution accent mirror the standalone setup screen
- * (`setup.css`).
+ * Deliberately framework-free: it renders straight into the DOM with no client
+ * runtime, since it has to work in exactly the cases where the client bundle
+ * never came up. Styles live in `error-overlay.css`, whose `<link>` sits in the
+ * static HTML and so loads independently of any of this running; each colour
+ * reads a Trilium Next theme variable (matching the user's actual theme when
+ * that CSS loaded) behind a hard-coded fallback (so it still looks right when it
+ * didn't). The card, gradient backdrop and caution accent mirror the standalone
+ * setup screen (`setup.css`).
  */
 
+import "./error-overlay.css";
+
 const OVERLAY_ID = "trilium-error-overlay";
-const STYLE_ID = "trilium-error-overlay-style";
 
 /** First failure wins — a hung worker can emit both `onerror` and `WORKER_ERROR`,
  *  and the first message is the one that names the actual cause. */
@@ -33,8 +34,6 @@ export function showErrorOverlay(title: string, message: string, detail?: string
     // The pre-client shell may still be hiding the body; reveal it so the
     // overlay is actually visible (mirrors main.ts's bootstrap catch).
     document.body.style.display = "block";
-
-    injectStyles();
 
     // Defensive: never stack two overlays if one was somehow left behind.
     document.getElementById(OVERLAY_ID)?.remove();
@@ -90,166 +89,3 @@ const WARNING_SVG = `
     <path d="M12 9.6v4.4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
     <circle cx="12" cy="16.9" r="1.05" fill="currentColor"/>
 </svg>`;
-
-function injectStyles(): void {
-    if (document.getElementById(STYLE_ID)) {
-        return;
-    }
-    const style = document.createElement("style");
-    style.id = STYLE_ID;
-    style.textContent = OVERLAY_CSS;
-    document.head.append(style);
-}
-
-// Every colour is `var(--trilium-token, fallback)`: the token wins when the
-// theme CSS loaded, the fallback (the theme's own light value, or its dark value
-// under prefers-color-scheme) covers the case where it never did.
-const OVERLAY_CSS = `
-#${OVERLAY_ID} {
-    --tn-eo-bg: var(--main-background-color, #fff);
-    --tn-eo-text: var(--main-text-color, #1a1a1a);
-    --tn-eo-muted: var(--muted-text-color, #666);
-    --tn-eo-border: var(--main-border-color, #dbdbdb);
-    --tn-eo-surface: var(--left-pane-background-color, #f2f2f2);
-    --tn-eo-accent: var(--admonition-caution-accent-color, #ff2e2e);
-    --tn-eo-detail-bg: var(--card-background-color, #0000000d);
-    --tn-eo-btn-bg: var(--cmd-button-background-color, #0000000f);
-    --tn-eo-btn-text: var(--cmd-button-text-color, #000000ad);
-    --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #00000016);
-    --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000040);
-
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-sizing: border-box;
-    padding: calc(1.5rem + env(safe-area-inset-top)) calc(1.5rem + env(safe-area-inset-right))
-             calc(1.5rem + env(safe-area-inset-bottom)) calc(1.5rem + env(safe-area-inset-left));
-    font-family: var(--main-font-family, "Inter", system-ui, -apple-system, sans-serif);
-    color: var(--tn-eo-text);
-    background:
-        radial-gradient(ellipse at 20% 50%, rgba(99, 102, 241, 0.3) 0%, transparent 50%),
-        radial-gradient(ellipse at 80% 20%, rgba(168, 85, 247, 0.25) 0%, transparent 50%),
-        radial-gradient(ellipse at 60% 80%, rgba(59, 130, 246, 0.25) 0%, transparent 50%),
-        var(--tn-eo-surface);
-}
-
-#${OVERLAY_ID} .tn-eo-card {
-    box-sizing: border-box;
-    width: 100%;
-    max-width: 460px;
-    max-height: 100%;
-    overflow: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 0.75rem;
-    padding: 2.25rem 2rem;
-    background: var(--tn-eo-bg);
-    border-radius: 16px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
-    animation: tn-eo-in 0.18s ease-out;
-}
-
-#${OVERLAY_ID} .tn-eo-illustration {
-    color: var(--tn-eo-accent);
-    line-height: 0;
-    margin-bottom: 0.25rem;
-}
-
-#${OVERLAY_ID} .tn-eo-title {
-    margin: 0;
-    font-size: 1.4em;
-    font-weight: 600;
-}
-
-#${OVERLAY_ID} .tn-eo-message {
-    margin: 0;
-    font-size: 0.95rem;
-    line-height: 1.5;
-    color: var(--tn-eo-muted);
-    white-space: pre-wrap;
-    word-break: break-word;
-}
-
-#${OVERLAY_ID} .tn-eo-detail {
-    align-self: stretch;
-    margin: 0.5rem 0 0;
-    padding: 0.75rem 0.85rem;
-    text-align: start;
-    background: var(--tn-eo-detail-bg);
-    border: 1px solid var(--tn-eo-border);
-    border-radius: 8px;
-    font-size: 0.75rem;
-    line-height: 1.45;
-    max-height: 200px;
-    overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
-    /* The message is meant to be copied into bug reports — opt back out of the
-       app-wide user-select: none. */
-    user-select: text;
-}
-
-#${OVERLAY_ID} .tn-eo-actions {
-    margin-top: 1rem;
-}
-
-#${OVERLAY_ID} .tn-eo-button {
-    min-width: 120px;
-    padding: 7px 18px;
-    border: none;
-    border-radius: 6px;
-    background: var(--tn-eo-btn-bg);
-    color: var(--tn-eo-btn-text);
-    box-shadow: 1px 1px 1px var(--tn-eo-btn-shadow);
-    font-family: inherit;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: background 0.15s ease-out;
-}
-
-#${OVERLAY_ID} .tn-eo-button:hover {
-    background: var(--tn-eo-btn-hover);
-}
-
-#${OVERLAY_ID} .tn-eo-button:active {
-    opacity: 0.85;
-    box-shadow: none;
-    transform: scale(0.96);
-}
-
-#${OVERLAY_ID} .tn-eo-button:focus-visible {
-    outline: 2px solid var(--input-focus-outline-color, #00000063);
-    outline-offset: 1px;
-}
-
-@keyframes tn-eo-in {
-    from { opacity: 0; transform: translateY(8px) scale(0.98); }
-    to   { opacity: 1; transform: none; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    #${OVERLAY_ID} .tn-eo-card { animation: none; }
-}
-
-@media (prefers-color-scheme: dark) {
-    #${OVERLAY_ID} {
-        --tn-eo-bg: var(--main-background-color, #242424);
-        --tn-eo-text: var(--main-text-color, #ccc);
-        --tn-eo-muted: var(--muted-text-color, #bbb);
-        --tn-eo-border: var(--main-border-color, #454545);
-        --tn-eo-surface: var(--left-pane-background-color, #1f1f1f);
-        --tn-eo-detail-bg: var(--card-background-color, #ffffff12);
-        --tn-eo-btn-bg: var(--cmd-button-background-color, #ffffff28);
-        --tn-eo-btn-text: var(--cmd-button-text-color, #ffffffc2);
-        --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #ffffff37);
-        --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000080);
-    }
-    #${OVERLAY_ID} .tn-eo-card {
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-    }
-}`;

--- a/apps/standalone/src/error-overlay.ts
+++ b/apps/standalone/src/error-overlay.ts
@@ -67,17 +67,13 @@ export function showErrorOverlay(title: string, message: string, detail?: string
         card.append(pre);
     }
 
-    const actions = document.createElement("div");
-    actions.className = "tn-eo-actions";
-
     const reload = document.createElement("button");
     reload.type = "button";
     reload.className = "tn-eo-button";
     reload.textContent = "Reload";
     reload.addEventListener("click", () => location.reload());
-    actions.append(reload);
 
-    card.append(actions);
+    card.append(reload);
     overlay.append(card);
     document.body.append(overlay);
 }

--- a/apps/standalone/src/error-overlay.ts
+++ b/apps/standalone/src/error-overlay.ts
@@ -1,0 +1,107 @@
+/**
+ * Full-screen error overlay for fatal standalone startup failures.
+ *
+ * The SQLite worker initialises asynchronously, so a failure there surfaces as a
+ * `WORKER_ERROR` message or the worker's `onerror` event — long after main.ts's
+ * bootstrap try/catch has already returned. With nowhere to show it, the page
+ * just sits on a blank white screen. This renders the failure straight into the
+ * DOM from wherever it is caught instead.
+ *
+ * Deliberately framework-free and self-contained (inline styles, no imports): it
+ * has to render in exactly the cases where the client bundle never came up, so
+ * it must not depend on anything the failure might have taken down with it.
+ */
+
+const OVERLAY_ID = "trilium-error-overlay";
+
+/** First failure wins — a hung worker can emit both `onerror` and `WORKER_ERROR`,
+ *  and the first message is the one that names the actual cause. */
+let shown = false;
+
+export function showErrorOverlay(title: string, message: string, detail?: string): void {
+    if (shown) {
+        return;
+    }
+    shown = true;
+
+    // The pre-client shell may still be hiding the body; reveal it so the
+    // overlay is actually visible (mirrors main.ts's bootstrap catch).
+    document.body.style.display = "block";
+
+    // Defensive: never stack two overlays if one was somehow left behind.
+    document.getElementById(OVERLAY_ID)?.remove();
+
+    const overlay = document.createElement("div");
+    overlay.id = OVERLAY_ID;
+    overlay.setAttribute("role", "alert");
+    overlay.style.cssText = [
+        "position: fixed",
+        "inset: 0",
+        "z-index: 2147483647",
+        "display: flex",
+        "align-items: center",
+        "justify-content: center",
+        "padding: 24px",
+        "background: rgba(15, 18, 20, 0.72)",
+        "font-family: system-ui, -apple-system, sans-serif"
+    ].join(";");
+
+    const card = document.createElement("div");
+    card.style.cssText = [
+        "max-width: 560px",
+        "width: 100%",
+        "max-height: 100%",
+        "overflow: auto",
+        "background: #ffffff",
+        "color: #1a1a1a",
+        "border-radius: 10px",
+        "box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35)",
+        "padding: 28px"
+    ].join(";");
+
+    const heading = document.createElement("h1");
+    heading.textContent = title;
+    heading.style.cssText = "margin: 0 0 12px; font-size: 20px; color: #c0392b;";
+
+    const body = document.createElement("p");
+    body.textContent = message;
+    body.style.cssText = "margin: 0 0 20px; font-size: 15px; line-height: 1.5; white-space: pre-wrap; word-break: break-word;";
+
+    card.append(heading, body);
+
+    if (detail) {
+        const pre = document.createElement("pre");
+        pre.textContent = detail;
+        pre.style.cssText = [
+            "margin: 0 0 20px",
+            "padding: 12px",
+            "background: #f4f5f6",
+            "border-radius: 6px",
+            "font-size: 12px",
+            "line-height: 1.45",
+            "max-height: 220px",
+            "overflow: auto",
+            "white-space: pre-wrap",
+            "word-break: break-word"
+        ].join(";");
+        card.append(pre);
+    }
+
+    const reload = document.createElement("button");
+    reload.type = "button";
+    reload.textContent = "Reload";
+    reload.style.cssText = [
+        "padding: 10px 22px",
+        "background: #1976d2",
+        "color: #ffffff",
+        "border: none",
+        "border-radius: 6px",
+        "font-size: 15px",
+        "cursor: pointer"
+    ].join(";");
+    reload.addEventListener("click", () => location.reload());
+    card.append(reload);
+
+    overlay.append(card);
+    document.body.append(overlay);
+}

--- a/apps/standalone/src/error-overlay.ts
+++ b/apps/standalone/src/error-overlay.ts
@@ -7,12 +7,18 @@
  * just sits on a blank white screen. This renders the failure straight into the
  * DOM from wherever it is caught instead.
  *
- * Deliberately framework-free and self-contained (inline styles, no imports): it
- * has to render in exactly the cases where the client bundle never came up, so
- * it must not depend on anything the failure might have taken down with it.
+ * Deliberately framework-free and self-contained: it has to render in exactly
+ * the cases where the client bundle never came up, so it depends on nothing the
+ * failure might have taken down with it — the styles ship as an injected
+ * stylesheet rather than a bundled `.css`, and every colour reads a Trilium Next
+ * theme variable (so it matches the user's actual theme when that CSS did load)
+ * behind a hard-coded fallback (so it still looks right when it didn't). The
+ * card, gradient backdrop and caution accent mirror the standalone setup screen
+ * (`setup.css`).
  */
 
 const OVERLAY_ID = "trilium-error-overlay";
+const STYLE_ID = "trilium-error-overlay-style";
 
 /** First failure wins — a hung worker can emit both `onerror` and `WORKER_ERROR`,
  *  and the first message is the one that names the actual cause. */
@@ -28,80 +34,222 @@ export function showErrorOverlay(title: string, message: string, detail?: string
     // overlay is actually visible (mirrors main.ts's bootstrap catch).
     document.body.style.display = "block";
 
+    injectStyles();
+
     // Defensive: never stack two overlays if one was somehow left behind.
     document.getElementById(OVERLAY_ID)?.remove();
 
     const overlay = document.createElement("div");
     overlay.id = OVERLAY_ID;
     overlay.setAttribute("role", "alert");
-    overlay.style.cssText = [
-        "position: fixed",
-        "inset: 0",
-        "z-index: 2147483647",
-        "display: flex",
-        "align-items: center",
-        "justify-content: center",
-        "padding: 24px",
-        "background: rgba(15, 18, 20, 0.72)",
-        "font-family: system-ui, -apple-system, sans-serif"
-    ].join(";");
 
     const card = document.createElement("div");
-    card.style.cssText = [
-        "max-width: 560px",
-        "width: 100%",
-        "max-height: 100%",
-        "overflow: auto",
-        "background: #ffffff",
-        "color: #1a1a1a",
-        "border-radius: 10px",
-        "box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35)",
-        "padding: 28px"
-    ].join(";");
+    card.className = "tn-eo-card";
+
+    const illustration = document.createElement("div");
+    illustration.className = "tn-eo-illustration";
+    // Static markup, no user data — safe to set as innerHTML.
+    illustration.innerHTML = WARNING_SVG;
 
     const heading = document.createElement("h1");
+    heading.className = "tn-eo-title";
     heading.textContent = title;
-    heading.style.cssText = "margin: 0 0 12px; font-size: 20px; color: #c0392b;";
 
     const body = document.createElement("p");
+    body.className = "tn-eo-message";
     body.textContent = message;
-    body.style.cssText = "margin: 0 0 20px; font-size: 15px; line-height: 1.5; white-space: pre-wrap; word-break: break-word;";
 
-    card.append(heading, body);
+    card.append(illustration, heading, body);
 
     if (detail) {
         const pre = document.createElement("pre");
+        pre.className = "tn-eo-detail";
         pre.textContent = detail;
-        pre.style.cssText = [
-            "margin: 0 0 20px",
-            "padding: 12px",
-            "background: #f4f5f6",
-            "border-radius: 6px",
-            "font-size: 12px",
-            "line-height: 1.45",
-            "max-height: 220px",
-            "overflow: auto",
-            "white-space: pre-wrap",
-            "word-break: break-word"
-        ].join(";");
         card.append(pre);
     }
 
+    const actions = document.createElement("div");
+    actions.className = "tn-eo-actions";
+
     const reload = document.createElement("button");
     reload.type = "button";
+    reload.className = "tn-eo-button";
     reload.textContent = "Reload";
-    reload.style.cssText = [
-        "padding: 10px 22px",
-        "background: #1976d2",
-        "color: #ffffff",
-        "border: none",
-        "border-radius: 6px",
-        "font-size: 15px",
-        "cursor: pointer"
-    ].join(";");
     reload.addEventListener("click", () => location.reload());
-    card.append(reload);
+    actions.append(reload);
 
+    card.append(actions);
     overlay.append(card);
     document.body.append(overlay);
 }
+
+const WARNING_SVG = `
+<svg viewBox="0 0 24 24" width="56" height="56" fill="none" aria-hidden="true" focusable="false">
+    <path d="M12 3.4 22.2 20.4H1.8L12 3.4Z" fill="currentColor" fill-opacity="0.14"/>
+    <path d="M12 3.4 22.2 20.4H1.8L12 3.4Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M12 9.6v4.4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+    <circle cx="12" cy="16.9" r="1.05" fill="currentColor"/>
+</svg>`;
+
+function injectStyles(): void {
+    if (document.getElementById(STYLE_ID)) {
+        return;
+    }
+    const style = document.createElement("style");
+    style.id = STYLE_ID;
+    style.textContent = OVERLAY_CSS;
+    document.head.append(style);
+}
+
+// Every colour is `var(--trilium-token, fallback)`: the token wins when the
+// theme CSS loaded, the fallback (the theme's own light value, or its dark value
+// under prefers-color-scheme) covers the case where it never did.
+const OVERLAY_CSS = `
+#${OVERLAY_ID} {
+    --tn-eo-bg: var(--main-background-color, #fff);
+    --tn-eo-text: var(--main-text-color, #1a1a1a);
+    --tn-eo-muted: var(--muted-text-color, #666);
+    --tn-eo-border: var(--main-border-color, #dbdbdb);
+    --tn-eo-surface: var(--left-pane-background-color, #f2f2f2);
+    --tn-eo-accent: var(--admonition-caution-accent-color, #ff2e2e);
+    --tn-eo-detail-bg: var(--card-background-color, #0000000d);
+    --tn-eo-btn-bg: var(--cmd-button-background-color, #0000000f);
+    --tn-eo-btn-text: var(--cmd-button-text-color, #000000ad);
+    --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #00000016);
+    --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000040);
+
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: calc(1.5rem + env(safe-area-inset-top)) calc(1.5rem + env(safe-area-inset-right))
+             calc(1.5rem + env(safe-area-inset-bottom)) calc(1.5rem + env(safe-area-inset-left));
+    font-family: var(--main-font-family, "Inter", system-ui, -apple-system, sans-serif);
+    color: var(--tn-eo-text);
+    background:
+        radial-gradient(ellipse at 20% 50%, rgba(99, 102, 241, 0.3) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 20%, rgba(168, 85, 247, 0.25) 0%, transparent 50%),
+        radial-gradient(ellipse at 60% 80%, rgba(59, 130, 246, 0.25) 0%, transparent 50%),
+        var(--tn-eo-surface);
+}
+
+#${OVERLAY_ID} .tn-eo-card {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 460px;
+    max-height: 100%;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 2.25rem 2rem;
+    background: var(--tn-eo-bg);
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
+    animation: tn-eo-in 0.18s ease-out;
+}
+
+#${OVERLAY_ID} .tn-eo-illustration {
+    color: var(--tn-eo-accent);
+    line-height: 0;
+    margin-bottom: 0.25rem;
+}
+
+#${OVERLAY_ID} .tn-eo-title {
+    margin: 0;
+    font-size: 1.4em;
+    font-weight: 600;
+}
+
+#${OVERLAY_ID} .tn-eo-message {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--tn-eo-muted);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+#${OVERLAY_ID} .tn-eo-detail {
+    align-self: stretch;
+    margin: 0.5rem 0 0;
+    padding: 0.75rem 0.85rem;
+    text-align: start;
+    background: var(--tn-eo-detail-bg);
+    border: 1px solid var(--tn-eo-border);
+    border-radius: 8px;
+    font-size: 0.75rem;
+    line-height: 1.45;
+    max-height: 200px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    /* The message is meant to be copied into bug reports — opt back out of the
+       app-wide user-select: none. */
+    user-select: text;
+}
+
+#${OVERLAY_ID} .tn-eo-actions {
+    margin-top: 1rem;
+}
+
+#${OVERLAY_ID} .tn-eo-button {
+    min-width: 120px;
+    padding: 7px 18px;
+    border: none;
+    border-radius: 6px;
+    background: var(--tn-eo-btn-bg);
+    color: var(--tn-eo-btn-text);
+    box-shadow: 1px 1px 1px var(--tn-eo-btn-shadow);
+    font-family: inherit;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: background 0.15s ease-out;
+}
+
+#${OVERLAY_ID} .tn-eo-button:hover {
+    background: var(--tn-eo-btn-hover);
+}
+
+#${OVERLAY_ID} .tn-eo-button:active {
+    opacity: 0.85;
+    box-shadow: none;
+    transform: scale(0.96);
+}
+
+#${OVERLAY_ID} .tn-eo-button:focus-visible {
+    outline: 2px solid var(--input-focus-outline-color, #00000063);
+    outline-offset: 1px;
+}
+
+@keyframes tn-eo-in {
+    from { opacity: 0; transform: translateY(8px) scale(0.98); }
+    to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    #${OVERLAY_ID} .tn-eo-card { animation: none; }
+}
+
+@media (prefers-color-scheme: dark) {
+    #${OVERLAY_ID} {
+        --tn-eo-bg: var(--main-background-color, #242424);
+        --tn-eo-text: var(--main-text-color, #ccc);
+        --tn-eo-muted: var(--muted-text-color, #bbb);
+        --tn-eo-border: var(--main-border-color, #454545);
+        --tn-eo-surface: var(--left-pane-background-color, #1f1f1f);
+        --tn-eo-detail-bg: var(--card-background-color, #ffffff12);
+        --tn-eo-btn-bg: var(--cmd-button-background-color, #ffffff28);
+        --tn-eo-btn-text: var(--cmd-button-text-color, #ffffffc2);
+        --tn-eo-btn-hover: var(--cmd-button-hover-background-color, #ffffff37);
+        --tn-eo-btn-shadow: var(--cmd-button-shadow-color, #00000080);
+    }
+    #${OVERLAY_ID} .tn-eo-card {
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    }
+}`;

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -56,7 +56,6 @@ function lastWorker(): MockWorker {
 afterEach(() => {
     delete (navigator as unknown as NavServiceWorker).serviceWorker;
     document.getElementById("trilium-error-overlay")?.remove();
-    document.getElementById("trilium-error-overlay-style")?.remove();
     vi.restoreAllMocks();
 });
 

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -56,6 +56,7 @@ function lastWorker(): MockWorker {
 afterEach(() => {
     delete (navigator as unknown as NavServiceWorker).serviceWorker;
     document.getElementById("trilium-error-overlay")?.remove();
+    document.getElementById("trilium-error-overlay-style")?.remove();
     vi.restoreAllMocks();
 });
 

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -55,6 +55,7 @@ function lastWorker(): MockWorker {
 
 afterEach(() => {
     delete (navigator as unknown as NavServiceWorker).serviceWorker;
+    document.getElementById("trilium-error-overlay")?.remove();
     vi.restoreAllMocks();
 });
 
@@ -79,15 +80,13 @@ describe("startLocalServerWorker", () => {
 });
 
 describe("worker message handling", () => {
-    it("shows a dialog on FATAL_ERROR", async () => {
-        const alertSpy = vi.fn();
-        vi.stubGlobal("alert", alertSpy);
+    it("shows an error overlay on FATAL_ERROR", async () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
         const bridge = await freshBridge();
         bridge.startLocalServerWorker();
         lastWorker().onmessage?.({ data: { type: "FATAL_ERROR", message: "boom" } });
-        expect(alertSpy).toHaveBeenCalledWith("boom");
-        vi.unstubAllGlobals();
+        const overlay = document.getElementById("trilium-error-overlay");
+        expect(overlay?.textContent).toContain("boom");
     });
 
     it("dispatches a window event for WS_MESSAGE", async () => {
@@ -134,16 +133,25 @@ describe("worker message handling", () => {
         await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: "HTTP_RESPONSE", id: "3", error: "plain rejection" })));
     });
 
-    it("rejects pending requests on WORKER_ERROR and on worker onerror", async () => {
+    it("shows an overlay and rejects pending requests on WORKER_ERROR", async () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
         const bridge = await freshBridge();
         bridge.startLocalServerWorker();
-        const worker = lastWorker();
 
-        // WORKER_ERROR path
-        worker.onmessage?.({ data: { type: "WORKER_ERROR", error: { message: "crash" } } });
-        // onerror path
-        expect(() => worker.onerror?.({ message: "fatal" })).not.toThrow();
+        lastWorker().onmessage?.({ data: { type: "WORKER_ERROR", error: { message: "crash", stack: "at boom" } } });
+
+        const overlay = document.getElementById("trilium-error-overlay");
+        expect(overlay?.textContent).toContain("crash");
+        expect(overlay?.textContent).toContain("at boom");
+    });
+
+    it("shows an overlay on worker onerror without throwing", async () => {
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        const bridge = await freshBridge();
+        bridge.startLocalServerWorker();
+
+        expect(() => lastWorker().onerror?.({ message: "fatal" })).not.toThrow();
+        expect(document.getElementById("trilium-error-overlay")?.textContent).toContain("fatal");
     });
 
     it("ignores messages without a recognized type", async () => {

--- a/apps/standalone/src/local-bridge.ts
+++ b/apps/standalone/src/local-bridge.ts
@@ -1,5 +1,6 @@
 import type { StandaloneRestoreProgress, StandaloneRestoreResult } from "@triliumnext/commons";
 
+import { showErrorOverlay } from "./error-overlay.js";
 import { isLeader } from "./leader_election.js";
 import LocalServerWorker from "./local-server-worker?worker";
 let localWorker: Worker | null = null;
@@ -161,10 +162,6 @@ export function registerNativeHttpHandler(handler: NativeHttpHandler) {
     nativeHttpHandler = handler;
 }
 
-function showFatalErrorDialog(message: string) {
-    alert(message);
-}
-
 export function startLocalServerWorker() {
     if (localWorker) return localWorker;
     localWorker = new LocalServerWorker();
@@ -177,6 +174,10 @@ export function startLocalServerWorker() {
     // Handle worker errors during initialization
     localWorker.onerror = (event) => {
         console.error("[LocalBridge] Worker error:", event);
+        showErrorOverlay(
+            "Trilium couldn't start",
+            event.message || "The database worker failed to start. See the console for details."
+        );
         // Reject all pending requests
         for (const [, resolver] of pending) {
             resolver.reject(new Error(`Worker error: ${event.message}`));
@@ -199,16 +200,25 @@ export function startLocalServerWorker() {
             return;
         }
 
-        // Handle fatal platform crashes (shown as a dialog to the user)
+        // Handle fatal platform crashes (shown as an overlay to the user)
         if (msg?.type === "FATAL_ERROR") {
             console.error("[LocalBridge] Fatal error:", msg.message);
-            showFatalErrorDialog(msg.message);
+            showErrorOverlay("Trilium crashed", msg.message);
             return;
         }
 
-        // Handle worker error reports
+        // Handle worker error reports. These are uncaught errors and unhandled
+        // rejections in the worker; an initialization failure in particular
+        // never resolves a request (it just hangs), so this message is the only
+        // signal the user would otherwise get — surface it instead of a blank
+        // screen.
         if (msg?.type === "WORKER_ERROR") {
             console.error("[LocalBridge] Worker reported error:", msg.error);
+            showErrorOverlay(
+                "Trilium couldn't start",
+                msg.error?.message || "The database worker reported an error.",
+                msg.error?.stack
+            );
             // Reject all pending requests with the error
             for (const [, resolver] of pending) {
                 resolver.reject(new Error(msg.error?.message || "Unknown worker error"));

--- a/apps/standalone/src/local-server-worker.spec.ts
+++ b/apps/standalone/src/local-server-worker.spec.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+// This spec sits next to the worker entry, so resolve it relative to __dirname
+// rather than depending on the test runner's cwd.
+const WORKER_ENTRY = join(__dirname, "local-server-worker.ts");
+
+// Static value imports intentionally permitted. Adding an entry here means you
+// have verified — ideally against the built worker bundle — that it pulls in no
+// heavy transitive graph and cannot throw before the error handlers are
+// installed. Prefer a dynamic import() instead; keep this list empty if you can.
+const ALLOWED_STATIC_VALUE_IMPORTS: readonly string[] = [];
+
+/**
+ * `local-server-worker.ts` is the standalone SQLite worker's entry module. Its
+ * design (see the file's own header) requires that nothing runs before the
+ * module body installs `self.onerror` / `self.onunhandledrejection` and waits
+ * for the INIT message — every heavy dependency is pulled in with a dynamic
+ * `import()` from inside `initialize()`, in a controlled order.
+ *
+ * Static *value* imports break that: they hoist above the module body and
+ * evaluate at worker startup. In 73a61ba1cc a static
+ *   `import { … } from './lightweight/database_restore'`
+ * dragged `@triliumnext/core` (~2 MB of i18n + sql + image code) into that
+ * hoisted startup, which reordered SQLite's wasm init and broke iOS standalone
+ * with "Unexpected response MIME type. Expected 'application/wasm'" — days of
+ * debugging. This test makes that class of regression impossible: the worker
+ * entry may only use type-only static imports (erased at runtime).
+ */
+describe("local-server-worker.ts static imports", () => {
+    it("has no static value imports — everything runtime must be dynamically imported", () => {
+        const offenders = staticValueImportsOf(WORKER_ENTRY).filter(
+            (specifier) => !ALLOWED_STATIC_VALUE_IMPORTS.includes(specifier)
+        );
+
+        expect(offenders, forbiddenImportMessage(offenders)).toEqual([]);
+    });
+});
+
+/** Module specifiers of every top-level static import that survives to runtime. */
+function staticValueImportsOf(entryPath: string): string[] {
+    const source = readFileSync(entryPath, "utf8");
+    const sourceFile = ts.createSourceFile(entryPath, source, ts.ScriptTarget.Latest, true);
+
+    const specifiers: string[] = [];
+    for (const statement of sourceFile.statements) {
+        // A dynamic `import(...)` is a CallExpression, not an ImportDeclaration,
+        // so the whole loadModules() block is correctly ignored here.
+        if (!ts.isImportDeclaration(statement)) {
+            continue;
+        }
+        // `import type … from "x"` is fully erased at runtime; detect it from
+        // the source text to avoid the TS API churn around the type-only flags.
+        // Everything else — a default or namespace binding, named value
+        // bindings, or a bare side-effect `import "x"` — reaches runtime and
+        // counts. (Write type imports in this file as `import type { … }`, not
+        // the inline `import { type … }` form, so this stays a simple check.)
+        if (/^import\s+type\b/.test(statement.getText(sourceFile))) {
+            continue;
+        }
+        if (ts.isStringLiteral(statement.moduleSpecifier)) {
+            specifiers.push(statement.moduleSpecifier.text);
+        }
+    }
+    return specifiers;
+}
+
+function forbiddenImportMessage(offenders: string[]): string {
+    return [
+        `local-server-worker.ts must not statically import runtime values: ${offenders.join(", ")}.`,
+        "",
+        "This file is the standalone SQLite worker's entry. Static value imports hoist and",
+        "evaluate at worker startup, before the error handlers are installed and before the",
+        "controlled load order in initialize() — which has broken SQLite's wasm init.",
+        "Load every dependency with a dynamic import() at its use site instead."
+    ].join("\n");
+}

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -49,8 +49,6 @@ console.log("[Worker] Error handlers installed, loading modules...");
 import type { BrowserRouter } from './lightweight/browser_router';
 import type { StandaloneRestoreProgress, StandaloneRestoreResult } from "@triliumnext/commons";
 
-import { readCurrentDatabaseName, RestoreFailure, restoreDatabase } from './lightweight/database_restore';
-
 // Build-time constant injected by Vite (see `define` in vite.config.mts).
 declare const __TRILIUM_INTEGRATION_TEST__: string;
 
@@ -228,6 +226,7 @@ async function initialize(): Promise<void> {
             // Which pool entry holds the database is a stored answer rather than a constant: a
             // restore cannot rename an entry, so it writes the new database in beside the old one
             // and changes this. Unrestored instances read the name they have always used.
+            const { readCurrentDatabaseName } = await import('./lightweight/database_restore.js');
             const dbName = await readCurrentDatabaseName();
 
             if (integrationTestMode === "memory") {
@@ -399,6 +398,8 @@ async function handleRestoreBackup(id: string, backup: File, passphrase?: string
     }
 
     restoreInProgress = true;
+
+    const { restoreDatabase, RestoreFailure } = await import('./lightweight/database_restore.js');
 
     try {
         await restoreDatabase(

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -1,3 +1,4 @@
+import { showErrorOverlay } from "./error-overlay.js";
 import { installIosInterceptors } from "./ios-interceptors.js";
 import { claimLeadership } from "./leader_election.js";
 import { announceLeadership, attachServiceWorkerBridge, registerNativeHttpHandler, restoreBackup, startLocalServerWorker } from "./local-bridge.js";
@@ -85,17 +86,10 @@ async function bootstrap() {
         }
 
         console.error("[Bootstrap] Fatal error:", err);
-        document.body.innerHTML = `
-            <div style="padding: 40px; max-width: 600px; margin: 0 auto; font-family: system-ui, sans-serif;">
-                <h1 style="color: #d32f2f;">Failed to Initialize</h1>
-                <p>The application failed to start. Please check the browser console for details.</p>
-                <pre style="background: #f5f5f5; padding: 16px; border-radius: 4px; overflow: auto; white-space: pre-wrap; word-wrap: break-word;">${err instanceof Error ? err.message : String(err)}</pre>
-                <button onclick="location.reload()" style="padding: 12px 24px; background: #1976d2; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 16px;">
-                    Reload Page
-                </button>
-            </div>
-        `;
-        document.body.style.display = "block";
+        showErrorOverlay(
+            "Failed to Initialize",
+            err instanceof Error ? err.message : String(err)
+        );
     }
 }
 


### PR DESCRIPTION
## Problem

On iOS, the standalone app failed to start — a blank white screen. The SQLite worker reported:

```
Unexpected response MIME type. Expected 'application/wasm'
```

## Root cause

Bisected to `73a61ba1cc` ("core/backup import: enable backup imports in standalone mode"), which added a **static** import to the SQLite worker entry:

```ts
// apps/standalone/src/local-server-worker.ts
import { readCurrentDatabaseName, RestoreFailure, restoreDatabase } from './lightweight/database_restore';
```

`database_restore` transitively static-imports `@triliumnext/core`, so ~2 MB of core (i18n + sql + image) was **hoisted into the worker's synchronous startup** — ahead of the error handlers and the controlled dynamic-import order in `initialize()`. That reordered SQLite's wasm initialisation, and on iOS (the one path with no service worker and a hard SPA fallback) the wasm fetch resolved to `index.html`, producing the MIME error.

The runtime wasm stack (the provider, `@sqlite.org/sqlite-wasm`, the Capacitor asset handler) was byte-identical to the last working release — the regression was purely the changed import graph. The worker file's own header even warns *"No static imports above this!"*.

## Changes

- **fix** — load `database_restore` via dynamic `import()` at its two use sites, restoring the worker entry's dynamic-only invariant (the worker behaves as it did at `73a61ba1cc~1`, the last good commit).
- **test** — `local-server-worker.spec.ts` parses the worker entry's AST and fails on any static *value* import, so this class of regression can't recur silently (red on the offending import, green once it's dynamic).
- **resilience** — a fatal-startup **error overlay** replaces the blank white screen. Worker init failures surface asynchronously (after the bootstrap `try/catch` has already returned), so they previously reached nothing on screen; they're now shown to the user with the message and stack.

## Verification

- Device bisect: `73a61ba1cc~1` good, `73a61ba1cc` bad.
- Guard test: red on the static import, green after the fix.
- Standalone unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
