### PR TITLE
Spike: stable block IDs for per-block deep links

### DIFF
--- a/apps/client/src/services/link.ts
+++ b/apps/client/src/services/link.ts
@@ -70,6 +70,8 @@ export interface ViewScope {
     tocCollapsedHeadings?:  Set<string>;
     /** When set, scrolls to a bookmark anchor within the note after navigation. */
     bookmark?: string;
+    /** When set, scrolls to the block carrying this `data-block-id` after navigation. */
+    blockId?: string;
 }
 
 /**
@@ -92,7 +94,32 @@ const NOTE_PATH_PATTERN = /^[_a-z0-9]{4,}(\/[_a-z0-9]{4,})*$/i;
 const MAX_SPLIT_PANES_IN_HASH = 8;
 
 /** Hash parameters that belong to a pane's view scope rather than to the window as a whole. */
-const VIEW_SCOPE_PARAMS = ["viewMode", "attachmentId", "bookmark"];
+const VIEW_SCOPE_PARAMS = ["viewMode", "attachmentId", "bookmark", "blockId"];
+
+/**
+ * The CSS selector for the in-note element a view scope wants scrolled into view — a named anchor
+ * (`?bookmark=`) or a block (`?blockId=`) — or `null` when it asks for neither.
+ *
+ * Consuming: the target is cleared as it is read, so a later re-render of the same note does not
+ * yank the reader back to it. Callers should therefore only call this once they are ready to
+ * scroll. Shared by the read-only and editable text views, which locate the element differently
+ * (rendered content vs. the editor's DOM root) but agree on what to look for.
+ */
+export function takeScrollTargetSelector(viewScope: ViewScope | undefined): string | null {
+    if (viewScope?.bookmark) {
+        const selector = `[id="${CSS.escape(viewScope.bookmark)}"]`;
+        viewScope.bookmark = undefined;
+        return selector;
+    }
+
+    if (viewScope?.blockId) {
+        const selector = `[data-block-id="${CSS.escape(viewScope.blockId)}"]`;
+        viewScope.blockId = undefined;
+        return selector;
+    }
+
+    return null;
+}
 
 interface CreateLinkOptions {
     title?: string;

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3957,6 +3957,7 @@
       "copy-anchor-reference-link": "Copy anchor reference link",
       "copy-formatting": "Copy formatting",
       "copy-image-to-clipboard": "Copy image to clipboard",
+      "copy-link-to-this-block": "Copy link to this block",
       "copy-to-clipboard": "Copy to clipboard",
       "copy-url": "Copy URL",
       "create-a-bulleted-list": "Create a bulleted list",

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 import appContext from "../../../components/app_context";
 import dialog from "../../../services/dialog";
 import { t } from "../../../services/i18n";
-import link, { parseNavigationStateFromUrl } from "../../../services/link";
+import link, { parseNavigationStateFromUrl, takeScrollTargetSelector } from "../../../services/link";
 import note_create from "../../../services/note_create";
 import options from "../../../services/options";
 import toast from "../../../services/toast";
@@ -65,14 +65,13 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
             contentRef.current = newContent;
             watchdogRef.current?.editor?.setData(newContent);
 
-            // Scroll to bookmark anchor if navigated with ?bookmark=...
-            const viewScope = noteContext?.viewScope;
-            if (viewScope?.bookmark) {
+            // Scroll to the anchor or block if navigated with ?bookmark=... / ?blockId=...
+            const selector = takeScrollTargetSelector(noteContext?.viewScope);
+            if (selector) {
                 requestAnimationFrame(() => {
-                    const el = watchdogRef.current?.editor?.editing.view.getDomRoot()
-                        ?.querySelector(`[id="${CSS.escape(viewScope.bookmark!)}"]`);
-                    el?.scrollIntoView({ behavior: "smooth", block: "center" });
-                    viewScope.bookmark = undefined;
+                    watchdogRef.current?.editor?.editing.view.getDomRoot()
+                        ?.querySelector(selector)
+                        ?.scrollIntoView({ behavior: "smooth", block: "center" });
                 });
             }
         },

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
@@ -11,6 +11,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef as usePreactRef } from "pre
 import appContext from "../../../components/app_context";
 import FNote from "../../../entities/fnote";
 import { applyInlineMermaid, rewriteMermaidDiagramsInContainer } from "../../../services/content_renderer_text";
