### PR TITLE
fix(client): keep options page header actions clear of the floated window buttons

### DIFF
--- a/apps/client/src/widgets/dialogs/OptionsDialog.css
+++ b/apps/client/src/widgets/dialogs/OptionsDialog.css
@@ -47,8 +47,10 @@ body.desktop .modal.options-dialog > .modal-dialog > .modal-content > .modal-mai
 /* The window buttons floated above occupy the top-right corner of the content (~72px with the
    close and "switch to full editor" buttons). When the dialog is narrow enough for the sticky
    page header to reach that corner, keep its actions — e.g. the AI/LLM and spell check master
-   toggles (#10938) — out from under the buttons. */
-body.desktop .modal.options-dialog .options-page-header {
+   toggles (#10938) — out from under the buttons. The shortcuts page brings its own clearance
+   (margin-inline-end: 3em on .shortcut-header-buttons, shortcuts.css), so leave it out rather
+   than reserve the corner twice. */
+body.desktop .modal.options-dialog .options-page-header:not(:has(.shortcut-header-buttons)) {
     padding-inline-end: 80px;
 }
 

--- a/apps/client/src/widgets/dialogs/OptionsDialog.css
+++ b/apps/client/src/widgets/dialogs/OptionsDialog.css
@@ -44,6 +44,14 @@ body.desktop .modal.options-dialog > .modal-dialog > .modal-content > .modal-mai
     z-index: 9999;
 }
 
+/* The window buttons floated above occupy the top-right corner of the content (~72px with the
+   close and "switch to full editor" buttons). When the dialog is narrow enough for the sticky
+   page header to reach that corner, keep its actions — e.g. the AI/LLM and spell check master
+   toggles (#10938) — out from under the buttons. */
+body.desktop .modal.options-dialog .options-page-header {
+    padding-inline-end: 80px;
+}
+
 .modal.options-dialog .options-section {
     margin: auto;
 }


### PR DESCRIPTION
Fixes #10938

## Problem

With the main window **not maximized**, the master toggles at the start of some options pages - the reporter names **AI / LLM** and **Spell Check** - slide underneath the floating window buttons of the settings dialog (close and "switch to full editor"). Because the page header is sticky, the overlap doesn't go away on scroll: the toggle stays hidden under the buttons permanently (though it remains clickable on the uncovered part).

## Root cause

Two pieces collide in the top-right corner of the settings dialog:

1. `apps/client/src/widgets/dialogs/OptionsDialog.css:40-45` floats the dialog header - the two 22px window buttons, ~72px wide in total - over the content with `position: absolute; top: 0; right: 4px; z-index: 9999`.
2. `apps/client/src/widgets/type_widgets/options/components/OptionsPageHeader.css:74-82` makes each options page header a full-width sticky bar (`position: sticky; top: 0`) whose actions - e.g. the master `FormToggle` of AI / LLM and Spell Check - are pushed to the end with `justify-content: flex-end` (`OptionsPageHeader.css:64-70`).

When the window is maximized, the content area exceeds the 900px inner column (`--options-card-max-width`), so the column centers and the toggle lands ~80px away from the edge - just clear of the buttons. When the window is smaller, the area drops below ~900px, the column fills the width and the toggle travels all the way to the corner, ending up under the floated buttons. On Linux with classic (non-overlay) scrollbars the whole button set shifts another ~15px over the content, covering the maximize button as well - the one shown in the issue.

## Fix

Reserve the buttons' footprint as inline-end padding on ordinary options-page headers, right next to the rule that floats the dialog header (+10 lines, one declaration). The Shortcuts page is excluded because it already reserves this corner itself:

```css
body.desktop .modal.options-dialog .options-page-header:not(:has(.shortcut-header-buttons)) {
    padding-inline-end: 80px;
}
```

- **Reserve, not restructure.** Adding `padding-top` to the content wouldn't work: the sticky bar would slide back to `top: 0` under the buttons as soon as you scroll, and it would reintroduce the empty band the floated header was designed to avoid.
- **80px for ordinary pages** = the buttons' real footprint (~72px) plus an 8px margin. AI / LLM and Spell Check do not contain `.shortcut-header-buttons`, so their master toggles receive this clearance. It only matters when the inner column reaches the edge in a narrow dialog; with the column centered at 900px nothing changes visually.
- **Shortcuts keeps its existing geometry.** Its header retains the new-layout `padding-inline-end: 25px`, while `.shortcut-header-buttons` contributes `margin-inline-end: 3em` (48px at the 16px root size): 73px total, matching its pre-fix clearance instead of stacking to 128px.
- **`padding-inline-end`** follows the file's logical-properties convention and satisfies the repo's `property-layout-mappings` stylelint rule. Scoped to `body.desktop`, matching the floated-header rule itself.
- The selector's specificity `(0,5,1)` beats the new-layout `padding-inline: 25px` (`OptionsPageHeader.css:87-90`) for ordinary headers. `:has()` is already used elsewhere in the same client CSS support matrix.

## Verification

I couldn't build/run the real app on my machine, so I built a minimal repro that copies the exact geometry and CSS of both pieces (file/line references kept in comments) and drove it with headless Chromium, measuring real bounding boxes:

- **Without the fix**: the toggle's rect intersects the buttons' zone -> red.
- **With the fix**: no intersection -> green.

| Without fix | With fix |
| --- | --- |
| ![Toggle hidden under the floated close button](https://raw.githubusercontent.com/pacocartones/Trilium/80bd5b87f1f15d1f399ffa86dde963b5a23d338b/pr-assets/10938-without-fix.png) | ![Toggle clear of the floated buttons](https://raw.githubusercontent.com/pacocartones/Trilium/80bd5b87f1f15d1f399ffa86dde963b5a23d338b/pr-assets/10938-with-fix.png) |

A second headless Chromium control for the V2 selector measured the computed styles directly: Shortcuts stays at `25px + 48px`, while ordinary headers - including the AI / LLM and Spell Check controls - get `80px`.

Also ran the repo-pinned stylelint 17.14.1 with `apps/client/.stylelintrc.json` on the changed file: no new violations (the two `right` / `border-right` hits are pre-existing on `main`). `git diff --check` passes. Greptile re-reviewed commit `4c7c0b9` at 5/5 with no blocking finding; the lightweight `main` check also passes.

## Not verified (honest list)

- **The real app** (Electron or server build): verification was the geometry-copied repro, not the authentic dialog. A quick in-app check (Settings -> AI / LLM and Spell Check with a non-maximized window) would be welcome.
- **Full repository workflows**: Dev, Playwright, CodeQL Advanced and Deploy Standalone App remain `action_required` for this first-time-contributor fork, so they have not run.
- **Legacy (non-theme-next) themes**: the buttons inherit different metrics there and the occupied zone may exceed 80px; not measured. The default theme-next is covered.
- **RTL**: the floated rule already uses physical `right: 4px` before this change, so any RTL overlap is a separate pre-existing matter.
