### PR TITLE
feat(collections): expand calendar events and geomap markers in place

### DIFF
--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -8,7 +8,7 @@ import bundleService from "../services/bundle.js";
 import froca from "../services/froca.js";
 import { initLocale, t } from "../services/i18n.js";
 import keyboardActionsService from "../services/keyboard_actions.js";
-import linkService, { type ViewScope } from "../services/link.js";
+import linkService, { type HashPane, type ViewScope } from "../services/link.js";
 import type LoadResults from "../services/load_results.js";
 import type { CreateNoteOpts } from "../services/note_create.js";
 import options from "../services/options.js";
@@ -76,6 +76,13 @@ export interface NoteCommandData extends CommandData {
     notePath?: string | null;
     hoistedNoteId?: string | null;
     viewScope?: ViewScope;
+    /**
+     * Panes to open beside `notePath`, in order — how a tab moved or copied into a window of its own
+     * takes its splits along. Honoured only while booting a detached window.
+     */
+    splits?: HashPane[] | null;
+    /** Index into `[main pane, ...splits]` of the pane to focus. Defaults to the main pane. */
+    activeSplit?: number;
 }
 
 export interface ExecuteCommandData<T> extends CommandData {

--- a/apps/client/src/components/entrypoints.ts
+++ b/apps/client/src/components/entrypoints.ts
@@ -136,8 +136,8 @@ export default class Entrypoints extends Component {
         utils.reloadFrontendApp("Switching to mobile version");
     }
 
-    async openInWindowCommand({ notePath, hoistedNoteId, viewScope }: NoteCommandData) {
-        const target = { notePath, hoistedNoteId, viewScope };
+    async openInWindowCommand({ notePath, hoistedNoteId, viewScope, splits, activeSplit }: NoteCommandData) {
+        const target = { notePath, hoistedNoteId, viewScope, splits, activeSplit };
 
         if (window.electronApi) {
             window.electronApi.window.createExtraWindow(linkService.calculateHash(target));

--- a/apps/client/src/components/tab_manager.spec.ts
+++ b/apps/client/src/components/tab_manager.spec.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import appContext from "./app_context.js";
 import TabManager, { buildNoteContextStatesFromUrl } from "./tab_manager.js";
 
 describe("TabManager tab placement", () => {
@@ -93,6 +94,47 @@ describe("moving a tab with splits into a window of its own", () => {
 
         // the tear-off fires from dragMove, so a second call for an already-removed tab is expected
         expect(tm.captureTabAsWindowTarget("gone")).toBeNull();
+    });
+});
+
+describe("handing a tab over to a window of its own", () => {
+    it("moves the tab, having described it before the close takes its panes down", async () => {
+        const tm = new TabManager();
+        // closing a pane asks the app which manager owns it, which only booting normally answers
+        appContext.tabManager = tm;
+        const [main, other] = await openEmptyTabs(tm, 2);
+        const split = await tm.openEmptyTab(null, "root", main.ntxId);
+        main.notePath = "root/aaaaaaaaaaaa";
+        split.notePath = "root/bbbbbbbbbbbb";
+        const triggerCommand = vi.spyOn(tm, "triggerCommand").mockReturnValue(undefined);
+
+        await tm.moveTabToNewWindowCommand({ ntxId: main.ntxId ?? "" });
+
+        expect(triggerCommand).toHaveBeenCalledWith("openInWindow", expect.objectContaining({
+            notePath: "root/aaaaaaaaaaaa",
+            splits: [ expect.objectContaining({ notePath: "root/bbbbbbbbbbbb" }) ]
+        }));
+        // the tab left with its split, leaving the neighbouring tab behind
+        expect(ntxOrder(tm)).toEqual([other.ntxId]);
+    });
+
+    it("copies the tab without closing it, and asks for nothing once the tab is gone", async () => {
+        const tm = new TabManager();
+        const [main] = await openEmptyTabs(tm, 2);
+        main.notePath = "root/aaaaaaaaaaaa";
+        const triggerCommand = vi.spyOn(tm, "triggerCommand").mockReturnValue(undefined);
+
+        await tm.copyTabToNewWindowCommand({ ntxId: main.ntxId ?? "" });
+
+        expect(triggerCommand).toHaveBeenCalledWith("openInWindow", expect.objectContaining({
+            notePath: "root/aaaaaaaaaaaa"
+        }));
+        expect(tm.noteContexts).toContain(main);
+
+        // the tear-off drag fires repeatedly, so a call for an already-removed tab is expected
+        triggerCommand.mockClear();
+        await tm.copyTabToNewWindowCommand({ ntxId: "gone" });
+        expect(triggerCommand).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/client/src/components/tab_manager.spec.ts
+++ b/apps/client/src/components/tab_manager.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import TabManager from "./tab_manager.js";
+import TabManager, { buildNoteContextStatesFromUrl } from "./tab_manager.js";
 
 describe("TabManager tab placement", () => {
     it("opens a blank tab at the end of the row, regardless of which tab is active", async () => {
@@ -53,6 +53,98 @@ describe("TabManager tab placement", () => {
 
         // inserting right after p1 would split the pinned group, so it clamps past the group
         expect(ntxOrder(tm)).toEqual([p1.ntxId, p2.ntxId, fromLink.ntxId, a.ntxId]);
+    });
+});
+
+describe("moving a tab with splits into a window of its own", () => {
+    it("captures every pane of the tab, in order, and which one is focused", async () => {
+        const tm = new TabManager();
+        const [main, other] = await openEmptyTabs(tm, 2);
+        const split1 = await tm.openEmptyTab(null, "root", main.ntxId);
+        const split2 = await tm.openEmptyTab(null, "root", main.ntxId);
+
+        main.notePath = "root/aaaaaaaaaaaa";
+        split1.notePath = "root/bbbbbbbbbbbb";
+        split1.viewScope = { viewMode: "source" };
+        split2.notePath = "root/cccccccccccc";
+        split2.hoistedNoteId = "h1";
+        other.notePath = "root/dddddddddddd"; // a neighbouring tab must not come along
+        main.lastActiveNtxId = split2.ntxId; // the last of the three panes had the focus
+
+        expect(tm.captureTabAsWindowTarget(main.ntxId ?? "")).toEqual({
+            notePath: "root/aaaaaaaaaaaa",
+            hoistedNoteId: "root",
+            viewScope: {},
+            splits: [
+                { notePath: "root/bbbbbbbbbbbb", hoistedNoteId: "root", viewScope: { viewMode: "source" } },
+                { notePath: "root/cccccccccccc", hoistedNoteId: "h1", viewScope: {} }
+            ],
+            activeSplit: 2
+        });
+    });
+
+    it("falls back to the main pane, and gives up once the tab is gone", async () => {
+        const tm = new TabManager();
+        const [main] = await openEmptyTabs(tm, 1);
+        await tm.openEmptyTab(null, "root", main.ntxId);
+        main.lastActiveNtxId = "vanished"; // remembered pane was closed since
+
+        expect(tm.captureTabAsWindowTarget(main.ntxId ?? "")).toMatchObject({ activeSplit: 0 });
+
+        // the tear-off fires from dragMove, so a second call for an already-removed tab is expected
+        expect(tm.captureTabAsWindowTarget("gone")).toBeNull();
+    });
+});
+
+describe("buildNoteContextStatesFromUrl", () => {
+    it("rebuilds the panes as one tab, with the focused one active", () => {
+        const states = buildNoteContextStatesFromUrl({
+            notePath: "root/aaaaaaaaaaaa",
+            splits: [
+                { notePath: "root/bbbbbbbbbbbb", viewScope: { viewMode: "source" } },
+                { notePath: null, hoistedNoteId: "h1" }
+            ],
+            activeSplit: 1
+        }, "main1");
+
+        expect(states).toMatchObject([
+            { notePath: "root/aaaaaaaaaaaa", ntxId: "main1", mainNtxId: null, active: false },
+            {
+                notePath: "root/bbbbbbbbbbbb",
+                mainNtxId: "main1",
+                active: true,
+                hoistedNoteId: "root",
+                viewScope: { viewMode: "source" }
+            },
+            // a pane torn off empty stays empty rather than falling back to root
+            { notePath: null, mainNtxId: "main1", active: false, hoistedNoteId: "h1" }
+        ]);
+        // the splits get ids of their own, and the tab remembers which of them held the focus
+        expect(new Set(states.map((s) => s.ntxId)).size).toBe(3);
+        expect(states[0].lastActiveNtxId).toBe(states[1].ntxId);
+    });
+
+    it("opens root for a bare address, and ignores an active index pointing nowhere", () => {
+        expect(buildNoteContextStatesFromUrl({}, "main1")).toMatchObject([
+            { notePath: "root", ntxId: "main1", mainNtxId: null, active: true }
+        ]);
+
+        // activeSplit arrives from the address bar, so it may be out of range in either direction
+        const states = buildNoteContextStatesFromUrl(
+            { notePath: "root/aaaaaaaaaaaa", splits: [{ notePath: "root/bbbb" }], activeSplit: 9 },
+            "main1"
+        );
+        expect(states.map((s) => s.active)).toEqual([false, true]);
+        expect(buildNoteContextStatesFromUrl({ activeSplit: -3 }, "main1")[0].active).toBe(true);
+    });
+
+    it("focuses a pane with a note, since an empty one would leave the window with none", () => {
+        const states = buildNoteContextStatesFromUrl(
+            { notePath: null, splits: [{ notePath: "root/bbbbbbbbbbbb" }], activeSplit: 0 },
+            "main1"
+        );
+
+        expect(states.map((s) => s.active)).toEqual([false, true]);
     });
 });
 

--- a/apps/client/src/components/tab_manager.ts
+++ b/apps/client/src/components/tab_manager.ts
@@ -9,7 +9,7 @@ import appContext from "./app_context.js";
 import Mutex from "../utils/mutex.js";
 import linkService from "../services/link.js";
 import { partitionPinnedFirst } from "../services/tab_pinning.js";
-import type { EventData } from "./app_context.js";
+import type { EventData, NoteCommandData } from "./app_context.js";
 import type FNote from "../entities/fnote.js";
 
 /** Where a newly created tab is inserted in the row: appended to the end, or right after the active tab. */
@@ -20,7 +20,7 @@ interface TabState {
     position: number;
 }
 
-interface NoteContextState {
+export interface NoteContextState {
     ntxId: string;
     mainNtxId: string | null;
     notePath: string | null;
@@ -102,13 +102,9 @@ export default class TabManager extends Component {
             if (filteredNoteContexts.length === 0) {
                 parsedFromUrl.ntxId = parsedFromUrl.ntxId || NoteContext.generateNtxId(); // generate already here, so that we later know which one to activate
 
-                filteredNoteContexts.push({
-                    notePath: parsedFromUrl.notePath || "root",
-                    ntxId: parsedFromUrl.ntxId,
-                    active: true,
-                    hoistedNoteId: parsedFromUrl.hoistedNoteId || "root",
-                    viewScope: parsedFromUrl.viewScope || {}
-                });
+                filteredNoteContexts.push(
+                    ...buildNoteContextStatesFromUrl(parsedFromUrl, parsedFromUrl.ntxId)
+                );
             } else if (!filteredNoteContexts.find((tab: NoteContextState) => tab.active)) {
                 filteredNoteContexts[0].active = true;
             }
@@ -133,7 +129,9 @@ export default class TabManager extends Component {
 
             // if there's a notePath in the URL, make sure it's open and active
             // (useful, for e.g., opening clipped notes from clipper or opening link in an extra window)
-            if (parsedFromUrl.notePath) {
+            // Splits are skipped: the panes were just built from this very URL, with the
+            // intended one focused, so switching would only pull focus back to the first pane.
+            if (parsedFromUrl.notePath && !parsedFromUrl.splits?.length) {
                 await appContext.tabManager.switchToNoteContext(
                     parsedFromUrl.ntxId,
                     parsedFromUrl.notePath,
@@ -744,18 +742,57 @@ export default class TabManager extends Component {
     }
 
     async moveTabToNewWindowCommand({ ntxId }: { ntxId: string }) {
-        const { notePath, hoistedNoteId, viewScope } = this.getNoteContextById(ntxId);
+        // capture before removing: closing the tab takes its split panes down with it
+        const target = this.captureTabAsWindowTarget(ntxId);
 
-        const removed = await this.removeNoteContext(ntxId);
-
-        if (removed) {
-            this.triggerCommand("openInWindow", { notePath, hoistedNoteId, viewScope });
+        if (target && await this.removeNoteContext(ntxId)) {
+            this.triggerCommand("openInWindow", target);
         }
     }
 
     async copyTabToNewWindowCommand({ ntxId }: { ntxId: string }) {
-        const { notePath, hoistedNoteId, viewScope } = this.getNoteContextById(ntxId);
-        this.triggerCommand("openInWindow", { notePath, hoistedNoteId, viewScope });
+        const target = this.captureTabAsWindowTarget(ntxId);
+
+        if (target) {
+            this.triggerCommand("openInWindow", target);
+        }
+    }
+
+    /** Every pane of one tab — its main context and the splits beside it — in row order. */
+    getTabPanes(mainNtxId: string | null) {
+        return this.noteContexts.filter((nc) =>
+            nc.ntxId === mainNtxId || nc.mainNtxId === mainNtxId);
+    }
+
+    /**
+     * Describes a whole tab — every split pane in order, and which of them is focused — as a target
+     * for `openInWindow`.
+     *
+     * Returns `null` when the tab is already gone. The tear-off drag fires from `dragMove`,
+     * which can deliver several events before the first removal completes, so a second call for
+     * the same tab is expected rather than exceptional.
+     */
+    captureTabAsWindowTarget(ntxId: string): NoteCommandData | null {
+        const mainContext = this.noteContexts.find((nc) => nc.ntxId === ntxId);
+
+        if (!mainContext) {
+            return null;
+        }
+
+        const panes = this.getTabPanes(ntxId);
+        const splits = panes.filter((nc) => nc.ntxId !== mainContext.ntxId);
+
+        return {
+            notePath: mainContext.notePath,
+            hoistedNoteId: mainContext.hoistedNoteId,
+            viewScope: mainContext.viewScope,
+            splits: splits.map((nc) => ({
+                notePath: nc.notePath,
+                hoistedNoteId: nc.hoistedNoteId,
+                viewScope: nc.viewScope
+            })),
+            activeSplit: Math.max(panes.indexOf(getFocusedPane(mainContext, panes)), 0)
+        };
     }
 
     async reopenLastTabCommand() {
@@ -888,4 +925,62 @@ export default class TabManager extends Component {
             await this.updateDocumentTitle(activeContext);
         }
     }
+}
+
+/**
+ * The pane holding the focus within a tab: the one remembered as last active if it is still open,
+ * otherwise the main pane — the same choice activating the tab would make.
+ */
+function getFocusedPane(mainContext: NoteContext, panes: NoteContext[]) {
+    return panes.find((nc) => nc.ntxId === mainContext.lastActiveNtxId) ?? mainContext;
+}
+
+/**
+ * Turns the navigation state parsed out of the address into the contexts to open at boot: the main
+ * pane, plus the split panes that a tab moved into a window of its own brought along with it.
+ */
+export function buildNoteContextStatesFromUrl(
+    parsed: NoteCommandData,
+    mainNtxId: string
+): NoteContextState[] {
+    const panes = [
+        {
+            notePath: parsed.notePath,
+            hoistedNoteId: parsed.hoistedNoteId,
+            viewScope: parsed.viewScope
+        },
+        ...(parsed.splits ?? [])
+    ];
+    // a bare boot with nothing in the address lands on root, but a pane torn off empty stays empty
+    const notePaths = panes.map((pane) => pane.notePath || (panes.length === 1 ? "root" : null));
+    const activeIdx = pickActivePane(notePaths, parsed.activeSplit ?? 0);
+
+    const states: NoteContextState[] = panes.map((pane, idx) => ({
+        notePath: notePaths[idx],
+        ntxId: idx === 0 ? mainNtxId : NoteContext.generateNtxId(),
+        mainNtxId: idx === 0 ? null : mainNtxId,
+        active: idx === activeIdx,
+        hoistedNoteId: pane.hoistedNoteId || "root",
+        viewScope: pane.viewScope || {}
+    }));
+
+    // so that leaving the tab and coming back returns to the pane that was focused
+    states[0].lastActiveNtxId = states[activeIdx].ntxId;
+
+    return states;
+}
+
+/**
+ * Which pane opens focused. The index comes off the address bar, so it is clamped into range; and
+ * because a pane holding no note never takes the focus anyway (`openContextWithNote` activates only
+ * once a note is set), an empty one hands over to the first pane that has one.
+ */
+function pickActivePane(notePaths: (string | null)[], requested: number) {
+    const clamped = Math.min(Math.max(requested, 0), notePaths.length - 1);
+
+    if (notePaths[clamped]) {
+        return clamped;
+    }
+
+    return Math.max(notePaths.findIndex((notePath) => !!notePath), 0);
 }

--- a/apps/client/src/desktop.ts
+++ b/apps/client/src/desktop.ts
@@ -14,6 +14,7 @@ import noteTooltipService from "./services/note_tooltip.js";
 import { setBackgroundEffectsSuspended } from "./services/theme.js";
 import toastService from "./services/toast.js";
 import utils from "./services/utils.js";
+import { preloadCommonNoteTypes } from "./widgets/note_types.js";
 
 await appContext.earlyInit();
 
@@ -22,7 +23,10 @@ bundleService.getWidgetBundlesByParent().then(async (widgetBundles) => {
     const DesktopLayout = (await import("./layouts/desktop_layout.js")).default;
 
     appContext.setLayout(new DesktopLayout(widgetBundles));
-    appContext.start().then(reportFullRenderStartupMetric).catch((e) => {
+    appContext.start().then(() => {
+        reportFullRenderStartupMetric();
+        preloadCommonNoteTypes();
+    }).catch((e) => {
         toastService.showPersistent({
             id: "critical-error",
             title: t("toast.critical-error.title"),

--- a/apps/client/src/mobile.ts
+++ b/apps/client/src/mobile.ts
@@ -4,6 +4,7 @@ import appContext from "./components/app_context.js";
 import { setupClipboardImageEmbed } from "./services/clipboard_image_embed.js";
 import glob from "./services/glob.js";
 import noteAutocompleteService from "./services/note_autocomplete.js";
+import { preloadCommonNoteTypes } from "./widgets/note_types.js";
 
 glob.setupGlobs();
 
@@ -17,4 +18,4 @@ setupClipboardImageEmbed();
 const MobileLayout = (await import("./layouts/mobile_layout.js")).default;
 
 appContext.setLayout(new MobileLayout());
-appContext.start();
+void appContext.start().then(preloadCommonNoteTypes);

--- a/apps/client/src/services/link.spec.ts
+++ b/apps/client/src/services/link.spec.ts
@@ -299,6 +299,16 @@ describe("split panes in the hash", () => {
         });
     });
 
+    it("shrugs off an active index that is not a number, and a parameter carrying no value", () => {
+        // Both reach the parser straight off the address bar, where anything at all may be typed.
+        expect(parseNavigationStateFromUrl(
+            asExtraWindowUrl(`#${A}?splits=${encodeURIComponent(B)}&activeSplit=whichever`)
+        )).toMatchObject({ activeSplit: 0, splits: [{ notePath: B }] });
+
+        // `popup` is a flag, so it is written bare — there is no `=` to split on.
+        expect(parseNavigationStateFromUrl(`#${A}?popup`)).toMatchObject({ openInPopup: true });
+    });
+
     it("ignores parameters that describe a window rather than a pane", () => {
         const nested = encodeURIComponent(`${B}?ntxId=n1&splits=${encodeURIComponent(C)}`);
         const parsed = parseNavigationStateFromUrl(asExtraWindowUrl(`#${A}?splits=${nested}`));

--- a/apps/client/src/services/link.spec.ts
+++ b/apps/client/src/services/link.spec.ts
@@ -223,6 +223,91 @@ describe("calculateExtraWindowUrl", () => {
     });
 });
 
+describe("split panes in the hash", () => {
+    const A = "root/aaaaaaaaaaaa";
+    const B = "root/bbbbbbbbbbbb";
+    const C = "root/cccccccccccc";
+
+    /** Wraps a bare hash in the address a detached window boots from. */
+    const asExtraWindowUrl = (hash: string) => `http://localhost:8080/?extraWindow=1${hash}`;
+
+    it("round-trips a tab's panes, keeping their order, hoisting and view scope", () => {
+        const hash = calculateHash({
+            notePath: A,
+            splits: [
+                { notePath: B, viewScope: { viewMode: "source" } },
+                { notePath: C, hoistedNoteId: "h1" }
+            ],
+            activeSplit: 1
+        });
+
+        // each pane is a hash body of its own, comma-joined and encoded as a single parameter
+        expect(hash).toBe(
+            `#${A}?splits=root%2Fbbbbbbbbbbbb%3FviewMode%3Dsource%2Croot%2Fcccccccccccc%3FhoistedNoteId%3Dh1&activeSplit=1`
+        );
+
+        expect(parseNavigationStateFromUrl(asExtraWindowUrl(hash))).toMatchObject({
+            notePath: A,
+            activeSplit: 1,
+            splits: [
+                { notePath: B, hoistedNoteId: null, viewScope: { viewMode: "source" } },
+                { notePath: C, hoistedNoteId: "h1", viewScope: { viewMode: "default" } }
+            ]
+        });
+    });
+
+    it("honours splits only when booting a detached window", () => {
+        // The same parser backs every link click inside a note. Were splits read there, any note —
+        // including an imported or synced one — could rearrange the panes of the window reading it.
+        const hash = calculateHash({ notePath: A, splits: [{ notePath: B }] });
+
+        expect(parseNavigationStateFromUrl(`http://localhost:8080/${hash}`)).toMatchObject({
+            notePath: A,
+            splits: null
+        });
+    });
+
+    it("keeps the layout of a tab whose first pane held no note", () => {
+        const hash = calculateHash({ notePath: null, splits: [{ notePath: B }] });
+
+        expect(hash).toBe("#?splits=root%2Fbbbbbbbbbbbb");
+        expect(parseNavigationStateFromUrl(asExtraWindowUrl(hash))).toMatchObject({
+            notePath: "",
+            noteId: null,
+            splits: [{ notePath: B }]
+        });
+
+        // without splits an empty note path still means "nothing to navigate to"
+        expect(parseNavigationStateFromUrl(asExtraWindowUrl("#"))).toStrictEqual({});
+    });
+
+    it("keeps empty panes, drops malformed ones and caps how many it will open", () => {
+        const parse = (splits: string) =>
+            parseNavigationStateFromUrl(asExtraWindowUrl(`#${A}?splits=${splits}`));
+
+        // an empty entry is a pane that held no note — kept, so the pane count survives
+        expect(parse(encodeURIComponent(`${B},,${C}`))).toMatchObject({
+            splits: [{ notePath: B }, { notePath: null }, { notePath: C }]
+        });
+
+        // a hand-written address shouldn't be able to open a pane on garbage, nor hundreds of them
+        expect(parse(encodeURIComponent(`${B},zz,${C}`))).toMatchObject({
+            splits: [{ notePath: B }, { notePath: C }]
+        });
+        expect(parse(encodeURIComponent(Array(20).fill(B).join(",")))).toMatchObject({
+            splits: Array(8).fill({ notePath: B })
+        });
+    });
+
+    it("ignores parameters that describe a window rather than a pane", () => {
+        const nested = encodeURIComponent(`${B}?ntxId=n1&splits=${encodeURIComponent(C)}`);
+        const parsed = parseNavigationStateFromUrl(asExtraWindowUrl(`#${A}?splits=${nested}`));
+
+        expect(parsed).toMatchObject({ splits: [{ notePath: B, viewScope: { viewMode: "default" } }] });
+        expect((parsed as any).splits[0]).not.toHaveProperty("ntxId");
+    });
+});
+
 describe("getNotePathFromUrl", () => {
     it("extracts the note path from a hash url and returns null otherwise", () => {
         expect(linkService.getNotePathFromUrl("https://x.test/#root/abc_123")).toBe("root/abc_123");

--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -72,6 +72,28 @@ export interface ViewScope {
     bookmark?: string;
 }
 
+/**
+ * The state of a single split pane, as carried by the `splits` hash parameter when a tab is
+ * moved or copied into a window of its own.
+ */
+export interface HashPane {
+    notePath?: string | null;
+    hoistedNoteId?: string | null;
+    viewScope?: ViewScope;
+}
+
+/** A note path as it may appear in a hash: slash-separated note ids. */
+const NOTE_PATH_PATTERN = /^[_a-z0-9]{4,}(\/[_a-z0-9]{4,})*$/i;
+
+/**
+ * How many extra panes a hash is allowed to carry. Well beyond any layout a user would build by
+ * hand, but low enough that a hand-written address can't ask the app to open hundreds of panes.
+ */
+const MAX_SPLIT_PANES_IN_HASH = 8;
+
+/** Hash parameters that belong to a pane's view scope rather than to the window as a whole. */
+const VIEW_SCOPE_PARAMS = ["viewMode", "attachmentId", "bookmark"];
+
 interface CreateLinkOptions {
     title?: string;
     showTooltip?: boolean;
@@ -198,13 +220,17 @@ async function createLink(notePath: string | undefined, options: CreateLinkOptio
     return $container;
 }
 
-export function calculateHash({ notePath, ntxId, hoistedNoteId, viewScope = {} }: NoteCommandData) {
+export function calculateHash(
+    { notePath, ntxId, hoistedNoteId, viewScope = {}, splits, activeSplit }: NoteCommandData
+) {
     notePath = notePath || "";
     const params = [
         ntxId ? { ntxId } : null,
         hoistedNoteId && hoistedNoteId !== "root" ? { hoistedNoteId } : null,
         viewScope.viewMode && viewScope.viewMode !== "default" ? { viewMode: viewScope.viewMode } : null,
-        viewScope.attachmentId ? { attachmentId: viewScope.attachmentId } : null
+        viewScope.attachmentId ? { attachmentId: viewScope.attachmentId } : null,
+        splits?.length ? { splits: splits.map(encodeSplitPane).join(",") } : null,
+        splits?.length && activeSplit ? { activeSplit: String(activeSplit) } : null
     ].filter((p) => !!p);
 
     const paramStr = params
@@ -212,7 +238,8 @@ export function calculateHash({ notePath, ntxId, hoistedNoteId, viewScope = {} }
             const name = Object.keys(pair)[0];
             const value = (pair as Record<string, string | undefined>)[name];
 
-            /* v8 ignore next -- the `value || ""` fallback is unreachable: every retained param pair has a truthy value (falsy ones were filtered out above) */
+            /* v8 ignore next -- `value` is never undefined: every retained pair holds a string. It
+               can be empty, but only for a `splits` list whose panes are all empty. */
             return `${encodeURIComponent(name)}=${encodeURIComponent(value || "")}`;
         })
         .join("&");
@@ -228,6 +255,16 @@ export function calculateHash({ notePath, ntxId, hoistedNoteId, viewScope = {} }
     }
 
     return hash;
+}
+
+/**
+ * Serializes one extra pane into an entry of the `splits` parameter: its own hash body, minus the
+ * leading `#`. Entries are joined with commas, which is unambiguous because neither a note path nor
+ * an encoded parameter value can contain one. A pane holding no note yields an empty entry, so that
+ * the pane count of the original tab survives the trip.
+ */
+function encodeSplitPane(pane: HashPane) {
+    return calculateHash(pane).slice(1);
 }
 
 /** The subset of `window.location` needed to build a URL, which a plain `URL` also satisfies. */
@@ -270,8 +307,10 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
         return {};
     }
 
+    const isExtraWindow = isExtraWindowUrl(url, hashIdx);
+
     // Exclude external links that contain #
-    if (hashIdx !== 0 && !url.includes("/#root") && !url.includes("/#?searchString") && !isExtraWindowUrl(url, hashIdx)) {
+    if (hashIdx !== 0 && !url.includes("/#root") && !url.includes("/#?searchString") && !isExtraWindow) {
         return {};
     }
 
@@ -285,26 +324,29 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
     let hoistedNoteId: string | null = null;
     let searchString: string | null = null;
     let openInPopup = false;
+    let splits: HashPane[] | null = null;
+    let activeSplit = 0;
 
-    if (paramString) {
-        for (const pair of paramString.split("&")) {
-            let [name, value] = pair.split("=");
-            name = decodeURIComponent(name);
-            value = decodeURIComponent(value);
-
-            if (name === "ntxId") {
-                ntxId = value;
-            } else if (name === "hoistedNoteId") {
-                hoistedNoteId = value;
-            } else if (name === "searchString") {
-                searchString = value; // supports triggering search from URL, e.g. #?searchString=blabla
-            } else if (["viewMode", "attachmentId", "bookmark"].includes(name)) {
-                (viewScope as any)[name] = value;
-            } else if (name === "popup") {
-                openInPopup = true;
-            } else {
-                console.warn(`Unrecognized hash parameter '${name}'.`);
-            }
+    for (const [name, value] of parseHashParams(paramString)) {
+        if (name === "ntxId") {
+            ntxId = value;
+        } else if (name === "hoistedNoteId") {
+            hoistedNoteId = value;
+        } else if (name === "searchString") {
+            searchString = value; // supports triggering search from URL, e.g. #?searchString=blabla
+        } else if (VIEW_SCOPE_PARAMS.includes(name)) {
+            (viewScope as any)[name] = value;
+        } else if (name === "popup") {
+            openInPopup = true;
+        } else if (name === "splits") {
+            // Splits lay out the whole window, so they are honoured only while booting a
+            // detached one. A link inside a note reaches this same parser, and no note should
+            // be able to rearrange the panes of the window it is read in.
+            splits = isExtraWindow ? parseSplitPanes(value) : null;
+        } else if (name === "activeSplit") {
+            activeSplit = Number.parseInt(value, 10) || 0;
+        } else {
+            console.warn(`Unrecognized hash parameter '${name}'.`);
         }
     }
 
@@ -312,7 +354,11 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
         return { searchString };
     }
 
-    if (!notePath.match(/^[_a-z0-9]{4,}(\/[_a-z0-9]{4,})*$/i)) {
+    // A hash carrying splits is one we wrote ourselves, so its main pane may hold no note —
+    // that is how a tab whose first pane was empty keeps the rest of its panes.
+    const isEmptyMainPaneWithSplits = !notePath && !!splits?.length;
+
+    if (!isEmptyMainPaneWithSplits && !NOTE_PATH_PATTERN.test(notePath)) {
         return {};
     }
 
@@ -323,8 +369,63 @@ export function parseNavigationStateFromUrl(url: string | undefined) {
         hoistedNoteId,
         viewScope,
         searchString,
-        openInPopup
+        openInPopup,
+        splits,
+        activeSplit
     };
+}
+
+/** Iterates the `name=value` pairs of a hash's parameter string, decoding both sides. */
+function parseHashParams(paramString: string | undefined) {
+    if (!paramString) {
+        return [];
+    }
+
+    return paramString.split("&").map((pair) => {
+        const [name, value] = pair.split("=");
+
+        return [decodeURIComponent(name), decodeURIComponent(value ?? "")] as const;
+    });
+}
+
+/**
+ * Parses the `splits` parameter — the panes that stood beside the main one, in order. Entries that
+ * aren't a well-formed pane are dropped rather than failing the whole hash, so a mangled address
+ * still opens what it can.
+ */
+function parseSplitPanes(value: string): HashPane[] {
+    return value
+        .split(",")
+        .slice(0, MAX_SPLIT_PANES_IN_HASH)
+        .map(parseSplitPane)
+        .filter((pane) => !!pane);
+}
+
+function parseSplitPane(entry: string): HashPane | null {
+    const [notePath, paramString] = entry.split("?");
+
+    // An empty entry is a pane that held no note; anything else has to be a real note path.
+    if (notePath && !NOTE_PATH_PATTERN.test(notePath)) {
+        return null;
+    }
+
+    const pane: HashPane = {
+        notePath: notePath || null,
+        hoistedNoteId: null,
+        viewScope: { viewMode: "default" }
+    };
+
+    for (const [name, paramValue] of parseHashParams(paramString)) {
+        if (name === "hoistedNoteId") {
+            pane.hoistedNoteId = paramValue;
+        } else if (VIEW_SCOPE_PARAMS.includes(name)) {
+            (pane.viewScope as any)[name] = paramValue;
+        }
+        // Everything else — `ntxId`, `searchString`, a nested `splits` — describes a window rather
+        // than a pane, and has no meaning this far down.
+    }
+
+    return pane;
 }
 
 /**

--- a/apps/client/src/stylesheets/ckeditor-theme.css
+++ b/apps/client/src/stylesheets/ckeditor-theme.css
@@ -106,8 +106,6 @@ body {
 
     --ck-color-engine-placeholder-text: var(--muted-text-color);
 
-    --ck-z-modal: 10000;
-
     --ck-color-widget-type-around-button: var(--main-border-color);
     --ck-color-widget-type-around-button-hover: var(--main-border-color);
 }

--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -782,26 +782,29 @@ table.promoted-attributes-in-tooltip th {
 
 .tooltip {
     font-size: var(--main-font-size) !important;
-    /* Just under CKEditor's panels (balloons, dropdowns), so a tooltip on an editor button doesn't
-       cover the panel that button opens.
+    /* Above every layer the app opens over the page: a tooltip is appended to `<body>`, so it
+       competes with a dialog in the root stacking context rather than painting inside it, and any
+       lower layer leaves it unreadable behind the very dialog it was asked for. Bootstrap's modal
+       sits at 1055, the dialogs the app lifts itself at up to 3000, the context menu at 2500.
 
-       The fallback is not decoration: `--ck-z-panel` is declared by CKEditor's own stylesheet, which
-       only enters the document with the lazily loaded editor bundle. Until something pulls it in
-       (a text note, the attribute editor), the variable is undefined, `calc()` is invalid at
-       computed-value time and the whole declaration — `!important` and all — resolves to the initial
-       `z-index: auto`. Tooltips then paint below every positioned layer with a z-index of its own,
-       the peeked right pane among them (they show up blurred through its backdrop-filter). The
-       fallback matches what CKEditor declares, so the value doesn't shift once the bundle loads. */
-    z-index: calc(var(--ck-z-panel, 1000) - 1) !important;
+       This layer used to be chained to CKEditor's own — `calc(var(--ck-z-panel) - 1)` — which
+       `ckeditor-theme.css` raised to 10000 for exactly this reason, landing tooltips at 9999.
+       Upstream renamed the variable (`--ck-z-modal` → `--ck-z-panel`) and the override went dead
+       with the old name, dropping tooltips to 999 — under every dialog. Nothing showed it because
+       the math form's rescue rule named a bare `[role="tooltip"]`, lifting every tooltip in the app
+       to 3000; keeping that rule to MathLive's own UI is what finally uncovered it. Stated here in
+       full, and no longer read from a variable another package owns. */
+    z-index: 9999 !important;
 }
 
 .tooltip.tooltip-top {
     z-index: 32767 !important;
 }
 
-/* Note tooltips are appended to <body> and are frequently triggered from inside modals
-   (e.g. links or deleted-note entries in a dialog). The base .tooltip z-index sits below
-   Bootstrap's modal, so raise them above it — matching .tooltip-top. */
+/* Note tooltips are appended to <body> and are frequently triggered from inside a dialog (a link,
+   a deleted-note entry), including the few that lift themselves above the base tooltip layer — the
+   content manager's active-content overlay among them. Held at the same "above everything" layer
+   .tooltip-top names, so they clear those too. */
 .tooltip.note-tooltip {
     z-index: 32767 !important;
 }

--- a/apps/client/src/stylesheets/theme-next/shell.css
+++ b/apps/client/src/stylesheets/theme-next/shell.css
@@ -1483,8 +1483,6 @@ body.experimental-feature-new-layout #center-pane .note-split > div.alert {
 
 /* The promoted attributes section */
 div.promoted-attributes-container {
-    /* The cards are sized by the container query below instead of wrapping. */
-    flex-wrap: nowrap;
     margin-inline-end: 10%;
     padding: 6px 0;
     gap: 8px;

--- a/apps/client/src/stylesheets/theme-next/shell.css
+++ b/apps/client/src/stylesheets/theme-next/shell.css
@@ -1579,13 +1579,18 @@ div.promoted-attribute-cell span.open-external-link-button {
 }
 
 div.promoted-attribute-cell .tn-checkbox {
-    --box-label-gap: 0;
+    --box-label-gap: 0px;
 
-    height: 1cap;
+    height: 1em;
+    vertical-align: calc((1cap - 1em) / 2);
+}
+
+div.promoted-attribute-cell .tn-checkbox > input[type="checkbox"] {
+    width: var(--box-size) !important;
 }
 
 div.promoted-attribute-cell.promoted-attribute-label-boolean > div:first-of-type {
-    margin-inline-end: 1.5em;
+    margin-inline-end: 0.5em;
 }
 
 /* The element containing the "new attribute" and "remove this attribute button" */

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2853,6 +2853,8 @@
     "quick-edit": "Quick edit"
   },
   "geo-map": {
+    "expand-details": "Expand the note to fill the map",
+    "restore-details": "Put the note back beside the map",
     "create-child-note-title": "Create a new child note and add it to the map",
     "create-child-note-cancel": "Cancel adding the note",
     "add-marker": "Add marker",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -1007,6 +1007,8 @@
     "pin_date": "Pin the current date so the calendar always opens on this interval instead of today",
     "unpin_date": "Unpin the date so the calendar opens on today's date again",
     "close_details": "Close event details",
+    "expand_details": "Expand the event to fill the window",
+    "restore_details": "Put the event back beside its place in the calendar",
     "dates": {
       "all_day": "All day",
       "date": "Date",

--- a/apps/client/src/widgets/EmbeddedNotePane.css
+++ b/apps/client/src/widgets/EmbeddedNotePane.css
@@ -1,53 +1,48 @@
-/*
- * The body of a pane holding an embedded note (see EmbeddedNotePane.tsx): the note's own widgets,
- * laid out for a third of the width they are written for. The class goes on the element that holds
- * them — the geo pane's body, the calendar dock's body — which brings the column they stand in;
- * whatever else that element is (its padding, whether it scrolls) stays with its own class.
- */
 .tn-embedded-note-pane {
     display: flex;
     flex-direction: column;
     gap: 10px;
 
-    /*
-     * The note fills the rest of the pane rather than ending where its content does, so that
-     * clicking below a short note still puts the caret in it — as it does in a note of its own.
-     */
     .note-detail {
         flex: 1;
-        /* Written for a note split, where the split hands it one; there is no split here, and an
-           unset `--max-content-width` would leave `max-width` invalid rather than absent. */
         max-width: none;
-        /* A floor rather than the 0 a flex item needs to scroll its own content: the fields above
-           it are as many as the note asks for, and without one they would squeeze the note out of
-           the pane instead of the body scrolling. Above the floor a long note still scrolls within
-           itself. */
         min-height: 120px;
     }
 
-    /*
-     * The note's promoted fields. A field reads across one line — its name, then what it holds —
-     * and stays that way here; what changes is the row they stand in. Across a note they stand side
-     * by side, each as wide as what it holds; in the pane there is room for one, so they come down
-     * the column instead, each taking the whole width.
-     */
     .promoted-attributes-container {
-        flex-direction: column;
-        flex-wrap: nowrap;
-        align-items: stretch;
         gap: 8px;
         margin: 0;
-        /* The body of the pane is the one thing that scrolls; a scroller inside it would take the
-           wheel off whichever of the two the pointer happened to be over. */
         max-height: none;
         overflow: visible;
     }
 
     .promoted-attribute-cell {
         margin: 0;
+    }
 
-        /* The field takes whatever its name leaves, rather than the width of what it holds: a card
-           standing alone on its line has that room whether it needs it or not. */
+    .promoted-attributes-widget:not(:has(.promoted-attribute-cell)) {
+        display: none;
+    }
+
+    .tn-embedded-note-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+
+        .tn-embedded-note-color {
+            margin-inline-start: auto;
+        }
+    }
+}
+
+.tn-embedded-note-pane:not(.tn-embedded-note-pane-wide) {
+    .promoted-attributes-container {
+        flex-direction: column;
+        flex-wrap: nowrap;
+        align-items: stretch;
+    }
+
+    .promoted-attribute-cell {
         > .input-group,
         > .promoted-attribute-values {
             flex: 1;
@@ -55,15 +50,11 @@
             margin-inline-start: 8px;
         }
 
-        /* Both are given a width in ems, which is a card's own width where cards stand side by
-           side. Marked as the theme marks them, there being no other way past it. */
         input[type="text"],
         input[type="number"] {
             width: auto !important;
         }
 
-        /* A name longer than the pane is cut short rather than pushing the field it names off the
-           end. */
         > label {
             min-width: 0;
             overflow: hidden;
@@ -75,42 +66,12 @@
             padding: 0;
         }
     }
-
-    /* The widget stands whether the note promotes anything or not, and an empty one would still
-       take its share of the gap between what stands above and below it. */
-    .promoted-attributes-widget:not(:has(.promoted-attribute-cell)) {
-        display: none;
-    }
-
-    /* The row of actions at the head of the pane (see EmbeddedNoteActions). */
-    .tn-embedded-note-actions {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-
-        /* Those that write rather than read stand apart from the ones being reached for repeatedly,
-           so the pointer cannot land on one of them by being a moment early. The gap falls before
-           the first of them, which is the colour: they are drawn together or not at all, a
-           read-only host having none of them. */
-        .tn-embedded-note-color {
-            margin-inline-start: auto;
-        }
-    }
 }
 
 :root .tn-embedded-note-pane .tn-embedded-note-remove.icon-action {
     color: var(--dropdown-item-icon-destructive-color);
 }
 
-/*
- * The maximize button (see MaximizeToQuickEditAction), dressed as the X it stands beside: the
- * compact round surface the theme reserves for close crosses (`.icon-action.bx-x` in
- * theme-next/forms.css), minus the red close hover. The icon keeps the stock ratio rather than the
- * X's 0.8 — the expand glyph fills its em box where the X's does not, so the stock size is what
- * stands at the X's visual weight. Stated from `:root` and with the icon's own class doubled on,
- * so as to outweigh the theme's blanket `border-radius` whichever way the stylesheets are ordered
- * (the bargain the attribute list's delete button strikes; see AttributeList.css).
- */
 :root .icon-action.bx-expand-alt.tn-embedded-note-maximize {
     --icon-button-size: 24px;
 

--- a/apps/client/src/widgets/EmbeddedNotePane.css
+++ b/apps/client/src/widgets/EmbeddedNotePane.css
@@ -33,6 +33,7 @@
      */
     .promoted-attributes-container {
         flex-direction: column;
+        flex-wrap: nowrap;
         align-items: stretch;
         gap: 8px;
         margin: 0;

--- a/apps/client/src/widgets/EmbeddedNotePane.tsx
+++ b/apps/client/src/widgets/EmbeddedNotePane.tsx
@@ -272,20 +272,48 @@ export const OTHER_WAYS_TO_OPEN = [
 ] as const;
 
 /**
+ * The button a pane is grown by, whatever growing means to the host: the quick editor for a pane
+ * that has no larger form of its own (see {@link MaximizeToQuickEditAction}), or the pane's own
+ * larger form where it has one — the calendar's event card, which grows in place so that what is
+ * being edited within it is never torn down (see EventPopover).
+ *
+ * Stands beside the header's X and is dressed as its neighbour is (see EmbeddedNotePane.css). Named
+ * by the host, there being no one word for it: what it does is the host's to say, and a card that
+ * can be put back down again says something different from one that hands over to another surface.
+ */
+export function MaximizeAction({ text, icon, onClick }: {
+    text: string;
+    /** The stock expand, unless the host has a way back and wants the arrows the other way about. */
+    icon?: string;
+    onClick(): void;
+}) {
+    return (
+        <ActionButton
+            className="tn-embedded-note-maximize"
+            icon={icon ?? "bx bx-expand-alt"}
+            text={text}
+            onClick={onClick}
+        />
+    );
+}
+
+/**
  * The pane grown into the quick editor: the same note in the larger surface, taking the pane's
  * place rather than standing over it — opened first and closed after, as the quick editor's own
  * maximize hands over to a tab. Which is what earns it the place in the header that the quick-edit
  * menu entry is denied in the row (see {@link OTHER_WAYS_TO_OPEN}): a maximize replaces the pane
  * instead of putting a modal back over it, the close giving whatever is being edited the chance to
- * save. Stands beside the header's X, and is dressed as its neighbour is (see EmbeddedNotePane.css).
+ * save.
+ *
+ * For a pane with no larger form of its own — the geo map's, whose note has nothing of the map
+ * about it to be carried into a bigger card. A pane that has one grows into that instead, and keeps
+ * what is peculiar to it.
  *
  * A path rather than an id, as the menu passes one, so the two roads into the quick editor agree.
  */
 export function MaximizeToQuickEditAction({ note, onClose }: { note: FNote; onClose(): void }) {
     return (
-        <ActionButton
-            className="tn-embedded-note-maximize"
-            icon="bx bx-expand-alt"
+        <MaximizeAction
             text={t("embedded_note.maximize")}
             onClick={() => {
                 const notePath = note.getBestNotePathString(appContext.tabManager.getActiveContext()?.hoistedNoteId);

--- a/apps/client/src/widgets/PromotedAttributes.spec.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.spec.tsx
@@ -72,7 +72,8 @@ import PromotedAttributes, { buildPromotedCells, PromotedAttributesContent, useP
 // A text field offers the values other notes hold under its name through the Algolia plugin, which
 // is not loaded here; a stub that chains like jQuery does keeps the field's setup on its feet.
 type PluggedIn = { autocomplete(...args: unknown[]): PluggedIn };
-($.fn as unknown as PluggedIn).autocomplete = function (this: PluggedIn) { return this; };
+const autocompleteMock = vi.fn(function (this: PluggedIn) { return this; });
+($.fn as unknown as PluggedIn).autocomplete = autocompleteMock;
 
 // The fields reach the server through these three; every suite stands them down, and the ones
 // asserting on what was written reach for these same handles.
@@ -576,6 +577,20 @@ describe("PromotedAttributesContent rendering", () => {
         serverGetMock.mockClear();
         await renderCells(note, [ buildCell(note, { definition: { labelType: "number" }, uniqueId: "num" }) ]);
         expect(serverGetMock).not.toHaveBeenCalled();
+    });
+
+    it("binds the suggestion list only where there is something to suggest", async () => {
+        serverGetMock.mockResolvedValueOnce([ "one", "two" ]);
+        await renderCells(note, [ buildCell(note, { name: "tags", definition: { labelType: "text" } }) ]);
+        expect(autocompleteMock).toHaveBeenCalled();
+
+        autocompleteMock.mockClear();
+        await renderCells(note, [ buildCell(note, { name: "flag", definition: { labelType: "boolean" }, uniqueId: "flag" }) ]);
+        expect(autocompleteMock).not.toHaveBeenCalled();
+
+        // A text field whose name nothing else holds a value under is bound no more than a flag is.
+        await renderCells(note, [ buildCell(note, { name: "fresh", definition: { labelType: "text" }, uniqueId: "fresh" }) ]);
+        expect(autocompleteMock).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -396,7 +396,7 @@ function useTextLabelAutocomplete(inputId: string, valueAttr: Attribute, definit
 
     // Initialize autocomplete.
     useEffect(() => {
-        if (attributeValues?.length === 0) return;
+        if (!attributeValues?.length) return;
         const el = document.getElementById(inputId) as HTMLInputElement | null;
         if (!el) return;
 

--- a/apps/client/src/widgets/collections/calendar/EventPopover.css
+++ b/apps/client/src/widgets/collections/calendar/EventPopover.css
@@ -1,13 +1,22 @@
 .calendar-event-popover {
-    /* One width whatever event it stands for, and as tall as that event needs; what it holds
-       scrolls within it (see the body below). Both are held to what the window can spare: the card
-       is anchored beside a chip rather than laid over the page, and Popper answers a card too big
-       for the room by shifting it into the viewport rather than by narrowing it (see the
-       preventOverflow modifier in Popover.tsx) — so a width the window cannot take would hang off
-       the edge instead of being given back.
-       The width must agree with `MAX_ANCHOR_WIDTH` in selection.ts. */
+    /* Held to the window: Popper shifts a card too wide for the room into the viewport rather than
+       narrowing it, so an unclamped width would hang off the edge.
+       Must agree with `MAX_ANCHOR_WIDTH` in selection.ts. */
     width: min(480px, calc(100vw - 4rem));
+    /* As tall as the event needs; what it holds scrolls within it (see the body below). */
     max-height: min(640px, 85vh);
+
+    /* The same card grown to the window (see the maximize in EventDetails); it takes its height
+       from the insets in `.maximized` in Popover.css, so the anchored ceiling is given up here. */
+    &.maximized {
+        width: min(var(--preferred-max-content-width, 900px), calc(100vw - 4rem));
+        max-height: none;
+
+        /* The card is now taller than the event, so the column has to take up the difference. */
+        .calendar-event-popover-inner {
+            flex: 1;
+        }
+    }
 
     .calendar-event-popover-inner {
         display: flex;

--- a/apps/client/src/widgets/collections/calendar/EventPopover.css
+++ b/apps/client/src/widgets/collections/calendar/EventPopover.css
@@ -1,7 +1,12 @@
 .calendar-event-popover {
-    width: 380px;
-    /* A fixed-width card as tall as its event needs, up to what the viewport can spare; what it
-       holds scrolls within it (see the body below). */
+    /* One width whatever event it stands for, and as tall as that event needs; what it holds
+       scrolls within it (see the body below). Both are held to what the window can spare: the card
+       is anchored beside a chip rather than laid over the page, and Popper answers a card too big
+       for the room by shifting it into the viewport rather than by narrowing it (see the
+       preventOverflow modifier in Popover.tsx) — so a width the window cannot take would hang off
+       the edge instead of being given back.
+       The width must agree with `MAX_ANCHOR_WIDTH` in selection.ts. */
+    width: min(480px, calc(100vw - 4rem));
     max-height: min(640px, 85vh);
 
     .calendar-event-popover-inner {

--- a/apps/client/src/widgets/collections/calendar/EventPopover.tsx
+++ b/apps/client/src/widgets/collections/calendar/EventPopover.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
 import { isMobile } from "../../../services/utils";
-import { announceEmbeddedNoteClosing, EmbeddedNoteActions, EmbeddedNoteScope, MaximizeToQuickEditAction, NoteColorAction, OpenNoteActions, useEmbeddedNoteContext, useFollowLinksWithin } from "../../EmbeddedNotePane";
+import { announceEmbeddedNoteClosing, EmbeddedNoteActions, EmbeddedNoteScope, MaximizeAction, NoteColorAction, OpenNoteActions, useEmbeddedNoteContext, useFollowLinksWithin } from "../../EmbeddedNotePane";
 import TitleRow from "../../layout/TitleRow";
 import NoteDetail from "../../NoteDetail";
 import PromotedAttributes from "../../PromotedAttributes";
@@ -56,6 +56,17 @@ export default function EventPopover({ noteId, anchor, container, parentNote, is
     const { noteContext, component } = useEmbeddedNoteContext(note ?? undefined, POPOVER_NTX_ID);
 
     /**
+     * Whether the card has been grown to the window (see the maximize in {@link EventDetails}, and
+     * `maximized` in Popover for what it does to the card). A state of the standing card and not a
+     * surface of its own, so that growing it neither saves nor reloads anything: the note's editor
+     * is the same editor either side of it, mid-edit and all.
+     *
+     * Kept across a switch from one event to another, a reader who asked for the room being taken
+     * to have meant the asking rather than the event they happened to ask it on.
+     */
+    const [ maximized, setMaximized ] = useState(false);
+
+    /**
      * Lets the surface go, having given whatever is being edited in it the chance to save — the
      * geo pane's bargain (see its closePane): announced first, while the editors are still
      * mounted, and not waited on. Every way out leads through here.
@@ -83,6 +94,8 @@ export default function EventPopover({ noteId, anchor, container, parentNote, is
                     updateKey={noteId}
                     parentNote={parentNote}
                     isEditable={isEditable}
+                    maximized={maximized}
+                    setMaximized={setMaximized}
                     onClose={close}
                     onFollowLink={onFollowLink}
                 />
@@ -91,16 +104,22 @@ export default function EventPopover({ noteId, anchor, container, parentNote, is
     );
 }
 
-/** The event beside its chip, as a desktop shows it. */
-function EventPopoverShell({ note, anchorRect, updateKey, parentNote, isEditable, onClose, onFollowLink }: {
+/** The event beside its chip, as a desktop shows it — or grown to the window, which is the same
+ *  card and the same standing editors (see {@link maximized} in Popover). */
+function EventPopoverShell({ note, anchorRect, updateKey, parentNote, isEditable, maximized, setMaximized, onClose, onFollowLink }: {
     note: FNote;
     anchorRect(): DOMRect;
     updateKey: string;
     parentNote: FNote;
     isEditable: boolean;
+    maximized: boolean;
+    setMaximized(maximized: boolean): void;
     onClose(): void;
     onFollowLink(noteId: string): boolean;
 }) {
+    // Escape closes the card whether it stands beside its chip or fills the window, as a press
+    // outside it does and as every dialog in the app answers the key. Being grown is a way the card
+    // is drawn rather than a mode to be let out of, and the maximize is its own way back down.
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.key === "Escape") onClose();
@@ -121,9 +140,14 @@ function EventPopoverShell({ note, anchorRect, updateKey, parentNote, isEditable
             // Named by the attribute eventDidMount stamps on every chip rather than by a
             // FullCalendar class: v7 emits hashed class names, so `.fc-event` no longer exists.
             keepOpenSelector="[data-event-note-id]"
+            maximized={maximized}
             onDismiss={onClose}
         >
-            <EventDetails note={note} parentNote={parentNote} isEditable={isEditable} onClose={onClose} onFollowLink={onFollowLink} />
+            <EventDetails
+                note={note} parentNote={parentNote} isEditable={isEditable}
+                maximized={maximized} setMaximized={setMaximized}
+                onClose={onClose} onFollowLink={onFollowLink}
+            />
         </Popover>
     );
 }
@@ -188,10 +212,12 @@ function EventSheet({ note, parentNote, isEditable, onClose, onFollowLink }: {
 const POPOVER_NTX_ID = "_calendar-event-popover";
 
 /** The popover's contents: what heads it, and the event under that. */
-function EventDetails({ note, parentNote, isEditable, onClose, onFollowLink }: {
+function EventDetails({ note, parentNote, isEditable, maximized, setMaximized, onClose, onFollowLink }: {
     note: FNote;
     parentNote: FNote;
     isEditable: boolean;
+    maximized: boolean;
+    setMaximized(maximized: boolean): void;
     onClose(): void;
     onFollowLink(noteId: string): boolean;
 }) {
@@ -210,7 +236,11 @@ function EventDetails({ note, parentNote, isEditable, onClose, onFollowLink }: {
             <div className="calendar-event-popover-header">
                 <TitleRow compact />
                 {/* A sheet is offered no maximize: it already has the whole screen to grow into. */}
-                <MaximizeToQuickEditAction note={note} onClose={onClose} />
+                <MaximizeAction
+                    icon={maximized ? "bx bx-collapse-alt" : "bx bx-expand-alt"}
+                    text={maximized ? t("calendar.restore_details") : t("calendar.expand_details")}
+                    onClick={() => setMaximized(!maximized)}
+                />
                 <ActionButton
                     icon="bx bx-x"
                     text={t("calendar.close_details")}

--- a/apps/client/src/widgets/collections/calendar/EventPopover.tsx
+++ b/apps/client/src/widgets/collections/calendar/EventPopover.tsx
@@ -1,5 +1,6 @@
 import "./EventPopover.css";
 
+import clsx from "clsx";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import FNote from "../../../entities/fnote";
@@ -248,7 +249,7 @@ function EventDetails({ note, parentNote, isEditable, maximized, setMaximized, o
                 />
             </div>
 
-            <EventDetailsBody note={note} parentNote={parentNote} isEditable={isEditable} onClose={onClose} />
+            <EventDetailsBody note={note} parentNote={parentNote} isEditable={isEditable} maximized={maximized} onClose={onClose} />
         </div>
     );
 }
@@ -258,10 +259,14 @@ function EventDetails({ note, parentNote, isEditable, maximized, setMaximized, o
  * promoted attributes and the note. Shared by the two shells, which differ only in what they put
  * around this and how they are dismissed.
  */
-function EventDetailsBody({ note, parentNote, isEditable, onClose }: {
+function EventDetailsBody({ note, parentNote, isEditable, maximized, onClose }: {
     note: FNote;
     parentNote: FNote;
     isEditable: boolean;
+    /** The card fills the window, so what it holds is laid out for a note's width rather than a
+     *  card's (see `tn-embedded-note-pane-wide` in EmbeddedNotePane.css). Never a sheet's, which is
+     *  a phone's whole screen and still only one field wide. */
+    maximized?: boolean;
     onClose(): void;
 }) {
     // The labels the body's own fields already speak for, so the promoted grid does not repeat
@@ -270,7 +275,7 @@ function EventDetailsBody({ note, parentNote, isEditable, onClose }: {
     const eventLabels = useEventLabelOmissions(note);
 
     return (
-        <div className="calendar-event-popover-body tn-embedded-note-pane">
+        <div className={clsx("calendar-event-popover-body tn-embedded-note-pane", maximized && "tn-embedded-note-pane-wide")}>
                 {/* What can be done with the event: the ways of opening its note (see
                     OpenNoteActions), then the ways of changing it — left out rather than disabled
                     where the calendar may not be edited, as the geo pane leaves them out. */}

--- a/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
@@ -143,8 +143,11 @@ describe("Promoted attributes", () => {
         const event = await buildEvent(note, { startDate: "2025-04-04" });
         expect(event).toHaveLength(1);
         expect(event[0]?.promotedAttributes).toMatchObject([
+            // No alias to go by, so the label says itself.
             [ "weight", "75" ],
-            [ "mood", "happy" ]
+            // Named as the definition names it, which is how the note's own promoted field is
+            // labelled — the chip would otherwise say the same value under a second name.
+            [ "Mood", "happy" ]
         ]);
     });
 
@@ -161,7 +164,20 @@ describe("Promoted attributes", () => {
         const event = await buildEvent(note, { startDate: "2025-04-04" });
         expect(event).toHaveLength(1);
         expect(event[0]?.promotedAttributes).toMatchObject([
-            [ "assignee", "Target note" ]
+            [ "Assignee", "Target note" ]
+        ]);
+    });
+
+    it("says an attribute nobody defined by its own name, promotion being no condition of showing one", async () => {
+        const note = buildNote({
+            title: "Hello",
+            "#mood": "happy",
+            "#calendar:displayedAttributes": "mood"
+        });
+
+        const event = await buildEvent(note, { startDate: "2025-04-04" });
+        expect(event[0]?.promotedAttributes).toMatchObject([
+            [ "mood", "happy" ]
         ]);
     });
 

--- a/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
@@ -229,7 +229,7 @@ describe("Recurrence", () => {
         expect(events[0]).toMatchObject({
             title: "Recurring Event Spanning Day Boundary",
             start: "2025-05-05T23:00:00",
-            duration: "02:00"
+            duration: { days: 0, hours: 2, minutes: 0 }
         });
         expect(events[0].rrule).toContain("DTSTART:20250505T230000");
         expect(events[0].end).toBeUndefined();
@@ -251,7 +251,7 @@ describe("Recurrence", () => {
         expect(events[0]).toMatchObject({
             title: "Timed Recurring Event",
             start: "2025-05-05T13:00:00",
-            duration: "02:30"
+            duration: { days: 0, hours: 2, minutes: 30 }
         });
         expect(events[0].rrule).toContain("DTSTART:20250505T130000");
         expect(events[0].end).toBeUndefined();
@@ -271,6 +271,57 @@ describe("Recurrence", () => {
         expect(events).toHaveLength(1);
         expect(events[0].rrule).toBeDefined();
         expect(events[0].end).toBeUndefined();
+    });
+
+    it("keeps a recurring event whole-day where it has no times", async () => {
+        const noteIds = buildNotes([
+            {
+                title: "Recurring Whole Day",
+                "#startDate": "2025-05-05",
+                "#recurrence": "FREQ=DAILY;COUNT=5"
+            },
+            {
+                title: "Recurring Timed",
+                "#startDate": "2025-05-05",
+                "#startTime": "13:00",
+                "#endTime": "15:30",
+                "#recurrence": "FREQ=DAILY;COUNT=5"
+            }
+        ]);
+        const events = await buildEvents(noteIds);
+
+        expect(events).toHaveLength(2);
+        // Said outright rather than left to FullCalendar to guess: the rrule plugin reads the whole
+        // of the rule for a time, and a `UNTIL=…T235959Z` — which the recurrence editor writes —
+        // makes it guess a timed event however the DTSTART is written.
+        expect(events[0].allDay).toBe(true);
+        expect(events[1].allDay).toBe(false);
+        // And the DTSTART says the same, no midnight invented for a day that has no hours.
+        expect(events[0].rrule).toContain("DTSTART:20250505\n");
+        expect(events[1].rrule).toContain("DTSTART:20250505T130000\n");
+    });
+
+    it("carries the length of a recurring event that runs over days", async () => {
+        const noteIds = buildNotes([
+            {
+                title: "Recurring Single Day",
+                "#startDate": "2025-05-05",
+                "#recurrence": "FREQ=WEEKLY;COUNT=3"
+            },
+            {
+                title: "Recurring Three Days",
+                "#startDate": "2025-05-05",
+                "#endDate": "2025-05-07",
+                "#recurrence": "FREQ=WEEKLY;COUNT=3"
+            }
+        ]);
+        const events = await buildEvents(noteIds);
+
+        expect(events).toHaveLength(2);
+        // Days rather than hours: an `HH:mm` duration has nowhere to put them, so a whole-day
+        // occurrence used to come out "00:00" — no length at all.
+        expect(events[0].duration).toEqual({ days: 1, hours: 0, minutes: 0 });
+        expect(events[1].duration).toEqual({ days: 3, hours: 0, minutes: 0 });
     });
 
     it("writes to console on invalid recurrence rule", async () => {

--- a/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.spec.ts
@@ -168,6 +168,20 @@ describe("Promoted attributes", () => {
         ]);
     });
 
+    it("says nothing for a relation whose target has no title, rather than the word for nothing", async () => {
+        const note = buildNote({
+            "title": "Hello",
+            "~assignee": buildNote({ "title": "" }).noteId,
+            "#calendar:displayedAttributes": "assignee",
+            "#relation:assignee": "promoted,alias=Assignee,single,text"
+        });
+
+        const event = await buildEvent(note, { startDate: "2025-04-04" });
+        expect(event[0]?.promotedAttributes).toMatchObject([
+            [ "Assignee", "" ]
+        ]);
+    });
+
     it("says an attribute nobody defined by its own name, promotion being no condition of showing one", async () => {
         const note = buildNote({
             title: "Hello",
@@ -338,6 +352,24 @@ describe("Recurrence", () => {
         // occurrence used to come out "00:00" — no length at all.
         expect(events[0].duration).toEqual({ days: 1, hours: 0, minutes: 0 });
         expect(events[1].duration).toEqual({ days: 3, hours: 0, minutes: 0 });
+    });
+
+    it("gives no length to an occurrence whose event says only when it starts", async () => {
+        const noteIds = buildNotes([
+            {
+                title: "Recurring Open-Ended",
+                "#startDate": "2025-05-05",
+                "#startTime": "13:00",
+                "#recurrence": "FREQ=DAILY;COUNT=5"
+            }
+        ]);
+        const events = await buildEvents(noteIds);
+
+        expect(events).toHaveLength(1);
+        // Nothing said about how long it runs, so nothing is invented: FullCalendar gives the
+        // occurrence its default length rather than one worked out from an end that isn't there.
+        expect(events[0].duration).toBeUndefined();
+        expect(events[0].rrule).toContain("DTSTART:20250505T130000");
     });
 
     it("writes to console on invalid recurrence rule", async () => {

--- a/apps/client/src/widgets/collections/calendar/event_builder.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.ts
@@ -105,30 +105,41 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
         displayedAttributesData = await buildDisplayedAttributes(note, calendarDisplayedAttributes);
     }
 
+    // An event with no start time takes the whole day, which is how the editor writes one too (see
+    // EventDatesEditor). When the event repeats this has to be said outright rather than left to
+    // FullCalendar's rrule plugin to infer from the rule: the plugin reads the whole of the rule
+    // looking for a time, so an `UNTIL=…T235959Z` — which the recurrence editor writes for an end
+    // date (see recurrence.ts) — makes it take the event for a timed one whatever its DTSTART says.
+    const allDay = !startTime;
+
+    // When the event happens is the same whatever the note is called, so it is worked out once for
+    // all the titles rather than inside the loop, which used to append the time to the dates again
+    // for every title past the first.
+    if (startTime && endTime && !endDate) {
+        endDate = startDate;
+    }
+
+    startDate = (startTime ? `${startDate}T${startTime}:00` : startDate);
+    if (!startTime) {
+        if (endDate) {
+            endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DD");
+        } else if (startDate) {
+            endDate = dayjs(startDate).add(1, "day").format("YYYY-MM-DD");
+        }
+    }
+
+    endDate = (endTime ? `${endDate}T${endTime}:00` : endDate);
+    // If the end date is now before the start date, bump it a day forward to account for times spanning the day boundary
+    if (endDate && endTime && dayjs(endDate).isBefore(dayjs(startDate))) {
+        endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DDTHH:mm:ss");
+    }
+
     for (const title of titles) {
-        if (startTime && endTime && !endDate) {
-            endDate = startDate;
-        }
-
-        startDate = (startTime ? `${startDate}T${startTime}:00` : startDate);
-        if (!startTime) {
-            if (endDate) {
-                endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DD");
-            } else if (startDate) {
-                endDate = dayjs(startDate).add(1, "day").format("YYYY-MM-DD");
-            }
-        }
-
-        endDate = (endTime ? `${endDate}T${endTime}:00` : endDate);
-        // If the end date is now before the start date, bump it a day forward to account for times spanning the day boundary
-        if (endDate && endTime && dayjs(endDate).isBefore(dayjs(startDate))) {
-            endDate = dayjs(endDate).add(1, "day").format("YYYY-MM-DDTHH:mm:ss");
-        }
-
         const eventData: EventInput = {
             id: note.noteId,
             title,
             start: startDate,
+            allDay,
             url: `#${note.noteId}?popup`,
             noteId: note.noteId,
             iconClass: note.getLabelValue("iconClass"),
@@ -140,8 +151,11 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
         }
 
         if (recurrence) {
-            // Generate rrule string
-            const rruleString = `DTSTART:${dayjs(startDate).format("YYYYMMDD[T]HHmmss")}\n${recurrence}`;
+            // Generate rrule string. A whole day is written as the bare date it is, no midnight
+            // invented for hours the event does not have. `DTSTART;VALUE=DATE:` — the way iCalendar
+            // spells the same thing — is not an option: the rrule library drops a DTSTART written
+            // that way without a word and starts the series from today instead.
+            const rruleString = `DTSTART:${dayjs(startDate).format(allDay ? "YYYYMMDD" : "YYYYMMDD[T]HHmmss")}\n${recurrence}`;
 
             // Validate rrule string
             let rruleValid = true;
@@ -155,8 +169,7 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
                 delete eventData.end;
                 eventData.rrule = rruleString;
                 if (endDate){
-                    const duration = dayjs.duration(dayjs(endDate).diff(dayjs(startDate)));
-                    eventData.duration = duration.format("HH:mm");
+                    eventData.duration = buildOccurrenceDuration(startDate, endDate);
                 }
             } else {
                 throw new Error(`Note "${note.noteId} ${note.title}" has an invalid #recurrence string ${recurrence}. Excluding...`);
@@ -165,6 +178,22 @@ export async function buildEvent(note: FNote, { startDate, endDate, startTime, e
         events.push(eventData);
     }
     return events;
+}
+
+/**
+ * How long one occurrence of a recurring event lasts, as the duration object FullCalendar builds
+ * its own from rather than as an `HH:mm` string. A string of hours and minutes has nowhere to put
+ * days: a whole-day occurrence came out of it as `"00:00"` — no length at all — and a span of days
+ * kept only the hours left over past the last of them.
+ */
+function buildOccurrenceDuration(startDate: string, endDate: string) {
+    const minutes = dayjs(endDate).diff(dayjs(startDate), "minute");
+
+    return {
+        days: Math.floor(minutes / (24 * 60)),
+        hours: Math.floor((minutes % (24 * 60)) / 60),
+        minutes: minutes % 60
+    };
 }
 
 async function parseCustomTitle(customTitlettributeName: string | null, note: FNote, allowRelations = true): Promise<string[]> {

--- a/apps/client/src/widgets/collections/calendar/event_builder.ts
+++ b/apps/client/src/widgets/collections/calendar/event_builder.ts
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import { EventInput, EventSourceFuncInfo, EventSourceInput } from "fullcalendar";
 import * as rruleLib from 'rrule';
 
+import FAttribute from "../../../entities/fattribute";
 import FNote from "../../../entities/fnote";
 import froca from "../../../services/froca";
 import server from "../../../services/server";
@@ -227,9 +228,24 @@ async function buildDisplayedAttributes(note: FNote, calendarDisplayedAttributes
     const result: Array<[string, string]> = [];
 
     for (const attribute of filteredDisplayedAttributes) {
-        if (attribute.type === "label") result.push([attribute.name, attribute.value]);
-        else result.push([attribute.name, (await attribute.getTargetNote())?.title || ""]);
+        const name = displayedAttributeName(note, attribute);
+        if (attribute.type === "label") result.push([name, attribute.value]);
+        else result.push([name, (await attribute.getTargetNote())?.title || ""]);
     }
 
     return result;
+}
+
+/**
+ * What a field is called on the chip: the alias its definition gives it, and the attribute's own
+ * name where no definition gives one.
+ *
+ * Both halves are needed. The alias is the name the reader chose — the promoted field in the note
+ * itself is labelled by it, and a chip saying something else is the same value under two names. The
+ * fallback is what lets the calendar go on showing an attribute that was never promoted, which is
+ * the whole point of `#calendar:displayedAttributes` naming attributes rather than definitions.
+ */
+function displayedAttributeName(note: FNote, attribute: FAttribute) {
+    const definition = note.getAttribute("label", `${attribute.type}:${attribute.name}`);
+    return definition?.getDefinition().promotedAlias || attribute.name;
 }

--- a/apps/client/src/widgets/collections/calendar/index.css
+++ b/apps/client/src/widgets/collections/calendar/index.css
@@ -31,10 +31,22 @@
     height: 100%;
 }
 
-/* Stacked beneath the title, the chip's own container being a column wherever these are shown at
-   all (see hasRoomForAttributes). Kept narrow so the overflow below has something to bite on. */
+/* Stacked beneath the title. Kept narrow so the overflow below has something to bite on. */
 .calendar-view .calendar-event-attributes {
     min-width: 0;
+}
+
+/* A month cell's chip is a row, so the title is fallen beneath rather than followed down: the
+   chip's own container is asked to wrap (see eventInnerClass) and the attributes claim a whole
+   line of it. The inline padding is the one the row's title wears — Forma states it on the title
+   rather than on the container — so that the two read as one column of text. */
+.calendar-view .calendar-event-inner-wrapped {
+    flex-wrap: wrap;
+
+    > .calendar-event-attributes {
+        flex-basis: 100%;
+        padding-inline: 4px;
+    }
 }
 
 .calendar-container .promoted-attribute {

--- a/apps/client/src/widgets/collections/calendar/index.css
+++ b/apps/client/src/widgets/collections/calendar/index.css
@@ -66,6 +66,15 @@
         }
     }
 
+    /* The end the view switcher stands at is the one asked to give where the bar is short: it holds
+       a row that folds into a menu when it no longer fits (see CollapseOnOverflow), which is a
+       better answer than either half of what happens otherwise — a flex item keeps its content's
+       width unless told it may not, so the bar would grow past the pane rather than hand the
+       switcher less, and the switcher would never learn that it was short. */
+    .right-container {
+        min-width: 0;
+    }
+
     @media (max-width: 991px) {
         >div {
             justify-content: flex-start;

--- a/apps/client/src/widgets/collections/calendar/index.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/index.spec.ts
@@ -16,9 +16,10 @@ describe("roomForAttributes", () => {
         expect(roomForAttributes(chip({ view: "dayGridMonth", allDay: true }))).toBe("wrapped");
         expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true }))).toBe("wrapped");
         expect(roomForAttributes(chip({ view: "timeGridDay", allDay: true }))).toBe("wrapped");
-        // A cell too narrow to hold much of a title is left as the one line it is.
-        expect(roomForAttributes(chip({ view: "dayGridMonth", isNarrow: true }))).toBe(null);
-        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true, isNarrow: true }))).toBe(null);
+        // Narrow as well — a phone's seven columns, where a few characters to the line is still
+        // more than the nothing they used to say.
+        expect(roomForAttributes(chip({ view: "dayGridMonth", isNarrow: true }))).toBe("wrapped");
+        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true, isNarrow: true }))).toBe("wrapped");
     });
 
     it("lets a timed event on a time grid stack them, its content being a column already", () => {

--- a/apps/client/src/widgets/collections/calendar/index.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/index.spec.ts
@@ -1,0 +1,33 @@
+import { EventDisplayInfo } from "fullcalendar";
+import { describe, expect, it } from "vitest";
+
+import { roomForAttributes } from "./index.js";
+
+/** As much of a chip as the question is asked of: which view it is drawn in, and how it sits there. */
+function chip({ view, allDay = false, isShort = false, isNarrow = false }: {
+    view: string, allDay?: boolean, isShort?: boolean, isNarrow?: boolean
+}) {
+    return { view: { type: view }, event: { allDay }, isShort, isNarrow } as EventDisplayInfo;
+}
+
+describe("roomForAttributes", () => {
+    it("wraps a month cell's chip, which is a row wide enough to be worth wrapping", () => {
+        expect(roomForAttributes(chip({ view: "dayGridMonth" }))).toBe("wrapped");
+        expect(roomForAttributes(chip({ view: "dayGridMonth", allDay: true }))).toBe("wrapped");
+        // A cell too narrow to hold much of a title is left as the one line it is.
+        expect(roomForAttributes(chip({ view: "dayGridMonth", isNarrow: true }))).toBe(null);
+    });
+
+    it("lets a timed event on a time grid stack them, its content being a column already", () => {
+        expect(roomForAttributes(chip({ view: "timeGridWeek" }))).toBe("stacked");
+        expect(roomForAttributes(chip({ view: "timeGridDay" }))).toBe("stacked");
+        // Too short to say anything beneath its title, and the all-day band is a row.
+        expect(roomForAttributes(chip({ view: "timeGridWeek", isShort: true }))).toBe(null);
+        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true }))).toBe(null);
+    });
+
+    it("has nowhere to put them on a year's chips or in a list", () => {
+        expect(roomForAttributes(chip({ view: "multiMonthYear" }))).toBe(null);
+        expect(roomForAttributes(chip({ view: "listMonth" }))).toBe(null);
+    });
+});

--- a/apps/client/src/widgets/collections/calendar/index.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/index.spec.ts
@@ -11,19 +11,21 @@ function chip({ view, allDay = false, isShort = false, isNarrow = false }: {
 }
 
 describe("roomForAttributes", () => {
-    it("wraps a month cell's chip, which is a row wide enough to be worth wrapping", () => {
+    it("wraps a row chip, be it a month cell's or the all-day band's above a time grid", () => {
         expect(roomForAttributes(chip({ view: "dayGridMonth" }))).toBe("wrapped");
         expect(roomForAttributes(chip({ view: "dayGridMonth", allDay: true }))).toBe("wrapped");
+        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true }))).toBe("wrapped");
+        expect(roomForAttributes(chip({ view: "timeGridDay", allDay: true }))).toBe("wrapped");
         // A cell too narrow to hold much of a title is left as the one line it is.
         expect(roomForAttributes(chip({ view: "dayGridMonth", isNarrow: true }))).toBe(null);
+        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true, isNarrow: true }))).toBe(null);
     });
 
     it("lets a timed event on a time grid stack them, its content being a column already", () => {
         expect(roomForAttributes(chip({ view: "timeGridWeek" }))).toBe("stacked");
         expect(roomForAttributes(chip({ view: "timeGridDay" }))).toBe("stacked");
-        // Too short to say anything beneath its title, and the all-day band is a row.
+        // Too short to say anything beneath its title.
         expect(roomForAttributes(chip({ view: "timeGridWeek", isShort: true }))).toBe(null);
-        expect(roomForAttributes(chip({ view: "timeGridWeek", allDay: true }))).toBe(null);
     });
 
     it("has nowhere to put them on a year's chips or in a list", () => {

--- a/apps/client/src/widgets/collections/calendar/index.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/index.spec.ts
@@ -1,7 +1,7 @@
 import { EventDisplayInfo } from "fullcalendar";
 import { describe, expect, it } from "vitest";
 
-import { roomForAttributes } from "./index.js";
+import { eventInnerClass, roomForAttributes } from "./index.js";
 
 /** As much of a chip as the question is asked of: which view it is drawn in, and how it sits there. */
 function chip({ view, allDay = false, isShort = false, isNarrow = false }: {
@@ -32,5 +32,27 @@ describe("roomForAttributes", () => {
     it("has nowhere to put them on a year's chips or in a list", () => {
         expect(roomForAttributes(chip({ view: "multiMonthYear" }))).toBe(null);
         expect(roomForAttributes(chip({ view: "listMonth" }))).toBe(null);
+    });
+});
+
+describe("eventInnerClass", () => {
+    /** A chip as the class is asked of it: where it is drawn, and whether it has anything to say. */
+    function chipWithAttributes(view: string, promotedAttributes?: [string, string][]) {
+        return {
+            ...chip({ view }),
+            event: { allDay: false, extendedProps: { promotedAttributes } }
+        } as unknown as EventDisplayInfo;
+    }
+
+    it("makes a row that wraps of a chip whose attributes must fall beneath it", () => {
+        expect(eventInnerClass(chipWithAttributes("dayGridMonth", [[ "mood", "happy" ]])))
+            .toBe("calendar-event-inner-wrapped");
+    });
+
+    it("leaves the inner alone where the attributes stack, or where there are none to place", () => {
+        // A timed chip on a time grid is a column already, so its attributes need no line of their own.
+        expect(eventInnerClass(chipWithAttributes("timeGridWeek", [[ "mood", "happy" ]]))).toBe("");
+        expect(eventInnerClass(chipWithAttributes("dayGridMonth", []))).toBe("");
+        expect(eventInnerClass(chipWithAttributes("dayGridMonth"))).toBe("");
     });
 });

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -169,7 +169,7 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
         return true;
     }, []);
 
-    const { eventContent, eventDidMount } = useEventDisplayCustomization(note, parentComponent?.componentId, dismissSurface);
+    const { eventContent, eventDidMount, eventInnerClass } = useEventDisplayCustomization(note, parentComponent?.componentId, dismissSurface);
     const editingProps = useEditing(note, isEditable, isCalendarRoot, parentComponent?.componentId,
         (draft, anchor) => setSelection({ draft, anchor }), effectiveSlotDuration);
 
@@ -368,6 +368,7 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
                         && "calendar-event-selected no-tooltip-preview"
                 )}
                 eventContent={eventContent}
+                eventInnerClass={eventInnerClass}
                 eventDidMount={eventDidMount}
                 viewDidMount={({ view }) => {
                     if (initialView.current !== view.type) {
@@ -654,7 +655,7 @@ function useEventDisplayCustomization(parentNote: FNote, componentId: string | u
                     {iconClass && <span className={`calendar-event-icon ${iconClass}`} />}
                     {e.event.title}
                 </div>
-                {!!promotedAttributes?.length && hasRoomForAttributes(e) && (
+                {!!promotedAttributes?.length && roomForAttributes(e) && (
                     <div className="calendar-event-attributes">
                         {(promotedAttributes as Array<[string, string]>).map(([name, value], i) => (
                             <div className="promoted-attribute" key={`${name}-${i}`}>
@@ -704,18 +705,43 @@ function useEventDisplayCustomization(parentNote: FNote, componentId: string | u
         // belongs to the event sheet, which offers what the menu offers and more (see onEventClick).
         e.el.addEventListener("contextmenu", onContextMenu);
     }, [ dismissSurface ]);
-    return { eventContent, eventDidMount };
+    return { eventContent, eventDidMount, eventInnerClass };
 }
 
 /**
- * Whether a chip has the room to say anything beyond its title.
+ * Whether a chip has the room to say anything beyond its title, and how that room is come by.
  *
- * Only a timed event on a time grid stacks its content, and only where it is tall enough to. A row
- * event — a month cell's chip, an all-day band — is one centred line however wide it gets, so
- * attributes put there crowd the title along it rather than fall beneath it.
+ * A timed event on a time grid stacks its content of its own accord, wherever it is tall enough to:
+ * the attributes follow the title down the column with nothing further asked of the chip.
+ *
+ * Every other chip is a row — a month cell's, an all-day band's, a list item's — one centred line
+ * however wide it gets, so attributes put there would crowd the title along it. A month cell is
+ * wide enough for the row to be worth wrapping instead, which is what puts them beneath the title
+ * there, where they stood before v7 (see eventInnerClass). A cell too narrow to hold much of a
+ * title, the all-day bands and the lists are left as one line.
  */
-function hasRoomForAttributes(e: EventDisplayInfo) {
-    return e.view.type.startsWith("timeGrid") && !e.event.allDay && !e.isShort;
+export function roomForAttributes(e: EventDisplayInfo): "stacked" | "wrapped" | null {
+    if (e.view.type === "dayGridMonth") {
+        return !e.isNarrow ? "wrapped" : null;
+    }
+
+    if (e.view.type.startsWith("timeGrid")) {
+        return (!e.event.allDay && !e.isShort) ? "stacked" : null;
+    }
+
+    return null;
+}
+
+/**
+ * Turns the chip's inner — Forma's, and a row wherever this says anything at all — into something
+ * the attributes can fall beneath: a row that wraps, of which they claim a whole line (see
+ * index.css). Said as a class on the inner rather than drawn in eventContent because wrapping is
+ * the container's to declare and the container is the theme's, not ours.
+ */
+function eventInnerClass(e: EventDisplayInfo) {
+    const { promotedAttributes } = e.event.extendedProps;
+    return clsx(!!promotedAttributes?.length && roomForAttributes(e) === "wrapped"
+        && "calendar-event-inner-wrapped");
 }
 
 function useOnDatesSet(calendarRef: RefObject<FullCalendar>) {

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -742,22 +742,28 @@ function useEventDisplayCustomization(parentNote: FNote, componentId: string | u
 /**
  * Whether a chip has the room to say anything beyond its title, and how that room is come by.
  *
- * A timed event on a time grid stacks its content of its own accord, wherever it is tall enough to:
- * the attributes follow the title down the column with nothing further asked of the chip.
+ * A chip drawn as a row — a month cell's, and an all-day band's, which is the very same row drawn
+ * above a time grid — is one centred line however wide it gets, so attributes put there would
+ * crowd the title along it. The row is asked to wrap instead and they take a line of their own
+ * beneath the title (see eventInnerClass), which is where they stood before v7. Only a band or a
+ * cell wide enough to be worth wrapping: a narrow one is left as the one line it is.
  *
- * Every other chip is a row — a month cell's, an all-day band's, a list item's — one centred line
- * however wide it gets, so attributes put there would crowd the title along it. A month cell is
- * wide enough for the row to be worth wrapping instead, which is what puts them beneath the title
- * there, where they stood before v7 (see eventInnerClass). A cell too narrow to hold much of a
- * title, the all-day bands and the lists are left as one line.
+ * A timed event on a time grid is a column already, wherever it is tall enough to be one, and its
+ * attributes follow the title down it with nothing further asked of the chip.
+ *
+ * Which leaves a year's chips and a list's, both of them one line with nothing to spare.
  */
 export function roomForAttributes(e: EventDisplayInfo): "stacked" | "wrapped" | null {
-    if (e.view.type === "dayGridMonth") {
+    const isTimeGrid = e.view.type.startsWith("timeGrid");
+
+    // An all-day event is the only kind the band above a time grid draws (see AllDaySplitter): a
+    // timed one is sliced into the columns below, however many days it runs.
+    if (e.view.type === "dayGridMonth" || (isTimeGrid && e.event.allDay)) {
         return !e.isNarrow ? "wrapped" : null;
     }
 
-    if (e.view.type.startsWith("timeGrid")) {
-        return (!e.event.allDay && !e.isShort) ? "stacked" : null;
+    if (isTimeGrid) {
+        return !e.isShort ? "stacked" : null;
     }
 
     return null;

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -25,6 +25,7 @@ import { isMobile } from "../../../services/utils";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import ActionButton from "../../react/ActionButton";
 import Button, { ButtonGroup } from "../../react/Button";
+import CollapseOnOverflow from "../../react/CollapseOnOverflow";
 import Dropdown from "../../react/Dropdown";
 import { FormListItem } from "../../react/FormList";
 import { useNoteLabel, useNoteLabelBoolean, useSpacedUpdate, useTriliumEvent, useTriliumOption, useTriliumOptionInt } from "../../react/hooks";
@@ -324,7 +325,7 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
 
     return (plugins &&
         <div className="calendar-view" ref={containerRef} tabIndex={100}>
-            <CalendarCollectionProperties note={note} calendarRef={calendarRef} />
+            <CalendarCollectionProperties note={note} calendarRef={calendarRef} containerRef={containerRef} />
             <Calendar
                 events={eventBuilder}
                 calendarRef={calendarRef}
@@ -404,9 +405,10 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
     );
 }
 
-function CalendarCollectionProperties({ note, calendarRef }: {
+function CalendarCollectionProperties({ note, calendarRef, containerRef }: {
     note: FNote;
     calendarRef: RefObject<FullCalendar>;
+    containerRef: RefObject<HTMLDivElement>;
 }) {
     const { title, viewType: currentViewType } = useOnDatesSet(calendarRef);
     const currentViewData = CALENDAR_VIEWS.find(v => calendarRef.current && v.type === currentViewType);
@@ -421,10 +423,12 @@ function CalendarCollectionProperties({ note, calendarRef }: {
                 <ActionButton icon="bx bx-chevron-right" text={currentViewData?.nextText ?? ""} onClick={() => calendarRef.current?.next()} />
                 <Button text={t("calendar.today")} onClick={() => calendarRef.current?.today()} />
                 <PinDateButton note={note} calendarRef={calendarRef} />
-                {isMobileLocal && <MobileCalendarViewSwitcher calendarRef={calendarRef} />}
+                {/* On a phone the switcher is a menu whatever the width, and stands with the date
+                    rather than on a right-hand end the wrapped bar no longer has. */}
+                {isMobileLocal && <CalendarViewSwitcher calendarRef={calendarRef} containerRef={containerRef} />}
             </>}
             rightChildren={<>
-                {!isMobileLocal && <DesktopCalendarViewSwitcher calendarRef={calendarRef} />}
+                {!isMobileLocal && <CalendarViewSwitcher calendarRef={calendarRef} containerRef={containerRef} />}
             </>}
         />
     );
@@ -455,42 +459,49 @@ function PinDateButton({ note, calendarRef }: {
     );
 }
 
-function DesktopCalendarViewSwitcher({ calendarRef }: { calendarRef: RefObject<FullCalendar> }) {
-    const { viewType: currentViewType } = useOnDatesSet(calendarRef);
-
-    return (
-        <>
-            <ButtonGroup>
-                {CALENDAR_VIEWS.map(viewData => (
-                    <Button
-                        key={viewData.type}
-                        text={viewData.name}
-                        className={currentViewType === viewData.type ? "active" : ""}
-                        onClick={() => calendarRef.current?.changeView(viewData.type)}
-                    />
-                ))}
-            </ButtonGroup>
-        </>
-    );
-}
-
-function MobileCalendarViewSwitcher({ calendarRef }: { calendarRef: RefObject<FullCalendar> }) {
+/**
+ * The choice of view, as a row of buttons where the bar has the width for one and as a menu where it
+ * has not — five names beside the date and its buttons outgrow a split pane long before they outgrow
+ * a screen, which is why the fold is decided by the view's own width rather than by the device.
+ */
+function CalendarViewSwitcher({ calendarRef, containerRef }: {
+    calendarRef: RefObject<FullCalendar>;
+    /** The view's own element, whose width the row of buttons is weighed against. */
+    containerRef: RefObject<HTMLDivElement>;
+}) {
     const { viewType: currentViewType } = useOnDatesSet(calendarRef);
     const currentViewTypeData = CALENDAR_VIEWS.find(view => view.type === currentViewType);
 
     return (
-        <Dropdown
-            text={currentViewTypeData?.name}
-        >
-            {CALENDAR_VIEWS.map(viewData => (
-                <FormListItem
-                    key={viewData.type}
-                    selected={currentViewType === viewData.type}
-                    icon={viewData.icon}
-                    onClick={() => calendarRef.current?.changeView(viewData.type)}
-                >{viewData.name}</FormListItem>
-            ))}
-        </Dropdown>
+        <CollapseOnOverflow container={containerRef} alwaysCollapsed={isMobile()}>
+            {(collapsed) => (collapsed
+                ? (
+                    // A handful of views, so the menu never scrolls and can be frosted the way that
+                    // survives being opened inside the note's own content (see noDropdownListStyle).
+                    <Dropdown text={currentViewTypeData?.name} noDropdownListStyle>
+                        {CALENDAR_VIEWS.map(viewData => (
+                            <FormListItem
+                                key={viewData.type}
+                                selected={currentViewType === viewData.type}
+                                icon={viewData.icon}
+                                onClick={() => calendarRef.current?.changeView(viewData.type)}
+                            >{viewData.name}</FormListItem>
+                        ))}
+                    </Dropdown>
+                )
+                : (
+                    <ButtonGroup>
+                        {CALENDAR_VIEWS.map(viewData => (
+                            <Button
+                                key={viewData.type}
+                                text={viewData.name}
+                                className={currentViewType === viewData.type ? "active" : ""}
+                                onClick={() => calendarRef.current?.changeView(viewData.type)}
+                            />
+                        ))}
+                    </ButtonGroup>
+                ))}
+        </CollapseOnOverflow>
     );
 }
 

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -37,7 +37,7 @@ import GhostPopover from "./GhostPopover";
 import { openCalendarContextMenu } from "./context_menu";
 import { CalendarSelection, EventDraft } from "./selection";
 import { buildEvents, buildEventsForCalendar } from "./event_builder";
-import { formatDateToLocalISO, formatTimeToLocalISO, isValidDuration, parseDurationSeconds, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
+import { formatDateToLocalISO, formatTimeToLocalISO, isAttributeChangeAffecting, isValidDuration, parseDurationSeconds, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
 
 interface CalendarViewData {
 
@@ -289,15 +289,27 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
         const api = calendarRef.current;
         if (!api) return;
 
-        // Subnote attribute change.
-        if (loadResults.getAttributeRows(parentComponent?.componentId).some((a) => noteIds.includes(a.noteId ?? ""))) {
+        // Attribute change on a note the calendar draws — written on the note itself, or inherited
+        // from an ancestor or a template, which is just as much a change to the chip (see
+        // isAttributeChangeAffecting).
+        //
+        // The notes asked about are the collection's own plus whatever chips stand on the grid: a
+        // calendar root draws day notes and their children, which are in no `noteIds` at all, and
+        // so answered nothing here.
+        const drawnNoteIds = new Set(noteIds);
+        for (const event of api.getEvents()) {
+            const noteId = event.extendedProps.noteId;
+            if (noteId) drawnNoteIds.add(String(noteId));
+        }
+
+        if (isAttributeChangeAffecting(loadResults.getAttributeRows(parentComponent?.componentId), drawnNoteIds)) {
             // Defer execution after the load results are processed so that the event builder has the updated data to work with.
             setTimeout(() => api.refetchEvents(), 0);
             return; // early return since we'll refresh the events anyway
         }
 
         // Title change.
-        for (const noteId of loadResults.getNoteIds().filter(noteId => noteIds.includes(noteId))) {
+        for (const noteId of loadResults.getNoteIds().filter(noteId => drawnNoteIds.has(noteId))) {
             const event = api.getEventById(noteId);
             const note = froca.getNoteFromCache(noteId);
             if (!event || !note) continue;

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -745,8 +745,11 @@ function useEventDisplayCustomization(parentNote: FNote, componentId: string | u
  * A chip drawn as a row — a month cell's, and an all-day band's, which is the very same row drawn
  * above a time grid — is one centred line however wide it gets, so attributes put there would
  * crowd the title along it. The row is asked to wrap instead and they take a line of their own
- * beneath the title (see eventInnerClass), which is where they stood before v7. Only a band or a
- * cell wide enough to be worth wrapping: a narrow one is left as the one line it is.
+ * beneath the title (see eventInnerClass), which is where they stood before v7.
+ *
+ * However narrow the cell: a phone's month is seven columns of some fifty pixels, and the fields
+ * asked for are wanted there as much as anywhere — read a few characters to the line, as they were
+ * before v7, rather than not at all.
  *
  * A timed event on a time grid is a column already, wherever it is tall enough to be one, and its
  * attributes follow the title down it with nothing further asked of the chip.
@@ -759,7 +762,7 @@ export function roomForAttributes(e: EventDisplayInfo): "stacked" | "wrapped" | 
     // An all-day event is the only kind the band above a time grid draws (see AllDaySplitter): a
     // timed one is sliced into the columns below, however many days it runs.
     if (e.view.type === "dayGridMonth" || (isTimeGrid && e.event.allDay)) {
-        return !e.isNarrow ? "wrapped" : null;
+        return "wrapped";
     }
 
     if (isTimeGrid) {

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -778,7 +778,7 @@ export function roomForAttributes(e: EventDisplayInfo): "stacked" | "wrapped" | 
  * index.css). Said as a class on the inner rather than drawn in eventContent because wrapping is
  * the container's to declare and the container is the theme's, not ours.
  */
-function eventInnerClass(e: EventDisplayInfo) {
+export function eventInnerClass(e: EventDisplayInfo) {
     const { promotedAttributes } = e.event.extendedProps;
     return clsx(!!promotedAttributes?.length && roomForAttributes(e) === "wrapped"
         && "calendar-event-inner-wrapped");

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -38,7 +38,7 @@ import GhostPopover from "./GhostPopover";
 import { openCalendarContextMenu } from "./context_menu";
 import { CalendarSelection, EventDraft } from "./selection";
 import { buildEvents, buildEventsForCalendar } from "./event_builder";
-import { formatDateToLocalISO, formatTimeToLocalISO, isAttributeChangeAffecting, isValidDuration, parseDurationSeconds, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
+import { formatDateToLocalISO, formatTimeToLocalISO, isAttributeChangeAffecting, isBranchChangeAffecting, isValidDuration, parseDurationSeconds, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
 
 interface CalendarViewData {
 
@@ -146,12 +146,12 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
     // Worked out once and handed to both the grid and the tap that makes an event of one of its
     // slots (see draftFromDateClick), so that the two cannot come to disagree on a slot's length.
     const effectiveSlotDuration = isValidDuration(slotDuration) ? slotDuration : DEFAULT_SLOT_DURATION;
-    const eventBuilder = useMemo(() => {
-        if (!isCalendarRoot) {
-            return async () => await buildEvents(noteIds);
-        }
-        return async (e: EventSourceFuncInfo) => await buildEventsForCalendar(note, e);
-    }, [isCalendarRoot, noteIds]);
+    // Memoized apart, and each on only what it reads: FullCalendar knows a source by the identity
+    // of the function, and a new one empties the grid before it fetches.
+    const rootEventBuilder = useMemo(() =>
+        async (e: EventSourceFuncInfo) => await buildEventsForCalendar(note, e), [note]);
+    const collectionEventBuilder = useMemo(() => async () => await buildEvents(noteIds), [noteIds]);
+    const eventBuilder = isCalendarRoot ? rootEventBuilder : collectionEventBuilder;
 
     const plugins = usePlugins(isEditable, isCalendarRoot);
     const locale = useLocale();
@@ -303,7 +303,15 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
             if (noteId) drawnNoteIds.add(String(noteId));
         }
 
-        if (isAttributeChangeAffecting(loadResults.getAttributeRows(parentComponent?.componentId), drawnNoteIds)) {
+        // A note filed anywhere in the journal may be a chip on a calendar root, which draws its
+        // day notes and their children rather than a list of ids (see isBranchChangeAffecting).
+        // Only for a root: a collection's own source is built from the ids, so it is renewed as
+        // they are, and asking here as well would fetch the same events twice.
+        const isFilingAffecting = isCalendarRoot
+            && isBranchChangeAffecting(loadResults.getBranchRows(), note.noteId, drawnNoteIds);
+
+        if (isFilingAffecting
+            || isAttributeChangeAffecting(loadResults.getAttributeRows(parentComponent?.componentId), drawnNoteIds)) {
             // Defer execution after the load results are processed so that the event builder has the updated data to work with.
             setTimeout(() => api.refetchEvents(), 0);
             return; // early return since we'll refresh the events anyway

--- a/apps/client/src/widgets/collections/calendar/index.tsx
+++ b/apps/client/src/widgets/collections/calendar/index.tsx
@@ -14,7 +14,6 @@ import { Calendar as FullCalendar, DateClickInfo, DateSelectInfo, EventChangeInf
 import { RefObject } from "preact";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "preact/hooks";
 
-import appContext from "../../../components/app_context";
 import FNote from "../../../entities/fnote";
 import contextMenu from "../../../menus/context_menu";
 import date_notes from "../../../services/date_notes";
@@ -172,7 +171,7 @@ export default function CalendarView({ note, noteIds }: ViewModeProps<CalendarVi
 
     const { eventContent, eventDidMount, eventInnerClass } = useEventDisplayCustomization(note, parentComponent?.componentId, dismissSurface);
     const editingProps = useEditing(note, isEditable, isCalendarRoot, parentComponent?.componentId,
-        (draft, anchor) => setSelection({ draft, anchor }), effectiveSlotDuration);
+        setSelection, effectiveSlotDuration);
 
     /**
      * Turns the standing ghost into the note: created only now, at the commit, and — where the
@@ -557,7 +556,8 @@ function useLocale() {
 }
 
 function useEditing(note: FNote, isEditable: boolean, isCalendarRoot: boolean, componentId: string | undefined,
-    onDraft: (draft: EventDraft, anchor: { x: number; y: number } | null) => void,
+    /** What the view's surfaces are to stand for from now on (see {@link CalendarSelection}). */
+    onSelect: (selection: CalendarSelection) => void,
     /** The length of one of the grid's slots, which is how long a tapped event lasts. */
     slotDuration: string) {
     const onCalendarSelection = useCallback((e: DateSelectInfo) => {
@@ -570,11 +570,11 @@ function useEditing(note: FNote, isEditable: boolean, isCalendarRoot: boolean, c
         // nothing. The range keeps its shading meanwhile, standing on the grid for the event to be;
         // the view lets it go when the draft resolves. Where the drag ended anchors the ghost
         // beside it (see ghostAnchorRect), which a sheet has no use for.
-        onDraft(
-            { startDate, endDate, startTime, endTime },
-            e.jsEvent ? { x: e.jsEvent.clientX, y: e.jsEvent.clientY } : null
-        );
-    }, [ onDraft ]);
+        onSelect({
+            draft: { startDate, endDate, startTime, endTime },
+            anchor: e.jsEvent ? { x: e.jsEvent.clientX, y: e.jsEvent.clientY } : null
+        });
+    }, [ onSelect ]);
 
     const onEventChange = useCallback(async (e: EventChangeInfo) => {
         // Only process actual date/time changes, not other property changes (e.g., title via setProp).
@@ -598,19 +598,31 @@ function useEditing(note: FNote, isEditable: boolean, isCalendarRoot: boolean, c
      * drag asks for a long press before it selects anything (`selectLongPressDelay`), so a tap
      * selects no range and nothing would open at all — the tap stands for a draft instead, which
      * costs nothing if it was a mistake.
+     *
+     * The day's note opens into the view's own event surface — the popover beside the day pressed,
+     * or a sheet where there is no beside — rather than the quick editor it used to be handed to.
+     * A day note is an event of this calendar like any other, and a click on the chip it will have
+     * from now on opens exactly that surface: the note just made and the note come back to are then
+     * the same thing to look at, and neither covers the grid the reader is working down.
      */
     const onDateClick = useCallback(async (e: DateClickInfo) => {
         if (isCalendarRoot) {
             const eventNote = await date_notes.getDayNote(e.dateStr, note.noteId);
             if (eventNote) {
-                appContext.triggerCommand("openInPopup", { noteIdOrPath: eventNote.noteId });
+                // Where the press fell, which is the anchor of last resort until the chip for the
+                // day appears on the grid — a day note made only now has nothing on the grid yet
+                // to stand beside (see eventAnchorRect in EventPopover).
+                onSelect({
+                    noteId: eventNote.noteId,
+                    anchor: { x: e.jsEvent.clientX, y: e.jsEvent.clientY }
+                });
             }
             return;
         }
 
         const draft = draftFromDateClick(e, slotDuration);
-        if (draft) onDraft(draft, null);
-    }, [ note, isCalendarRoot, onDraft, slotDuration ]);
+        if (draft) onSelect({ draft, anchor: null });
+    }, [ note, isCalendarRoot, onSelect, slotDuration ]);
 
     return {
         select: onCalendarSelection,

--- a/apps/client/src/widgets/collections/calendar/selection.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/selection.spec.ts
@@ -15,7 +15,9 @@ describe("narrowAnchorRect", () => {
     it("leaves a piece that can be stood beside as it stands", () => {
         expect(narrowAnchorRect(chip, { x: 720, y: 205 })).toBe(chip);
         // Right up to the width of the widest card, which still leaves the grid's own room.
-        expect(narrowAnchorRect(new DOMRect(700, 200, 380, 20), { x: 720, y: 205 })).toEqual(new DOMRect(700, 200, 380, 20));
+        expect(narrowAnchorRect(new DOMRect(700, 200, 480, 20), { x: 720, y: 205 })).toEqual(new DOMRect(700, 200, 480, 20));
+        // A hair over it is narrowed, the card no longer having room to stand beside the piece.
+        expect(narrowAnchorRect(new DOMRect(700, 200, 481, 20), { x: 720, y: 205 })).toEqual(new DOMRect(720, 200, 0, 20));
     });
 
     it("narrows a piece too wide to be stood beside to the press within it", () => {

--- a/apps/client/src/widgets/collections/calendar/selection.ts
+++ b/apps/client/src/widgets/collections/calendar/selection.ts
@@ -62,5 +62,8 @@ export function narrowAnchorRect(rect: DOMRect, point: AnchorPoint | null): DOMR
 }
 
 /** How wide a piece may be and still be stood beside: the width of the widest card the calendar
- *  anchors — the event popover's 380px, the ghost's own being narrower (see their CSS). */
-const MAX_ANCHOR_WIDTH = 380;
+ *  anchors — the event popover's 480px, the ghost's own being narrower (see their CSS). The
+ *  popover's full width rather than the lesser one a narrow window leaves it: a piece that wide on
+ *  a window that narrow fills it, and the card is then placed by the viewport whatever anchor it is
+ *  handed. */
+const MAX_ANCHOR_WIDTH = 480;

--- a/apps/client/src/widgets/collections/calendar/utils.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/utils.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { AttributeRow } from "../../../services/load_results";
+import { AttributeRow, BranchRow } from "../../../services/load_results";
 import { buildNote } from "../../../test/easy-froca";
-import { formatDateToLocalISO, formatTimeToLocalISO, getMonthsInDateRange, isAttributeChangeAffecting, offsetDate, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
+import { formatDateToLocalISO, formatTimeToLocalISO, getMonthsInDateRange, isAttributeChangeAffecting, isBranchChangeAffecting, offsetDate, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
 
 /**
  * A moment built in the machine's own zone, which is what the calendar hands these functions: a
@@ -175,5 +175,35 @@ describe("isAttributeChangeAffecting", () => {
 
         expect(isAttributeChangeAffecting([ changed("elsewhere", "color", true) ], [ "drawn" ])).toBe(false);
         expect(isAttributeChangeAffecting([], [ "drawn" ])).toBe(false);
+    });
+});
+
+describe("isBranchChangeAffecting", () => {
+    /** What a reload hands over for one branch; only where it puts the note is read. */
+    function filed(parentNoteId: string): BranchRow {
+        return { branchId: `${parentNoteId}_child`, componentId: "some-component", parentNoteId };
+    }
+
+    it("answers for a note filed under the calendar itself, which is where a new year lands", () => {
+        expect(isBranchChangeAffecting([ filed("journal") ], "journal", [])).toBe(true);
+    });
+
+    it("answers for a note filed under one the calendar already knows of", () => {
+        // The day note a click on an empty day makes: filed under a month the calendar knows, and
+        // itself unknown until the events are built again.
+        expect(isBranchChangeAffecting([ filed("month") ], "journal", [ "year", "month" ])).toBe(true);
+    });
+
+    it("answers where only the outermost of several new notes hangs off something known", () => {
+        // A click on a day of a month that has never been opened makes all three at once, and the
+        // day's own parent is as new as the day is.
+        const rows = [ filed("journal"), filed("year"), filed("month") ];
+
+        expect(isBranchChangeAffecting(rows, "journal", [])).toBe(true);
+    });
+
+    it("keeps quiet for a note filed somewhere else entirely, and for no filing at all", () => {
+        expect(isBranchChangeAffecting([ filed("elsewhere") ], "journal", [ "year", "month" ])).toBe(false);
+        expect(isBranchChangeAffecting([], "journal", [ "year" ])).toBe(false);
     });
 });

--- a/apps/client/src/widgets/collections/calendar/utils.spec.ts
+++ b/apps/client/src/widgets/collections/calendar/utils.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { formatDateToLocalISO, formatTimeToLocalISO, getMonthsInDateRange, offsetDate, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
+import { AttributeRow } from "../../../services/load_results";
+import { buildNote } from "../../../test/easy-froca";
+import { formatDateToLocalISO, formatTimeToLocalISO, getMonthsInDateRange, isAttributeChangeAffecting, offsetDate, parseStartEndDateFromEvent, parseStartEndTimeFromEvent } from "./utils";
 
 /**
  * A moment built in the machine's own zone, which is what the calendar hands these functions: a
@@ -122,5 +124,56 @@ describe("getMonthsInDateRange", () => {
         expect(months[0]).toBe("2026-01");
         expect(months[8]).toBe("2026-09");
         expect(months[9]).toBe("2026-10");
+    });
+});
+
+describe("isAttributeChangeAffecting", () => {
+    /** What a reload hands over for one changed attribute; only the owner and the inheritance flag are read. */
+    function changed(noteId: string, name: string, isInheritable = false): AttributeRow {
+        return { attributeId: `${noteId}_${name}`, componentId: "some-component", noteId, type: "label", name, isInheritable };
+    }
+
+    it("answers for a label written on a drawn note itself", () => {
+        const note = buildNote({ id: "own", title: "Event", "#color": "red" });
+
+        expect(isAttributeChangeAffecting([ changed(note.noteId, "color") ], [ note.noteId ])).toBe(true);
+    });
+
+    it("answers for an inheritable label on an ancestor, which is drawn on the chip all the same", () => {
+        const parent = buildNote({
+            id: "inh-parent",
+            title: "Collection",
+            "#color(inheritable)": "red",
+            children: [ { id: "inh-child", title: "Event", "#startDate": "2026-06-05" } ]
+        });
+
+        // The collection note is nowhere in the drawn notes — only its child is.
+        expect(isAttributeChangeAffecting([ changed(parent.noteId, "color", true) ], [ "inh-child" ])).toBe(true);
+    });
+
+    it("answers for a label on a template the drawn note points at", () => {
+        buildNote({ id: "tpl", title: "Template", "#color": "blue" });
+        buildNote({ id: "tpl-instance", title: "Event", "~template": "tpl" });
+
+        expect(isAttributeChangeAffecting([ changed("tpl", "color") ], [ "tpl-instance" ])).toBe(true);
+    });
+
+    it("keeps quiet for an ancestor's label that no child inherits", () => {
+        buildNote({
+            id: "own-parent",
+            title: "Collection",
+            "#color": "red",
+            children: [ { id: "own-child", title: "Event" } ]
+        });
+
+        expect(isAttributeChangeAffecting([ changed("own-parent", "color") ], [ "own-child" ])).toBe(false);
+    });
+
+    it("keeps quiet for a change with nothing to do with the calendar, and for no change at all", () => {
+        buildNote({ id: "elsewhere", title: "Somewhere else", "#color": "green" });
+        buildNote({ id: "drawn", title: "Event" });
+
+        expect(isAttributeChangeAffecting([ changed("elsewhere", "color", true) ], [ "drawn" ])).toBe(false);
+        expect(isAttributeChangeAffecting([], [ "drawn" ])).toBe(false);
     });
 });

--- a/apps/client/src/widgets/collections/calendar/utils.ts
+++ b/apps/client/src/widgets/collections/calendar/utils.ts
@@ -3,7 +3,7 @@ import { DateSelectInfo, EventApi } from "fullcalendar";
 import FNote from "../../../entities/fnote";
 import attributes from "../../../services/attributes";
 import froca from "../../../services/froca";
-import { AttributeRow } from "../../../services/load_results";
+import { AttributeRow, BranchRow } from "../../../services/load_results";
 
 export function parseStartEndDateFromEvent(e: DateSelectInfo | EventApi) {
     const startDate = formatDateToLocalISO(e.start);
@@ -92,6 +92,25 @@ export function isAttributeChangeAffecting(attributeRows: AttributeRow[], noteId
 
         return false;
     });
+}
+
+/**
+ * Whether a note has been filed somewhere a calendar root draws from, and so asks for the events to
+ * be built again — a day note made by a click on an empty day, a note dropped under one afterwards,
+ * or either of them taken away.
+ *
+ * Asked of the branches rather than of the ids because a root builds its events from the calendar
+ * note and the range it is showing, not from a list: the day note just made is in no list yet, and
+ * the list the collection keeps is a refresh behind at this point anyway. Anywhere within the
+ * journal counts, a day note being reachable only through the year and month notes above it —
+ * whichever of the three the reload happens to name, the branch of the outermost new one hangs off
+ * something already known.
+ */
+export function isBranchChangeAffecting(branchRows: BranchRow[], rootNoteId: string, noteIds: Iterable<string>) {
+    const drawnNoteIds = new Set(noteIds);
+
+    return branchRows.some(({ parentNoteId }) =>
+        parentNoteId === rootNoteId || (!!parentNoteId && drawnNoteIds.has(parentNoteId)));
 }
 
 /** The labels the calendar draws an event by, each of which a note may rename for itself via the

--- a/apps/client/src/widgets/collections/calendar/utils.ts
+++ b/apps/client/src/widgets/collections/calendar/utils.ts
@@ -1,6 +1,9 @@
 import { DateSelectInfo, EventApi } from "fullcalendar";
 
 import FNote from "../../../entities/fnote";
+import attributes from "../../../services/attributes";
+import froca from "../../../services/froca";
+import { AttributeRow } from "../../../services/load_results";
 
 export function parseStartEndDateFromEvent(e: DateSelectInfo | EventApi) {
     const startDate = formatDateToLocalISO(e.start);
@@ -57,6 +60,38 @@ export function formatTimeToLocalISO(date: Date | null | undefined) {
     return localDate.toISOString()
         .split("T")[1]
         .substring(0, 5);
+}
+
+/**
+ * Whether an attribute change reaches any of the notes the calendar draws, and so asks for the
+ * events to be built again.
+ *
+ * A label written on the note itself is the plain case, and the only one this used to answer. But
+ * everything the event builder reads — the colour, the icon, the dates, the promoted attributes —
+ * it reads through inheritance (`getLabelValue`), so the same value can just as well come from an
+ * inheritable label on an ancestor or from a template, neither of which is one of the drawn notes.
+ * A `#color` moved onto the collection note itself changed every chip's colouring and refreshed
+ * nothing.
+ *
+ * Rows naming a drawn note outright are answered by a set lookup, and only the rest are put to
+ * {@link attributes.isAffecting}, which walks the very inheritance the builder reads through.
+ */
+export function isAttributeChangeAffecting(attributeRows: AttributeRow[], noteIds: Iterable<string>) {
+    const drawnNoteIds = new Set(noteIds);
+
+    return attributeRows.some((row) => {
+        if (row.noteId && drawnNoteIds.has(row.noteId)) {
+            return true;
+        }
+
+        for (const noteId of drawnNoteIds) {
+            if (attributes.isAffecting(row, froca.getNoteFromCache(noteId))) {
+                return true;
+            }
+        }
+
+        return false;
+    });
 }
 
 /** The labels the calendar draws an event by, each of which a note may rename for itself via the

--- a/apps/client/src/widgets/collections/geomap/DetailPane.css
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.css
@@ -24,6 +24,13 @@
     width: var(--geo-detail-pane-width);
     /* An embedded map may be narrower than the pane would like to be. */
     max-width: calc(100% - 2 * var(--geo-map-inset));
+
+    /* Grown over the map (see the maximize in MarkerDetails). Only the width gives: the pane
+       already stands the height of the map. What the map places around the pane is suppressed
+       while it is grown rather than recomputed — see `maximized` in DetailPane.tsx. */
+    &.maximized {
+        width: calc(100% - 2 * var(--geo-map-inset));
+    }
     /* Clear of MapLibre's own control corners, which sit at 2 (see MapToolbar.css). */
     z-index: 3;
 }

--- a/apps/client/src/widgets/collections/geomap/DetailPane.css
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.css
@@ -78,7 +78,8 @@
  * to press: it is a line of text that happens to answer to a click, so it stands on no plate of its
  * own until it is aimed at.
  */
-.geo-map-container .geo-detail-pane .geo-detail-pane-location {
+.geo-map-container .geo-detail-pane .geo-detail-pane-location,
+.modal.geo-detail-sheet .geo-detail-pane-location {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -99,3 +100,18 @@
     }
 }
 
+.modal.geo-detail-sheet .modal-dialog {
+    max-height: var(--tn-modal-max-height);
+    height: 100%;
+}
+
+.modal.geo-detail-sheet .modal-content {
+    overflow: hidden;
+}
+
+.modal.geo-detail-sheet .modal-body {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: auto;
+}

--- a/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
@@ -187,6 +187,8 @@ describe("DetailPane", () => {
         notes: FNote[]; placing: boolean; isReadOnly: boolean; initialSelection?: PaneSelection;
     }) {
         const [ selection, setSelection ] = useState<PaneSelection | null>(initialSelection ?? null);
+        // Held here for the same reason, the map view owning whether the pane stands over it.
+        const [ maximized, setMaximized ] = useState(false);
         return <DetailPane
             notes={notes}
             parentNote={froca.notes["root"] ?? buildNote({ id: "root", title: "root" })}
@@ -195,6 +197,8 @@ describe("DetailPane", () => {
             selection={selection}
             onSelect={setSelection}
             onRelocate={onRelocate}
+            maximized={maximized}
+            onMaximizedChange={setMaximized}
         />;
     }
 
@@ -662,33 +666,72 @@ describe("DetailPane", () => {
         });
 
         /**
-         * The maximize in the header: the pane grown into the quick editor, which takes the pane's
-         * place rather than standing over it — the quick editor opened on the path the menu's own
-         * entry would open, and the pane standing down having told its editors to save (see
-         * MaximizeToQuickEditAction).
+         * The maximize in the header grows the pane over the map rather than handing the note to the
+         * quick editor, which has none of what the pane offers — the place under the title, the ways
+         * of moving the marker or taking it off the map. Growing the surface would have shrunk what
+         * could be done in it.
+         *
+         * What is pinned here above all is that the note's editor is the very same element on the
+         * other side of it: the pane is restyled where it stands, so nothing it holds is torn down
+         * and nothing has to be saved and read back to grow it. A pane replaced by a larger one
+         * would lose whatever had been typed and not yet saved.
          */
-        it("maximizes into the quick editor, the pane standing down behind it", async () => {
+        it("grows over the map without rebuilding what it holds, and comes back down again", async () => {
             const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
             const map = fakeMap();
-
-            const notePath = "root/places/somewhere";
-            const bestNotePath = vi.spyOn(note, "getBestNotePathString").mockReturnValue(notePath);
             const triggerCommand = vi.spyOn(appContext, "triggerCommand").mockResolvedValue(undefined as never);
 
             try {
                 await openPaneFor(note, map);
+                const editorEl = pane()?.querySelector(".note-detail-stub");
+                expect(editorEl).toBeTruthy();
 
-                await act(async () => {
+                const maximize = () => act(async () => {
                     pane()?.querySelector<HTMLButtonElement>(".tn-overlay-panel-header-actions button.tn-embedded-note-maximize")?.click();
                 });
 
-                expect(triggerCommand).toHaveBeenCalledWith("openInPopup", { noteIdOrPath: notePath });
-                expect(editorAskedToSave).toHaveBeenCalled();
-                expect(pane()).toBeNull();
+                await maximize();
+                expect(pane()?.classList.contains("maximized")).toBe(true);
+                // The same editor, never having been away.
+                expect(pane()?.querySelector(".note-detail-stub")).toBe(editorEl);
+                // Neither a hand-over to another surface nor a dismissal: the pane is still up, and
+                // nothing was asked to save because nothing is closing.
+                expect(triggerCommand).not.toHaveBeenCalledWith("openInPopup", expect.anything());
+                expect(editorAskedToSave).not.toHaveBeenCalled();
+
+                await maximize();
+                expect(pane()?.classList.contains("maximized")).toBe(false);
+                expect(pane()?.querySelector(".note-detail-stub")).toBe(editorEl);
             } finally {
-                bestNotePath.mockRestore();
                 triggerCommand.mockRestore();
             }
+        });
+
+        /**
+         * The map holds a selected marker clear of the pane, which a pane covering the whole map
+         * leaves nowhere to hold it in — so the offset is given up while it is grown, and taken up
+         * again as it comes back down (see paneOffset).
+         */
+        it("stops holding the marker clear of itself while it covers the map", async () => {
+            const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
+            const map = fakeMap();
+            await openPaneFor(note, map);
+
+            const maximize = () => act(async () => {
+                pane()?.querySelector<HTMLButtonElement>(".tn-overlay-panel-header-actions button.tn-embedded-note-maximize")?.click();
+            });
+
+            await maximize();
+            await maximize();
+
+            // Held clear of the pane as it opens; brought back to the middle as the pane grows over
+            // the map, there being no uncovered half left to hold it in; and held clear once more as
+            // the pane comes down, rather than left under it until something else moves the camera.
+            expect(map.eased).toEqual([
+                { center: [ 2, 1 ], offset: [ -200, 0 ] },
+                { center: [ 2, 1 ], offset: [ 0, 0 ] },
+                { center: [ 2, 1 ], offset: [ -200, 0 ] }
+            ]);
         });
 
         /**

--- a/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
@@ -1157,4 +1157,52 @@ describe("DetailPane", () => {
         expect(onMouseDown).not.toHaveBeenCalled();
         expect(onKeyDown).not.toHaveBeenCalled();
     });
+
+    /*
+     * A phone shows the marker as a dialog over the whole screen rather than as a pane beside the
+     * map (see MarkerSheet). A pane holding a whole note takes most of the screen there whatever is
+     * done to it, so the maximize that would give it the rest has nothing left to give — and the
+     * camera, which holds a marker clear of the pane, has no uncovered half to hold it in.
+     */
+    describe("on a phone", () => {
+        beforeEach(() => { window.glob.device = "mobile"; });
+        afterEach(() => { window.glob.device = "desktop"; });
+
+        async function openSheetFor(note: FNote, map: ReturnType<typeof fakeMap>) {
+            await mount([ note ], map);
+            map.setUnderPointer([ markerFeature(note, [ 2, 1 ]) ]);
+            await act(async () => map.click());
+            // The dialog goes up first and reads its note out of the context after, so what it
+            // holds is drawn a turn later than the pane's is.
+            await act(async () => {});
+        }
+
+        const sheet = () => document.querySelector(".modal.geo-detail-sheet");
+
+        it("shows the marker as a dialog rather than as a pane over the map", async () => {
+            const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
+            await openSheetFor(note, fakeMap());
+
+            expect(pane()).toBeNull();
+            expect(sheet()).toBeTruthy();
+            // The same contents either way: the note, and what may be done with the marker.
+            expect(sheet()?.querySelector(".note-detail-stub")).toBeTruthy();
+            expect(sheet()?.querySelector(".geo-detail-pane-location")).toBeTruthy();
+        });
+
+        it("offers no maximize, the dialog already having the screen", async () => {
+            const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
+            await openSheetFor(note, fakeMap());
+
+            expect(document.querySelector(".tn-embedded-note-maximize")).toBeNull();
+        });
+
+        it("leaves the camera alone, there being no pane to hold the marker clear of", async () => {
+            const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
+            const map = fakeMap();
+            await openSheetFor(note, map);
+
+            expect(map.eased).toEqual([]);
+        });
+    });
 });

--- a/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
@@ -690,8 +690,15 @@ describe("DetailPane", () => {
                     pane()?.querySelector<HTMLButtonElement>(".tn-overlay-panel-header-actions button.tn-embedded-note-maximize")?.click();
                 });
 
+                const body = () => pane()?.querySelector(".geo-detail-pane-body");
+                expect(body()?.classList.contains("tn-embedded-note-pane-wide")).toBe(false);
+
                 await maximize();
                 expect(pane()?.classList.contains("maximized")).toBe(true);
+                // Having a note's width, what it holds is laid out for one: the promoted fields
+                // stand side by side as the quick editor shows them, rather than one to a line
+                // (see `tn-embedded-note-pane-wide` in EmbeddedNotePane.css).
+                expect(body()?.classList.contains("tn-embedded-note-pane-wide")).toBe(true);
                 // The same editor, never having been away.
                 expect(pane()?.querySelector(".note-detail-stub")).toBe(editorEl);
                 // Neither a hand-over to another surface nor a dismissal: the pane is still up, and

--- a/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.spec.tsx
@@ -708,11 +708,12 @@ describe("DetailPane", () => {
         });
 
         /**
-         * The map holds a selected marker clear of the pane, which a pane covering the whole map
-         * leaves nowhere to hold it in — so the offset is given up while it is grown, and taken up
-         * again as it comes back down (see paneOffset).
+         * The camera waits out a pane that covers the map rather than aiming into it: there is
+         * nowhere left to hold the marker clear of, and a move made behind the pane would be a move
+         * to somewhere nobody can see — seen all the same, the map sliding while the pane is still
+         * growing over it. It is the coming back down that is worth framing for.
          */
-        it("stops holding the marker clear of itself while it covers the map", async () => {
+        it("leaves the camera alone while it covers the map, and frames again as it comes down", async () => {
             const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
             const map = fakeMap();
             await openPaneFor(note, map);
@@ -722,14 +723,14 @@ describe("DetailPane", () => {
             });
 
             await maximize();
-            await maximize();
+            // Nothing moved for the growing.
+            expect(map.eased).toEqual([ { center: [ 2, 1 ], offset: [ -200, 0 ] } ]);
 
-            // Held clear of the pane as it opens; brought back to the middle as the pane grows over
-            // the map, there being no uncovered half left to hold it in; and held clear once more as
-            // the pane comes down, rather than left under it until something else moves the camera.
+            await maximize();
+            // And the marker is framed clear of the pane again as it comes back down, rather than
+            // left wherever it was until something else happens to move the camera.
             expect(map.eased).toEqual([
                 { center: [ 2, 1 ], offset: [ -200, 0 ] },
-                { center: [ 2, 1 ], offset: [ 0, 0 ] },
                 { center: [ 2, 1 ], offset: [ -200, 0 ] }
             ]);
         });

--- a/apps/client/src/widgets/collections/geomap/DetailPane.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.tsx
@@ -8,12 +8,14 @@ import FNote from "../../../entities/fnote";
 import { copyTextWithToast } from "../../../services/clipboard_ext";
 import { t } from "../../../services/i18n";
 import link from "../../../services/link";
+import { isMobile } from "../../../services/utils";
 import { announceEmbeddedNoteClosing, EmbeddedNoteActions, EmbeddedNoteScope, MaximizeAction, NoteColorAction, OpenNoteActions, SelectTitleOnFirstOpen, useEmbeddedNoteContext, useFollowLinksWithin } from "../../EmbeddedNotePane";
 import TitleRow from "../../layout/TitleRow";
 import NoteDetail from "../../NoteDetail";
 import PromotedAttributes from "../../PromotedAttributes";
 import ActionButton from "../../react/ActionButton";
 import { useLegacyComponentElement, useNoteColorClass, useNoteLabel, useStaticTooltip } from "../../react/hooks";
+import Modal from "../../react/Modal";
 import OverlayPanel, { OverlayPanelBody } from "../../react/OverlayPanel";
 import { removeFromMap } from "./api";
 import { GPX_MIME, trackHitLayers, trackSourceId } from "./GpxTrack";
@@ -170,11 +172,15 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
     // or only what the click named where it named more (see PaneFocus).
     useEffect(() => {
         if (!map || !note) return;
-        // Nothing is aimed at behind a pane that covers the map: the camera would be moving to a
+        // Nothing is aimed at behind a surface that covers the map: the camera would be moving to a
         // place nobody can see, and the move is seen — the map slides while the pane is still
         // growing over it. Waiting instead is what makes the dependency below worth having, the
         // pane coming back down being the moment the marker is worth framing again.
-        if (maximized) return;
+        //
+        // A phone shows the marker as a dialog over the whole screen rather than as a pane beside
+        // the map (see MarkerSheet), so there is never a half of the map to hold it clear of: the
+        // camera has nothing to do there at all, and what it did was pan the map behind a sheet.
+        if (maximized || isMobile()) return;
 
         if (note.mime === GPX_MIME) {
             const focus = selection?.focus;
@@ -231,9 +237,10 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
     }, [ map, note?.noteId, location, selection?.focus, maximized ]);
 
     // Bound only while something is selected, so the map's other Escape — giving up on placing a
-    // marker (see index.tsx) — stands alone when nothing is.
+    // marker (see index.tsx) — stands alone when nothing is. A phone's dialog answers the key
+    // itself (see MarkerSheet), and two answers to one press would close it twice over.
     useEffect(() => {
-        if (!selection) return;
+        if (!selection || isMobile()) return;
 
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
@@ -256,11 +263,18 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
         // EmbeddedNotePane) — the map would otherwise rebind to the marker's note, tear the map
         // down and take the WebGL context with it.
         <EmbeddedNoteScope component={paneComponent} noteContext={noteContext}>
-            <MarkerDetails
-                note={note} parentNote={parentNote} isReadOnly={isReadOnly}
-                maximized={maximized} onMaximizedChange={onMaximizedChange}
-                onClose={closePane} onRelocate={relocate} onFollowLink={followLink}
-            />
+            {isMobile() ? (
+                <MarkerSheet
+                    note={note} parentNote={parentNote} isReadOnly={isReadOnly}
+                    onClose={closePane} onRelocate={relocate} onFollowLink={followLink}
+                />
+            ) : (
+                <MarkerDetails
+                    note={note} parentNote={parentNote} isReadOnly={isReadOnly}
+                    maximized={maximized} onMaximizedChange={onMaximizedChange}
+                    onClose={closePane} onRelocate={relocate} onFollowLink={followLink}
+                />
+            )}
             {selection?.isNew && <SelectTitleOnFirstOpen />}
         </EmbeddedNoteScope>
     );
@@ -446,26 +460,85 @@ function MarkerDetails({ note, parentNote, isReadOnly, maximized, onMaximizedCha
             {/* Grown over the map, the pane has a note's width, so what it holds is laid out for one
                 (see `tn-embedded-note-pane-wide` in EmbeddedNotePane.css). */}
             <OverlayPanelBody className={clsx("geo-detail-pane-body tn-embedded-note-pane", maximized && "tn-embedded-note-pane-wide")}>
-                <MarkerLocation note={note} />
-
-                <MarkerActions note={note} parentNote={parentNote} isReadOnly={isReadOnly} onRelocate={onRelocate} />
-
-                {/* Whatever fields the note's own definitions ask for, ahead of the note as the quick
-                    editor puts them — a marker is often a note whose type says less about it than
-                    its fields do. Nothing at all is shown for a note that promotes none.
-
-                    The location is not among them, the line above naming it better: promoted, it is
-                    a box of raw digits standing beside a map of the very place it names, and the way
-                    to put a marker somewhere else here is to move it. */}
-                <PromotedAttributes omit={[ LOCATION_ATTRIBUTE ]} />
-
-                {/* The note itself, drawn by whichever widget its type calls for — the same one the
-                    quick editor mounts, so a marker is written in exactly as it is anywhere else.
-                    No toolbar stands beside it: the pane asks for the floating one, which the editor
-                    carries with it (see the view scope below). */}
-                <NoteDetail />
+                <MarkerContents note={note} parentNote={parentNote} isReadOnly={isReadOnly} onRelocate={onRelocate} />
             </OverlayPanelBody>
         </OverlayPanel>
+    );
+}
+
+/**
+ * The marker as a phone shows it: the sheet the app raises its dialogs as, rather than a pane laid
+ * over the map. A pane holding a whole note takes most of a phone's screen whatever is done to it,
+ * so one drawn over the map leaves the map neither readable nor reachable — and the maximize that
+ * would give it the rest of the screen has nothing left to give. The note is shown as a note
+ * instead, and the map is left alone behind it (see the camera above).
+ *
+ * Dressed as the quick editor and the calendar's own sheet are, those being the app's ways of
+ * showing a whole note over whatever raised it (see the shared rules in PopupEditor.css).
+ *
+ * `show` is not a state because every way out of this dialog is also a way out of the selection:
+ * what answers `onHidden` clears it, and the sheet goes with it. Bootstrap is told to hide as the
+ * element leaves the tree, so nothing is left dimming the page behind it (see Modal).
+ */
+function MarkerSheet({ note, parentNote, isReadOnly, onClose, onRelocate, onFollowLink }: {
+    note: FNote;
+    parentNote: FNote;
+    isReadOnly: boolean;
+    onClose(): void;
+    onRelocate(): void;
+    onFollowLink(noteId: string): boolean;
+}) {
+    // Marked on the dialog rather than on its body, so that what heads it — the note's own title
+    // row, handed to the dialog — is inside the marked element too (see the pane above).
+    const modalRef = useRef<HTMLDivElement>(null);
+    useLegacyComponentElement(modalRef);
+    useFollowLinksWithin(modalRef, onFollowLink);
+
+    return (
+        <Modal
+            className="geo-detail-sheet"
+            size="lg"
+            title={<TitleRow />}
+            modalRef={modalRef}
+            show
+            onHidden={onClose}
+        >
+            <div className="geo-detail-pane-body tn-embedded-note-pane">
+                <MarkerContents note={note} parentNote={parentNote} isReadOnly={isReadOnly} onRelocate={onRelocate} />
+            </div>
+        </Modal>
+    );
+}
+
+/** What is shown of the marker, under whatever heads it. Shared by the pane and the sheet, which
+ *  differ only in what they put around this and how they are dismissed. */
+function MarkerContents({ note, parentNote, isReadOnly, onRelocate }: {
+    note: FNote;
+    parentNote: FNote;
+    isReadOnly: boolean;
+    onRelocate(): void;
+}) {
+    return (
+        <>
+            <MarkerLocation note={note} />
+
+            <MarkerActions note={note} parentNote={parentNote} isReadOnly={isReadOnly} onRelocate={onRelocate} />
+
+            {/* Whatever fields the note's own definitions ask for, ahead of the note as the quick
+                editor puts them — a marker is often a note whose type says less about it than
+                its fields do. Nothing at all is shown for a note that promotes none.
+
+                The location is not among them, the line above naming it better: promoted, it is
+                a box of raw digits standing beside a map of the very place it names, and the way
+                to put a marker somewhere else here is to move it. */}
+            <PromotedAttributes omit={[ LOCATION_ATTRIBUTE ]} />
+
+            {/* The note itself, drawn by whichever widget its type calls for — the same one the
+                quick editor mounts, so a marker is written in exactly as it is anywhere else.
+                No toolbar stands beside it: the pane asks for the floating one, which the editor
+                carries with it (see the view scope above). */}
+            <NoteDetail />
+        </>
     );
 }
 

--- a/apps/client/src/widgets/collections/geomap/DetailPane.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.tsx
@@ -8,7 +8,7 @@ import FNote from "../../../entities/fnote";
 import { copyTextWithToast } from "../../../services/clipboard_ext";
 import { t } from "../../../services/i18n";
 import link from "../../../services/link";
-import { announceEmbeddedNoteClosing, EmbeddedNoteActions, EmbeddedNoteScope, MaximizeToQuickEditAction, NoteColorAction, OpenNoteActions, SelectTitleOnFirstOpen, useEmbeddedNoteContext, useFollowLinksWithin } from "../../EmbeddedNotePane";
+import { announceEmbeddedNoteClosing, EmbeddedNoteActions, EmbeddedNoteScope, MaximizeAction, NoteColorAction, OpenNoteActions, SelectTitleOnFirstOpen, useEmbeddedNoteContext, useFollowLinksWithin } from "../../EmbeddedNotePane";
 import TitleRow from "../../layout/TitleRow";
 import NoteDetail from "../../NoteDetail";
 import PromotedAttributes from "../../PromotedAttributes";
@@ -54,7 +54,7 @@ export type PaneFocus =
  * pane outside it would leave the screen. It reads as a dock because the map keeps out of its way
  * (see {@link paneOffset}).
  */
-export default function DetailPane({ notes, parentNote, placing, isReadOnly, selection, onSelect, onRelocate }: {
+export default function DetailPane({ notes, parentNote, placing, isReadOnly, selection, onSelect, onRelocate, maximized, onMaximizedChange }: {
     notes: FNote[];
     /** The map's own note, which is how the tree is told what the map holds a note by. */
     parentNote: FNote;
@@ -68,6 +68,15 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
     onSelect: (selection: PaneSelection | null) => void;
     /** Arms this map for the selected marker to be put somewhere else, the next click being where. */
     onRelocate: (noteId: string) => void;
+    /**
+     * The pane has been grown to cover the map (see {@link MaximizeAction} in the header below).
+     * Owned by the map view rather than by the pane for the reason the selection is: the map places
+     * what it draws around the pane, and a pane covering the whole of it leaves nothing to place
+     * around — the marker previews have nowhere to stand clear to (see Tooltips), and the camera has
+     * no uncovered half to hold the marker in (see {@link paneOffset}).
+     */
+    maximized: boolean;
+    onMaximizedChange: (maximized: boolean) => void;
 }) {
     const map = useContext(ParentMap);
     const note = notes.find((note) => note.noteId === selection?.noteId);
@@ -111,6 +120,15 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
         onSelect({ noteId });
         return true;
     }, [ notes, onSelect ]);
+
+    // The pane comes back up beside the map rather than over it, however it was left: the state
+    // outlives the pane, being the map's (see the props), where a card that is taken down and built
+    // again would have forgotten by itself. Switching from one marker to another keeps it — the room
+    // was asked for, not the marker it was asked on — which is why this waits on the pane going down
+    // rather than on the note changing.
+    useEffect(() => {
+        if (!selection) onMaximizedChange(false);
+    }, [ selection, onMaximizedChange ]);
 
     // A note no longer on the map takes the pane with it. Its location may merely have been cleared
     // — which is all "remove from map" does — so the note being gone is not the only case. A GPX
@@ -160,7 +178,7 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
             // were reading at, exactly as a note marker is — flying out to frame the whole file
             // would lose the very flag they clicked.
             if (focus && "at" in focus) {
-                map.easeTo({ center: focus.at, offset: paneOffset(map) });
+                map.easeTo({ center: focus.at, offset: paneOffset(map, maximized) });
                 return;
             }
 
@@ -175,7 +193,7 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
                 if (done || !bounds) return;
                 done = true;
                 map.off("sourcedata", onSourceData);
-                map.fitBounds(bounds, { padding: trackFitPadding(map), maxZoom: TRACK_FIT_MAX_ZOOM });
+                map.fitBounds(bounds, { padding: trackFitPadding(map, maximized), maxZoom: TRACK_FIT_MAX_ZOOM });
             };
 
             // A track selected the moment it was brought onto the map has no line yet: its content
@@ -198,10 +216,14 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
         const coordinates = parseLocation(location);
         if (!coordinates) return;
 
-        map.easeTo({ center: coordinates, offset: paneOffset(map) });
+        map.easeTo({ center: coordinates, offset: paneOffset(map, maximized) });
         // The focus is depended on by identity, which a click renews even on the same note: every
         // click is a fresh ask, and re-clicking what is already open brings it back into view.
-    }, [ map, note?.noteId, location, selection?.focus ]);
+        //
+        // Growing and shrinking the pane are asks of the same kind, the room the camera is aiming
+        // into being what changed: a pane put back down brings its marker clear of it again, rather
+        // than leaving it under the pane until something else happens to move the camera.
+    }, [ map, note?.noteId, location, selection?.focus, maximized ]);
 
     // Bound only while something is selected, so the map's other Escape — giving up on placing a
     // marker (see index.tsx) — stands alone when nothing is.
@@ -229,7 +251,11 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
         // EmbeddedNotePane) — the map would otherwise rebind to the marker's note, tear the map
         // down and take the WebGL context with it.
         <EmbeddedNoteScope component={paneComponent} noteContext={noteContext}>
-            <MarkerDetails note={note} parentNote={parentNote} isReadOnly={isReadOnly} onClose={closePane} onRelocate={relocate} onFollowLink={followLink} />
+            <MarkerDetails
+                note={note} parentNote={parentNote} isReadOnly={isReadOnly}
+                maximized={maximized} onMaximizedChange={onMaximizedChange}
+                onClose={closePane} onRelocate={relocate} onFollowLink={followLink}
+            />
             {selection?.isNew && <SelectTitleOnFirstOpen />}
         </EmbeddedNoteScope>
     );
@@ -254,9 +280,11 @@ export const PANE_REACH = PANE_WIDTH + PANE_INSET;
  * transform, so `getCenter()` — which the view is saved from (see map.tsx) — would report the middle
  * of the uncovered half from then on, walking the saved viewport sideways on every open.
  */
-function paneOffset(map: MapLibreGLMap): [number, number] {
-    // An embedded map narrower than the pane leaves nowhere to hold the marker clear of.
-    if (map.getContainer().clientWidth <= PANE_REACH) {
+function paneOffset(map: MapLibreGLMap, maximized: boolean): [number, number] {
+    // A pane grown over the whole map leaves nowhere to hold the marker clear of, as an embedded map
+    // narrower than the pane does. Reading the note is what a grown pane is for; the marker is
+    // brought clear again as it is put back down (see the camera effect above).
+    if (maximized || map.getContainer().clientWidth <= PANE_REACH) {
         return [ 0, 0 ];
     }
 
@@ -353,12 +381,14 @@ async function trackBounds(map: MapLibreGLMap, noteId: string, track?: number): 
  * the map does not clip the fit but forfeits it: MapLibre cannot solve the camera and leaves it
  * where it stands.
  */
-function trackFitPadding(map: MapLibreGLMap) {
+function trackFitPadding(map: MapLibreGLMap, maximized: boolean) {
     const { clientWidth, clientHeight } = map.getContainer();
     const air = Math.max(0, Math.min(TRACK_FIT_AIR, Math.floor(Math.min(clientWidth, clientHeight) / 4)));
     const padding = { top: air, bottom: air, left: air, right: air };
 
-    if (clientWidth > PANE_REACH + 2 * air) {
+    // Nothing is reserved for a pane that covers the map: there is no uncovered side to fit the
+    // track into, and reserving one would forfeit the fit outright (see above).
+    if (!maximized && clientWidth > PANE_REACH + 2 * air) {
         padding[glob.isRtl ? "left" : "right"] += PANE_REACH;
     }
 
@@ -366,10 +396,12 @@ function trackFitPadding(map: MapLibreGLMap) {
 }
 
 /** The pane itself, for a marker there is one to draw. */
-function MarkerDetails({ note, parentNote, isReadOnly, onClose, onRelocate, onFollowLink }: {
+function MarkerDetails({ note, parentNote, isReadOnly, maximized, onMaximizedChange, onClose, onRelocate, onFollowLink }: {
     note: FNote;
     parentNote: FNote;
     isReadOnly: boolean;
+    maximized: boolean;
+    onMaximizedChange(maximized: boolean): void;
     onClose(): void;
     onRelocate(): void;
     /** Offered a link's note; answers whether the map took the navigation over. */
@@ -400,7 +432,14 @@ function MarkerDetails({ note, parentNote, isReadOnly, onClose, onRelocate, onFo
             containerRef={paneRef}
             className={clsx("geo-detail-pane", colorClass)}
             header={<TitleRow compact />}
-            headerActions={<MaximizeToQuickEditAction note={note} onClose={onClose} />}
+            maximized={maximized}
+            headerActions={
+                <MaximizeAction
+                    icon={maximized ? "bx bx-collapse-alt" : "bx bx-expand-alt"}
+                    text={maximized ? t("geo-map.restore-details") : t("geo-map.expand-details")}
+                    onClick={() => onMaximizedChange(!maximized)}
+                />
+            }
             close={{ text: t("geo-map.close-details"), onClick: onClose }}
         >
             <OverlayPanelBody className="geo-detail-pane-body tn-embedded-note-pane">

--- a/apps/client/src/widgets/collections/geomap/DetailPane.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.tsx
@@ -72,8 +72,8 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
      * The pane has been grown to cover the map (see {@link MaximizeAction} in the header below).
      * Owned by the map view rather than by the pane for the reason the selection is: the map places
      * what it draws around the pane, and a pane covering the whole of it leaves nothing to place
-     * around — the marker previews have nowhere to stand clear to (see Tooltips), and the camera has
-     * no uncovered half to hold the marker in (see {@link paneOffset}).
+     * around — the marker previews have nowhere to stand clear to (see Tooltips), and the camera
+     * has no uncovered half to aim into (see the easing effect below).
      */
     maximized: boolean;
     onMaximizedChange: (maximized: boolean) => void;
@@ -170,6 +170,11 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
     // or only what the click named where it named more (see PaneFocus).
     useEffect(() => {
         if (!map || !note) return;
+        // Nothing is aimed at behind a pane that covers the map: the camera would be moving to a
+        // place nobody can see, and the move is seen — the map slides while the pane is still
+        // growing over it. Waiting instead is what makes the dependency below worth having, the
+        // pane coming back down being the moment the marker is worth framing again.
+        if (maximized) return;
 
         if (note.mime === GPX_MIME) {
             const focus = selection?.focus;
@@ -178,7 +183,7 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
             // were reading at, exactly as a note marker is — flying out to frame the whole file
             // would lose the very flag they clicked.
             if (focus && "at" in focus) {
-                map.easeTo({ center: focus.at, offset: paneOffset(map, maximized) });
+                map.easeTo({ center: focus.at, offset: paneOffset(map) });
                 return;
             }
 
@@ -193,7 +198,7 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
                 if (done || !bounds) return;
                 done = true;
                 map.off("sourcedata", onSourceData);
-                map.fitBounds(bounds, { padding: trackFitPadding(map, maximized), maxZoom: TRACK_FIT_MAX_ZOOM });
+                map.fitBounds(bounds, { padding: trackFitPadding(map), maxZoom: TRACK_FIT_MAX_ZOOM });
             };
 
             // A track selected the moment it was brought onto the map has no line yet: its content
@@ -216,7 +221,7 @@ export default function DetailPane({ notes, parentNote, placing, isReadOnly, sel
         const coordinates = parseLocation(location);
         if (!coordinates) return;
 
-        map.easeTo({ center: coordinates, offset: paneOffset(map, maximized) });
+        map.easeTo({ center: coordinates, offset: paneOffset(map) });
         // The focus is depended on by identity, which a click renews even on the same note: every
         // click is a fresh ask, and re-clicking what is already open brings it back into view.
         //
@@ -280,11 +285,9 @@ export const PANE_REACH = PANE_WIDTH + PANE_INSET;
  * transform, so `getCenter()` — which the view is saved from (see map.tsx) — would report the middle
  * of the uncovered half from then on, walking the saved viewport sideways on every open.
  */
-function paneOffset(map: MapLibreGLMap, maximized: boolean): [number, number] {
-    // A pane grown over the whole map leaves nowhere to hold the marker clear of, as an embedded map
-    // narrower than the pane does. Reading the note is what a grown pane is for; the marker is
-    // brought clear again as it is put back down (see the camera effect above).
-    if (maximized || map.getContainer().clientWidth <= PANE_REACH) {
+function paneOffset(map: MapLibreGLMap): [number, number] {
+    // An embedded map narrower than the pane leaves nowhere to hold the marker clear of.
+    if (map.getContainer().clientWidth <= PANE_REACH) {
         return [ 0, 0 ];
     }
 
@@ -381,14 +384,12 @@ async function trackBounds(map: MapLibreGLMap, noteId: string, track?: number): 
  * the map does not clip the fit but forfeits it: MapLibre cannot solve the camera and leaves it
  * where it stands.
  */
-function trackFitPadding(map: MapLibreGLMap, maximized: boolean) {
+function trackFitPadding(map: MapLibreGLMap) {
     const { clientWidth, clientHeight } = map.getContainer();
     const air = Math.max(0, Math.min(TRACK_FIT_AIR, Math.floor(Math.min(clientWidth, clientHeight) / 4)));
     const padding = { top: air, bottom: air, left: air, right: air };
 
-    // Nothing is reserved for a pane that covers the map: there is no uncovered side to fit the
-    // track into, and reserving one would forfeit the fit outright (see above).
-    if (!maximized && clientWidth > PANE_REACH + 2 * air) {
+    if (clientWidth > PANE_REACH + 2 * air) {
         padding[glob.isRtl ? "left" : "right"] += PANE_REACH;
     }
 

--- a/apps/client/src/widgets/collections/geomap/DetailPane.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.tsx
@@ -443,7 +443,9 @@ function MarkerDetails({ note, parentNote, isReadOnly, maximized, onMaximizedCha
             }
             close={{ text: t("geo-map.close-details"), onClick: onClose }}
         >
-            <OverlayPanelBody className="geo-detail-pane-body tn-embedded-note-pane">
+            {/* Grown over the map, the pane has a note's width, so what it holds is laid out for one
+                (see `tn-embedded-note-pane-wide` in EmbeddedNotePane.css). */}
+            <OverlayPanelBody className={clsx("geo-detail-pane-body tn-embedded-note-pane", maximized && "tn-embedded-note-pane-wide")}>
                 <MarkerLocation note={note} />
 
                 <MarkerActions note={note} parentNote={parentNote} isReadOnly={isReadOnly} onRelocate={onRelocate} />

--- a/apps/client/src/widgets/collections/geomap/Tooltips.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/Tooltips.spec.tsx
@@ -173,12 +173,13 @@ describe("Tooltips", () => {
     });
 
     /** Mounts — or, called again, re-renders — the component. `selectedNoteId` is the marker the
-     *  detail pane stands for, as the map view passes it down. */
-    function mount(map: ReturnType<typeof fakeMap>, selectedNoteId: string | null = null) {
+     *  detail pane stands for and `paneMaximized` whether that pane covers the map, as the map view
+     *  passes the two of them down. */
+    function mount(map: ReturnType<typeof fakeMap>, selectedNoteId: string | null = null, paneMaximized = false) {
         return act(async () => {
             render(
                 <ParentMap.Provider value={map as never}>
-                    <Tooltips selectedNoteId={selectedNoteId} />
+                    <Tooltips selectedNoteId={selectedNoteId} paneMaximized={paneMaximized} />
                 </ParentMap.Provider>,
                 container as HTMLElement
             );
@@ -354,6 +355,33 @@ describe("Tooltips", () => {
         expect(popup?.options.anchor).toBe("bottom");
         // Slid left until its right edge stands its air short of the pane, not merely of the map.
         expect(popup?.options.offset).toEqual([ (1200 - 8 - 400) - PREVIEW_WIDTH / 2 - 1000, -(MARKER_HEIGHT + 8) ]);
+    });
+
+    /**
+     * A pane grown over the map leaves nowhere for a preview to be slid to, and the markers it would
+     * preview are behind it. Nothing is shown at all rather than shown somewhere out of sight — and
+     * a preview already up is taken down as the pane grows, rather than left standing over it.
+     */
+    it("shows nothing at all while the detail pane covers the map", async () => {
+        const selected = buildNote({ title: "Open in the pane", "#geolocation": "5,6" });
+        const note = buildNote({ title: "Somewhere", "#geolocation": "1,2" });
+        const map = fakeMap({ width: 1200, point: { x: 1000, y: 300 } });
+        await mount(map, selected.noteId);
+
+        map.hover(note);
+        await advance(500);
+        expect(shownPreview()).toContain("Body of Somewhere");
+
+        // The pane grows over the map with the preview still up.
+        await mount(map, selected.noteId, true);
+        expect(shownPreview()).toBeUndefined();
+
+        // And nothing the pointer does while it is grown brings one back.
+        renderTooltip.mockClear();
+        map.hover(note);
+        await advance(500);
+        expect(shownPreview()).toBeUndefined();
+        expect(renderTooltip).not.toHaveBeenCalled();
     });
 
     it("centres on the pin where the map is too narrow to slide within", async () => {

--- a/apps/client/src/widgets/collections/geomap/Tooltips.tsx
+++ b/apps/client/src/widgets/collections/geomap/Tooltips.tsx
@@ -74,15 +74,21 @@ const EDGE_PADDING = 8;
  * on click for the same reason (see note_tooltip.ts). Without this, a preview whose marker was
  * clicked stood exactly where the pane then opened, and one still on its way landed on top of it.
  */
-export default function Tooltips({ selectedNoteId }: {
+export default function Tooltips({ selectedNoteId, paneMaximized }: {
     /** The note the detail pane stands for, or `null` while the pane is down and every marker
      *  previews. See the selection in DetailPane. */
     selectedNoteId: string | null;
+    /** The pane has been grown over the map, which leaves no room a preview could be shown in. See
+     *  the maximized pane in DetailPane. */
+    paneMaximized: boolean;
 }) {
     const map = useContext(ParentMap);
 
     useEffect(() => {
-        if (!map) return;
+        // Nothing previews while the pane covers the map: there is no room left for a preview to be
+        // slid into, and the markers it would preview are behind the pane. Gated here rather than
+        // at the placing, so a preview already up is taken down with the handlers as the pane grows.
+        if (!map || paneMaximized) return;
 
         const tooltip = new Popup({
             closeButton: false,
@@ -232,7 +238,7 @@ export default function Tooltips({ selectedNoteId }: {
         // Depending on the selection makes every change of it a dismissal in itself, which covers
         // the selections no click announces: a note created onto the map is opened into the pane
         // by the code that created it (see index.tsx).
-    }, [ map, selectedNoteId ]);
+    }, [ map, selectedNoteId, paneMaximized ]);
 
     return null;
 }

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -61,6 +61,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // Which marker the detail pane stands for. Held here rather than in the pane so that creating a
     // note can open the pane on it (see createNoteAt below).
     const [ selection, setSelection ] = useState<PaneSelection | null>(null);
+    // Whether that pane has been grown over the map. Held here for the reason the selection is: what
+    // the map places around the pane has to know of it too (see the maximized pane in DetailPane).
+    const [ paneMaximized, setPaneMaximized ] = useState(false);
     const [ coordinates, setCoordinates ] = useState(viewConfig?.view?.center);
     const [ zoom, setZoom ] = useState(viewConfig?.view?.zoom);
     const [ hasScale ] = useNoteLabelBoolean(note, "map:scale");
@@ -249,12 +252,16 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                     onTogglePlacement={toggleNotePlacement}
                     onAddGpxTrack={addGpxTrack}
                 />
-                <Tooltips selectedNoteId={selection?.noteId ?? null} />
+                <Tooltips selectedNoteId={selection?.noteId ?? null} paneMaximized={paneMaximized} />
                 {/* The preview under the pointer while a click is armed to mean a place — the note
                     being moved wearing its own pin, a note to be created wearing the pin it will be
                     given (see api.ts). */}
                 {placement && <GhostPin note={placement.mode === "move" ? notes.find((n) => n.noteId === placement.noteId) : undefined} />}
-                <DetailPane notes={notes} parentNote={note} placing={!!placement} isReadOnly={isReadOnly} selection={selection} onSelect={setSelection} onRelocate={startMarkerRelocation} />
+                <DetailPane
+                    notes={notes} parentNote={note} placing={!!placement} isReadOnly={isReadOnly}
+                    selection={selection} onSelect={setSelection} onRelocate={startMarkerRelocation}
+                    maximized={paneMaximized} onMaximizedChange={setPaneMaximized}
+                />
                 <ContextMenus parentNote={note} isReadOnly={isReadOnly} onRelocate={startMarkerRelocation} onCreateNote={createNoteAt} />
                 {/* Stood up only while the view is leaned over, so the 3D button changes the map
                     and not merely the angle it is seen from. */}

--- a/apps/client/src/widgets/dialogs/PopupEditor.css
+++ b/apps/client/src/widgets/dialogs/PopupEditor.css
@@ -35,13 +35,14 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
     font-size: 1.1em;
 }
 
-/* The note-title header (icon + editable title) is shared with the tree popup and the calendar's
-   event sheet, which reuse the same TitleRow; keep the selectors together so the dialogs stay
-   pixel-identical. This file is loaded wherever the app is: the quick editor keeps itself in the
-   DOM and so is never lazily loaded (see layout_commons.tsx). */
+/* The note-title header (icon + editable title) is shared with the tree popup, the calendar's event
+   sheet and the geo map's marker sheet, which reuse the same TitleRow; keep the selectors together
+   so the dialogs stay pixel-identical. This file is loaded wherever the app is: the quick editor
+   keeps itself in the DOM and so is never lazily loaded (see layout_commons.tsx). */
 .modal.popup-editor-dialog .modal-header .title-row,
 .modal.tree-popup-editor-dialog .modal-header .title-row,
-.modal.calendar-event-sheet .modal-header .title-row {
+.modal.calendar-event-sheet .modal-header .title-row,
+.modal.geo-detail-sheet .modal-header .title-row {
     flex-grow: 1;
     display: flex;
     align-items: center;
@@ -56,7 +57,8 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
 
 .modal.popup-editor-dialog .modal-header .note-title-widget,
 .modal.tree-popup-editor-dialog .modal-header .note-title-widget,
-.modal.calendar-event-sheet .modal-header .note-title-widget {
+.modal.calendar-event-sheet .modal-header .note-title-widget,
+.modal.geo-detail-sheet .modal-header .note-title-widget {
     display: flex;
     align-items: center;
 }
@@ -86,14 +88,17 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
 .modal.tree-popup-editor-dialog .title-row,
 .modal.tree-popup-editor-dialog .note-icon-widget,
 .modal.calendar-event-sheet .title-row,
-.modal.calendar-event-sheet .note-icon-widget {
+.modal.calendar-event-sheet .note-icon-widget,
+.modal.geo-detail-sheet .title-row,
+.modal.geo-detail-sheet .note-icon-widget {
     height: 32px;
     min-height: unset;
 }
 
 :root div.modal.popup-editor-dialog div.note-title-widget,
 :root div.modal.tree-popup-editor-dialog div.note-title-widget,
-:root div.modal.calendar-event-sheet div.note-title-widget {
+:root div.modal.calendar-event-sheet div.note-title-widget,
+:root div.modal.geo-detail-sheet div.note-title-widget {
     --note-title-padding-inline: 8px;
 }
 
@@ -102,7 +107,9 @@ body.mobile .modal.popup-editor-dialog .modal-dialog {
 .modal.tree-popup-editor-dialog .note-icon-widget button.note-icon,
 .modal.tree-popup-editor-dialog .note-title-widget input.note-title,
 .modal.calendar-event-sheet .note-icon-widget button.note-icon,
-.modal.calendar-event-sheet .note-title-widget input.note-title {
+.modal.calendar-event-sheet .note-title-widget input.note-title,
+.modal.geo-detail-sheet .note-icon-widget button.note-icon,
+.modal.geo-detail-sheet .note-title-widget input.note-title {
     font-size: 1em;
 }
 

--- a/apps/client/src/widgets/layout/TitleRow.css
+++ b/apps/client/src/widgets/layout/TitleRow.css
@@ -1,10 +1,3 @@
-/*
- * The title row sized as chrome rather than as a note's heading.
- *
- * It is written for the head of a note split — 50px tall, title at 180%, and `display: flex` coming
- * from the split rather than from the row itself, so anywhere else its children stack. Gathered here
- * so each narrow header (the quick editor's, the geo map's pane) need not work it out again.
- */
 .title-row.tn-title-row-compact {
     display: flex;
     align-items: center;
@@ -19,15 +12,19 @@
         margin-inline-start: 0;
     }
 
-    /* The title takes what the icon leaves, as it does in a split (see note_title.css); all that is
-       wanted here is a row for it to do that in. */
+    .note-icon-widget.note-icon-widget {
+        margin-inline-end: 8px;
+    }
+
     .note-title-widget {
         display: flex;
         align-items: center;
-        --note-title-padding-inline: 8px;
     }
 
-    /* Both are sized in the heading's terms — the title at 180% of it — and neither is a heading. */
+    .note-title-widget.note-title-widget {
+        --note-title-padding-inline: 0;
+    }
+
     .note-icon-widget button.note-icon,
     .note-title-widget input.note-title {
         font-size: 1em;

--- a/apps/client/src/widgets/note_types.spec.ts
+++ b/apps/client/src/widgets/note_types.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Loads a fresh copy of the module, so that the "only the first call counts" latch of
+ * `preloadCommonNoteTypes` starts out untripped in every test.
+ */
+async function loadModule() {
+    vi.resetModules();
+    return import("./note_types");
+}
+
+describe("preloadCommonNoteTypes", () => {
+    let idleCallbacks: (() => void)[];
+
+    beforeEach(() => {
+        idleCallbacks = [];
+        vi.stubGlobal("requestIdleCallback", (callback: () => void) => {
+            idleCallbacks.push(callback);
+            return 1;
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("fetches the text editor's module once the browser is idle, and only ever once", async () => {
+        const { preloadCommonNoteTypes, TYPE_MAPPINGS } = await loadModule();
+        const view = vi.fn(() => Promise.resolve({ default: () => undefined }));
+        TYPE_MAPPINGS.editableText.view = view;
+
+        // Merely asking for the preload must not fetch anything yet — the whole point is to wait for
+        // a moment where the application has nothing better to do.
+        preloadCommonNoteTypes();
+        expect(view).not.toHaveBeenCalled();
+        expect(idleCallbacks).toHaveLength(1);
+
+        idleCallbacks[0]();
+        expect(view).toHaveBeenCalledOnce();
+
+        // Repeated calls (e.g. a second window, or a restart of the layout) are a no-op: the module
+        // is in hand already, and re-importing it would only add noise.
+        preloadCommonNoteTypes();
+        expect(idleCallbacks).toHaveLength(1);
+        expect(view).toHaveBeenCalledOnce();
+    });
+
+    it("swallows a failed fetch rather than leaving an unhandled rejection behind", async () => {
+        const { preloadCommonNoteTypes, TYPE_MAPPINGS } = await loadModule();
+        const rejection = Promise.reject(new Error("offline"));
+        TYPE_MAPPINGS.editableText.view = () => rejection;
+
+        preloadCommonNoteTypes();
+        idleCallbacks[0]();
+
+        await expect(rejection.catch(() => "handled")).resolves.toBe("handled");
+    });
+
+    it("falls back to a timer where the browser has no notion of idleness", async () => {
+        vi.stubGlobal("requestIdleCallback", undefined);
+        vi.useFakeTimers();
+        try {
+            const { preloadCommonNoteTypes, TYPE_MAPPINGS } = await loadModule();
+            const view = vi.fn(() => Promise.resolve({ default: () => undefined }));
+            TYPE_MAPPINGS.editableText.view = view;
+
+            preloadCommonNoteTypes();
+            expect(view).not.toHaveBeenCalled();
+
+            vi.runAllTimers();
+            expect(view).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/apps/client/src/widgets/note_types.tsx
+++ b/apps/client/src/widgets/note_types.tsx
@@ -171,3 +171,51 @@ export const TYPE_MAPPINGS: Record<ExtendedNoteType, NoteTypeMapping> = {
         isFullHeight: true
     }
 };
+
+/** The note types whose modules are fetched ahead of time by {@link preloadCommonNoteTypes}. */
+const PRELOADED_NOTE_TYPES: ExtendedNoteType[] = [ "editableText" ];
+
+let preloadRequested = false;
+
+/**
+ * Fetches ahead of time the modules of the note types most likely to be displayed, so that the first
+ * note to be displayed does not have to wait for them.
+ *
+ * The text note's are by far the largest: its editor — CKEditor together with Trilium's plugins for
+ * it — is around 1.4 MB of script (≈ 375 kB compressed), fetched and parsed only once a text note is
+ * actually shown. That is long enough to be felt as a delay when opening the first text note after a
+ * reload, or when clicking a calendar event to have it open in the popup editor. Fetching it while
+ * the application sits idle instead moves that cost away from the moment the user is waiting on it.
+ *
+ * Deliberately kept to the text note: note types are lazily loaded so that a session never pays for
+ * what it never displays, and warming more of them would erode that. Creating the editor itself is
+ * comparatively cheap (tens of milliseconds), so only the modules are fetched here — no editor is
+ * built in advance.
+ *
+ * Calling this more than once does nothing: the first call is the one that counts.
+ */
+export function preloadCommonNoteTypes() {
+    if (preloadRequested) return;
+    preloadRequested = true;
+
+    whenIdle(() => {
+        for (const noteType of PRELOADED_NOTE_TYPES) {
+            // A failure here is of no consequence: the module is fetched again, and reported on
+            // then, when the note type is actually displayed.
+            void Promise.resolve(TYPE_MAPPINGS[noteType].view()).catch(() => {});
+        }
+    });
+}
+
+/**
+ * Runs the callback once the browser is idle, or after a short delay where the browser has no notion
+ * of idleness (older Safari / WebKit). The timeout keeps the work from being put off indefinitely on
+ * a page that never goes idle.
+ */
+function whenIdle(callback: () => void) {
+    if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(callback, { timeout: 5_000 });
+    } else {
+        setTimeout(callback, 1_000);
+    }
+}

--- a/apps/client/src/widgets/react/CollapseOnOverflow.css
+++ b/apps/client/src/widgets/react/CollapseOnOverflow.css
@@ -1,0 +1,22 @@
+/* A control drawn one of two ways — wide, or folded into a menu — by whether the wide one has the
+   room it wants. See CollapseOnOverflow.tsx, which measures the two classes below. */
+.tn-collapse-on-overflow {
+    display: flex;
+    /* Free to be handed less than it asks for: what cannot be squeezed never reports being too wide. */
+    min-width: 0;
+}
+
+/*
+ * While the wide rendering is up it keeps its own width and is cut off rather than squeezed, so that
+ * what it spills is the measure of how much room is missing.
+ *
+ * Left off the folded rendering, which is a dropdown: this would cut its menu off at the control's
+ * own edge.
+ */
+.tn-collapse-on-overflow-wide {
+    overflow: hidden;
+}
+
+.tn-collapse-on-overflow-wide > * {
+    flex-shrink: 0;
+}

--- a/apps/client/src/widgets/react/CollapseOnOverflow.spec.tsx
+++ b/apps/client/src/widgets/react/CollapseOnOverflow.spec.tsx
@@ -1,0 +1,170 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import CollapseOnOverflow, { nextCollapsedState } from "./CollapseOnOverflow";
+
+describe("nextCollapsedState", () => {
+    /** The folded rendering, which fits wherever it is put and hangs outside nothing. */
+    const fitting = { wantedWidth: 90, givenWidth: 90, spilledWidth: 0 };
+
+    it("folds once the row is handed less than it asked for, and notes the width it was short of", () => {
+        expect(nextCollapsedState({ collapsed: false, expandAt: 0 }, { wantedWidth: 420, givenWidth: 380, spilledWidth: 0, containerWidth: 700 }))
+            .toStrictEqual({ collapsed: true, expandAt: 740 });
+    });
+
+    it("folds on a row that is not squeezed but hangs outside the container instead", () => {
+        // A bar with no room left may hand its parts nothing less and grow past the pane, which is
+        // the same shortage read off the other end.
+        expect(nextCollapsedState({ collapsed: false, expandAt: 0 }, { wantedWidth: 420, givenWidth: 420, spilledWidth: 93, containerWidth: 700 }))
+            .toStrictEqual({ collapsed: true, expandAt: 793 });
+    });
+
+    it("leaves the wide rendering up where it fits, a rounded pixel being no shortage", () => {
+        const fits = { collapsed: false, expandAt: 0 };
+        expect(nextCollapsedState(fits, { wantedWidth: 380, givenWidth: 380, spilledWidth: 0, containerWidth: 700 })).toStrictEqual(fits);
+        // Whole numbers off a fractional layout: a row that fits exactly is as likely to report one
+        // over as one under, and folding on that would fold rows that are perfectly well shown.
+        expect(nextCollapsedState(fits, { wantedWidth: 381, givenWidth: 380, spilledWidth: 1, containerWidth: 700 })).toStrictEqual(fits);
+    });
+
+    it("stays folded until the container has grown by what was missing", () => {
+        const folded = { collapsed: true, expandAt: 740 };
+        // The folded rendering fits wherever it is put, so its own measurement says nothing: what is
+        // waited on is the container.
+        expect(nextCollapsedState(folded, { ...fitting, containerWidth: 739 })).toStrictEqual(folded);
+        expect(nextCollapsedState(folded, { ...fitting, containerWidth: 740 }))
+            .toStrictEqual({ collapsed: false, expandAt: 0 });
+    });
+
+    it("settles rather than flipping, where unfolding shows the mark to have been set short", () => {
+        // The row may be given only its own share of a shortage the whole bar takes part in, so the
+        // mark it sets on folding can be too low. Unfolding at that mark folds straight back — but
+        // with a mark above the width just shown not to work, so the same width cannot flip again.
+        const first = nextCollapsedState({ collapsed: false, expandAt: 0 }, { wantedWidth: 420, givenWidth: 400, spilledWidth: 0, containerWidth: 700 });
+        expect(first).toStrictEqual({ collapsed: true, expandAt: 720 });
+
+        const unfolded = nextCollapsedState(first, { ...fitting, containerWidth: 720 });
+        expect(unfolded.collapsed).toBe(false);
+
+        const refolded = nextCollapsedState(unfolded, { wantedWidth: 420, givenWidth: 410, spilledWidth: 0, containerWidth: 720 });
+        expect(refolded).toStrictEqual({ collapsed: true, expandAt: 730 });
+        expect(nextCollapsedState(refolded, { ...fitting, containerWidth: 720 })).toStrictEqual(refolded);
+    });
+});
+
+describe("CollapseOnOverflow", () => {
+    let root: HTMLDivElement;
+    let container: HTMLDivElement;
+
+    beforeEach(() => {
+        observers = [];
+        globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+        root = document.createElement("div");
+        container = document.createElement("div");
+        document.body.append(root, container);
+    });
+
+    afterEach(() => {
+        render(null, root);
+        root.remove();
+        container.remove();
+    });
+
+    it("draws the wide rendering while it fits, and clips it so that what it wants can be read off it", () => {
+        renderChoice();
+
+        const wrapper = root.querySelector(".tn-collapse-on-overflow");
+        expect(wrapper?.textContent).toBe("wide");
+        expect(wrapper?.classList.contains("tn-collapse-on-overflow-wide")).toBe(true);
+        // Watched from both ends: what the control is given comes from the row it is in, and what
+        // that row has to give comes from the container.
+        expect(observers[0]?.observed).toStrictEqual([ wrapper, container ]);
+    });
+
+    it("folds when the wide rendering no longer fits, and lifts the clipping off the menu", () => {
+        renderChoice();
+        resize({ wantedWidth: 420, givenWidth: 380, containerWidth: 700 });
+
+        const wrapper = root.querySelector(".tn-collapse-on-overflow");
+        expect(wrapper?.textContent).toBe("folded");
+        // The folded rendering is a dropdown, whose menu clipping would cut off at the control's edge.
+        expect(wrapper?.classList.contains("tn-collapse-on-overflow-wide")).toBe(false);
+
+        // Held folded at a width the wide rendering has already been shown not to fit, and let back
+        // out once the container has grown by what was missing.
+        resize({ wantedWidth: 90, givenWidth: 90, containerWidth: 700 });
+        expect(root.querySelector(".tn-collapse-on-overflow")?.textContent).toBe("folded");
+        resize({ wantedWidth: 90, givenWidth: 90, containerWidth: 740 });
+        expect(root.querySelector(".tn-collapse-on-overflow")?.textContent).toBe("wide");
+    });
+
+    it("folds a row that its own bar will not squeeze, and so hangs past the container", () => {
+        renderChoice();
+        resize({ wantedWidth: 282, givenWidth: 282, spilledWidth: 93, containerWidth: 700 });
+
+        expect(root.querySelector(".tn-collapse-on-overflow")?.textContent).toBe("folded");
+    });
+
+    it("stays folded without measuring anything where the caller says there is no room at all", () => {
+        renderChoice(true);
+
+        expect(root.querySelector(".tn-collapse-on-overflow")?.textContent).toBe("folded");
+        expect(observers).toHaveLength(0);
+    });
+
+    /** Renders a control naming which of its two renderings is up. */
+    function renderChoice(alwaysCollapsed?: boolean) {
+        act(() => render(
+            <CollapseOnOverflow container={{ current: container }} alwaysCollapsed={alwaysCollapsed}>
+                {(collapsed) => <span>{collapsed ? "folded" : "wide"}</span>}
+            </CollapseOnOverflow>,
+            root));
+    }
+
+    /**
+     * Hands the component a layout, happy-dom measuring everything as nought. The control is laid
+     * against the container's right edge, `spilledWidth` putting it that far past it.
+     */
+    function resize({ wantedWidth, givenWidth, containerWidth, spilledWidth = 0 }: {
+        wantedWidth: number;
+        givenWidth: number;
+        containerWidth: number;
+        spilledWidth?: number;
+    }) {
+        const wrapper = root.querySelector(".tn-collapse-on-overflow") as HTMLElement;
+        stateWidth(wrapper, "scrollWidth", wantedWidth);
+        stateWidth(wrapper, "clientWidth", givenWidth);
+        stateWidth(container, "clientWidth", containerWidth);
+        stateBox(container, 0, containerWidth);
+        stateBox(wrapper, containerWidth + spilledWidth - givenWidth, containerWidth + spilledWidth);
+        act(() => observers.forEach((observer) => observer.callback()));
+    }
+});
+
+function stateWidth(element: HTMLElement, property: "scrollWidth" | "clientWidth", value: number) {
+    Object.defineProperty(element, property, { value, configurable: true });
+}
+
+function stateBox(element: HTMLElement, left: number, right: number) {
+    element.getBoundingClientRect = () => ({ left, right }) as DOMRect;
+}
+
+let observers: ResizeObserverStub[] = [];
+
+/** happy-dom has no ResizeObserver, and lays nothing out for one to report on. */
+class ResizeObserverStub {
+    observed: Element[] = [];
+
+    constructor(readonly callback: () => void) {
+        observers.push(this);
+    }
+
+    observe(element: Element) {
+        this.observed.push(element);
+    }
+
+    unobserve() {}
+
+    disconnect() {}
+}

--- a/apps/client/src/widgets/react/CollapseOnOverflow.tsx
+++ b/apps/client/src/widgets/react/CollapseOnOverflow.tsx
@@ -1,0 +1,145 @@
+import "./CollapseOnOverflow.css";
+
+import clsx from "clsx";
+import { ComponentChildren, RefObject } from "preact";
+import { useLayoutEffect, useRef, useState } from "preact/hooks";
+
+interface CollapseOnOverflowProps {
+    /**
+     * The element the control is weighed against — the pane or the bar it sits in, whose width is
+     * decided by something other than which of the two renderings is currently up.
+     *
+     * It cannot be the control's own box: the folded rendering fits wherever it is put, so a control
+     * measuring itself would find room the moment it folded and unfold straight back into the same
+     * shortage.
+     */
+    container: RefObject<HTMLElement | null>;
+    /** Keeps the folded rendering up whatever the width — for a phone, which has room for no other. */
+    alwaysCollapsed?: boolean;
+    className?: string;
+    /** Draws the control, told which of its two renderings is being asked for. */
+    children: (collapsed: boolean) => ComponentChildren;
+}
+
+/**
+ * Shows a control one of two ways — as it stands, or folded into something narrower — by whether the
+ * wide way fits the room it is given.
+ *
+ * For a row of named options that is worth showing whole where there is width for it (a calendar's
+ * views, say) and is better as a menu where there is not: an alternative to hiding it behind a menu
+ * everywhere, or to switching on the screen's own size, which says nothing about the width of the one
+ * pane the control is in.
+ *
+ * A shortage is read either from the width the control is handed or from what it hangs outside the
+ * container by, since a bar out of room may squeeze its parts or may simply grow past the pane. The
+ * first is the tidier of the two and is worth arranging: `min-width: 0` on whatever the control sits
+ * in, a flex item otherwise refusing to go under its content's width.
+ */
+export default function CollapseOnOverflow({ container, alwaysCollapsed, className, children }: CollapseOnOverflowProps) {
+    const ref = useRef<HTMLDivElement>(null);
+    const collapsed = useCollapsed(ref, container, alwaysCollapsed);
+
+    return (
+        <div
+            ref={ref}
+            className={clsx(
+                "tn-collapse-on-overflow",
+                // Stated only while the wide rendering is up: it is measured by what it spills, and the
+                // folded one is a menu that clipping would cut off (see the CSS).
+                !collapsed && "tn-collapse-on-overflow-wide",
+                className
+            )}
+        >
+            {children(collapsed)}
+        </div>
+    );
+}
+
+interface CollapseState {
+    collapsed: boolean;
+    /**
+     * The container width the wide rendering is owed before it is tried again — nought while it is
+     * up, there being nothing to wait for.
+     */
+    expandAt: number;
+}
+
+interface CollapseMeasurement {
+    /** What the wide rendering asks for. */
+    wantedWidth: number;
+    /** What it is given where it stands, which is less than it asked for once the row is squeezed. */
+    givenWidth: number;
+    /**
+     * How far it hangs outside the container, for a row that is not squeezed but spills.
+     *
+     * The other way a shortage shows itself, and the one that shows where a row cannot be squeezed:
+     * a flex item keeps its content's width unless something states otherwise, so a bar with no room
+     * left hands its parts nothing less and grows past the pane instead.
+     */
+    spilledWidth: number;
+    /** The width of the container it is weighed against. */
+    containerWidth: number;
+}
+
+/**
+ * Whether the folded rendering should be up, from a measurement of the wide one.
+ *
+ * Folding is decided by what the wide rendering spills. Unfolding cannot be — the folded one spills
+ * nothing wherever it is put — so the container width at the moment of folding is kept, raised by
+ * what was missing, and the wide rendering is not tried again until the container has grown that far.
+ *
+ * What was missing is the control's own share of the shortage, the row it sits in sharing a shortage
+ * out between everything that can give, so the mark can be set short and unfolding then folds
+ * straight back with a higher one. It settles after a step or two, and each step puts the mark above
+ * a width just shown not to work, so no single width can flip back and forth.
+ */
+export function nextCollapsedState(state: CollapseState, { wantedWidth, givenWidth, spilledWidth, containerWidth }: CollapseMeasurement): CollapseState {
+    if (state.collapsed) {
+        return containerWidth < state.expandAt ? state : { collapsed: false, expandAt: 0 };
+    }
+
+    // A pixel of slack: these widths are whole numbers rounded off a fractional layout, and a row
+    // that fits exactly is as likely to report one over as one under.
+    const missing = Math.max(wantedWidth - givenWidth, spilledWidth);
+    return missing > 1 ? { collapsed: true, expandAt: containerWidth + missing } : state;
+}
+
+/** Watches the control and its container, answering which rendering the width allows for. */
+function useCollapsed(ref: RefObject<HTMLDivElement>, container: RefObject<HTMLElement | null>, alwaysCollapsed?: boolean) {
+    const [ collapsed, setCollapsed ] = useState(false);
+    // Held rather than read from the state: the measuring below happens outside of a render, and what
+    // it decides from is its own last answer along with the width it then found wanting.
+    const stateRef = useRef<CollapseState>({ collapsed: false, expandAt: 0 });
+
+    useLayoutEffect(() => {
+        const element = ref.current;
+        const containerElement = container.current;
+        if (alwaysCollapsed || !element || !containerElement) return;
+
+        const measure = () => {
+            const box = element.getBoundingClientRect();
+            const containerBox = containerElement.getBoundingClientRect();
+            const next = nextCollapsedState(stateRef.current, {
+                wantedWidth: element.scrollWidth,
+                givenWidth: element.clientWidth,
+                // Which edge it hangs past is a matter of the writing direction, so both are asked.
+                spilledWidth: Math.max(0, box.right - containerBox.right, containerBox.left - box.left),
+                containerWidth: containerElement.clientWidth
+            });
+            stateRef.current = next;
+            setCollapsed(next.collapsed);
+        };
+
+        // Measured before the first paint rather than after it, so a control with no room for its
+        // wide rendering is never shown wearing it.
+        measure();
+        // Both are watched: what the control is given comes from the row it is in, and what that row
+        // has to give comes from the container.
+        const resizes = new ResizeObserver(measure);
+        resizes.observe(element);
+        resizes.observe(containerElement);
+        return () => resizes.disconnect();
+    }, [ ref, container, alwaysCollapsed ]);
+
+    return alwaysCollapsed || collapsed;
+}

--- a/apps/client/src/widgets/react/ContextualHelp.tsx
+++ b/apps/client/src/widgets/react/ContextualHelp.tsx
@@ -40,9 +40,9 @@ function HoveredHelp({ helpMessage }: ContextualHelpProps) {
     useStaticTooltip(ref, useMemo(() => ({
         title: helpMessage,
         placement: "bottom" as const,
-        // Bootstrap appends tooltips to `<body>`, where the base `.tooltip` z-index sits below a
-        // modal — and these icons are often shown inside the settings dialog, so without this the
-        // hint would open behind the dialog that triggered it.
+        // These icons are often shown inside the settings dialog, and the dialog's own overlays
+        // (the content manager's, say) lift themselves above the base tooltip layer. `tooltip-top`
+        // is the app's "above everything" layer, so the hint clears those too.
         customClass: "tooltip-top"
     }), [ helpMessage ]));
 

--- a/apps/client/src/widgets/react/OverlayPanel.css
+++ b/apps/client/src/widgets/react/OverlayPanel.css
@@ -21,6 +21,16 @@
     backdrop-filter: var(--dropdown-backdrop-filter, blur(10px));
 }
 
+/* Frosting suits a card standing over a canvas, not a panel grown to cover one: there is little
+   left to see through it, and a surface that size reads as smeared rather than glassy. The opaque
+   menu colour is the one the theme falls back to wherever the blur cannot be had (see the
+   `body.background-effects` rules in theme-next/base.css); the themes that state no such colour
+   have an opaque menu colour to begin with. */
+.tn-overlay-panel.maximized {
+    background: var(--menu-background-color-no-backdrop, var(--menu-background-color));
+    backdrop-filter: none;
+}
+
 /*
  * The head of the panel: a strip of tabs or a heading of one line, and beside either of them the
  * button that sends the panel away. Only the placing of that button is this row's business — what

--- a/apps/client/src/widgets/react/OverlayPanel.tsx
+++ b/apps/client/src/widgets/react/OverlayPanel.tsx
@@ -19,8 +19,14 @@ interface OverlayPanelProps {
      */
     header: ComponentChildren;
     /** Whatever else the header row offers, standing between the header and the close button —
-     *  the geo pane's maximize, say (see MaximizeToQuickEditAction). */
+     *  the geo pane's maximize, say (see MaximizeAction). */
     headerActions?: ComponentChildren;
+    /**
+     * The panel has been grown to fill the canvas it stands over, which is a way it is drawn and
+     * not a surface of its own: what it holds — a note's editor, mid-edit — is never unmounted for
+     * it. Where it grows to is the caller's to state, as where it stands is (see the CSS).
+     */
+    maximized?: boolean;
     /** The way to send the panel away, offered at the end of the header row. Left out, the panel
      *  has no way of dismissing itself. */
     close?: {
@@ -41,11 +47,11 @@ interface OverlayPanelProps {
  * left to the caller, which is what differs between two of them. The same division
  * {@link OverlayToolbar} makes for the bars those canvases carry.
  */
-export default function OverlayPanel({ className, containerRef, header, headerActions, close, children }: OverlayPanelProps) {
+export default function OverlayPanel({ className, containerRef, header, headerActions, close, maximized, children }: OverlayPanelProps) {
     return (
         <div
             ref={containerRef}
-            className={clsx("tn-overlay-panel", className)}
+            className={clsx("tn-overlay-panel", maximized && "maximized", className)}
             /* Keep interactions inside the panel from reaching the canvas underneath. */
             onMouseDown={(e) => e.stopPropagation()}
             onKeyDown={(e) => e.stopPropagation()}

--- a/apps/client/src/widgets/react/Popover.css
+++ b/apps/client/src/widgets/react/Popover.css
@@ -41,6 +41,16 @@
     display: none;
 }
 
+/* Frosting suits a card standing beside something, not one grown to fill the window: there is
+   little left to see through it, and a surface that size reads as smeared rather than glassy. The
+   opaque menu colour is the one the theme falls back to wherever the blur cannot be had (see the
+   `body.background-effects` rules in theme-next/base.css); the themes that state no such colour
+   have an opaque menu colour to begin with. */
+.tn-popover.maximized {
+    background: var(--menu-background-color-no-backdrop, var(--menu-background-color));
+    backdrop-filter: none;
+}
+
 /* The card's sibling rather than its child: `backdrop-filter` above makes the card the containing
    block for anything fixed within it. */
 .tn-popover-backdrop {

--- a/apps/client/src/widgets/react/Popover.css
+++ b/apps/client/src/widgets/react/Popover.css
@@ -12,6 +12,9 @@
 
     /* Above the note split's own layers; menus and dialogs stand higher still. */
     z-index: 998;
+    /* Popper writes this too, but gives it back as it is destroyed; without it here the panel
+       falls into the page's flow for a frame on the way back from being maximized. */
+    position: fixed;
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
@@ -21,6 +24,33 @@
     border-radius: 8px;
     box-shadow: 0 2px 8px #0003;
     backdrop-filter: var(--dropdown-backdrop-filter, blur(10px));
+}
+
+/* The card let go of its anchor and grown to the window (see `maximized` in Popover.tsx). Popper
+   takes the placement attribute off as it is destroyed, so its absence is what says the inline
+   placement has been given back and the stylesheet may place the card itself. */
+.tn-popover.maximized:not([data-popper-placement]) {
+    position: fixed;
+    inset-block: 5vh;
+    inset-inline: 0;
+    margin-inline: auto;
+    max-width: calc(100vw - 4rem);
+}
+
+.tn-popover.maximized > .tn-popover-arrow {
+    display: none;
+}
+
+/* The card's sibling rather than its child: `backdrop-filter` above makes the card the containing
+   block for anything fixed within it. */
+.tn-popover-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 997;
+    /* Each theme states the colour opaque and leaves the dimming to `.modal-backdrop.show`, which
+       is Bootstrap's and not in play here. */
+    background: var(--modal-backdrop-color, #000);
+    opacity: 0.5;
 }
 
 /*

--- a/apps/client/src/widgets/react/Popover.maximized.spec.tsx
+++ b/apps/client/src/widgets/react/Popover.maximized.spec.tsx
@@ -1,0 +1,94 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import Popover from "./Popover";
+
+/**
+ * Growing an anchored card to fill the window (see `maximized` in Popover), which is a way the same
+ * card is drawn and not a surface put up in its place. What that buys is the point of these: a note
+ * being edited within the card lives across the change, where a dialog raised instead would tear
+ * the editor down and build it again with whatever was typed still unsaved.
+ */
+describe("Popover, maximized", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+        document.body.innerHTML = "";
+    });
+
+    const anchorRect = () => new DOMRect(100, 100, 50, 20);
+
+    /**
+     * Drawn, and then given the turn of the loop Popper places a card in: `createPopper` schedules
+     * its first placement rather than doing it there and then, so the attribute that says where the
+     * card ended up is not on it until the microtasks have run out.
+     */
+    async function mount(maximized: boolean) {
+        await act(async () => {
+            render(
+                <Popover getAnchorRect={anchorRect} maximized={maximized}>
+                    <div className="held-content" />
+                </Popover>,
+                container);
+            await Promise.resolve();
+        });
+    }
+
+    const popover = () => document.querySelector<HTMLElement>(".tn-popover");
+    const backdrop = () => document.querySelector<HTMLElement>(".tn-popover-backdrop");
+    const held = () => document.querySelector<HTMLElement>(".held-content");
+
+    it("keeps what it holds across the change, rather than building it again", async () => {
+        await mount(false);
+        const before = held();
+        expect(before).toBeTruthy();
+
+        await mount(true);
+        expect(held()).toBe(before);
+
+        // And back down again: the card is anchored once more and what it holds has still never
+        // been away.
+        await mount(false);
+        expect(held()).toBe(before);
+    });
+
+    it("lets go of the anchor as it grows, and takes hold again as it comes down", async () => {
+        await mount(false);
+        // Popper places the card and says where it ended up; the styling of a grown card waits on
+        // that attribute being gone (see the `.maximized` rules in Popover.css).
+        expect(popover()?.getAttribute("data-popper-placement")).toBeTruthy();
+
+        await mount(true);
+        expect(popover()?.classList.contains("maximized")).toBe(true);
+        // Given back as the popper is destroyed, along with the inline placement it wrote — which
+        // is what leaves the stylesheet free to put the card where it likes.
+        expect(popover()?.hasAttribute("data-popper-placement")).toBe(false);
+        expect(popover()?.style.transform).toBe("");
+
+        await mount(false);
+        expect(popover()?.classList.contains("maximized")).toBe(false);
+        expect(popover()?.getAttribute("data-popper-placement")).toBeTruthy();
+    });
+
+    it("dims the page only while it is grown", async () => {
+        await mount(false);
+        expect(backdrop()).toBeNull();
+
+        await mount(true);
+        // A sibling of the card and not a child: the card carries a backdrop filter, which would
+        // make it the containing block of anything fixed within it (see Popover.css).
+        expect(backdrop()).toBeTruthy();
+        expect(backdrop()?.contains(popover() ?? null)).toBe(false);
+
+        await mount(false);
+        expect(backdrop()).toBeNull();
+    });
+});

--- a/apps/client/src/widgets/react/Popover.tsx
+++ b/apps/client/src/widgets/react/Popover.tsx
@@ -37,6 +37,18 @@ export interface PopoverProps {
      *  press itself still lands where it fell — dismissal must not swallow it, or pressing the
      *  thing the popover stands beside would take two tries. */
     onDismiss?(): void;
+    /**
+     * Lets go of the anchor: the panel keeps its place in the body and is left to the stylesheet to
+     * put where it likes — a card grown to fill the window (see the `.maximized` rules in
+     * Popover.css), rather than one standing beside something.
+     *
+     * A state of this popover and not a surface of its own, which is the whole of the point: what
+     * the card holds — a note's editor, mid-edit — stays mounted across the change, where a dialog
+     * raised in its place would tear it down and build it again with whatever was typed still
+     * unsaved. Popper is not merely stopped but taken down, its `applyStyles` giving back the
+     * inline placement it wrote (see the effect below) so the stylesheet has the field to itself.
+     */
+    maximized?: boolean;
     children: ComponentChildren;
 }
 
@@ -46,7 +58,7 @@ export interface PopoverProps {
  * container clips it and no containment root flattens its frosting (see the Dropdown notes in
  * CLAUDE.md); positioned by Popper, which also keeps it in place while ancestors scroll.
  */
-export default function Popover({ getAnchorRect, placement, updateKey, className, keepOpenSelector, onDismiss, children }: PopoverProps) {
+export default function Popover({ getAnchorRect, placement, updateKey, className, keepOpenSelector, onDismiss, maximized, children }: PopoverProps) {
     const elRef = useRef<HTMLDivElement>(null);
     const arrowRef = useRef<HTMLDivElement>(null);
     const popperRef = useRef<Instance>();
@@ -58,7 +70,11 @@ export default function Popover({ getAnchorRect, placement, updateKey, className
 
     useEffect(() => {
         const el = elRef.current;
-        if (!el) return;
+        // A maximized card is placed by the stylesheet rather than beside anything, so it is given
+        // no popper at all. Tearing down the one it had is what hands its placement back: Popper's
+        // `applyStyles` remembers the inline styles it found and restores them as it is destroyed,
+        // which the cleanup below runs on the way into this state.
+        if (!el || maximized) return;
 
         const anchor: VirtualElement = { getBoundingClientRect: () => getRectRef.current() };
         const popper = createPopper(anchor, el, {
@@ -89,7 +105,7 @@ export default function Popover({ getAnchorRect, placement, updateKey, className
             popperRef.current = undefined;
             popper.destroy();
         };
-    }, [ placement ]);
+    }, [ placement, maximized ]);
 
     useEffect(() => {
         void popperRef.current?.update();
@@ -122,13 +138,21 @@ export default function Popover({ getAnchorRect, placement, updateKey, className
     }, [ onDismiss, keepOpenSelector ]);
 
     return createPortal(
-        <div ref={elRef} className={clsx("tn-popover", className)}>
-            {/* What the popover is pointing at, drawn by Popper against whichever side it ended up
-                on (see the placements in Popover.css). First in the panel so its static position is
-                the panel's own corner, which is what Popper's offset is reckoned from. */}
-            <div ref={arrowRef} className="tn-popover-arrow" />
-            {children}
-        </div>,
+        <>
+            {/* What dims the page behind a maximized card — its sibling rather than its child, for
+                the reason given in Popover.css. Drawn before it, so it stands behind it whatever
+                the two are given to stand at. */}
+            {maximized && <div className="tn-popover-backdrop" />}
+
+            <div ref={elRef} className={clsx("tn-popover", maximized && "maximized", className)}>
+                {/* What the popover is pointing at, drawn by Popper against whichever side it ended
+                    up on (see the placements in Popover.css). First in the panel so its static
+                    position is the panel's own corner, which is what Popper's offset is reckoned
+                    from. */}
+                <div ref={arrowRef} className="tn-popover-arrow" />
+                {children}
+            </div>
+        </>,
         document.body
     );
 }

--- a/apps/client/src/widgets/react/charts/chart_tooltip.tsx
+++ b/apps/client/src/widgets/react/charts/chart_tooltip.tsx
@@ -49,9 +49,10 @@ export function useChartTooltip<T extends HTMLElement>() {
         tooltipNode: tooltip && (
             // The `tooltip show` classes matter: the themes set the colours on `.tooltip` and scope
             // the text colour to `.tooltip .tooltip-inner`, so a bare inner would inherit the page's.
-            // `tooltip-top` is the app's "raise above everything" class: the base `.tooltip` z-index
-            // is derived from a CKEditor variable that is out of scope here, leaving the bubble at
-            // `auto` — under the hovered mark, which lifts itself to draw its outline.
+            // `tooltip-top` is the app's "raise above everything" class. Unlike a Bootstrap tooltip,
+            // this bubble is rendered inside the chart rather than appended to `<body>`, so it is
+            // stacked against the chart's own marks — and the hovered one lifts itself to draw its
+            // outline, which the base tooltip layer would not clear.
             <div
                 className={clsx(
                     "tooltip", "show", "tooltip-top", "chart-tooltip",

--- a/apps/client/src/widgets/type_widgets/options/content_manager/space_usage/index.tsx
+++ b/apps/client/src/widgets/type_widgets/options/content_manager/space_usage/index.tsx
@@ -128,8 +128,8 @@ export default function SpaceUsage({ sectionSwitcher }: ContentManagerSectionPro
  */
 function StatusEntry({ text, hint }: { text: string, hint: string }) {
     const ref = useRef<HTMLSpanElement>(null);
-    // `tooltip-top` raises the popup above the settings dialog: Bootstrap appends tooltips to
-    // `<body>`, where the base `.tooltip` z-index sits below a modal.
+    // `tooltip-top` is the app's "above everything" layer, which the status line needs: the content
+    // manager's own active-content overlay stands above the base tooltip layer.
     useStaticTooltip(ref, useMemo(
         () => ({ title: hint, placement: "top", customClass: "tooltip-top" }),
         [ hint ]


### PR DESCRIPTION
Opening a note from a calendar event or a geomap marker used to hand off to the quick editor, a modal that covered the very view you were reading. Both now grow their existing card/pane in place instead, and the surrounding chrome (popovers, promoted attributes, tooltips, the view switcher) was fixed up to survive at the sizes that made possible.

## Expand in place instead of the quick editor

- **Calendar** — the event card grows in place rather than opening the quick editor; a day's note opens in the event popover too.
- **Geomap** — the detail pane grows over the map, and the camera is left alone while the pane covers it. On a phone the marker shows as a dialog instead.
- The maximized card/pane drops its backdrop frosting, and `Popover` gained a maximized mode.

## Promoted attributes in collections

- Month chips show their promoted attributes beneath them again, and say them however narrow the chip gets (new `CollapseOnOverflow` component).
- The all-day band says its promoted attributes too.
- A chip's field is labelled with the name its definition gives it.
- The embedded-note pane lays a grown pane's promoted fields out the way a note does, and no longer widens the pane to fit them.
- The suggestion list is bound only where there is something to suggest.
- Cards wrap again on the modern theme.

## Calendar fixes

- The event popover is wider and held inside the window.
- A recurring whole-day event draws as whole-day.
- Events redraw when an inherited attribute changes.
- A journal no longer empties its grid to redraw the same events.
- The view switcher folds into a menu where it doesn't fit.

## Elsewhere

- **Tabs** — splits are kept when a tab moves to its own window.
- **Tooltips** — the tooltip layer gets its own z-index, above the dialogs.
- **Layout** — the icon stays clear of the title in a compact row.
- **Perf** — the text editor's modules are preloaded while idle.

## Test plan

Unit tests were added or extended alongside the changes: `tab_manager`, `link`, `note_types`, `CollapseOnOverflow`, `Popover.maximized`, the geomap `DetailPane`/`Tooltips`, and the calendar `event_builder`/`utils`/`index`/`selection` specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