+import { takeScrollTargetSelector } from "../../../services/link";
 import { applyLinkEmbeds } from "../../../services/link_embed";
 import { renderMathInElement } from "../../../services/math";
 import { trackPendingRender } from "../../../services/pending_renders";
@@ -36,14 +37,14 @@ export default function ReadOnlyText({ note, noteContext, ntxId, parentComponent
     const { isRtl } = useNoteLanguage(note);
     const readOnlyContentRef = usePreactRef<HTMLDivElement>(null);
 
-    // Scroll to bookmark anchor if navigated with ?bookmark=...
+    // Scroll to the anchor or block if navigated with ?bookmark=... / ?blockId=...
     useEffect(() => {
-        const viewScope = noteContext?.viewScope;
-        if (!viewScope?.bookmark || !readOnlyContentRef.current) return;
+        if (!readOnlyContentRef.current) return;
 
-        const el = readOnlyContentRef.current.querySelector(`[id="${CSS.escape(viewScope.bookmark)}"]`);
-        el?.scrollIntoView({ behavior: "smooth", block: "center" });
-        viewScope.bookmark = undefined;
+        const selector = takeScrollTargetSelector(noteContext?.viewScope);
+        if (!selector) return;
+
+        readOnlyContentRef.current.querySelector(selector)?.scrollIntoView({ behavior: "smooth", block: "center" });
     }, [blob]);
 
     return (

--- a/apps/client/src/widgets/type_widgets/text/toolbar.ts
+++ b/apps/client/src/widgets/type_widgets/text/toolbar.ts
@@ -104,6 +104,7 @@ export function buildClassicToolbar(multilineToolbar: boolean) {
                 "insertTemplate",
                 "markdownImport",
                 "cuttonote",
+                "copyBlockLink",
                 "|",
                 "undo",
                 "redo"
@@ -166,7 +167,9 @@ export function buildFloatingToolbar() {
             "insertTemplate",
             "markdownImport",
             "specialCharacters",
-            "emoji"
+            "emoji",
+            "|",
+            "copyBlockLink"
         ]
     };
 }

--- a/packages/ckeditor5/src/plugins.ts
+++ b/packages/ckeditor5/src/plugins.ts
@@ -30,6 +30,7 @@ import Collapsible from "./plugins/collapsible/collapsible.js";
 import Footnotes from "./plugins/footnotes/footnotes.js";
 import Math from "./plugins/math/math.js";
 import AutoformatMath from "./plugins/math/autoformat_math.js";
+import BlockId from "./plugins/block_id.js";
 import CopyAnchorLinkButton from "./plugins/copy_anchor_link.js";
 import CopyLinkUrlButton from "./plugins/copy_link_url.js";
 import ImageActions from "./plugins/image_actions.js";
@@ -88,6 +89,7 @@ const TRILIUM_PLUGINS: typeof Plugin[] = [
     TodoListMultistate,
     CollapsibleListItems,
     TableIndent,
+    BlockId,
     CopyAnchorLinkButton,
     CopyLinkUrlButton,
     ImageActions,

--- a/packages/ckeditor5/src/plugins/block_id.spec.ts
+++ b/packages/ckeditor5/src/plugins/block_id.spec.ts
@@ -115,6 +115,22 @@ describe("BlockId", () => {
             expect(root?.getChild(1)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("two");
         });
 
+        it("leaves a lone ID alone across later edits", () => {
+            // Regression: the post-fixer walked with `elementEnd` included, so a block was visited
+            // twice and its ID collided with itself. Every pass reissued it and returned `true`,
+            // re-running the post-fixer forever — the editor hung the moment any block had an ID.
+            setModelData(editor.model, `<paragraph ${BLOCK_ID_ATTRIBUTE}="keep-me">Text[]</paragraph>`);
+
+            expect(editor.model.document.getRoot()?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("keep-me");
+
+            // An unrelated insert is what re-arms the post-fixer; the ID must still survive it.
+            editor.model.change((writer) => {
+                writer.insertElement("paragraph", editor.model.document.getRoot(), "end");
+            });
+
+            expect(editor.model.document.getRoot()?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("keep-me");
+        });
+
         it("ignores blocks that carry no ID", () => {
             setModelData(editor.model, "<paragraph>[]First</paragraph><paragraph>Second</paragraph>");
 

--- a/packages/ckeditor5/src/plugins/block_id.spec.ts
+++ b/packages/ckeditor5/src/plugins/block_id.spec.ts
@@ -1,0 +1,176 @@
+import { _getModelData as getModelData, _setModelData as setModelData, ClassicEditor, Essentials, Heading, Paragraph } from "ckeditor5";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestEditor } from "../../test/editor-kit.js";
+import { installGlobMock, mockClipboard } from "../../test/globals-test-kit.js";
+import BlockId, { BLOCK_ID_ATTRIBUTE, BLOCK_ID_VIEW_ATTRIBUTE } from "./block_id.js";
+
+describe("BlockId", () => {
+    let editor: ClassicEditor;
+    let getActiveContextNote: ReturnType<typeof vi.fn>;
+    let getReferenceLinkTitleSync: ReturnType<typeof vi.fn>;
+    let clipboardWrite: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        getActiveContextNote = vi.fn(() => ({ noteId: "noteAbc" }));
+        getReferenceLinkTitleSync = vi.fn(() => "Some title");
+        installGlobMock({ getActiveContextNote, getReferenceLinkTitleSync });
+
+        clipboardWrite = vi.fn(() => Promise.resolve());
+        mockClipboard({ write: clipboardWrite });
+
+        editor = await createTestEditor([Essentials, Paragraph, Heading, BlockId]);
+    });
+
+    /** The href handed to the clipboard by the last `copyBlockLink` execution. */
+    function copiedHref(): string {
+        return getReferenceLinkTitleSync.mock.calls[0]?.[0] as string;
+    }
+
+    it("registers the plugin, the command and the toolbar button", () => {
+        expect(editor.plugins.get(BlockId)).toBeInstanceOf(BlockId);
+        expect(editor.commands.get("copyBlockLink")).toBeDefined();
+        expect(editor.ui.componentFactory.has("copyBlockLink")).toBe(true);
+    });
+
+    describe("conversion", () => {
+        it("round-trips data-block-id through the data pipeline", () => {
+            editor.setData(`<p ${BLOCK_ID_VIEW_ATTRIBUTE}="abc123">Hello</p>`);
+
+            expect(getModelData(editor.model, { withoutSelection: true }))
+                .toContain(`${BLOCK_ID_ATTRIBUTE}="abc123"`);
+            expect(editor.getData()).toContain(`${BLOCK_ID_VIEW_ATTRIBUTE}="abc123"`);
+        });
+
+        it("applies to headings as well as paragraphs", () => {
+            editor.setData(`<h2 ${BLOCK_ID_VIEW_ATTRIBUTE}="head-1">Title</h2>`);
+
+            expect(editor.getData()).toContain(`${BLOCK_ID_VIEW_ATTRIBUTE}="head-1"`);
+        });
+
+        it("drops the view attribute when the model attribute is removed", () => {
+            setModelData(editor.model, `<paragraph ${BLOCK_ID_ATTRIBUTE}="gone">[]Text</paragraph>`);
+
+            editor.model.change((writer) => {
+                const block = editor.model.document.getRoot()?.getChild(0);
+                if (block?.is("element")) {
+                    writer.removeAttribute(BLOCK_ID_ATTRIBUTE, block);
+                }
+            });
+
+            expect(editor.getData()).not.toContain(BLOCK_ID_VIEW_ATTRIBUTE);
+        });
+
+        it("omits block IDs on the clipboard pipeline so a paste cannot duplicate one", () => {
+            setModelData(editor.model, `[<paragraph ${BLOCK_ID_ATTRIBUTE}="copied">Text</paragraph>]`);
+
+            const model = editor.model;
+            const view = editor.data.toView(
+                model.getSelectedContent(model.document.selection),
+                { isClipboardPipeline: true }
+            );
+
+            expect(editor.data.processor.toData(view)).not.toContain(BLOCK_ID_VIEW_ATTRIBUTE);
+            // …while the ordinary data pipeline keeps it.
+            expect(editor.getData()).toContain(`${BLOCK_ID_VIEW_ATTRIBUTE}="copied"`);
+        });
+    });
+
+    describe("duplicate IDs", () => {
+        it("reissues a duplicate, letting the first block in document order keep the ID", () => {
+            setModelData(
+                editor.model,
+                `<paragraph ${BLOCK_ID_ATTRIBUTE}="dup">[]First</paragraph>`
+                + `<paragraph ${BLOCK_ID_ATTRIBUTE}="dup">Second</paragraph>`
+            );
+
+            const root = editor.model.document.getRoot();
+            expect(root?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("dup");
+
+            const second = root?.getChild(1)?.getAttribute(BLOCK_ID_ATTRIBUTE);
+            expect(second).toBeTruthy();
+            expect(second).not.toBe("dup");
+        });
+
+        it("gives the lower half a fresh ID when a linked block is split", () => {
+            setModelData(editor.model, `<paragraph ${BLOCK_ID_ATTRIBUTE}="split-me">Above[]Below</paragraph>`);
+
+            editor.execute("enter");
+
+            const root = editor.model.document.getRoot();
+            expect(root?.childCount).toBe(2);
+            expect(root?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("split-me");
+            expect(root?.getChild(1)?.getAttribute(BLOCK_ID_ATTRIBUTE)).not.toBe("split-me");
+        });
+
+        it("leaves distinct IDs untouched", () => {
+            setModelData(
+                editor.model,
+                `<paragraph ${BLOCK_ID_ATTRIBUTE}="one">[]First</paragraph>`
+                + `<paragraph ${BLOCK_ID_ATTRIBUTE}="two">Second</paragraph>`
+            );
+
+            const root = editor.model.document.getRoot();
+            expect(root?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("one");
+            expect(root?.getChild(1)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("two");
+        });
+
+        it("ignores blocks that carry no ID", () => {
+            setModelData(editor.model, "<paragraph>[]First</paragraph><paragraph>Second</paragraph>");
+
+            expect(editor.getData()).not.toContain(BLOCK_ID_VIEW_ATTRIBUTE);
+        });
+    });
+
+    describe("copyBlockLink", () => {
+        it("mints an ID on demand and copies a reference link to it", () => {
+            setModelData(editor.model, "<paragraph>Some text[]</paragraph>");
+
+            editor.execute("copyBlockLink");
+
+            const blockId = editor.model.document.getRoot()?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE);
+            expect(blockId).toBeTruthy();
+            expect(copiedHref()).toBe(`#root/noteAbc?blockId=${blockId}`);
+            expect(clipboardWrite).toHaveBeenCalledTimes(1);
+        });
+
+        it("reuses an ID the block already has", () => {
+            setModelData(editor.model, `<paragraph ${BLOCK_ID_ATTRIBUTE}="existing">Text[]</paragraph>`);
+
+            editor.execute("copyBlockLink");
+
+            expect(editor.model.document.getRoot()?.getChild(0)?.getAttribute(BLOCK_ID_ATTRIBUTE)).toBe("existing");
+            expect(copiedHref()).toBe("#root/noteAbc?blockId=existing");
+        });
+
+        it("copies both an HTML reference link and the bare href", () => {
+            setModelData(editor.model, `<paragraph ${BLOCK_ID_ATTRIBUTE}="abc">Text[]</paragraph>`);
+
+            editor.execute("copyBlockLink");
+
+            const item = clipboardWrite.mock.calls[0]?.[0]?.[0] as ClipboardItem;
+            expect(item.types).toContain("text/html");
+            expect(item.types).toContain("text/plain");
+        });
+
+        it("is driven by the toolbar button", () => {
+            setModelData(editor.model, "<paragraph>Text[]</paragraph>");
+
+            const button = editor.ui.componentFactory.create("copyBlockLink") as { fire(name: string): void };
+            button.fire("execute");
+
+            expect(clipboardWrite).toHaveBeenCalledTimes(1);
+        });
+
+        it("is disabled, and does nothing, without an active note", async () => {
+            installGlobMock({ getActiveContextNote: vi.fn(() => undefined), getReferenceLinkTitleSync });
+            const noNoteEditor = await createTestEditor([Essentials, Paragraph, BlockId]);
+            setModelData(noNoteEditor.model, "<paragraph>Text[]</paragraph>");
+
+            expect(noNoteEditor.commands.get("copyBlockLink")?.isEnabled).toBe(false);
+
+            noNoteEditor.execute("copyBlockLink");
+            expect(clipboardWrite).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/ckeditor5/src/plugins/block_id.ts
+++ b/packages/ckeditor5/src/plugins/block_id.ts
@@ -1,0 +1,192 @@
+import { ButtonView, Command, type DowncastAttributeEvent, type Editor, type ModelElement, type ModelWriter, Plugin, uid } from "ckeditor5";
+
+import copyIcon from "../icons/copy.svg?raw";
+import { escapeHtml } from "../utils";
+
+/** Model attribute holding a block's stable identity. */
+export const BLOCK_ID_ATTRIBUTE = "blockId";
+
+/** How {@link BLOCK_ID_ATTRIBUTE} is serialized. `data-*` passes the note sanitizer on every element. */
+export const BLOCK_ID_VIEW_ATTRIBUTE = "data-block-id";
+
+/**
+ * Gives a block (paragraph, heading, list item, …) a stable identity so a link can point at it and
+ * still resolve after the note is reloaded — the substrate under "copy link to this block".
+ *
+ * Three decisions are worth stating, because each one removes a problem rather than solving it:
+ *
+ * - **`data-block-id`, not `id`.** The note sanitizer allows `id` only on `a`, `h2` and `li`
+ *   (`sanitizer.ts`), but allows `data-*` on everything, so this round-trips with no sanitizer
+ *   change. It also stays out of the document-global `id` namespace.
+ * - **Assigned lazily.** An ID is minted only when someone copies a link to the block. Blocks
+ *   nobody references never get one, which is what keeps exported HTML clean — the reason
+ *   CKEditor's always-on list item IDs are not persisted here.
+ * - **Skipped on the clipboard pipeline.** Copied HTML carries no IDs, so a paste can never
+ *   duplicate an ID that something already links to. `cuttonote.ts` relies on the same CKEditor
+ *   behaviour for list item IDs. That leaves block *split* as the only duplication vector, which
+ *   {@link dedupeBlockIds} handles.
+ */
+export default class BlockId extends Plugin {
+
+    public static get pluginName() {
+        return "BlockId" as const;
+    }
+
+    public init() {
+        const editor = this.editor;
+
+        editor.model.schema.extend("$block", { allowAttributes: BLOCK_ID_ATTRIBUTE });
+
+        editor.conversion.for("upcast").attributeToAttribute({
+            view: BLOCK_ID_VIEW_ATTRIBUTE,
+            model: BLOCK_ID_ATTRIBUTE
+        });
+
+        // Registered for both pipelines: the editing view needs the attribute so the scroll-to
+        // handler can find the block while the note is open in the editor, and the data view
+        // needs it so the link survives a save. The clipboard pipeline is the one that opts out.
+        editor.conversion.for("downcast").add((dispatcher) => {
+            dispatcher.on<DowncastAttributeEvent>(`attribute:${BLOCK_ID_ATTRIBUTE}`, (evt, data, conversionApi) => {
+                if (conversionApi.options?.isClipboardPipeline) {
+                    return;
+                }
+
+                if (!conversionApi.consumable.consume(data.item, evt.name)) {
+                    return;
+                }
+
+                const viewElement = conversionApi.mapper.toViewElement(data.item as ModelElement);
+                /* v8 ignore next 3 -- a block carrying the attribute always maps to a view element */
+                if (!viewElement) {
+                    return;
+                }
+
+                if (typeof data.attributeNewValue === "string" && data.attributeNewValue) {
+                    conversionApi.writer.setAttribute(BLOCK_ID_VIEW_ATTRIBUTE, data.attributeNewValue, viewElement);
+                } else {
+                    conversionApi.writer.removeAttribute(BLOCK_ID_VIEW_ATTRIBUTE, viewElement);
+                }
+            });
+        });
+
+        editor.model.document.registerPostFixer((writer) => dedupeBlockIds(editor, writer));
+
+        editor.commands.add("copyBlockLink", new CopyBlockLinkCommand(editor));
+
+        editor.ui.componentFactory.add("copyBlockLink", (locale) => {
+            const button = new ButtonView(locale);
+            const command = editor.commands.get("copyBlockLink");
+            const t = locale.t;
+
+            button.set({
+                label: t("Copy link to this block"),
+                icon: copyIcon,
+                tooltip: true
+            });
+
+            if (command) {
+                button.bind("isEnabled").to(command, "isEnabled");
+            }
+
+            this.listenTo(button, "execute", () => editor.execute("copyBlockLink"));
+
+            return button;
+        });
+    }
+
+}
+
+/**
+ * Copies a reference link addressing the selected block, minting the block's ID if it does not
+ * have one yet.
+ *
+ * Minting on copy is what keeps IDs off every other block, but it does mean this command edits the
+ * note — a gesture the user reads as read-only produces a content change, and therefore possibly a
+ * revision. That trade is deliberate; the alternative is stamping every block up front.
+ */
+class CopyBlockLinkCommand extends Command {
+
+    public override refresh() {
+        this.isEnabled = !!getSelectedBlock(this.editor) && !!glob.getActiveContextNote()?.noteId;
+    }
+
+    public override execute() {
+        const editor = this.editor;
+        const block = getSelectedBlock(editor);
+        const noteId = glob.getActiveContextNote()?.noteId;
+
+        if (!block || !noteId) {
+            return;
+        }
+
+        const existingId = block.getAttribute(BLOCK_ID_ATTRIBUTE);
+        let blockId = typeof existingId === "string" ? existingId : "";
+
+        if (!blockId) {
+            blockId = uid();
+            editor.model.change((writer) => writer.setAttribute(BLOCK_ID_ATTRIBUTE, blockId, block));
+        }
+
+        const href = `#root/${noteId}?blockId=${encodeURIComponent(blockId)}`;
+        const title = glob.getReferenceLinkTitleSync(href);
+        const html = `<a class="reference-link" href="${escapeHtml(href)}">${escapeHtml(title)}</a>`;
+
+        navigator.clipboard.write([
+            new ClipboardItem({
+                "text/html": new Blob([html], { type: "text/html" }),
+                "text/plain": new Blob([href], { type: "text/plain" })
+            })
+        ]);
+    }
+
+}
+
+/** The block the selection sits in, or `null` when the selection spans none. */
+function getSelectedBlock(editor: Editor): ModelElement | null {
+    const [first] = editor.model.document.selection.getSelectedBlocks();
+    return first ?? null;
+}
+
+/**
+ * Keeps block IDs unique within the document.
+ *
+ * Splitting a block (Enter mid-paragraph) copies its attributes onto both halves, so the ID would
+ * otherwise address two blocks at once. Document order decides who keeps it: the first occurrence
+ * wins and later duplicates are reissued, so splitting a linked paragraph leaves existing links
+ * pointing at the top half.
+ *
+ * Gated on insertions — an attribute-only change cannot introduce a duplicate, since the only
+ * writer of this attribute mints a fresh value.
+ */
+function dedupeBlockIds(editor: Editor, writer: ModelWriter): boolean {
+    const document = editor.model.document;
+
+    if (!document.differ.getChanges().some((change) => change.type === "insert")) {
+        return false;
+    }
+
+    const seen = new Set<string>();
+    let changed = false;
+
+    for (const root of document.getRoots()) {
+        for (const { item } of writer.createRangeIn(root).getWalker()) {
+            if (!item.is("element")) {
+                continue;
+            }
+
+            const blockId = item.getAttribute(BLOCK_ID_ATTRIBUTE);
+            if (typeof blockId !== "string" || !blockId) {
+                continue;
+            }
+
+            if (seen.has(blockId)) {
+                writer.setAttribute(BLOCK_ID_ATTRIBUTE, uid(), item);
+                changed = true;
+            } else {
+                seen.add(blockId);
+            }
+        }
+    }
+
+    return changed;
+}

--- a/packages/ckeditor5/src/plugins/block_id.ts
+++ b/packages/ckeditor5/src/plugins/block_id.ts
@@ -166,10 +166,15 @@ function dedupeBlockIds(editor: Editor, writer: ModelWriter): boolean {
     }
 
     const seen = new Set<string>();
-    let changed = false;
+    const duplicates: ModelElement[] = [];
 
     for (const root of document.getRoots()) {
-        for (const { item } of writer.createRangeIn(root).getWalker()) {
+        // `ignoreElementEnd` is load-bearing, not tidiness: the default walker visits an element
+        // twice, as `elementStart` and again as `elementEnd`, handing back the same element both
+        // times. Without it every ID collides with itself, gets reissued, and returning `true`
+        // re-runs the post-fixer over a document that still looks equally broken — an endless loop
+        // that hangs the editor as soon as any block carries an ID.
+        for (const { item } of writer.createRangeIn(root).getWalker({ ignoreElementEnd: true })) {
             if (!item.is("element")) {
                 continue;
             }
@@ -180,13 +185,17 @@ function dedupeBlockIds(editor: Editor, writer: ModelWriter): boolean {
             }
 
             if (seen.has(blockId)) {
-                writer.setAttribute(BLOCK_ID_ATTRIBUTE, uid(), item);
-                changed = true;
+                duplicates.push(item);
             } else {
                 seen.add(blockId);
             }
         }
     }
 
-    return changed;
+    // Applied after the walk rather than during it, so the tree is never mutated mid-iteration.
+    for (const element of duplicates) {
+        writer.setAttribute(BLOCK_ID_ATTRIBUTE, uid(), element);
+    }
+
+    return duplicates.length > 0;
 }


### PR DESCRIPTION
Draft spike, not for merge — opened to make the shape reviewable. Comes out of an analysis of six years of "block-based system" requests.

> **Update:** the first push had a hang bug (infinite post-fixer loop), found by running it. Fixed in `e771f5b`; details in [Status](#status--please-read-before-reviewing) below.

## Why: the demand, and what it actually is

There is no single block-system request. There's a cluster of ~17 issues from **~26 distinct people** (11 issue authors, 15 more backing them in comments) plus ~36 👍, splitting into four asks:

| Ask | Issues |
|---|---|
| Block references / transclusion (Roam, Obsidian `[[ ]]`, Logseq) | #1233, #2726, #4533 |
| Deep links to a paragraph/block (OneNote-style) | #1021 (19 👍), #9336 |
| Blocks as manipulable objects (reorder, collapse, annotate) | #319, #940, #3112, #8229, #10570, #10284 |
| Replace/augment the editor to get blocks | #4969 (9 👍), TriliumNext/Notes#24 |

Counter-signal worth stating: discussion #24 polled "Should TriliumNext aim to replace CKEditor?" — ~97 votes, roughly 7% in favour. The demand is for block *capabilities*, not a new editor.

Much of cluster 3 has already shipped (`move_block_updown`, `collapsible`, anchors via the relabelled `Bookmark` plugin + `copy_anchor_link`). What's missing is the data-model piece: blocks have no stable identity, so there are no block-level backlinks, no transclusion, no search-result-to-block positioning.

## What this spike does

Adds an optional `blockId` model attribute on `$block`, serialized as `data-block-id`, plus a `copyBlockLink` command that mints one on demand and copies `#root/<noteId>?blockId=<id>`.

Three decisions, each of which removes a problem rather than solving it:

**`data-block-id`, not `id`.** `sanitizer.ts` allows `id` only on `a`, `h2`, `li` — a `<p id>` is stripped on save. It allows `data-*` on every element, so this round-trips with **no sanitizer change**, and stays out of the document-global `id` namespace.

**Assigned lazily.** An ID is minted only when someone copies a link to that block. This is what keeps exported HTML clean, and it's the asymmetry that makes this viable where CKEditor's list item IDs weren't: list IDs are *structural* (every item needs one, hence the export clutter that got them turned off here), whereas a block ID is *referential* — nothing breaks if a block hasn't got one.

**Skipped on the clipboard pipeline**, exactly as list item IDs already are (see the comment in `cuttonote.ts`). Copied HTML carries no IDs, so a paste can never duplicate an ID something links to. That leaves block *split* as the only duplication vector, handled by a post-fixer where **document order decides**: the first occurrence keeps the ID, so splitting a linked paragraph leaves existing links pointing at the top half.

Deliberately **not** routed through `GeneralHtmlSupport` — `htmlSupport.allow` is driven by the user-configurable `allowedHtmlTags` option, so a restrictive setting would silently drop IDs on save.

## Files

- `packages/ckeditor5/src/plugins/block_id.ts` — schema, conversion, post-fixer, command, button
- `packages/ckeditor5/src/plugins/block_id.spec.ts` — conversion round-trip, clipboard-pipeline omission, split/duplicate handling, lazy minting
- `link.ts` — `blockId` view scope + a shared `takeScrollTargetSelector()` now used by both text views (this also drops an existing non-null assertion in `EditableText.tsx`)
- `plugins.ts`, `toolbar.ts`, `en/translation.json` — registration, toolbar placement, label

## Status — please read before reviewing

**Nothing here has been executed.** `pnpm install` fails on an egress-policy `403` for `codeload.github.com` (the `electron/node-gyp` tarball pinned in the lockfile), which leaves no pnpm virtual store. The Chrome-for-Testing hosts webdriverio would fetch a browser from are `403` as well, and the local Chromium/chromedriver pair is version-mismatched (141 vs 147) — so this environment cannot run this package's browser suite by any route. Symbols and converter shape were verified against existing in-repo usage (`table_indent.ts` is the closest analogue), which catches wrong imports but not logic errors.

That gap already cost one bug, and it is the main thing to weigh when reviewing:

> **`e771f5b` — infinite loop in the post-fixer.** The default tree walker visits each element *twice*, as `elementStart` and again as `elementEnd`, handing back the same element both times. The dedupe walk therefore saw every ID collide with itself, reissued it, and returned `true` — which re-runs the post-fixer over a document that still looks equally broken. The editor hung as soon as any block carried an ID, which copying a block link is exactly what creates. Fixed by walking with `ignoreElementEnd` and applying reissues after the walk rather than mutating mid-iteration. The existing specs would have caught it had they been runnable; a regression test now pins it explicitly.

**Please treat the remaining tests as unvalidated** and run the suite locally before trusting any of this.

## Open decisions

1. **Revision side effect.** Lazy minting means "copy link" edits note content — a gesture users read as read-only can produce a revision. The alternative is stamping every block up front, which reintroduces the export clutter.
2. **Toolbar placement.** `copyBlockLink` was added to *both* the classic toolbar and the block toolbar, because `toolbar.spec.ts` asserts the two carry identical item sets and there is no block-only escape hatch (only `FIXED_ONLY_ITEMS`). The block toolbar is the natural home; the classic-toolbar entry exists to satisfy that invariant and may not be what you want.
3. **Markdown export drops block IDs** (`export/markdown.ts` keeps only `kbd`/`sup`/`sub`). HTML-only concept — fine, but should be a stated limitation.
4. **Post-fixer cost** — gated on insert changes, but still a full walk of the roots when one fires. Fine for a spike; worth profiling on large notes.

## What this unlocks (not in this PR)

Block IDs are only worth what's built on them: transclusion (#1233, #2726 — `backlink_excerpts.ts` already parses note HTML and emits `ck-content` fragments, so extracting one block is the same shape of function), block-level backlinks, and block-precise search results (#319). Not block *cloning* (#4533) — that needs write-back into a foreign note's content blob and collides with note-granular `EntityChange` sync.