### PR TITLE
Backup improvements

### DIFF
--- a/apps/client/src/services/backup_download.ts
+++ b/apps/client/src/services/backup_download.ts
@@ -41,12 +41,13 @@ export function backupFileName(name: string): string {
  */
 export async function startBackupDownload(
     fileName: string,
-    passphrase?: string
+    passphrase?: string,
+    onProgress?: (sentBytes: number, totalBytes: number) => void
 ): Promise<StandaloneDownloadResult> {
     const api = window.standaloneApi;
     if (!api) {
         return { status: "failed", message: "This platform does not back up by download." };
     }
 
-    return await api.backup.downloadDatabase(fileName, passphrase || undefined);
+    return await api.backup.downloadDatabase(fileName, passphrase || undefined, onProgress);
 }

--- a/apps/client/src/services/database_files.spec.ts
+++ b/apps/client/src/services/database_files.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+// i18next is never initialised in these tests, so t() would return nothing at all. Echoing the key
+// keeps the assertions about which sentence is chosen rather than about its English.
+vi.mock("./i18n.js", () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+        [ key, ...Object.values(values ?? {}) ].join(" ")
+}));
+
+import { describeDatabaseFile } from "./database_files.js";
+
+const FILE = {
+    fileName: "backup-daily.tnbackup",
+    filePath: "/data/backup/backup-daily.tnbackup",
+    mtime: new Date("2026-02-03T04:05:06Z"),
+    fileSize: 2 * 1024 * 1024
+};
+
+describe("the line under a backup's name", () => {
+    it("states when it was taken and how big it is", () => {
+        expect(describeDatabaseFile(FILE)).toContain("2 MiB");
+        expect(describeDatabaseFile(FILE)).not.toContain("database_file_list");
+    });
+
+    it("states both sizes for a backup smaller than the database it was made from", () => {
+        const described = describeDatabaseFile({ ...FILE, plaintextSize: 8 * 1024 * 1024 });
+
+        expect(described).toContain("8 MiB");
+        expect(described).toContain("database_file_list.size_on_disk 2 MiB");
+    });
+
+    it.each([
+        [ "invalid" as const, "database_file_list.invalid_backup" ],
+        [ "unsupported-version" as const, "database_file_list.unsupported_version" ]
+    ])("says a %s backup cannot be restored from, without dropping what it is", (
+        unreadable,
+        expected
+    ) => {
+        const described = describeDatabaseFile({ ...FILE, unreadable });
+
+        expect(described.endsWith(expected)).toBe(true);
+        // The date and the size stay: a backup that stopped halfway is the size of how far it got,
+        // which is what tells the user why this one is no good.
+        expect(described).toContain("2 MiB");
+    });
+});

--- a/apps/client/src/services/database_files.ts
+++ b/apps/client/src/services/database_files.ts
@@ -14,6 +14,11 @@ export interface DatabaseFile {
      * size — a compressed backup, say. Both are then shown, so the saving is visible.
      */
     plaintextSize?: number;
+    /**
+     * Why the file cannot be restored from, where its own header says as much. Absent for a plain
+     * copy and for a container this build can open.
+     */
+    unreadable?: "invalid" | "unsupported-version";
 }
 
 /**
@@ -52,6 +57,15 @@ export function describeDatabaseFile(file: DatabaseFile): string {
         parts.push(formatSize(file.plaintextSize), t("database_file_list.size_on_disk", { size: formatSize(file.fileSize) }));
     } else {
         parts.push(formatSize(file.fileSize));
+    }
+
+    // Last, after the two facts that identify which file this is. The date and the size are kept
+    // rather than replaced because they are what tells the user why it is no good: a backup that
+    // stopped halfway is the size of how far it got.
+    if (file.unreadable) {
+        parts.push(file.unreadable === "invalid"
+            ? t("database_file_list.invalid_backup")
+            : t("database_file_list.unsupported_version"));
     }
 
     return parts.join(" • ");

--- a/apps/client/src/services/utils.spec.ts
+++ b/apps/client/src/services/utils.spec.ts
@@ -109,6 +109,24 @@ describe("formatSize", () => {
         expect(formatSize(5 * 1024 * 1024)).toBe("5 MiB");
         expect(formatSize(3 * 1024 * 1024 * 1024)).toBe("3 GiB");
     });
+
+    it("stays in the largest unit it knows rather than running off the end of them", () => {
+        // Past the last unit this used to name it "undefined", since it indexed straight into the
+        // list with whatever power of 1024 the size came to.
+        expect(formatSize(3 * 1024 ** 4)).toBe("3 TiB");
+        expect(formatSize(5 * 1024 ** 5)).toBe("5120 TiB");
+    });
+
+    it("keeps the places it is given, trailing zeros and all", () => {
+        // For a counter that is still climbing: dropping the zero shortens the text on every other
+        // update, and the line shifts about while it is being read.
+        expect(formatSize(1.5 * 1024 ** 3, 2)).toBe("1.50 GiB");
+        expect(formatSize(1.55 * 1024 ** 3, 2)).toBe("1.55 GiB");
+        expect(formatSize(2 * 1024 ** 3, 2)).toBe("2.00 GiB");
+        expect(formatSize(10 * 1024 ** 2, 1)).toBe("10.0 MiB");
+        // Nothing below a byte to show, however many places were asked for.
+        expect(formatSize(512, 2)).toBe("512 B");
+    });
 });
 
 describe("formatDateTime / date helpers", () => {

--- a/apps/client/src/services/utils.ts
+++ b/apps/client/src/services/utils.ts
@@ -247,20 +247,32 @@ export function escapeQuotes(value: string) {
     return value.replaceAll('"', "&quot;");
 }
 
-export function formatSize(size: number | null | undefined) {
+/** The units a size is shown in, largest last, each 1024 of the one before it. */
+const SIZE_UNITS = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+/**
+ * A byte count in the largest unit it fits in.
+ *
+ * @param decimals places to keep, trailing zeros and all. Omit it to round to at most two and drop
+ *   what is not needed, which reads best for a size at rest. Pass a number for a counter that is
+ *   still climbing: there, dropping a trailing zero shortens the text on every other update and the
+ *   line shifts about while it is being read.
+ */
+export function formatSize(size: number | null | undefined, decimals?: number) {
     if (size === null || size === undefined) {
         return "";
     }
 
-    if (size === 0) {
+    if (size <= 0) {
         return "0 B";
     }
 
-    const k = 1024;
-    const sizes = ["B", "KiB", "MiB", "GiB"];
-    const i = Math.floor(Math.log(size) / Math.log(k));
+    const unit = Math.min(Math.floor(Math.log(size) / Math.log(1024)), SIZE_UNITS.length - 1);
+    const value = size / Math.pow(1024, unit);
+    // Nothing below a byte to show, however many places were asked for.
+    const places = decimals !== undefined && unit === 0 ? 0 : decimals;
 
-    return `${Math.round((size / Math.pow(k, i)) * 100) / 100} ${sizes[i]}`;
+    return `${places === undefined ? Math.round(value * 100) / 100 : value.toFixed(places)} ${SIZE_UNITS[unit]}`;
 }
 
 function toObject<T, R>(array: T[], fn: (arg0: T) => [key: string, value: R]) {

--- a/apps/client/src/setup_backup.css
+++ b/apps/client/src/setup_backup.css
@@ -13,10 +13,38 @@
         text-align: center;
     }
 
-    .backup-download-message {
-        display: flex;
+    /* The spinner beside the words rather than above them, with the label and its count stacked in
+       the second column. Left-aligned, so a percentage does not shift the line about as it grows
+       from one digit to two, and the panel's own centring places the block as a whole. */
+    .backup-download-status {
+        display: grid;
+        grid-template-columns: auto 1fr;
         align-items: center;
         gap: 0.75em;
+        text-align: start;
+    }
+
+    .backup-download-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15em;
+    }
+
+    .backup-download-progress {
+        display: flex;
+        gap: 0.4em;
+        font-size: 0.85em;
+        color: var(--muted-text-color);
+        /* Every digit the same width, so a count that climbs does not jitter the line under it. */
+        font-variant-numeric: tabular-nums;
+
+        /* Held open for the widest it will ever be, so the sizes beside it start at the same place
+           whether the count reads 9% or 100%. Filled from the start, not the end: the reserved
+           space belongs after the number, or a short one would sit indented from the label above
+           it. With tabular figures a digit is exactly 1ch, so five covers "100%". */
+        .backup-download-percent {
+            min-width: 5ch;
+        }
     }
 
     .backup-download-hint {

--- a/apps/client/src/setup_backup.spec.tsx
+++ b/apps/client/src/setup_backup.spec.tsx
@@ -6,7 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("./services/i18n", () => ({ t: (key: string) => key }));
 
 const mocks = vi.hoisted(() => ({
-    startBackupDownload: vi.fn(async () => ({ status: "done" }) as { status: string; message?: string })
+    startBackupDownload: vi.fn(
+        async (
+            _fileName: string,
+            _passphrase?: string,
+            _onProgress?: (sentBytes: number, totalBytes: number) => void
+        ) => ({ status: "done" }) as { status: string; message?: string }
+    )
 }));
 
 vi.mock("./services/backup_download", async (importOriginal) => ({
@@ -162,7 +168,7 @@ describe("choosing what the backup is called and whether it is locked", () => {
         await settle();
 
         expect(mocks.startBackupDownload)
-            .toHaveBeenCalledWith("Before the big import.tnbackup", "hunter2");
+            .toHaveBeenCalledWith("Before the big import.tnbackup", "hunter2", expect.any(Function));
     });
 
     it("downloads under the suggested name, without a password, when neither was touched", async () => {
@@ -173,7 +179,8 @@ describe("choosing what the backup is called and whether it is locked", () => {
         await settle();
 
         // Empty, not absent: the service turns that into an unencrypted container.
-        expect(mocks.startBackupDownload).toHaveBeenCalledWith(`${chosen}.tnbackup`, "");
+        expect(mocks.startBackupDownload)
+            .toHaveBeenCalledWith(`${chosen}.tnbackup`, "", expect.any(Function));
     });
 });
 
@@ -331,6 +338,31 @@ describe("backing up from the setup screen", () => {
         expect(button("setup.backup-download")?.disabled).toBe(false);
         expect(container.querySelector(".backup-download-file")).not.toBeNull();
         expect(button("setup.backup-finish")?.disabled).toBe(false);
+    });
+
+    it("counts the download as it goes, since the browser's own progress is out of sight on a phone", async () => {
+        let report: ((sent: number, total: number) => void) | undefined;
+        mocks.startBackupDownload.mockImplementation((_name, _passphrase, onProgress) => {
+            report = onProgress;
+
+            return new Promise(() => {});
+        });
+        await reachDownload();
+
+        button("setup.backup-download")?.click();
+        await settle();
+        // Nothing yet: a total of nothing has no percentage, and the spinner already says "working".
+        expect(container.querySelector(".backup-download-progress")).toBeNull();
+
+        report?.(512 * 1024 * 1024, 1024 * 1024 * 1024);
+        await settle();
+        expect(container.querySelector(".backup-download-progress")?.textContent)
+            .toContain("setup.backup-downloading-size");
+        // Its own element, which is what lets a width be held for it.
+        expect(container.querySelector(".backup-download-percent")?.textContent)
+            .toBe("setup.backup-downloading-percent");
+        expect(mocks.startBackupDownload).toHaveBeenCalledWith(
+            expect.any(String), "", expect.any(Function));
     });
 
     it("shows what stopped a failed download, and offers another go", async () => {

--- a/apps/client/src/setup_backup.tsx
+++ b/apps/client/src/setup_backup.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from "preact/hooks";
 
 import { backupFileName, startBackupDownload } from "./services/backup_download";
 import { t } from "./services/i18n";
+import { formatSize } from "./services/utils";
 import Admonition from "./widgets/react/Admonition";
 import Button from "./widgets/react/Button";
 import { Card, CardOption, CardSection } from "./widgets/react/Card";
@@ -39,6 +40,8 @@ export interface BackupDownload {
     state: "idle" | "running" | "done" | "failed";
     /** What stopped it, once `failed`. */
     error?: string;
+    /** How far it has got, once the first bytes have gone. */
+    progress?: { sentBytes: number; totalBytes: number };
     start: () => void;
 }
 
@@ -54,15 +57,22 @@ export function useBackupDownload(settings: SetupBackupSettings): BackupDownload
     const fileName = useMemo(() => backupFileName(settings.name), [ settings.name ]);
     const [ state, setState ] = useState<BackupDownload["state"]>("idle");
     const [ error, setError ] = useState<string>();
+    const [ progress, setProgress ] = useState<BackupDownload["progress"]>();
 
     return {
         fileName,
         state,
         error,
+        progress,
         start: () => {
             setState("running");
             setError(undefined);
-            void startBackupDownload(fileName, settings.passphrase).then((result) => {
+            setProgress(undefined);
+
+            const onProgress = (sentBytes: number, totalBytes: number) =>
+                setProgress({ sentBytes, totalBytes });
+
+            void startBackupDownload(fileName, settings.passphrase, onProgress).then((result) => {
                 setState(result.status === "done" ? "done" : "failed");
                 setError(result.status === "done" ? undefined : result.message);
             });
@@ -200,9 +210,15 @@ export function BackupDownloadPanel({ download }: { download: BackupDownload }) 
     if (download.state === "running") {
         return (
             <div class="backup-download">
-                <div class="backup-download-message">
+                {/* The count sits with the spinner rather than apart from it: on a phone the
+                    browser's own download UI is behind the notification shade, so this is the only
+                    sign the application is doing anything, and a spinner alone reads as stuck. */}
+                <div class="backup-download-status">
                     <span class="spinner-border" role="status" aria-hidden="true" />
-                    <span>{t("setup.backup-downloading")}</span>
+                    <div class="backup-download-text">
+                        <span>{t("setup.backup-downloading")}</span>
+                        <DownloadProgress progress={download.progress} />
+                    </div>
                 </div>
                 <div class="backup-download-hint">{t("setup.backup-do-not-close")}</div>
             </div>
@@ -234,6 +250,40 @@ export function BackupDownloadPanel({ download }: { download: BackupDownload }) 
                 kind="primary"
                 onClick={download.start}
             />
+        </div>
+    );
+}
+
+/**
+ * How much of the download has gone, in the two forms a waiting user reads differently: the
+ * percentage answers "how much longer", the sizes answer "is it moving at all".
+ *
+ * Absent until the first bytes are handed over, since a total of nothing has no percentage and
+ * "0 B of 0 B" says less than the spinner does on its own.
+ */
+function DownloadProgress({ progress }: { progress?: BackupDownload["progress"] }) {
+    if (!progress || progress.totalBytes <= 0) {
+        return null;
+    }
+
+    return (
+        <div class="backup-download-progress">
+            {/* Its own element so a width can be held for it: the count grows from one digit to
+                three, and without that the sizes beside it would be shoved along twice. */}
+            <span class="backup-download-percent">
+                {t("setup.backup-downloading-percent", {
+                    // Rounded down, so it never reads 100% while there is still something to write.
+                    percent: Math.floor(100 * progress.sentBytes / progress.totalBytes)
+                })}
+            </span>
+            <span>
+                {/* Fixed places, since these are still counting: dropping a trailing zero would
+                    shorten the line on every other update. */}
+                {t("setup.backup-downloading-size", {
+                    done: formatSize(progress.sentBytes, 2),
+                    total: formatSize(progress.totalBytes, 2)
+                })}
+            </span>
         </div>
     );
 }

--- a/apps/client/src/setup_existing.spec.tsx
+++ b/apps/client/src/setup_existing.spec.tsx
@@ -414,7 +414,8 @@ describe("backing up straight to a download on standalone", () => {
         // The suggested name, and no password, which is what the parameters screen was left at.
         expect(downloadDatabase).toHaveBeenCalledWith(
             expect.stringMatching(/^Trilium data \(\d{4}-\d{2}-\d{2} \d{2}-\d{2}-\d{2}\)\.tnbackup$/),
-            undefined);
+            undefined,
+            expect.any(Function));
         expect(container.textContent).toContain("setup.backup-downloading");
         expect(arrivingButton("setup.continue")?.disabled).toBe(true);
 

--- a/apps/client/src/setup_restore.spec.tsx
+++ b/apps/client/src/setup_restore.spec.tsx
@@ -7,6 +7,8 @@ vi.mock("./services/i18n", () => ({
     t: (key: string, values?: Record<string, unknown>) => [ key, ...Object.values(values ?? {}) ].join(" ")
 }));
 
+import en from "./translations/en/translation.json";
+
 const serverMock = vi.hoisted(() => ({
     // The default serves what transitively imported modules ask for as they load (keyboard_actions
     // fetches its shortcut list on import); the routing installed in beforeEach overrides it.
@@ -27,7 +29,7 @@ const uploadMock = vi.hoisted(() => ({
 }));
 vi.mock("./services/chunked_upload", () => uploadMock);
 
-import RestoreFromBackup from "./setup_restore";
+import RestoreFromBackup, { stageLabel } from "./setup_restore";
 
 const BACKUPS = [
     { fileName: "backup-daily.db", filePath: "/data/backup/backup-daily.db", mtime: "2026-08-01T10:00:00Z", fileSize: 2048, encrypted: false },
@@ -672,5 +674,33 @@ describe("following the restore", () => {
         restore = { stage: "failed", reason: "database-too-old", error: "version 200" };
         await nextPoll();
         expect(headline()).toBe("setup.restore-error-too-old");
+    });
+});
+
+describe("what the restore calls the stage it is at", () => {
+    // Every stage either restore reports: the server's, and the browser-only one which is alone in
+    // reporting the two that end it.
+    const stages = [ "staging", "validating", "swapping", "migrating", "done", "failed" ];
+
+    it("has a sentence for every stage a restore can report", () => {
+        // t() is mocked to hand back the key, so what a label comes back as is the key it looked
+        // up: it has to be one the catalogue actually defines, or the user is shown the key itself.
+        for (const stage of stages) {
+            const label = stageLabel(stage);
+            if (!label) {
+                continue;
+            }
+
+            const [ namespace, key ] = label.split(".");
+            expect(namespace).toBe("setup");
+            expect(en.setup).toHaveProperty(key);
+        }
+    });
+
+    it("says what happens next once the restore is done, rather than naming a finished step", () => {
+        // The frame between the last step and the reload, and the one the user watches hardest.
+        expect(stageLabel("done")).toBe("setup.redirecting");
+        // Nothing is said about a failure here: the screen replacing this one says it properly.
+        expect(stageLabel("failed")).toBe("");
     });
 });

--- a/apps/client/src/setup_restore.spec.tsx
+++ b/apps/client/src/setup_restore.spec.tsx
@@ -697,7 +697,7 @@ describe("what the restore calls the stage it is at", () => {
         }
     });
 
-    it("says what happens next once the restore is done, rather than naming a finished step", () => {
+    it("says what happens next once it is done, rather than naming a finished step", () => {
         // The frame between the last step and the reload, and the one the user watches hardest.
         expect(stageLabel("done")).toBe("setup.redirecting");
         // Nothing is said about a failure here: the screen replacing this one says it properly.

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -605,7 +605,7 @@ function RestoreProgress({ reported, onRestored, onFailed }: {
     // the user three things they will never see happen.
     return (
         <div class="restore-current-step">
-            <div class="restore-step-name">{t(`setup.restore-stage-${shownStage}`)}</div>
+            <div class="restore-step-name">{stageLabel(shownStage)}</div>
 
             {/* Only where the step can say how far it has got. The ones that cannot show nothing,
                 rather than an empty bar that never moves. */}
@@ -619,4 +619,29 @@ function RestoreProgress({ reported, onRestored, onFailed }: {
             <small class="restore-do-not-close">{t("setup.restore-do-not-close")}</small>
         </div>
     );
+}
+
+/**
+ * What to call the stage the restore says it is at.
+ *
+ * Spelled out rather than composed into a key. Built as `restore-stage-${stage}`, a stage nobody
+ * wrote a sentence for printed its own key at the user: `done` is reported by the browser-only
+ * restore in the moment between the last step and the reload, and that moment is the one the user
+ * is watching hardest.
+ *
+ * `done` is not a step at all but what follows the last one, so it says what is about to happen
+ * instead of naming something already finished. A failure says nothing here, because the screen it
+ * is about to be replaced by says it properly.
+ */
+export function stageLabel(stage: string): string {
+    switch (stage) {
+        case "validating": return t("setup.restore-stage-validating");
+        case "swapping": return t("setup.restore-stage-swapping");
+        case "migrating": return t("setup.restore-stage-migrating");
+        case "done": return t("setup.redirecting");
+        case "failed": return "";
+        // Staging both as itself and as the answer for a stage this does not know: whatever it is
+        // called, a restore that has not ended is one still working on the backup.
+        default: return t("setup.restore-stage-staging");
+    }
 }

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -321,6 +321,7 @@ function headlineFor(reason: string | undefined): string {
         case "swap-failed-reload": return t("setup.restore-error-swap-failed-reload");
         case "check-failed": return t("setup.restore-error-check-failed");
         case "restore-failed": return t("setup.restore-error-failed");
+        case "backup-incomplete": return t("setup.restore-error-incomplete");
         case "migration-failed": return t("setup.restore-error-would-not-open");
         case "restore-refused": return t("setup.restore-error-refused");
         case "already-initialized": return t("setup.restore-error-already-initialized");

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -319,6 +319,8 @@ function headlineFor(reason: string | undefined): string {
         case "database-not-initialized": return t("setup.restore-error-unfinished");
         case "swap-failed": return t("setup.restore-error-swap-failed");
         case "swap-failed-reload": return t("setup.restore-error-swap-failed-reload");
+        case "check-failed": return t("setup.restore-error-check-failed");
+        case "restore-failed": return t("setup.restore-error-failed");
         case "migration-failed": return t("setup.restore-error-would-not-open");
         case "restore-refused": return t("setup.restore-error-refused");
         case "already-initialized": return t("setup.restore-error-already-initialized");

--- a/apps/client/src/setup_restore.tsx
+++ b/apps/client/src/setup_restore.tsx
@@ -318,6 +318,7 @@ function headlineFor(reason: string | undefined): string {
         case "database-too-old": return t("setup.restore-error-too-old");
         case "database-not-initialized": return t("setup.restore-error-unfinished");
         case "swap-failed": return t("setup.restore-error-swap-failed");
+        case "swap-failed-reload": return t("setup.restore-error-swap-failed-reload");
         case "migration-failed": return t("setup.restore-error-would-not-open");
         case "restore-refused": return t("setup.restore-error-refused");
         case "already-initialized": return t("setup.restore-error-already-initialized");

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3747,6 +3747,8 @@
     "restore-error-unfinished": "This backup was taken from a setup that was never finished, so there is nothing in it to restore.",
     "restore-error-swap-failed": "The database could not be replaced. Your previous database is back in place.",
     "restore-error-swap-failed-reload": "The database could not be replaced. Your previous database is back in place, but Trilium could not reopen it. Reload this page to continue.",
+    "restore-error-check-failed": "The backup could not be checked. This may be a problem on this device rather than with the backup itself, so it is worth trying again.",
+    "restore-error-failed": "The restore could not be completed. Nothing was replaced, so your knowledge base is as it was.",
     "restore-error-would-not-open": "The restored database could not be opened. Your previous database is back in place.",
     "restore-error-refused": "Another setup step is already running.",
     "restore-error-already-initialized": "This instance already has a knowledge base, so it cannot be restored over. Reload the page.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3749,6 +3749,7 @@
     "restore-error-swap-failed-reload": "The database could not be replaced. Your previous database is back in place, but Trilium could not reopen it. Reload this page to continue.",
     "restore-error-check-failed": "The backup could not be checked. This may be a problem on this device rather than with the backup itself, so it is worth trying again.",
     "restore-error-failed": "The restore could not be completed. Nothing was replaced, so your knowledge base is as it was.",
+    "restore-error-incomplete": "This backup file is incomplete. It was probably not copied or downloaded in full, so try transferring it again.",
     "restore-error-would-not-open": "The restored database could not be opened. Your previous database is back in place.",
     "restore-error-refused": "Another setup step is already running.",
     "restore-error-already-initialized": "This instance already has a knowledge base, so it cannot be restored over. Reload the page.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3746,6 +3746,7 @@
     "restore-error-too-old": "This backup is from a version of Trilium that is too old to be restored.",
     "restore-error-unfinished": "This backup was taken from a setup that was never finished, so there is nothing in it to restore.",
     "restore-error-swap-failed": "The database could not be replaced. Your previous database is back in place.",
+    "restore-error-swap-failed-reload": "The database could not be replaced. Your previous database is back in place, but Trilium could not reopen it. Reload this page to continue.",
     "restore-error-would-not-open": "The restored database could not be opened. Your previous database is back in place.",
     "restore-error-refused": "Another setup step is already running.",
     "restore-error-already-initialized": "This instance already has a knowledge base, so it cannot be restored over. Reload the page.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3723,6 +3723,8 @@
     "backup-file": "Backup will be saved as",
     "backup-download": "Generate and download backup",
     "backup-downloading": "Downloading...",
+    "backup-downloading-percent": "{{percent}}%",
+    "backup-downloading-size": "({{done}} of {{total}})",
     "backup-do-not-close": "Please do not switch away or close this screen until the download completes.",
     "backup-downloaded": "The download has completed. Press \"Finish\" to return to the application.",
     "backup-download-failed": "The download did not finish.",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2106,7 +2106,9 @@
     "encrypted": "Encrypted"
   },
   "database_file_list": {
-    "size_on_disk": "{{size}} on disk"
+    "size_on_disk": "{{size}} on disk",
+    "invalid_backup": "Invalid backup file",
+    "unsupported_version": "Unsupported backup file format version"
   },
   "password_with_confirmation": {
     "password": "Password",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ import { setupDialogHandlers } from "./services/dialog";
 import { setupExportHandlers } from "./services/export";
 import { setupImportHandlers } from "./services/import";
 import {
+    adoptBackupPassphrase,
     getBackupPassphrase,
     registerBackupPassphraseIpcHandlers
 } from "./services/backup_passphrase";
@@ -275,7 +276,11 @@ export async function main() {
         // Only the desktop lets the user pick where backups go; the server uses TRILIUM_BACKUP_DIR.
         backup: new ServerBackupService(
             options,
-            { allowCustomDirectory: true, getPassphrase: getBackupPassphrase }
+            {
+                allowCustomDirectory: true,
+                getPassphrase: getBackupPassphrase,
+                setPassphrase: adoptBackupPassphrase
+            }
         ),
         image: (await import("@triliumnext/server/src/services/image_provider.js")).serverImageProvider,
         config,

--- a/apps/desktop/src/services/backup_passphrase.spec.ts
+++ b/apps/desktop/src/services/backup_passphrase.spec.ts
@@ -142,6 +142,19 @@ describe("backup passphrase storage", () => {
         expect(h.errors.join()).toContain("keyring is locked");
         expect(h.errors.join()).not.toContain("hunter2");
     });
+
+    it("takes on a restored backup's password, and drops the old one when it brings none", async () => {
+        // The passphrase is not in the database, so a restore replaces every option saying how this
+        // instance backs up and leaves the password those options are carried out with. Kept, the
+        // instance encrypts with a password belonging to a database that is no longer here.
+        await passphrase.storeBackupPassphrase("the previous database's");
+
+        await passphrase.adoptBackupPassphrase("the restored database's");
+        expect(await passphrase.getBackupPassphrase()).toBe("the restored database's");
+
+        await passphrase.adoptBackupPassphrase(null);
+        expect(await passphrase.getBackupPassphrase()).toBeNull();
+    });
 });
 
 describe("keyring availability", () => {

--- a/apps/desktop/src/services/backup_passphrase.ts
+++ b/apps/desktop/src/services/backup_passphrase.ts
@@ -61,6 +61,27 @@ export function clearBackupPassphrase(): void {
 }
 
 /**
+ * Takes on the passphrase a restored backup was locked with, or lets the stored one go when the
+ * backup brought none.
+ *
+ * Unlike the renderer's way in, this asks nothing first. What the user typed to open the backup is
+ * a password for this database, given moments ago and for this purpose; the confirmation on the
+ * options screen guards against a password being changed behind someone's back, and here there is
+ * nobody's back to go behind.
+ *
+ * Clearing is the honest answer to a backup with no passphrase to take: the stored one belongs to a
+ * database that is no longer here, and going on encrypting with it produces backups the user cannot
+ * open. Encrypted backups then fall back to unencrypted and local, which says so out loud.
+ */
+export async function adoptBackupPassphrase(passphrase: string | null): Promise<void> {
+    if (passphrase) {
+        await storeBackupPassphrase(passphrase);
+    } else {
+        clearBackupPassphrase();
+    }
+}
+
+/**
  * Reads the passphrase back, for the main process alone. Never reachable from the renderer.
  *
  * Returns `null` when there is nothing stored, or when the blob cannot be decrypted — which happens

--- a/apps/server/src/backup_provider.spec.ts
+++ b/apps/server/src/backup_provider.spec.ts
@@ -679,3 +679,21 @@ describe("ServerBackupService: sending a backup for download", () => {
         expect(desktopService(CUSTOM_DIR).sendBackup?.("/etc/passwd", res as any)).toBe(false);
     });
 });
+
+describe("ServerBackupService.adoptPassphrase", () => {
+    it("hands the password to wherever this platform keeps one, and clears it on null", async () => {
+        const stored: (string | null)[] = [];
+        const service = desktopService("", {}, { setPassphrase: async (p) => void stored.push(p) });
+
+        await service.adoptPassphrase("the restored database's password");
+        await service.adoptPassphrase(null);
+
+        expect(stored).toEqual([ "the restored database's password", null ]);
+    });
+
+    it("does nothing where there is nowhere to keep one, rather than failing the restore", async () => {
+        // The server has no keyring, so it has no stored passphrase for a restore to bring up to
+        // date; the restore calls this the same way regardless of the platform it is running on.
+        await expect(serverService(null).adoptPassphrase("a password")).resolves.toBeUndefined();
+    });
+});

--- a/apps/server/src/backup_provider.spec.ts
+++ b/apps/server/src/backup_provider.spec.ts
@@ -257,7 +257,7 @@ describe("ServerBackupService: backup format", () => {
         expect(byName.get("backup-plain.db")).not.toHaveProperty("plaintextSize");
     });
 
-    it("lists a container it cannot make sense of, rather than dropping it", async () => {
+    it("lists a container it cannot make sense of, saying so rather than dropping it", async () => {
         fs.mkdirSync(DEFAULT_DIR, { recursive: true });
         fs.writeFileSync(
             path.join(DEFAULT_DIR, "backup-damaged.tnbackup"),
@@ -266,9 +266,32 @@ describe("ServerBackupService: backup format", () => {
 
         const backups = await desktopService("").getExistingBackups();
 
+        // Listed, because a file sitting in the backup directory is one the user is relying on,
+        // and saying it is no good is the whole point of listing it.
         expect(backups.map((b) => b.fileName)).toEqual([ "backup-damaged.tnbackup" ]);
+        expect(backups[0]).toMatchObject({ unreadable: "invalid" });
         expect(backups[0]).not.toHaveProperty("compressed");
         expect(backups[0]).not.toHaveProperty("encrypted");
+    });
+
+    it("tells a backup from a newer Trilium apart from one that is not a backup", async () => {
+        fs.mkdirSync(DEFAULT_DIR, { recursive: true });
+
+        const compressing = desktopService("", { backupEnableCompression: "true" });
+        const newer = fs.readFileSync(await compressing.backupNow("daily"));
+        // The version byte, straight after the magic. Everything else about the file is intact,
+        // which is exactly the case that must not read as damaged.
+        newer.writeUInt8(2, 20);
+        fs.writeFileSync(path.join(DEFAULT_DIR, "backup-newer.tnbackup"), newer);
+
+        const byName = new Map(
+            (await desktopService("").getExistingBackups()).map((b) => [ b.fileName, b ])
+        );
+
+        expect(byName.get("backup-newer.tnbackup")).toMatchObject({
+            unreadable: "unsupported-version"
+        });
+        expect(byName.get("backup-daily.tnbackup")).not.toHaveProperty("unreadable");
     });
 });
 

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -305,7 +305,8 @@ function listBackupsIn(directory: string): DatabaseBackup[] {
  * the shape it was written in, whatever the settings have since become.
  *
  * Only the fixed header is read, so this costs a few dozen bytes per file and never needs the
- * passphrase. A file whose header does not parse is listed as a plain one rather than not at all.
+ * passphrase. A file that is not a container this build can open is still listed, saying why: it is
+ * sitting in the backup directory being counted as a backup, and the user is relying on it.
  */
 function describeContainer(filePath: string, fileName: string): Partial<DatabaseBackup> {
     if (!fileName.endsWith(CONTAINER_EXTENSION)) {
@@ -313,11 +314,13 @@ function describeContainer(filePath: string, fileName: string): Partial<Database
     }
 
     const head = Buffer.alloc(FIXED_HEADER_BYTES);
+    let read: number;
     let descriptor: number | undefined;
     try {
         descriptor = fs.openSync(filePath, "r");
-        fs.readSync(descriptor, head, 0, head.length, 0);
+        read = fs.readSync(descriptor, head, 0, head.length, 0);
     } catch {
+        // Nothing was learned, which is not the same as having learned the file is no good.
         return {};
     } finally {
         if (descriptor !== undefined) {
@@ -325,9 +328,14 @@ function describeContainer(filePath: string, fileName: string): Partial<Database
         }
     }
 
-    const info = getInfo(head);
-    if (!info.isValid || !info.isSupported) {
-        return {};
+    // Only what the file actually held, so a file too short to have a header is judged on that
+    // rather than on the zeroes the buffer came with.
+    const info = getInfo(head.subarray(0, read));
+    if (!info.isValid) {
+        return { unreadable: "invalid" };
+    }
+    if (!info.isSupported) {
+        return { unreadable: "unsupported-version" };
     }
 
     return {

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -1,6 +1,6 @@
 import {
     FIXED_HEADER_BYTES,
-    peekBackupContainer,
+    getInfo,
     writeBackupContainer
 } from "@triliumnext/backup-container";
 import type {
@@ -325,16 +325,16 @@ function describeContainer(filePath: string, fileName: string): Partial<Database
         }
     }
 
-    const info = peekBackupContainer(head);
-    if (!info) {
+    const info = getInfo(head);
+    if (!info.isValid || !info.isSupported) {
         return {};
     }
 
     return {
-        compressed: info.compressed,
-        encrypted: info.encrypted,
+        compressed: info.isCompressed,
+        encrypted: info.isEncrypted,
         // Recorded as 0 when the writer did not know it, which reads the same as "not stated".
-        plaintextSize: info.plaintextSize > 0 ? info.plaintextSize : undefined
+        plaintextSize: info.size > 0 ? info.size : undefined
     };
 }
 

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -35,6 +35,13 @@ export interface ServerBackupConfig {
      * desktop application, which is the only one with an OS keyring to keep a passphrase in.
      */
     getPassphrase?: () => Promise<string | null>;
+    /**
+     * Stores the backup passphrase, or lets go of the stored one when given `null`. Set alongside
+     * {@link getPassphrase}, and used by the restore rather than by any screen: unset, an instance
+     * simply has nowhere to keep a passphrase, and there is nothing for a restore to bring up to
+     * date.
+     */
+    setPassphrase?: (passphrase: string | null) => Promise<void>;
 }
 
 /** How a backup is to be written, once the options and the passphrase have both had their say. */
@@ -180,6 +187,19 @@ export default class ServerBackupService extends BackupService {
     /** Whether there is a passphrase to be had, without letting the caller learn what it is. */
     override async hasStoredPassphrase(): Promise<boolean> {
         return !!(await this.config.getPassphrase?.());
+    }
+
+    /**
+     * Takes on the passphrase a restored backup was locked with, or lets go of the stored one when
+     * the backup brought none.
+     *
+     * The passphrase is not kept in the database, so a restore replaces every option that says how
+     * this instance backs up while leaving the password those options are carried out with. What is
+     * left is an instance encrypting its backups with the password of a database that is no longer
+     * here, saying nothing about it, and producing backups the user cannot open.
+     */
+    async adoptPassphrase(passphrase: string | null): Promise<void> {
+        await this.config.setPassphrase?.(passphrase);
     }
 
     /**

--- a/apps/server/src/backup_provider.ts
+++ b/apps/server/src/backup_provider.ts
@@ -11,7 +11,6 @@ import type {
 import { BackupOptionsService, BackupService, getLog, sync_mutex as syncMutexService, utils as coreUtils, ws } from "@triliumnext/core";
 import type { Response } from "express";
 import fs from "fs";
-import fsp from "fs/promises";
 import { t } from "i18next";
 import path from "path";
 
@@ -401,17 +400,7 @@ async function writeContainer(
             compress: format.compress,
             passphrase: format.passphrase ?? undefined,
             plaintextSize: fs.statSync(snapshot).size,
-            onProgress,
-            // The digest is only known once the payload is written, so it is patched in afterwards.
-            patchHeader: async (offset, data) => {
-                const handle = await fsp.open(partial, "r+");
-                try {
-                    await handle.write(data, 0, data.length, offset);
-                    await handle.sync();
-                } finally {
-                    await handle.close();
-                }
-            }
+            onProgress
         });
 
         // Renamed last, so a half-written container is never mistaken for a finished one.

--- a/apps/server/src/services/database_restore.spec.ts
+++ b/apps/server/src/services/database_restore.spec.ts
@@ -2,7 +2,6 @@ import { writeBackupContainer } from "@triliumnext/backup-container";
 import { app_info as appInfo, getLog, getSql } from "@triliumnext/core";
 import Database from "better-sqlite3";
 import fs from "fs";
-import fsp from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -57,15 +56,7 @@ async function containerOf(source: string, passphrase?: string, compress = false
     await writeBackupContainer(fs.createReadStream(source), fs.createWriteStream(filePath), {
         compress,
         passphrase,
-        plaintextSize: fs.statSync(source).size,
-        patchHeader: async (offset, data) => {
-            const handle = await fsp.open(filePath, "r+");
-            try {
-                await handle.write(data, 0, data.length, offset);
-            } finally {
-                await handle.close();
-            }
-        }
+        plaintextSize: fs.statSync(source).size
     });
 
     return filePath;

--- a/apps/server/src/services/database_restore.spec.ts
+++ b/apps/server/src/services/database_restore.spec.ts
@@ -1,13 +1,15 @@
 import { writeBackupContainer } from "@triliumnext/backup-container";
-import { app_info as appInfo, getLog, getSql } from "@triliumnext/core";
+import { app_info as appInfo, getBackup, getLog, getSql } from "@triliumnext/core";
 import Database from "better-sqlite3";
 import fs from "fs";
 import os from "os";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type ServerBackupService from "../backup_provider.js";
 import dataDir from "./data_dir.js";
 import {
+    adoptBackupPassphrase,
     exchangeDatabaseFiles,
     getRestoreProgress,
     logRestore,
@@ -18,6 +20,7 @@ import {
     reportRestoreFailure,
     restoreDatabase,
     RestoreFailure,
+    type RestoreRequest,
     stageBackup
 } from "./database_restore.js";
 
@@ -477,5 +480,49 @@ describe("restoring a database", () => {
 
         expect(detach).not.toHaveBeenCalled();
         expect(getRestoreProgress()).toMatchObject({ stage: "failed", reason: "database-too-new" });
+    });
+});
+
+describe("the backup password after a restore", () => {
+    /** What the restore reaches for: the desktop's keyring, by way of the backup service. */
+    const backupService = () => getBackup() as ServerBackupService;
+
+    function request(passphrase?: string): RestoreRequest {
+        const fileName = "backup.tnbackup";
+
+        return { path: fileName, fileName, consumable: false, passphrase };
+    }
+
+    it("takes on the password that opened the backup, which is this database's now", async () => {
+        const adopted = vi.spyOn(backupService(), "adoptPassphrase").mockResolvedValue();
+
+        await adoptBackupPassphrase(request("the newer database's password"), true);
+
+        expect(adopted).toHaveBeenCalledWith("the newer database's password");
+    });
+
+    it.each([
+        [ "an unlocked backup", undefined ],
+        [ "a password typed for a backup that turned out not to need one", "typed anyway" ]
+    ])("lets go of the stored password after %s", async (_label, passphrase) => {
+        // The stored one belongs to the database that was here before. Kept, this instance goes on
+        // encrypting with it and writes backups the password the user expects will not open.
+        const adopted = vi.spyOn(backupService(), "adoptPassphrase").mockResolvedValue();
+
+        await adoptBackupPassphrase(request(passphrase), false);
+
+        expect(adopted).toHaveBeenCalledWith(null);
+    });
+
+    it("does not fail a restore that already happened over a keyring that will not answer", async () => {
+        const said: string[] = [];
+        vi.spyOn(getLog(), "error").mockImplementation((message) => said.push(String(message)));
+        vi.spyOn(backupService(), "adoptPassphrase")
+            .mockRejectedValue(new Error("the keyring is locked"));
+
+        // The database is in place and open by this point; there is nothing left to undo and no
+        // honest way to call the restore failed.
+        await expect(adoptBackupPassphrase(request("a password"), true)).resolves.toBeUndefined();
+        expect(said.join("\n")).toContain("the keyring is locked");
     });
 });

--- a/apps/server/src/services/database_restore.ts
+++ b/apps/server/src/services/database_restore.ts
@@ -10,6 +10,7 @@ import {
     cls,
     type DatabaseRejection,
     events as eventService,
+    getBackup,
     getLog,
     getSql,
     leaveSetupMode,
@@ -19,6 +20,7 @@ import {
 import fs from "fs";
 import path from "path";
 
+import type ServerBackupService from "../backup_provider.js";
 import config from "./config.js";
 import dataDir from "./data_dir.js";
 import { validateDatabaseFile } from "./database_validation.js";
@@ -256,6 +258,10 @@ export async function restoreDatabase(request: RestoreRequest): Promise<void> {
     // is stated below in terms that are not.
     logRestore(`starting, from ${request.consumable ? "a backup this instance was given" : "a backup already on this device"}`);
 
+    // Read here rather than taken from the staging that follows, which consumes a backup this
+    // instance was given: by the time the restore has finished there may be no file left to ask.
+    const wasEncrypted = readBackupFormat(request.path)?.encrypted ?? false;
+
     // Announced through `report` like every other step, so that a log can be read by looking for the
     // steps alone and the first one is not the exception that is missing.
     progress = { stage: "staging", fileName: request.fileName };
@@ -283,6 +289,8 @@ export async function restoreDatabase(request: RestoreRequest): Promise<void> {
             await openRestoredDatabase(validation.needsMigration);
         });
 
+        await adoptBackupPassphrase(request, wasEncrypted);
+
         report("done");
         logRestore(`finished in ${describeElapsed(startedAt)}`);
     } catch (e) {
@@ -307,6 +315,39 @@ export async function restoreDatabase(request: RestoreRequest): Promise<void> {
         // a directory that would not delete used to bury the reason the restore actually failed —
         // and with it the client's only way of telling a wrong passphrase from a broken backup.
         removeQuietly(stagingDirectory(), { recursive: true });
+    }
+}
+
+/**
+ * Brings the stored backup passphrase into line with the database that has just been restored.
+ *
+ * The passphrase lives outside the database — an OS keyring on the desktop, nowhere at all
+ * elsewhere — so it is the one thing about how this instance backs up that a restore does not
+ * replace. Left alone, an instance restored from someone else's backup goes on encrypting with the
+ * password of the database it used to hold: the backups look fine, and the password the user
+ * expects does not open them.
+ *
+ * Never allowed to fail the restore. The database is already in place and open by this point, and a
+ * keyring that would not answer is not a reason to tell the user their restore did not work.
+ *
+ * @param wasEncrypted whether the backup was locked, which is what decides there is a password here
+ *                     worth taking on at all.
+ */
+export async function adoptBackupPassphrase(
+    request: RestoreRequest,
+    wasEncrypted: boolean
+): Promise<void> {
+    // A backup with no lock on it brings no password to take on, and the stored one is not an
+    // answer: it was the previous database's.
+    const passphrase = wasEncrypted ? request.passphrase ?? null : null;
+
+    try {
+        await (getBackup() as ServerBackupService).adoptPassphrase(passphrase);
+        logRestore(passphrase
+            ? "the backup password is now the one that opened this backup"
+            : "let go of the backup password, which belonged to the previous database");
+    } catch (e) {
+        logRestoreError(`the backup password could not be brought up to date: ${messageOf(e)}`);
     }
 }
 

--- a/apps/server/src/services/database_restore.ts
+++ b/apps/server/src/services/database_restore.ts
@@ -1,8 +1,8 @@
 import {
     type BackupContainerErrorReason,
     FIXED_HEADER_BYTES,
+    getInfo,
     isBackupContainerError,
-    peekBackupContainer,
     type ProgressCallback,
     readBackupContainer
 } from "@triliumnext/backup-container";
@@ -416,9 +416,12 @@ export function readBackupFormat(filePath: string): BackupFormat | null {
         }
     }
 
-    const container = peekBackupContainer(head);
+    const container = getInfo(head);
+    // A version this build cannot open is left to the reader to refuse, which it does by name; here
+    // it is only ever a file this path has no way to unwrap.
+    const readable = container.isValid && container.isSupported;
 
-    return { container: !!container, encrypted: container?.encrypted ?? false };
+    return { container: readable, encrypted: readable && container.isEncrypted };
 }
 
 /**

--- a/apps/standalone/src/lightweight/backup-download.spec.ts
+++ b/apps/standalone/src/lightweight/backup-download.spec.ts
@@ -15,10 +15,13 @@ const FAST_SCRYPT = { log2N: 10, r: 8, p: 1 };
 /** A reader serving `PAGE_COUNT` constant-filled pages, with steady write counters. */
 function fakeReader(): LiveDatabaseReader {
     return {
-        getValue(sql: string, params?: unknown[]) {
-            if (sql.includes("sqlite_dbpage")) {
-                return new Uint8Array(PAGE_SIZE).fill((params?.[0] as number) & 0xff);
-            }
+        getColumn(_sql: string, params?: unknown[]) {
+            const [ first, last ] = params as [ number, number ];
+
+            return Array.from({ length: last - first + 1 }, (_unused, index) =>
+                new Uint8Array(PAGE_SIZE).fill((first + index) & 0xff));
+        },
+        getValue(sql: string) {
             if (sql.includes("page_size")) {
                 return PAGE_SIZE;
             }
@@ -172,7 +175,7 @@ describe("streamDatabaseDownload", () => {
 
     it("reports a database that cannot even be sized, before any begin", async () => {
         const port = fakePort();
-        const outcome = await streamDatabaseDownload({ getValue: () => 0 }, port);
+        const outcome = await streamDatabaseDownload({ getValue: () => 0, getColumn: () => [] }, port);
 
         expect(outcome).toMatchObject({ status: "failed" });
         expect(port.sent).toHaveLength(1);
@@ -184,8 +187,9 @@ describe("streamDatabaseDownload", () => {
     it("reports a failure mid-stream through the port rather than throwing", async () => {
         const reader = fakeReader();
         const broken: LiveDatabaseReader = {
-            getValue: (sql, params) =>
-                sql.includes("sqlite_dbpage") ? new Uint8Array(3) : reader.getValue(sql, params)
+            getValue: (sql, params) => reader.getValue(sql, params),
+            getColumn: (sql, params) =>
+                (reader.getColumn(sql, params) as Uint8Array[]).map(() => new Uint8Array(3))
         };
         const port = fakePort();
         const running = streamDatabaseDownload(broken, port);

--- a/apps/standalone/src/lightweight/backup-download.spec.ts
+++ b/apps/standalone/src/lightweight/backup-download.spec.ts
@@ -1,5 +1,5 @@
 import { readBackupContainer } from "@triliumnext/backup-container";
-import { streamedContainerSize } from "@triliumnext/backup-container/web";
+import { containerSize } from "@triliumnext/backup-container/web";
 import { Readable, Writable } from "stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -106,7 +106,7 @@ describe("streamDatabaseDownload", () => {
         expect(outcome).toEqual({ status: "done" });
         // One format whether or not a password was given, so one extension and one restore path.
         expect(port.sent[0])
-            .toEqual({ type: "begin", byteSize: streamedContainerSize(PAGE_SIZE * PAGE_COUNT, false) });
+            .toEqual({ type: "begin", byteSize: containerSize(PAGE_SIZE * PAGE_COUNT, false) });
         expect(port.chunks().reduce((total, chunk) => total + chunk.byteLength, 0))
             .toBe(port.sent[0].byteSize);
         expect(port.sent.at(-1)).toEqual({ type: "end" });
@@ -131,7 +131,7 @@ describe("streamDatabaseDownload", () => {
         expect(outcome).toEqual({ status: "done" });
         // The announced size is what the download's Content-Length becomes, so it must be exact.
         const announced = port.sent[0].byteSize;
-        expect(announced).toBe(streamedContainerSize(PAGE_SIZE * PAGE_COUNT, true));
+        expect(announced).toBe(containerSize(PAGE_SIZE * PAGE_COUNT, true));
         const streamed = port.chunks().reduce((total, chunk) => total + chunk.byteLength, 0);
         expect(streamed).toBe(announced);
 

--- a/apps/standalone/src/lightweight/backup-download.ts
+++ b/apps/standalone/src/lightweight/backup-download.ts
@@ -1,6 +1,6 @@
 import {
     type ScryptParams,
-    streamedContainerSize,
+    containerSize,
     writeBackupContainer
 } from "@triliumnext/backup-container/web";
 
@@ -19,11 +19,11 @@ import { type LiveDatabaseReader, streamLiveDatabasePages } from "./backup-strea
  * the service worker asks for a chunk each time the download can take more, so a slow disk slows
  * the database reads rather than piling chunks up in a message queue.
  *
- * The payload is the plain database, or, given a passphrase, a streamed encrypted container: the
- * format's forward-only shape, whose GCM frames carry the integrity a patched-in digest cannot on
- * a destination already streamed away. Compression is never used here — at these sizes it is more
- * than a low-end device can afford — and either shape's exact size is known up front, which is
- * what gives the download its `Content-Length` and the browser its progress bar.
+ * The payload is always a container, encrypted when a passphrase is given and plain otherwise, and
+ * either way its trailer carries a digest over what was written. Nothing is ever written back to,
+ * which is what lets a destination like this one hold the format at all. Compression is never used
+ * here, at these sizes it is more than a low-end device can afford, and leaving it off is also what
+ * keeps the size exact: that is what gives the download its `Content-Length` and its progress bar.
  *
  * Protocol, from the service worker's side: it receives `begin` (with the exact byte size), then
  * one `chunk` per `pull` it sends, then `end`; `error` may arrive at any point, and `cancel` may
@@ -47,7 +47,7 @@ export interface DownloadOutcome {
 }
 
 export interface DownloadOptions {
-    /** Wraps the stream in an encrypted, streamed container. Plain database bytes otherwise. */
+    /** Encrypts the container. Without one it is still a container, just an unlocked one. */
     passphrase?: string;
     /** scrypt cost override, for tests that cannot afford the production one. */
     scrypt?: ScryptParams;
@@ -130,18 +130,18 @@ export async function streamDatabaseDownload(
         source = stream;
 
         // A container either way, so every backup this application writes has one shape and one
-        // extension. Without a passphrase it is the database with a header in front of it, held to
-        // the size that header records; with one, every frame is authenticated as well.
+        // extension. Without a passphrase it is the database between a header and a trailer, the
+        // trailer's digest vouching for it; with one, every frame is authenticated as well.
         const encrypted = !!options.passphrase;
-        port.postMessage({ type: "begin", byteSize: streamedContainerSize(byteSize, encrypted) });
+        port.postMessage({ type: "begin", byteSize: containerSize(byteSize, encrypted) });
         await writeBackupContainer(
             stream,
             new WritableStream<Uint8Array>({ write: sendChunk }),
             {
                 passphrase: options.passphrase,
-                streamed: true,
                 // Never compressed: at these sizes it costs more than a low-end device can spare,
-                // and the browser is downloading to a disk rather than over a wire.
+                // and the browser is downloading to a disk rather than over a wire. It is also what
+                // keeps the size above exact, which is what gives the download a progress bar.
                 plaintextSize: byteSize,
                 scrypt: options.scrypt
             }

--- a/apps/standalone/src/lightweight/backup-download.ts
+++ b/apps/standalone/src/lightweight/backup-download.ts
@@ -4,7 +4,11 @@ import {
     writeBackupContainer
 } from "@triliumnext/backup-container/web";
 
-import { type LiveDatabaseReader, streamLiveDatabasePages } from "./backup-stream.js";
+import {
+    type LiveDatabaseReader,
+    streamLiveDatabasePages,
+    type StreamTiming
+} from "./backup-stream.js";
 
 /**
  * Feeds a database backup into a download the service worker is holding open.
@@ -110,9 +114,21 @@ export async function streamDatabaseDownload(
         return requests.shift() ?? "cancel";
     };
 
+    /**
+     * How long was spent with a chunk ready and nowhere to put it.
+     *
+     * The one thing this side cannot make faster: the browser asks for the next piece as it commits
+     * the last one to disk, so a large figure here means the download itself is the limit and no
+     * amount of reading or hashing faster would show up in the total.
+     */
+    let waitedMs = 0;
+
     /** Posts one chunk per granted pull, or throws the stop that was granted instead. */
     const sendChunk = async (chunk: Uint8Array): Promise<void> => {
+        const waitingSince = Date.now();
         const request = await nextRequest();
+        waitedMs += Date.now() - waitingSince;
+
         if (request !== "pull") {
             throw new DownloadStopped(request);
         }
@@ -125,8 +141,9 @@ export async function streamDatabaseDownload(
     };
 
     let source: ReadableStream<Uint8Array> | undefined;
+    const startedAt = Date.now();
     try {
-        const { byteSize, stream } = streamLiveDatabasePages(db);
+        const { byteSize, stream, timing } = streamLiveDatabasePages(db);
         source = stream;
 
         // A container either way, so every backup this application writes has one shape and one
@@ -147,6 +164,8 @@ export async function streamDatabaseDownload(
             }
         );
         port.postMessage({ type: "end" });
+        reportTiming(byteSize, timing, waitedMs, Date.now() - startedAt);
+
         return { status: "done" };
     } catch (e) {
         if (e instanceof DownloadStopped) {
@@ -167,6 +186,34 @@ export async function streamDatabaseDownload(
         port.onmessage = null;
         port.close?.();
     }
+}
+
+/**
+ * One line saying where a backup's time went, split three ways so a slow one can be acted on.
+ *
+ * `read` is the database coming out through SQLite, `waiting` is having a chunk ready and the
+ * download not yet asking for it, and what neither accounts for is the hashing and encryption in
+ * between. Only the first is worth optimising: waiting is the browser committing the file to disk,
+ * which is the floor, and the rest is a hash the format cannot do without.
+ */
+function reportTiming(
+    byteSize: number,
+    timing: StreamTiming,
+    waitedMs: number,
+    totalMs: number
+): void {
+    const mib = byteSize / (1024 * 1024);
+    const rate = (ms: number) => (ms > 0 ? mib / (ms / 1000) : 0).toFixed(1);
+    const share = (ms: number) => Math.round(100 * ms / Math.max(totalMs, 1));
+    const restMs = Math.max(0, totalMs - timing.readMs - waitedMs);
+
+    console.log(
+        `[Backup] ${mib.toFixed(0)} MiB in ${(totalMs / 1000).toFixed(1)}s (${rate(totalMs)} MiB/s). `
+            + `Reads ${(timing.readMs / 1000).toFixed(1)}s (${share(timing.readMs)}%, `
+            + `${rate(timing.readMs)} MiB/s over ${timing.pages} pages), `
+            + `waiting on the download ${(waitedMs / 1000).toFixed(1)}s (${share(waitedMs)}%), `
+            + `hashing and crypto ${(restMs / 1000).toFixed(1)}s (${share(restMs)}%).`
+    );
 }
 
 /** A best-effort message: the port may already be gone, and this report is all that would say so. */

--- a/apps/standalone/src/lightweight/backup-download.ts
+++ b/apps/standalone/src/lightweight/backup-download.ts
@@ -55,7 +55,23 @@ export interface DownloadOptions {
     passphrase?: string;
     /** scrypt cost override, for tests that cannot afford the production one. */
     scrypt?: ScryptParams;
+    /**
+     * How much of the download has been handed over, for a screen to show.
+     *
+     * Called no more often than {@link PROGRESS_INTERVAL_MS}, and once at the end. Bytes rather
+     * than a fraction, because the screen shows both, and this is the only place that knows the
+     * total before the browser does.
+     */
+    onProgress?: (sentBytes: number, totalBytes: number) => void;
 }
+
+/**
+ * How often progress is worth reporting.
+ *
+ * A backup hands over thousands of chunks, and a message per chunk would be thousands of renders
+ * for a number that a person reads a few times a minute.
+ */
+const PROGRESS_INTERVAL_MS = 250;
 
 /**
  * How long the stream waits to be asked for more before giving the download up for dead.
@@ -122,6 +138,9 @@ export async function streamDatabaseDownload(
      * amount of reading or hashing faster would show up in the total.
      */
     let waitedMs = 0;
+    let sentBytes = 0;
+    let totalBytes = 0;
+    let reportedAt = 0;
 
     /** Posts one chunk per granted pull, or throws the stop that was granted instead. */
     const sendChunk = async (chunk: Uint8Array): Promise<void> => {
@@ -133,11 +152,20 @@ export async function streamDatabaseDownload(
             throw new DownloadStopped(request);
         }
 
+        const length = chunk.byteLength;
         // Fresh, whole buffers are handed over rather than copied; anything else is copied first.
         const data = chunk.byteOffset === 0 && chunk.byteLength === chunk.buffer.byteLength
             ? chunk.buffer
             : chunk.slice().buffer;
         port.postMessage({ type: "chunk", data }, [ data ]);
+
+        // Counted after the hand-over, so what is reported is what has actually gone.
+        sentBytes += length;
+        const now = Date.now();
+        if (now - reportedAt >= PROGRESS_INTERVAL_MS) {
+            reportedAt = now;
+            options.onProgress?.(sentBytes, totalBytes);
+        }
     };
 
     let source: ReadableStream<Uint8Array> | undefined;
@@ -150,7 +178,8 @@ export async function streamDatabaseDownload(
         // extension. Without a passphrase it is the database between a header and a trailer, the
         // trailer's digest vouching for it; with one, every frame is authenticated as well.
         const encrypted = !!options.passphrase;
-        port.postMessage({ type: "begin", byteSize: containerSize(byteSize, encrypted) });
+        totalBytes = containerSize(byteSize, encrypted);
+        port.postMessage({ type: "begin", byteSize: totalBytes });
         await writeBackupContainer(
             stream,
             new WritableStream<Uint8Array>({ write: sendChunk }),
@@ -164,6 +193,9 @@ export async function streamDatabaseDownload(
             }
         );
         port.postMessage({ type: "end" });
+        // The last one is unconditional: a throttled report would otherwise leave the screen a
+        // chunk short of the total it is about to be told is finished.
+        options.onProgress?.(sentBytes, totalBytes);
         reportTiming(byteSize, timing, waitedMs, Date.now() - startedAt);
 
         return { status: "done" };

--- a/apps/standalone/src/lightweight/backup-stream.spec.ts
+++ b/apps/standalone/src/lightweight/backup-stream.spec.ts
@@ -49,7 +49,10 @@ async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
 
 describe("streamLiveDatabasePages against the real engine", () => {
     function readerFor(provider: BrowserSqlProvider): LiveDatabaseReader {
-        return { getValue: (sql, params) => provider.prepare(sql).pluck().get(params ?? []) };
+        return {
+            getValue: (sql, params) => provider.prepare(sql).pluck().get(params ?? []),
+            getColumn: (sql, params) => provider.prepare(sql).pluck().all(params ?? []) as unknown[]
+        };
     }
 
     function populatedProvider(): BrowserSqlProvider {
@@ -98,11 +101,21 @@ describe("streamLiveDatabasePages against the real engine", () => {
 
     it("errors the stream when a page comes back the wrong size", async () => {
         const reader: LiveDatabaseReader = {
-            getValue: (sql) => sql.includes("sqlite_dbpage")
-                ? new Uint8Array(3)
-                : sql.includes("page_size") ? 512 : sql.includes("page_count") ? 4 : 0
+            getValue: (sql) =>
+                sql.includes("page_size") ? 512 : sql.includes("page_count") ? 4 : 0,
+            // A page short of what the page size says it must be, four times over.
+            getColumn: () => Array.from({ length: 4 }, () => new Uint8Array(3))
         };
         await expect(drain(streamLiveDatabasePages(reader).stream)).rejects.toThrow(/malformed/);
+    });
+
+    it("errors the stream when the range comes back short of the pages it asked for", async () => {
+        const reader: LiveDatabaseReader = {
+            getValue: (sql) =>
+                sql.includes("page_size") ? 512 : sql.includes("page_count") ? 4 : 0,
+            getColumn: () => [ new Uint8Array(512) ]
+        };
+        await expect(drain(streamLiveDatabasePages(reader).stream)).rejects.toThrow(/got 1 of 4/);
     });
 });
 

--- a/apps/standalone/src/lightweight/backup-stream.ts
+++ b/apps/standalone/src/lightweight/backup-stream.ts
@@ -15,12 +15,29 @@
  * @module
  */
 
-/** How many pages travel per stream chunk: 1 MiB at the default 8 KiB page size. */
-const BATCH_PAGES = 128;
+/**
+ * How many pages are fetched, and travel, per stream chunk.
+ *
+ * One statement covers the whole batch, so this is the number of rows a single query steps through
+ * rather than the number of queries. Larger batches therefore cost almost nothing extra in
+ * round trips and only buy fewer of them, while the memory held is one batch: 4 MiB at an 8 KiB
+ * page, 2 MiB at 4 KiB, which the container immediately re-cuts into its own 1 MiB frames.
+ */
+const BATCH_PAGES = 512;
 
 /** Reads the live database through the core SQL layer, which fronts the one connection there is. */
 export interface LiveDatabaseReader {
     getValue(sql: string, params?: unknown[]): unknown;
+    /** One column of every row, which is how a whole batch of pages arrives in one statement. */
+    getColumn(sql: string, params?: unknown[]): unknown[];
+}
+
+/** What the read cost, for a caller that wants to say where a slow backup spent its time. */
+export interface StreamTiming {
+    /** Milliseconds spent inside the page reads, as against waiting on whatever consumes them. */
+    readMs: number;
+    /** Pages handed over so far. */
+    pages: number;
 }
 
 /** Thrown by {@link streamLiveDatabasePages} when a write lands mid-stream. The caller retries. */
@@ -35,6 +52,8 @@ export interface DatabaseStream {
     /** Exact size of the streamed database, known before the first byte flows. */
     byteSize: number;
     stream: ReadableStream<Uint8Array>;
+    /** Updated as the stream runs, so a caller can report where the time went. */
+    timing: StreamTiming;
 }
 
 /**
@@ -56,11 +75,15 @@ export function streamLiveDatabasePages(db: LiveDatabaseReader): DatabaseStream 
     const pageCount = countOf(db.getValue("PRAGMA page_count"), "page_count");
     const fingerprint = fingerprintOf(db);
 
+    const timing: StreamTiming = { readMs: 0, pages: 0 };
     let nextPage = 1;
+
     return {
         byteSize: pageSize * pageCount,
+        timing,
         stream: new ReadableStream<Uint8Array>({
             pull(controller) {
+                const startedAt = Date.now();
                 try {
                     if (fingerprintOf(db) !== fingerprint) {
                         throw new DatabaseChangedError();
@@ -71,26 +94,54 @@ export function streamLiveDatabasePages(db: LiveDatabaseReader): DatabaseStream 
                     }
 
                     const pages = Math.min(BATCH_PAGES, pageCount - nextPage + 1);
-                    const batch = new Uint8Array(pages * pageSize);
-                    for (let index = 0; index < pages; index++, nextPage++) {
-                        batch.set(readLivePage(db, nextPage, pageSize), index * pageSize);
-                    }
+                    const batch = readLivePages(db, nextPage, pages, pageSize);
+                    nextPage += pages;
+                    timing.pages += pages;
+
                     controller.enqueue(batch);
                 } catch (e) {
                     controller.error(e);
+                } finally {
+                    timing.readMs += Date.now() - startedAt;
                 }
             }
         })
     };
 }
 
-/** One page, checked to be exactly a page: anything else means the file is not what it claims. */
-function readLivePage(db: LiveDatabaseReader, pageNumber: number, pageSize: number): Uint8Array {
-    const data = db.getValue("SELECT data FROM sqlite_dbpage WHERE pgno = ?", [ pageNumber ]);
-    if (!(data instanceof Uint8Array) || data.byteLength !== pageSize) {
-        throw new Error(`Page ${pageNumber} came back malformed.`);
+/**
+ * A run of pages, in one statement rather than one per page.
+ *
+ * This is the whole of what a backup costs to read, and the difference between the two shapes is
+ * not small: a page at a time means preparing, binding, stepping and finalising a query against a
+ * virtual table for every page in the database, which for a multi-gigabyte one is over a million
+ * round trips into WebAssembly. Stepping one statement across the range does the same work once.
+ */
+function readLivePages(
+    db: LiveDatabaseReader,
+    firstPage: number,
+    pages: number,
+    pageSize: number
+): Uint8Array {
+    const rows = db.getColumn(
+        "SELECT data FROM sqlite_dbpage WHERE pgno BETWEEN ? AND ? ORDER BY pgno",
+        [ firstPage, firstPage + pages - 1 ]
+    );
+
+    if (rows.length !== pages) {
+        throw new Error(`Pages ${firstPage} to ${firstPage + pages - 1}: got ${rows.length} of ${pages}.`);
     }
-    return data;
+
+    const batch = new Uint8Array(pages * pageSize);
+    for (let index = 0; index < pages; index++) {
+        const data = rows[index];
+        if (!(data instanceof Uint8Array) || data.byteLength !== pageSize) {
+            throw new Error(`Page ${firstPage + index} came back malformed.`);
+        }
+        batch.set(data, index * pageSize);
+    }
+
+    return batch;
 }
 
 /**

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -94,12 +94,30 @@ function fakePool() {
         close() { /* nothing to release */ }
     }
 
+    /**
+     * Whether the browser has taken the pool's access handles away, and what it took to get them
+     * back. A pool never notices the taking, which is the whole difficulty: only pausing clears its
+     * belief that it still holds them.
+     */
+    const handles = { closed: false, paused: 0, unpaused: 0 };
+
     const pool = {
         OpfsSAHPoolDb: FakeDb,
         getCapacity: () => 6,
         getFileCount: () => files.size,
         addCapacity: async () => 1,
         unlink: (name: string) => files.delete(name),
+        pauseVfs() {
+            handles.paused++;
+
+            return pool;
+        },
+        async unpauseVfs() {
+            handles.unpaused++;
+            handles.closed = false;
+
+            return pool;
+        },
         importDb: async (name: string, pull: () => Promise<Uint8Array | undefined>) => {
             const chunks: Uint8Array[] = [];
             for (let chunk = await pull(); chunk; chunk = await pull()) {
@@ -111,7 +129,12 @@ function fakePool() {
         }
     };
 
-    return { asked, files, answers, pool: pool as unknown as SAHPoolUtil };
+    return { asked, files, answers, handles, pool: pool as unknown as SAHPoolUtil };
+}
+
+/** What WebKit throws once it has closed a sync access handle underneath the pool holding it. */
+function closedAccessHandle(): DOMException {
+    return new DOMException("AccessHandle is closed", "InvalidStateError");
 }
 
 function concat(chunks: Uint8Array[]): Uint8Array {
@@ -127,12 +150,23 @@ function concat(chunks: Uint8Array[]): Uint8Array {
 }
 
 /** The database the restore acts on, recording what it was asked to do and in what order. */
-function fakeTarget(pool: SAHPoolUtil, options: { failToOpen?: string } = {}) {
+function fakeTarget(pool: SAHPoolUtil, options: {
+    failToOpen?: string;
+    /** Run before each open; throwing from it is how a test makes that open fail its own way. */
+    beforeOpen?: (dbName: string) => void;
+} = {}) {
     const acted: string[] = [];
     const target: RestoreTarget = {
         pool,
         close: () => { acted.push("close"); },
         open: (dbName) => {
+            try {
+                options.beforeOpen?.(dbName);
+            } catch (e) {
+                acted.push(`open-failed:${dbName}`);
+                throw e;
+            }
+
             if (dbName === options.failToOpen) {
                 acted.push(`open-failed:${dbName}`);
                 throw new Error("database is locked");
@@ -303,13 +337,61 @@ describe("a backup that cannot be restored", () => {
     });
 
     it("puts the previous database back when the restored one will not open", async () => {
-        const { pool } = fakePool();
+        const { pool, handles } = fakePool();
         const { target, acted } = fakeTarget(pool, { failToOpen: CANDIDATE_NAME });
 
         await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
             .rejects.toMatchObject({ reason: "swap-failed" });
 
         expect(acted).toEqual([ "close", `open-failed:${CANDIDATE_NAME}`, `open:${DEFAULT_DATABASE_NAME}` ]);
+        expect(pointer).toBe(DEFAULT_DATABASE_NAME);
+        // Tried once and not retried: the handles were never the problem, and an open refused for
+        // any other reason is refused just the same the second time.
+        expect(handles.paused).toBe(0);
+    });
+
+    it("takes the pool's access handles back where the browser has closed them, and opens", async () => {
+        const { pool, handles } = fakePool();
+        // Closed while the restore was working, which is what a file picker, a screen lock or a
+        // switch to another application does on iOS. The pool is never told, so the open is what
+        // finds out.
+        const { target, acted } = fakeTarget(pool, {
+            beforeOpen: () => {
+                if (handles.closed) {
+                    throw closedAccessHandle();
+                }
+            }
+        });
+        handles.closed = true;
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]));
+
+        expect(acted).toEqual([ "close", `open-failed:${CANDIDATE_NAME}`, `open:${CANDIDATE_NAME}` ]);
+        // Paused before unpausing: a pool whose handles were taken still believes it holds them, so
+        // unpausing on its own would return having done nothing at all.
+        expect(handles).toMatchObject({ paused: 1, unpaused: 1 });
+        expect(pointer).toBe(CANDIDATE_NAME);
+    });
+
+    it("reports what stopped the swap, not what stopped the rollback, and asks for a reload", async () => {
+        const { pool } = fakePool();
+        // The candidate will not open, and the previous one cannot be reopened either. Both halves
+        // failing is what used to leave the browser's own error standing in place of ours, over a
+        // sentence promising the previous database was back.
+        const { target } = fakeTarget(pool, {
+            failToOpen: CANDIDATE_NAME,
+            beforeOpen: (dbName) => {
+                if (dbName === DEFAULT_DATABASE_NAME) {
+                    throw closedAccessHandle();
+                }
+            }
+        });
+
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ reason: "swap-failed-reload", message: "database is locked" });
+
+        // The pointer is the whole of what a start reads, so the notes that were here are still the
+        // ones it opens; this instance just cannot get to them without one.
         expect(pointer).toBe(DEFAULT_DATABASE_NAME);
     });
 });

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -70,7 +70,10 @@ async function containerOf(payload: Uint8Array, options: { passphrase?: string; 
  * The same, written front to back the way the standalone download writes one: no digest patched in
  * afterwards, and the plaintext size recorded, which is what makes its total length predictable.
  */
-async function streamedContainerOf(payload: Uint8Array, options: { passphrase?: string } = {}) {
+async function streamedContainerOf(
+    payload: Uint8Array,
+    options: { passphrase?: string; compress?: boolean } = {}
+) {
     const filePath = path.join(tempRoot, `streamed-${Math.random().toString(36).slice(2)}.tnbackup`);
 
     await writeBackupContainer(
@@ -79,7 +82,7 @@ async function streamedContainerOf(payload: Uint8Array, options: { passphrase?: 
         fs.createWriteStream(filePath),
         {
             streamed: true,
-            compress: false,
+            compress: options.compress ?? false,
             passphrase: options.passphrase,
             scrypt: { log2N: 10, r: 8, p: 1 },
             plaintextSize: payload.length
@@ -414,6 +417,20 @@ describe("a backup that cannot be restored", () => {
             reason: "backup-incomplete",
             message: expect.stringContaining(String(real.length))
         });
+    });
+
+    it("does not measure a streamed container that is compressed, since its length is not stated", async () => {
+        const { files, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const original = databaseBytes();
+        // Compresses to far less than the plaintext size the header records, so measuring the file
+        // against that size would condemn a complete backup.
+        const whole = await streamedContainerOf(original, { compress: true });
+        expect(whole.size).toBeLessThan(original.length);
+
+        await restoreDatabase(target, whole);
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
     });
 
     it("refuses a streamed container the file is too small to hold, without reading it", async () => {

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -350,6 +350,69 @@ describe("a backup that cannot be restored", () => {
         expect(handles.paused).toBe(0);
     });
 
+    it("takes the handles back mid-import and starts the import over", async () => {
+        const { pool, files, handles } = fakePool();
+        const { target, acted } = fakeTarget(pool);
+        const original = databaseBytes();
+        // Closed while the backup was being read, which is the suspension this cannot otherwise
+        // survive: the database being replaced is still open, so the pool cannot even be paused
+        // until it is let go of.
+        let imports = 0;
+        const importDb = pool.importDb.bind(pool);
+        pool.importDb = async (name, pull) => {
+            if (imports++ === 0) {
+                handles.closed = true;
+                throw closedAccessHandle();
+            }
+
+            return importDb(name, pull);
+        };
+
+        await restoreDatabase(target, new Blob([ original ]));
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
+        expect(imports).toBe(2);
+        // Let go of, taken back, put straight back: the screen behind the restore still reads from
+        // the database that has not been replaced yet.
+        expect(acted.slice(0, 2)).toEqual([ "close", `open:${DEFAULT_DATABASE_NAME}` ]);
+        expect(handles).toMatchObject({ paused: 1, unpaused: 1 });
+        expect(pointer).toBe(CANDIDATE_NAME);
+    });
+
+    it("takes the handles back mid-check rather than calling the backup damaged", async () => {
+        const { pool, handles } = fakePool();
+        const { target } = fakeTarget(pool);
+        const answered = { times: 0 };
+        const tables = pool.OpfsSAHPoolDb.prototype.selectValues;
+        pool.OpfsSAHPoolDb.prototype.selectValues = function (sql: string) {
+            if (answered.times++ === 0) {
+                handles.closed = true;
+                throw closedAccessHandle();
+            }
+
+            return tables.call(this, sql);
+        };
+
+        await restoreDatabase(target, new Blob([ databaseBytes() ]));
+
+        expect(handles).toMatchObject({ paused: 1, unpaused: 1 });
+        expect(pointer).toBe(CANDIDATE_NAME);
+    });
+
+    it("reports what stopped an import that no recovery could help", async () => {
+        const { pool, handles } = fakePool();
+        const { target } = fakeTarget(pool);
+        pool.importDb = async () => {
+            throw new Error("the pool is full");
+        };
+
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ message: expect.stringContaining("the pool is full") });
+
+        // Nothing to take back, so nothing was let go of either.
+        expect(handles.paused).toBe(0);
+    });
+
     it("takes the pool's access handles back where the browser has closed them, and opens", async () => {
         const { pool, handles } = fakePool();
         // Closed while the restore was working, which is what a file picker, a screen lock or a

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -180,9 +180,12 @@ function fakeTarget(pool: SAHPoolUtil, options: {
 
 /** Stands in for the origin's private filesystem, which is where the pointer lives. */
 let pointer: string | undefined;
+/** Set by a test to make writing the pointer fail, which is the one write nothing else can repair. */
+let refusePointer: ((name: string) => boolean) | undefined;
 
 beforeEach(() => {
     pointer = undefined;
+    refusePointer = undefined;
     vi.stubGlobal("navigator", {
         storage: {
             getDirectory: async () => ({
@@ -194,7 +197,12 @@ beforeEach(() => {
                     return {
                         getFile: async () => ({ text: async () => pointer ?? "" }),
                         createWritable: async () => ({
-                            write: async (text: string) => { pointer = text; },
+                            write: async (text: string) => {
+                                if (refusePointer?.(text)) {
+                                    throw new Error("the pointer could not be written");
+                                }
+                                pointer = text;
+                            },
                             close: async () => {}
                         })
                     };
@@ -387,7 +395,10 @@ describe("a backup that cannot be restored", () => {
         pool.OpfsSAHPoolDb.prototype.selectValues = function (sql: string) {
             if (answered.times++ === 0) {
                 handles.closed = true;
-                throw closedAccessHandle();
+                // Worded differently on purpose, and reported wrapped in the checks' own failure:
+                // what marks it out has to be the kind of error it is, not the sentence a given
+                // browser version happens to use.
+                throw new DOMException("The file handle was invalidated", "InvalidStateError");
             }
 
             return tables.call(this, sql);
@@ -399,6 +410,24 @@ describe("a backup that cannot be restored", () => {
         expect(pointer).toBe(CANDIDATE_NAME);
     });
 
+    it("says the check could not be carried out, rather than calling the backup damaged", async () => {
+        const { pool, files } = fakePool();
+        const { target } = fakeTarget(pool);
+        pool.OpfsSAHPoolDb.prototype.selectValues = () => {
+            throw new Error("out of memory");
+        };
+
+        // The checks call a database damaged by looking at it. Where the looking is what failed,
+        // there is nothing to conclude about the file, and concluding anyway is how someone deletes
+        // the only copy of their notes.
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ reason: "check-failed", message: expect.stringContaining("out of memory") });
+
+        // Still cleaned up after, and the live database is untouched.
+        expect(files.has(CANDIDATE_NAME)).toBe(false);
+        expect(pointer).toBeUndefined();
+    });
+
     it("reports what stopped an import that no recovery could help", async () => {
         const { pool, handles } = fakePool();
         const { target } = fakeTarget(pool);
@@ -406,11 +435,32 @@ describe("a backup that cannot be restored", () => {
             throw new Error("the pool is full");
         };
 
+        // Never reached the swap, so it must not say the database was replaced and put back.
         await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
-            .rejects.toMatchObject({ message: expect.stringContaining("the pool is full") });
+            .rejects.toMatchObject({
+                reason: "restore-failed",
+                message: expect.stringContaining("the pool is full")
+            });
 
         // Nothing to take back, so nothing was let go of either.
         expect(handles.paused).toBe(0);
+        expect(pointer).toBeUndefined();
+    });
+
+    it("keeps the restored database when the pointer cannot be put back on the old one", async () => {
+        const { pool, files } = fakePool();
+        const { target } = fakeTarget(pool, { failToOpen: CANDIDATE_NAME });
+        // The swap fails, and so does putting the pointer back, which leaves it naming the
+        // candidate: the one state where that entry is not a leftover but the database itself.
+        refusePointer = (name) => name === DEFAULT_DATABASE_NAME;
+
+        await expect(restoreDatabase(target, new Blob([ databaseBytes() ])))
+            .rejects.toMatchObject({ reason: "swap-failed-reload" });
+
+        // Kept, because a start would open it and removing it would leave nothing to open at all.
+        // It has passed its checks by this point, so opening it is safe.
+        expect(files.has(CANDIDATE_NAME)).toBe(true);
+        expect(pointer).toBe(CANDIDATE_NAME);
     });
 
     it("takes the pool's access handles back where the browser has closed them, and opens", async () => {

--- a/apps/standalone/src/lightweight/database_restore.spec.ts
+++ b/apps/standalone/src/lightweight/database_restore.spec.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     DEFAULT_DATABASE_NAME,
     readCurrentDatabaseName,
+    readInSlices,
     restoreDatabase,
     type RestoreProgress,
     type RestoreTarget
@@ -59,6 +60,29 @@ async function containerOf(payload: Uint8Array, options: { passphrase?: string; 
                     await handle.close();
                 }
             }
+        }
+    );
+
+    return new Blob([ fs.readFileSync(filePath) ]);
+}
+
+/**
+ * The same, written front to back the way the standalone download writes one: no digest patched in
+ * afterwards, and the plaintext size recorded, which is what makes its total length predictable.
+ */
+async function streamedContainerOf(payload: Uint8Array, options: { passphrase?: string } = {}) {
+    const filePath = path.join(tempRoot, `streamed-${Math.random().toString(36).slice(2)}.tnbackup`);
+
+    await writeBackupContainer(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- a Node stream over the bytes.
+        (await import("stream")).Readable.from([ Buffer.from(payload) ]) as any,
+        fs.createWriteStream(filePath),
+        {
+            streamed: true,
+            compress: false,
+            passphrase: options.passphrase,
+            scrypt: { log2N: 10, r: 8, p: 1 },
+            plaintextSize: payload.length
         }
     );
 
@@ -259,6 +283,23 @@ describe("restoring from a picked backup", () => {
         expect(pointer).toBe(CANDIDATE_NAME);
     });
 
+    it("reads the file in slices rather than as one read for the whole of it", async () => {
+        const { files, pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const original = databaseBytes();
+        const backup = new Blob([ original ]);
+        const sliced = vi.spyOn(backup, "slice");
+        const streamed = vi.spyOn(backup, "stream");
+
+        await restoreDatabase(target, backup);
+
+        expect(files.get(CANDIDATE_NAME)).toEqual(original);
+        // One read living for the whole file is what a low-memory WebView was seen ending early,
+        // with nothing to say it had; bounded reads are what the chunked upload has always used.
+        expect(streamed).not.toHaveBeenCalled();
+        expect(sliced.mock.calls.length).toBeGreaterThan(1);
+    });
+
     it("unwraps a container back into the database it was made from", async () => {
         const { files, pool } = fakePool();
         const { target } = fakeTarget(pool);
@@ -307,6 +348,43 @@ describe("restoring from a picked backup", () => {
     });
 });
 
+describe("reading a file in slices", () => {
+    /** Drains a stream the way the readers here do, a chunk at a time. */
+    async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+        const reader = stream.getReader();
+        const chunks: Uint8Array[] = [];
+        for (let next = await reader.read(); !next.done; next = await reader.read()) {
+            chunks.push(next.value);
+        }
+
+        return concat(chunks);
+    }
+
+    it("hands back exactly the file, whatever the slices fall across", async () => {
+        const bytes = Uint8Array.from({ length: 1000 }, (_, at) => at % 251);
+
+        // A size that divides the file evenly, one that leaves a remainder, and one larger than
+        // the file: the boundaries are the only thing this has to get right.
+        for (const sliceSize of [ 100, 128, 4096 ]) {
+            await expect(collect(readInSlices(new Blob([ bytes ]), sliceSize))).resolves.toEqual(bytes);
+        }
+    });
+
+    it("refuses to end quietly where the file gives less than it claims", async () => {
+        const real = Uint8Array.from({ length: 256 }, (_, at) => at);
+        const backup = {
+            size: 1024,
+            slice: (start: number, end: number) =>
+                new Blob([ real.slice(start, Math.min(end, real.length)) ])
+        } as unknown as Blob;
+
+        await expect(collect(readInSlices(backup, 64))).rejects.toMatchObject({
+            reason: "backup-incomplete",
+            message: expect.stringContaining("256")
+        });
+    });
+});
+
 describe("a backup that cannot be restored", () => {
     it("asks for a passphrase before reading an encrypted container, and imports nothing", async () => {
         const { files, pool } = fakePool();
@@ -318,6 +396,37 @@ describe("a backup that cannot be restored", () => {
         expect(files.size).toBe(0);
         expect(acted).toEqual([]);
         expect(pointer).toBeUndefined();
+    });
+
+    it("says a file that ends early is incomplete, in the bytes it had and the bytes it needed", async () => {
+        const { pool } = fakePool();
+        const { target } = fakeTarget(pool);
+        const real = databaseBytes();
+        // A file whose size claims more than it can give, which is the shape the Android WebView
+        // presented: the read stops and the reader can only take that at its word.
+        const backup = {
+            size: real.length * 4,
+            slice: (start: number, end: number) =>
+                new Blob([ real.slice(start, Math.min(end, real.length)) ])
+        } as unknown as Blob;
+
+        await expect(restoreDatabase(target, backup)).rejects.toMatchObject({
+            reason: "backup-incomplete",
+            message: expect.stringContaining(String(real.length))
+        });
+    });
+
+    it("refuses a streamed container the file is too small to hold, without reading it", async () => {
+        const { pool, files } = fakePool();
+        const { target } = fakeTarget(pool);
+        const whole = await streamedContainerOf(databaseBytes());
+
+        await expect(restoreDatabase(target, whole.slice(0, whole.size - 64)))
+            .rejects.toMatchObject({ reason: "backup-incomplete" });
+
+        // Settled from the header alone: a container states the size it should be, so an
+        // incomplete one costs a second rather than however long its payload would have taken.
+        expect(files.size).toBe(0);
     });
 
     it("refuses a file that is neither a database nor a backup", async () => {

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -6,7 +6,7 @@ import {
     peekBackupContainer,
     type ProgressCallback,
     readBackupContainer,
-    streamedContainerSize
+    containerSize
 } from "@triliumnext/backup-container/web";
 import {
     type CandidateDatabase,
@@ -413,16 +413,16 @@ async function readBackupFormat(backup: Blob): Promise<{ container: boolean; enc
 /**
  * Refuses a container the file is too small to hold, before a minute of work goes into it.
  *
- * Only a streamed one can be measured this way: it is written front to back with no compression, so
- * its length follows from the size it records. Anything else is compressed, or was written by a
- * writer that could revisit its own header, and its length says nothing in advance.
+ * Only an uncompressed one can be measured this way: its length follows exactly from the size its
+ * header records. Compression breaks the derivation, since the payload is then shorter than the
+ * plaintext by a ratio nothing states in advance.
  */
 function requireWholeContainer(container: BackupContainerInfo, size: number): void {
-    if (!container.streamed || container.plaintextSize <= 0) {
+    if (container.compressed || container.plaintextSize <= 0) {
         return;
     }
 
-    const expected = streamedContainerSize(container.plaintextSize, container.encrypted);
+    const expected = containerSize(container.plaintextSize, container.encrypted);
     if (size < expected) {
         throw incompleteBackup(size, expected);
     }

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -1,11 +1,11 @@
 import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
 import {
-    type BackupContainerInfo,
     FIXED_HEADER_BYTES,
+    getInfo,
     isBackupContainerError,
-    peekBackupContainer,
     type ProgressCallback,
     readBackupContainer,
+    type SupportedBackupContainer,
     containerSize
 } from "@triliumnext/backup-container/web";
 import {
@@ -399,12 +399,12 @@ export async function writeCurrentDatabaseName(dbName: string): Promise<void> {
  */
 async function readBackupFormat(backup: Blob): Promise<{ container: boolean; encrypted: boolean } | null> {
     const head = new Uint8Array(await backup.slice(0, FIXED_HEADER_BYTES).arrayBuffer());
-    const container = peekBackupContainer(head);
+    const container = getInfo(head);
 
-    if (container) {
+    if (container.isValid && container.isSupported) {
         requireWholeContainer(container, backup.size);
 
-        return { container: true, encrypted: container.encrypted };
+        return { container: true, encrypted: container.isEncrypted };
     }
 
     return looksLikeSqlite(head) ? { container: false, encrypted: false } : null;
@@ -417,12 +417,12 @@ async function readBackupFormat(backup: Blob): Promise<{ container: boolean; enc
  * header records. Compression breaks the derivation, since the payload is then shorter than the
  * plaintext by a ratio nothing states in advance.
  */
-function requireWholeContainer(container: BackupContainerInfo, size: number): void {
-    if (container.compressed || container.plaintextSize <= 0) {
+function requireWholeContainer(container: SupportedBackupContainer, size: number): void {
+    if (container.isCompressed || container.size <= 0) {
         return;
     }
 
-    const expected = containerSize(container.plaintextSize, container.encrypted);
+    const expected = containerSize(container.size, container.isEncrypted);
     if (size < expected) {
         throw incompleteBackup(size, expected);
     }

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -230,17 +230,90 @@ async function swapIn(target: RestoreTarget, previous: string, candidate: string
     await writeCurrentDatabaseName(candidate);
 
     try {
-        target.open(candidate);
+        await openWithHandles(target, candidate);
     } catch (e) {
         // Put back what was live, so a candidate that will not open costs nothing.
-        await writeCurrentDatabaseName(previous);
-        target.open(previous);
-
-        throw new RestoreFailure("swap-failed", messageOf(e));
+        throw await rollBackTo(target, previous, e);
     }
 
     // Only once the restored database is open: until then the old one is what a restart needs.
     await removeQuietly(target.pool, previous);
+}
+
+/**
+ * Opens `dbName`, taking the pool's access handles back first where the browser has closed them.
+ *
+ * Retried once, and only for that: a database that will not open for any other reason will not open
+ * the second time either, and the first failure is the one worth reporting.
+ */
+async function openWithHandles(target: RestoreTarget, dbName: string): Promise<void> {
+    try {
+        target.open(dbName);
+    } catch (e) {
+        if (!isClosedAccessHandle(e)) {
+            throw e;
+        }
+
+        await reacquireAccessHandles(target.pool);
+        target.open(dbName);
+    }
+}
+
+/**
+ * Puts the previous database back after a swap that did not take.
+ *
+ * The pointer is the whole of what decides which database a start opens, so restoring it is what
+ * makes a failed swap harmless: whatever happens next, the notes are the ones that were here before.
+ * Reopening it is the part that can fail again, since the handles the reopen needs may be the very
+ * thing that was taken, and that failure must not replace the one being reported or the screen would
+ * explain the wrong problem.
+ */
+async function rollBackTo(
+    target: RestoreTarget,
+    previous: string,
+    cause: unknown
+): Promise<RestoreFailure> {
+    await writeCurrentDatabaseName(previous);
+
+    try {
+        await openWithHandles(target, previous);
+    } catch {
+        // The pointer is back, so a start comes up on the database that was here all along. This
+        // instance simply cannot get there without one, which is the one thing the user has to be
+        // told rather than left to discover.
+        return new RestoreFailure("swap-failed-reload", messageOf(cause));
+    }
+
+    return new RestoreFailure("swap-failed", messageOf(cause));
+}
+
+/**
+ * Whether a failure is the browser having closed the pool's access handles underneath it.
+ *
+ * WebKit closes them whenever it suspends the page: a file picker, a screen lock, a switch to
+ * another application. The pool takes its handles once and holds them for its lifetime, so it never
+ * learns they are gone, and the next operation against it fails with this.
+ */
+function isClosedAccessHandle(e: unknown): boolean {
+    if (e instanceof DOMException && e.name === "InvalidStateError") {
+        return true;
+    }
+
+    return /access\s*handle.*closed|closed.*access\s*handle/i.test(messageOf(e));
+}
+
+/**
+ * Takes the pool's access handles back.
+ *
+ * The pause is the part that matters, and `isPaused` is no help in deciding whether to do it: it
+ * reports what the pool did to itself, and a pool whose handles were taken from underneath it still
+ * believes it holds them, so `unpauseVfs` on its own returns having done nothing. Pausing is what
+ * clears that belief. It is refused while any database is open, which is why this belongs to the
+ * moment between closing one and opening the next.
+ */
+async function reacquireAccessHandles(pool: SAHPoolUtil): Promise<void> {
+    pool.pauseVfs();
+    await pool.unpauseVfs();
 }
 
 /** Points the next start at `dbName`, which is the whole of what makes a database the live one. */

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -122,8 +122,13 @@ export async function restoreDatabase(
         report({ stage: "done" });
     } catch (e) {
         const failure = asFailure(e);
-        // The candidate is no use to anyone now, and the pool's slots are finite.
-        await removeQuietly(target.pool, candidate);
+        // The candidate is no use to anyone now, and the pool's slots are finite. Unless a start
+        // would open it, which is the one case where it is not a leftover but the database itself:
+        // the pointer is only ever put on it once it has passed its checks, and removing what the
+        // pointer names would leave nothing to open at all.
+        if (await readCurrentDatabaseName() !== candidate) {
+            await removeQuietly(target.pool, candidate);
+        }
         report({ stage: "failed", error: failure.message, reason: failure.reason });
 
         throw failure;
@@ -132,8 +137,8 @@ export async function restoreDatabase(
 
 /** A failure with a reason attached, so the setup screen can tell the cases apart. */
 export class RestoreFailure extends Error {
-    constructor(readonly reason: string, message: string) {
-        super(message);
+    constructor(readonly reason: string, message: string, options?: ErrorOptions) {
+        super(message, options);
         this.name = "RestoreFailure";
     }
 }
@@ -199,19 +204,11 @@ function validate(pool: SAHPoolUtil, candidate: string): DatabaseValidation {
     try {
         return validateDatabase(candidateOf(db), { skipIntegrityCheck: true });
     } catch (e) {
-        // The browser taking the pool's handles away is not this database being damaged, and saying
-        // so would condemn a backup that is perfectly good. Left to the caller, which can take them
-        // back and ask again.
-        if (isClosedAccessHandle(e)) {
-            throw e;
-        }
-
-        // What a database too damaged to query throws is this driver's business, not the checks'.
-        return {
-            valid: false,
-            rejection: "damaged-database",
-            message: `The database could not be read: ${messageOf(e)}`
-        };
+        // Not a verdict on the backup. The checks call a database damaged by looking at it and
+        // finding it so; this is the looking itself having failed, which says nothing about what
+        // was being looked at. Calling it damaged because the device ran out of memory, or because
+        // the browser took the pool's handles away, is how a perfectly good backup gets thrown out.
+        throw new RestoreFailure("check-failed", messageOf(e), { cause: e });
     } finally {
         db.close();
     }
@@ -235,9 +232,11 @@ function candidateOf(db: InstanceType<SAHPoolUtil["OpfsSAHPoolDb"]>): CandidateD
  */
 async function swapIn(target: RestoreTarget, previous: string, candidate: string): Promise<void> {
     target.close();
-    await writeCurrentDatabaseName(candidate);
 
     try {
+        // Inside the rollback's reach, because a pointer half-written is the one failure that could
+        // leave a start reading neither name.
+        await writeCurrentDatabaseName(candidate);
         await openWithHandles(target, candidate);
     } catch (e) {
         // Put back what was live, so a candidate that will not open costs nothing.
@@ -281,7 +280,14 @@ async function rollBackTo(
     previous: string,
     cause: unknown
 ): Promise<RestoreFailure> {
-    await writeCurrentDatabaseName(previous);
+    try {
+        await writeCurrentDatabaseName(previous);
+    } catch {
+        // The pointer is whatever it was left as, which may be the candidate. That one has passed
+        // its checks, so a start finding it is not in danger; it is simply not the database this
+        // instance was told to keep, and only a start can settle which it opens.
+        return new RestoreFailure("swap-failed-reload", messageOf(cause));
+    }
 
     try {
         await openWithHandles(target, previous);
@@ -346,6 +352,12 @@ async function keepingHandles<T>(
  */
 function isClosedAccessHandle(e: unknown): boolean {
     if (e instanceof DOMException && e.name === "InvalidStateError") {
+        return true;
+    }
+
+    // Through whatever wrapped it. A step reports a failure in its own terms, and it has no business
+    // deciding on the way whether the browser's error underneath is one that can be recovered from.
+    if (e instanceof Error && e.cause !== undefined && isClosedAccessHandle(e.cause)) {
         return true;
     }
 
@@ -429,7 +441,10 @@ function asFailure(e: unknown): RestoreFailure {
         return new RestoreFailure(e.reason, e.message);
     }
 
-    return new RestoreFailure("swap-failed", messageOf(e));
+    // Not "swap-failed": everything that reaches here failed before the swap was reached, and
+    // saying otherwise would tell the user their database had been replaced and put back when it
+    // was never touched.
+    return new RestoreFailure("restore-failed", messageOf(e));
 }
 
 function messageOf(e: unknown): string {

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -1,10 +1,12 @@
 import type { SAHPoolUtil } from "@sqlite.org/sqlite-wasm";
 import {
+    type BackupContainerInfo,
     FIXED_HEADER_BYTES,
     isBackupContainerError,
     peekBackupContainer,
     type ProgressCallback,
-    readBackupContainer
+    readBackupContainer,
+    streamedContainerSize
 } from "@triliumnext/backup-container/web";
 import {
     type CandidateDatabase,
@@ -167,7 +169,7 @@ async function stageCandidate(
     }
 
     if (!format.container) {
-        await pool.importDb(candidate, pullFrom(backup.stream()));
+        await pool.importDb(candidate, pullFrom(readInSlices(backup)));
         onProgress(1);
         return;
     }
@@ -179,7 +181,7 @@ async function stageCandidate(
     }
 
     const relay = new TransformStream<Uint8Array, Uint8Array>();
-    const unwrapped = readBackupContainer(backup.stream(), relay.writable, { passphrase, onProgress });
+    const unwrapped = readBackupContainer(readInSlices(backup), relay.writable, { passphrase, onProgress });
     const imported = pool.importDb(candidate, pullFrom(relay.readable));
 
     // Awaited together: either failing has to stop the other, which is what a rejected pipe does.
@@ -400,10 +402,80 @@ async function readBackupFormat(backup: Blob): Promise<{ container: boolean; enc
     const container = peekBackupContainer(head);
 
     if (container) {
+        requireWholeContainer(container, backup.size);
+
         return { container: true, encrypted: container.encrypted };
     }
 
     return looksLikeSqlite(head) ? { container: false, encrypted: false } : null;
+}
+
+/**
+ * Refuses a container the file is too small to hold, before a minute of work goes into it.
+ *
+ * Only a streamed one can be measured this way: it is written front to back with no compression, so
+ * its length follows from the size it records. Anything else is compressed, or was written by a
+ * writer that could revisit its own header, and its length says nothing in advance.
+ */
+function requireWholeContainer(container: BackupContainerInfo, size: number): void {
+    if (!container.streamed || container.plaintextSize <= 0) {
+        return;
+    }
+
+    const expected = streamedContainerSize(container.plaintextSize, container.encrypted);
+    if (size < expected) {
+        throw incompleteBackup(size, expected);
+    }
+}
+
+/**
+ * Reads a file a slice at a time, rather than as one read that lives for the whole of it.
+ *
+ * `Blob.stream()` is that one long read, and a browser is free to end it early. A low-memory Android
+ * WebView was seen doing exactly that with a complete 4.8 GB backup: the same byte every time, no
+ * error, just an end of input that a reader can only take at its word — which surfaced as a container
+ * that had run out of frames. Asking for a bounded range at a time is what the chunked upload has
+ * always done with files this size on the same hardware, and it is how the header below is read.
+ *
+ * Reaching the end before the file says it should is a failure here rather than silence, so a file
+ * that really is short says so in its own terms instead of through whatever was parsing it.
+ */
+export function readInSlices(blob: Blob, sliceSize = SLICE_BYTES): ReadableStream<Uint8Array> {
+    let offset = 0;
+
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            if (offset >= blob.size) {
+                controller.close();
+                return;
+            }
+
+            const end = Math.min(offset + sliceSize, blob.size);
+            const slice = new Uint8Array(await blob.slice(offset, end).arrayBuffer());
+            if (slice.length === 0) {
+                throw incompleteBackup(offset, blob.size);
+            }
+
+            offset += slice.length;
+            controller.enqueue(slice);
+        }
+    });
+}
+
+/**
+ * How much is asked for at once: large enough that the per-read cost is lost against the work done
+ * with it, small enough that a device with very little memory never holds much. The container reads
+ * in frames a quarter of this size, and the stream keeps one slice queued.
+ */
+const SLICE_BYTES = 4 * 1024 * 1024;
+
+/** A file that stops before it should have, said in bytes because that is what makes it checkable. */
+function incompleteBackup(read: number, expected: number): RestoreFailure {
+    return new RestoreFailure(
+        "backup-incomplete",
+        `The backup file ends after ${read} bytes, short of the ${expected} it should hold. `
+            + "It was probably not copied or downloaded in full."
+    );
 }
 
 /** Turns a stream into the pull `importDb` asks for: a chunk each call, nothing at the end. */

--- a/apps/standalone/src/lightweight/database_restore.ts
+++ b/apps/standalone/src/lightweight/database_restore.ts
@@ -106,11 +106,12 @@ export async function restoreDatabase(
 
     try {
         report({ stage: "staging" });
-        await stageCandidate(target.pool, candidate, backup, options.passphrase, (fraction) =>
-            report({ stage: "staging", fraction }));
+        await keepingHandles(target, live, () =>
+            stageCandidate(target.pool, candidate, backup, options.passphrase, (fraction) =>
+                report({ stage: "staging", fraction })));
 
         report({ stage: "validating" });
-        const validation = validate(target.pool, candidate);
+        const validation = await keepingHandles(target, live, async () => validate(target.pool, candidate));
         if (!validation.valid) {
             throw new RestoreFailure(validation.rejection, validation.message);
         }
@@ -198,6 +199,13 @@ function validate(pool: SAHPoolUtil, candidate: string): DatabaseValidation {
     try {
         return validateDatabase(candidateOf(db), { skipIntegrityCheck: true });
     } catch (e) {
+        // The browser taking the pool's handles away is not this database being damaged, and saying
+        // so would condemn a backup that is perfectly good. Left to the caller, which can take them
+        // back and ask again.
+        if (isClosedAccessHandle(e)) {
+            throw e;
+        }
+
         // What a database too damaged to query throws is this driver's business, not the checks'.
         return {
             valid: false,
@@ -285,6 +293,48 @@ async function rollBackTo(
     }
 
     return new RestoreFailure("swap-failed", messageOf(cause));
+}
+
+/**
+ * Runs `work`, and where the browser closed the pool's handles underneath it, takes them back and
+ * runs it once more.
+ *
+ * This is for the part of a restore that happens before the swap, where the database being replaced
+ * is still open and serving the screen behind all this. Taking the handles back means letting go of
+ * it for a moment, since the pool refuses to be paused while anything is open at all, so it is
+ * closed and opened again around the recovery.
+ *
+ * The retry starts the work over rather than resuming it, which for the import means reading the
+ * backup from the beginning. That is worth it against the alternative: without it a restore that
+ * was suspended halfway is simply lost, and the suspension is usually the user coming back to the
+ * application rather than leaving it.
+ *
+ * @param live the database to put back, which is the one this restore has not replaced yet.
+ */
+async function keepingHandles<T>(
+    target: RestoreTarget,
+    live: string,
+    work: () => Promise<T>
+): Promise<T> {
+    try {
+        return await work();
+    } catch (e) {
+        if (!isClosedAccessHandle(e)) {
+            throw e;
+        }
+
+        try {
+            target.close();
+            await reacquireAccessHandles(target.pool);
+            target.open(live);
+        } catch {
+            // The handles could not be had back, so the failure to report is the one that was
+            // actually hit rather than whatever went wrong trying to recover from it.
+            throw e;
+        }
+
+        return await work();
+    }
 }
 
 /**

--- a/apps/standalone/src/local-bridge.ts
+++ b/apps/standalone/src/local-bridge.ts
@@ -133,6 +133,7 @@ const DOWNLOAD_START_TIMEOUT_MS = 45_000;
 let pendingDownload: {
     resolve: (result: StandaloneDownloadResult) => void;
     startTimer: ReturnType<typeof setTimeout>;
+    onProgress?: (sentBytes: number, totalBytes: number) => void;
 } | null = null;
 
 /** Carried from {@link downloadDatabase} to the stream relay, so it never rides the URL. */
@@ -163,7 +164,11 @@ let pendingDownloadPassphrase: string | undefined;
  * leader's, and the passphrase asked for here never leaves this tab, so a follower would produce
  * either no backup or an unencrypted one under the belief it was encrypted.
  */
-export function downloadDatabase(fileName: string, passphrase?: string): Promise<StandaloneDownloadResult> {
+export function downloadDatabase(
+    fileName: string,
+    passphrase?: string,
+    onProgress?: (sentBytes: number, totalBytes: number) => void
+): Promise<StandaloneDownloadResult> {
     if (!isLeader()) {
         return Promise.resolve({
             status: "failed",
@@ -186,6 +191,7 @@ export function downloadDatabase(fileName: string, passphrase?: string): Promise
     return new Promise((resolve) => {
         pendingDownload = {
             resolve,
+            onProgress,
             startTimer: setTimeout(
                 () => settlePendingDownload({ status: "failed", message: "The download did not start." }),
                 DOWNLOAD_START_TIMEOUT_MS
@@ -344,6 +350,13 @@ export function startLocalServerWorker() {
         // resets that clock, so one is sent for as long as the worker says the stream is running.
         // The end of the stream also carries its outcome, which is what the caller of
         // downloadDatabase() has been waiting on.
+        // How far the download has got, which the screen shows because a phone hides its own
+        // download UI behind the notification shade.
+        if (msg?.type === "BACKUP_STREAM_PROGRESS") {
+            pendingDownload?.onProgress?.(Number(msg.sentBytes), Number(msg.totalBytes));
+            return;
+        }
+
         if (msg?.type === "BACKUP_STREAM_ACTIVE") {
             setBackupPinging(msg.active === true);
             if (msg.active === true) {

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -543,7 +543,10 @@ async function handleBackupStream(port: MessagePort, passphrase?: string): Promi
 
     const { streamDatabaseDownload } = await import("./lightweight/backup-download.js");
     const result = await streamDatabaseDownload(
-        { getValue: (sql, params) => core.getSql().getValue(sql, params) },
+        {
+            getValue: (sql, params) => core.getSql().getValue(sql, params),
+            getColumn: (sql, params) => core.getSql().getColumn(sql, params)
+        },
         // A MessagePort satisfies the seam at runtime; only the `onmessage` property's event
         // parameter is typed wider here than the seam's, which a cast is the whole cost of.
         port as unknown as import("./lightweight/backup-download.js").DownloadPort,

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -550,7 +550,16 @@ async function handleBackupStream(port: MessagePort, passphrase?: string): Promi
         // A MessagePort satisfies the seam at runtime; only the `onmessage` property's event
         // parameter is typed wider here than the seam's, which a cast is the whole cost of.
         port as unknown as import("./lightweight/backup-download.js").DownloadPort,
-        { passphrase }
+        {
+            passphrase,
+            // To the page rather than the port: the browser's own download UI is out of reach on
+            // a phone until the notification shade is pulled down, so the screen says it itself.
+            onProgress: (sentBytes, totalBytes) => (self as unknown as Worker).postMessage({
+                type: "BACKUP_STREAM_PROGRESS",
+                sentBytes,
+                totalBytes
+            })
+        }
     );
 
     announce(false, result);

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -186,6 +186,14 @@ export interface DatabaseBackup {
      * for a plain copy, where the file size already says it.
      */
     plaintextSize?: number;
+    /**
+     * Why the file cannot be restored from, where its own header says as much. Absent for a plain
+     * copy and for a container this build can open.
+     *
+     * Worth a listing telling the user about: a file that has been sitting in the backup directory
+     * for months, being counted as a backup, is one they are relying on.
+     */
+    unreadable?: "invalid" | "unsupported-version";
 }
 
 export interface ExistingBackupsResponse {

--- a/packages/commons/src/lib/standalone_api_interface.ts
+++ b/packages/commons/src/lib/standalone_api_interface.ts
@@ -65,7 +65,11 @@ export interface StandaloneBackupApi {
      * to "the download finished" as the application can see: the browser's download manager may
      * still be settling the last bytes to disk for a moment after.
      */
-    downloadDatabase(fileName: string, passphrase?: string): Promise<StandaloneDownloadResult>;
+    downloadDatabase(
+        fileName: string,
+        passphrase?: string,
+        onProgress?: (sentBytes: number, totalBytes: number) => void
+    ): Promise<StandaloneDownloadResult>;
 }
 
 /** The complete surface the standalone build exposes to the client. */

--- a/packages/trilium-backup-container/README.md
+++ b/packages/trilium-backup-container/README.md
@@ -31,35 +31,51 @@ database, and `skipVerifier: true` is a recovery path for a container whose veri
 
 ## Writing a container
 
-The payload digest is only known once the payload has been written, so the caller supplies
-`patchHeader` to write it into the header afterwards.
+Everything only knowable once the payload has been written, the digest and the length it came to,
+goes in a trailer after it. Nothing is written back to, so a container is produced in one forward
+pass and the destination need not be seekable.
 
 ```ts
 import { createReadStream, createWriteStream } from "node:fs";
-import { open, rename, stat } from "node:fs/promises";
+import { rename, stat } from "node:fs/promises";
 import { writeBackupContainer } from "@triliumnext/backup-container";
 
 await writeBackupContainer(createReadStream(source), createWriteStream(partial), {
     compress: true,
     passphrase,                          // omit to leave the container unencrypted
-    plaintextSize: (await stat(source)).size,
-    patchHeader: async (offset, data) => {
-        const handle = await open(partial, "r+");
-        try {
-            await handle.write(data, 0, data.length, offset);
-            await handle.sync();
-        } finally {
-            await handle.close();
-        }
-    }
+    plaintextSize: (await stat(source)).size
 });
 
 await rename(partial, destination);      // rename last, so a partial file never looks finished
 ```
 
-Write to a temporary name and rename on success. Do not hand the payload stream a `FileHandle` opened
-with `autoClose: false` and patch through that same handle: its `close()` then waits forever on a
-stream that never emits `close`.
+Write to a temporary name and rename on success.
+
+## Describing a container without opening it
+
+What a container is, is stated in the clear, so a listing can be built from the first
+`FIXED_HEADER_BYTES` bytes of each file: no passphrase, no payload, nothing to decompress.
+
+```ts
+import { FIXED_HEADER_BYTES, getInfo } from "@triliumnext/backup-container";
+
+const info = getInfo(head);              // ArrayBuffer, Uint8Array, Buffer or any view
+```
+
+It never throws, so one foreign or damaged file among a hundred costs the listing a row rather than
+the listing, and it answers in three parts:
+
+| Answer | Means |
+| --- | --- |
+| `{ isValid: false }` | Not a container: the magic is not there |
+| `{ isValid: true, isSupported: false, version }` | One of ours, past what this build implements |
+| `{ isValid: true, isSupported: true, … }` | Readable, and described below |
+
+The fields exist only in the third case, because a version whose layout this module does not
+implement is one whose flags and sizes it would only be guessing at: `size` is the database inside
+before compression, or 0 where the writer did not record it; `creationTimestamp` is when the backup
+was taken, in milliseconds since the Unix epoch, or 0 where it was not recorded; `isCompressed` and
+`isEncrypted` are the flags.
 
 ## Using it in a browser
 
@@ -83,10 +99,9 @@ Three platform limits are worth knowing. WebCrypto's `subtle` interface only exi
 contexts (HTTPS, localhost, workers of either), so encrypted containers cannot be handled on a page
 served over plain HTTP. `CompressionStream` takes no compression level, so `compressionLevel` is
 ignored and the platform default applies; the header normalisation keeps the output canonical
-regardless. And `patchHeader` still needs random access to the finished bytes, which OPFS provides
-(`write` with `at`) but a streamed download does not, so writing a container means staging it
-somewhere seekable first. Key derivation is pure JavaScript here and takes seconds rather than
-milliseconds at the default cost; run it in a worker and say so in the UI.
+regardless. And key derivation is pure JavaScript here and takes seconds rather than milliseconds at
+the default cost; run it in a worker and say so in the UI. Writing needs nothing seekable, so a
+container may be streamed straight into a download.
 
 ## Reporting progress
 
@@ -143,13 +158,13 @@ The ones worth handling by name:
 | `passphrase-required` | The container is encrypted and no passphrase was given |
 | `wrong-passphrase-or-damaged-header` | The verifier tag did not match. A wrong passphrase, or a damaged header, and the two cannot be told apart from the tag alone |
 | `damaged-payload` | A frame failed authentication, or a compressed payload could not be decoded |
-| `digest-mismatch` | The payload does not match the digest recorded in the header, i.e. bit rot |
+| `digest-mismatch` | The payload does not match the digest recorded in the trailer, i.e. bit rot |
 | `truncated` | The file ends before the container does |
 | `trailing-data` | Bytes follow the final frame |
 | `not-a-database` | The unwrapped payload is not a SQLite database |
 | `output-too-large` | Output hit the ceiling, which is how a crafted compressed payload is stopped |
 | `unsupported-version` | Written by a newer Trilium |
-| `invalid-options` | The caller's options are unusable, e.g. a missing `patchHeader` |
+| `invalid-options` | The caller's options are unusable, e.g. a negative `plaintextSize` |
 
 The full set is the `BackupContainerErrorReason` union.
 

--- a/packages/trilium-backup-container/src/backend-node.ts
+++ b/packages/trilium-backup-container/src/backend-node.ts
@@ -1,6 +1,15 @@
-import { createCipheriv, createDecipheriv, createHash, randomBytes, scrypt } from "node:crypto";
+import {
+    type BinaryLike,
+    createCipheriv,
+    createDecipheriv,
+    createHash,
+    randomBytes,
+    scrypt,
+    type ScryptOptions
+} from "node:crypto";
 import { once } from "node:events";
 import type { Duplex } from "node:stream";
+import { promisify } from "node:util";
 import { createGunzip, createGzip } from "node:zlib";
 
 import type { ByteSource, ContainerBackend } from "./backend.js";
@@ -30,28 +39,15 @@ export const nodeBackend: ContainerBackend = {
         };
     },
 
-    deriveKey(passphrase, salt, params, maxMemoryBytes) {
-        const options = {
+    // Async, which is what makes both of scrypt's failure modes one thing to the caller: it refuses
+    // impossible parameters by throwing where it is called and reports everything else through the
+    // callback, and an async function turns the first of those into a rejection like the second.
+    async deriveKey(passphrase, salt, params, maxMemoryBytes) {
+        return scryptAsync(passphrase, salt, KEY_BYTES, {
             N: 2 ** params.log2N,
             r: params.r,
             p: params.p,
             maxmem: maxMemoryBytes
-        };
-
-        return new Promise((resolve, reject) => {
-            // scrypt rejects impossible parameters synchronously and everything else through the
-            // callback.
-            try {
-                scrypt(
-                    passphrase,
-                    salt,
-                    KEY_BYTES,
-                    options,
-                    (error, key) => (error ? reject(error) : resolve(key))
-                );
-            } catch (error) {
-                reject(error);
-            }
         });
     },
 
@@ -85,6 +81,9 @@ export const nodeBackend: ContainerBackend = {
     }
 
 };
+
+/** Spelled out because `scrypt` is overloaded, and `promisify` picks the wrong one on its own. */
+const scryptAsync = promisify<BinaryLike, BinaryLike, number, ScryptOptions, Buffer>(scrypt);
 
 /**
  * Runs a byte source through a zlib stream, yielding what comes out the other side.

--- a/packages/trilium-backup-container/src/container.spec.ts
+++ b/packages/trilium-backup-container/src/container.spec.ts
@@ -8,7 +8,8 @@ import {
     FRAME_SIZE,
     HEADER_BYTES_ENCRYPTED,
     HEADER_BYTES_PLAIN,
-    streamedContainerSize,
+    containerSize,
+    TRAILER_BYTES,
     TAG_BYTES
 } from "./format.js";
 import { readBackupContainer, writeBackupContainer } from "./node-streams.js";
@@ -51,7 +52,6 @@ describe("round trip", () => {
             { ...options, plaintextSize: database.length }
         );
         expect(written.result.headerLength).toBe(headerLength);
-        expect(written.patchedAt).toEqual([ headerLength - 32 ]);
 
         const read = await readFromBuffer(written.bytes, { passphrase: PASSPHRASE });
         expect(read.bytes.equals(database)).toBe(true);
@@ -81,7 +81,7 @@ describe("round trip", () => {
             Buffer.alloc(0),
             { passphrase: PASSPHRASE, scrypt: FAST_SCRYPT }
         );
-        expect(written.bytes).toHaveLength(HEADER_BYTES_ENCRYPTED + FRAME_OVERHEAD);
+        expect(written.bytes).toHaveLength(HEADER_BYTES_ENCRYPTED + FRAME_OVERHEAD + TRAILER_BYTES);
 
         const read = await readFromBuffer(
             written.bytes,
@@ -101,14 +101,14 @@ describe("round trip", () => {
 });
 
 describe("payload digest", () => {
-    it("is the SHA-256 of the payload as stored, patched in after the payload", async () => {
+    it("is the SHA-256 of the payload as stored, written into the trailer after it", async () => {
         const written = await writeToBuffer(
             fakeDatabase(20_000),
             { passphrase: PASSPHRASE, scrypt: FAST_SCRYPT }
         );
 
-        const payload = written.bytes.subarray(HEADER_BYTES_ENCRYPTED);
-        const stored = written.bytes.subarray(HEADER_BYTES_ENCRYPTED - 32, HEADER_BYTES_ENCRYPTED);
+        const payload = written.bytes.subarray(HEADER_BYTES_ENCRYPTED, -TRAILER_BYTES);
+        const stored = written.bytes.subarray(-TRAILER_BYTES, -TRAILER_BYTES + 32);
 
         expect(stored.equals(createHash("sha256").update(payload).digest())).toBe(true);
         expect(Buffer.from(written.result.digest).equals(stored)).toBe(true);
@@ -117,7 +117,7 @@ describe("payload digest", () => {
 
     it("catches damage to an unencrypted payload", async () => {
         const written = await writeToBuffer(fakeDatabase(4096));
-        const damaged = flipByte(written.bytes, written.bytes.length - 5);
+        const damaged = flipByte(written.bytes, written.bytes.length - TRAILER_BYTES - 5);
 
         expect(await failureOf(damaged)).toBe("digest-mismatch");
     });
@@ -127,7 +127,7 @@ describe("gzip payload", () => {
     it("is a plain gzip stream with no metadata, recoverable with stock tools", async () => {
         const database = fakeDatabase(5_000);
         const written = await writeToBuffer(database, { compress: true });
-        const payload = written.bytes.subarray(HEADER_BYTES_PLAIN);
+        const payload = written.bytes.subarray(HEADER_BYTES_PLAIN, -TRAILER_BYTES);
 
         expect(payload.readUInt16BE(0)).toBe(0x1f8b);
         expect(payload.readUInt8(3)).toBe(0);              // no FNAME, no FEXTRA
@@ -146,7 +146,7 @@ describe("canonical framing", () => {
         );
 
         const fullFrames = 2 * (FRAME_SIZE + FRAME_OVERHEAD);
-        expect(written.bytes).toHaveLength(HEADER_BYTES_ENCRYPTED + fullFrames + FRAME_OVERHEAD);
+        expect(written.bytes).toHaveLength(HEADER_BYTES_ENCRYPTED + fullFrames + FRAME_OVERHEAD + TRAILER_BYTES);
 
         const read = await readFromBuffer(written.bytes, { passphrase: PASSPHRASE });
         expect(read.bytes.equals(database)).toBe(true);
@@ -161,6 +161,7 @@ describe("canonical framing", () => {
 
         expect(written.bytes).toHaveLength(
             HEADER_BYTES_ENCRYPTED + (FRAME_SIZE + FRAME_OVERHEAD) + (1_000 + FRAME_OVERHEAD)
+            + TRAILER_BYTES
         );
     });
 });
@@ -221,7 +222,7 @@ describe("damage and tampering", () => {
 
     it("recovers when only the verifier tag is damaged", async () => {
         const written = await encrypted();
-        const damaged = flipByte(written.bytes, 65);   // inside the verifier tag, bytes 60 to 75
+        const damaged = flipByte(written.bytes, 73);   // inside the verifier tag, bytes 68 to 83
 
         expect(await failureOf(damaged, { passphrase: PASSPHRASE }))
             .toBe("wrong-passphrase-or-damaged-header");
@@ -236,7 +237,7 @@ describe("damage and tampering", () => {
 
     it("rejects a flipped bit in the salt, which no recovery can undo", async () => {
         const written = await encrypted();
-        const damaged = flipByte(written.bytes, 40);
+        const damaged = flipByte(written.bytes, 48);
 
         const reason = await failureOf(damaged, { passphrase: PASSPHRASE, skipVerifier: true });
 
@@ -324,7 +325,7 @@ describe("peeking at a container", () => {
         expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES))).toEqual({
             version: 1,
             plaintextSize: 9_000,
-            streamed: false,
+            timestamp: expect.any(Number),
             ...expected
         });
     });
@@ -339,7 +340,7 @@ describe("peeking at a container", () => {
         [ "fewer bytes than a header", Buffer.alloc(20) ],
         [ "something that is not a container", Buffer.alloc(64, 9) ],
         [ "a version it does not know", tamper((bytes) => bytes.writeUInt8(2, 20)) ],
-        [ "a reserved flag bit", tamper((bytes) => bytes.writeUInt8(0b1000, 21)) ]
+        [ "a reserved flag bit", tamper((bytes) => bytes.writeUInt8(0b100, 29)) ]
     ])("answers null for %s, so one bad file cannot derail a listing", (_label, bytes) => {
         expect(peekBackupContainer(bytes)).toBeNull();
     });
@@ -349,7 +350,7 @@ function tamper(mutate: (bytes: Buffer) => void): Buffer {
     const header = Buffer.alloc(FIXED_HEADER_BYTES);
     Buffer.from("Trilium Notes Backup", "ascii").copy(header, 0);
     header.writeUInt8(1, 20);
-    header.writeUInt16LE(64, 22);
+    header.writeUInt16LE(40, 30);
     mutate(header);
 
     return header;
@@ -392,7 +393,7 @@ describe("output bounds", () => {
             { compress: true, plaintextSize: database.length }
         );
         const tightened = Buffer.from(written.bytes);
-        tightened.writeBigUInt64LE(1_000n, 24);
+        tightened.writeBigUInt64LE(1_000n, 32);
 
         expect(await failureOf(tightened)).toBe("output-too-large");
     });
@@ -400,7 +401,7 @@ describe("output bounds", () => {
     it("never lets a crafted plaintext size widen the ceiling", async () => {
         const written = await writeToBuffer(fakeDatabase(64 * 1024), { compress: true });
         const crafted = Buffer.from(written.bytes);
-        crafted.writeBigUInt64LE(2n ** 63n, 24);
+        crafted.writeBigUInt64LE(2n ** 63n, 32);
 
         expect(await failureOf(crafted, { maxOutputBytes: 1_000 })).toBe("output-too-large");
     });
@@ -409,7 +410,7 @@ describe("output bounds", () => {
         const database = fakeDatabase(4096);
         const written = await writeToBuffer(database, { plaintextSize: database.length });
         const lying = Buffer.from(written.bytes);
-        lying.writeBigUInt64LE(5_000n, 24);
+        lying.writeBigUInt64LE(5_000n, 32);
 
         expect(await failureOf(lying)).toBe("size-mismatch");
     });
@@ -432,83 +433,23 @@ describe("SQLite check", () => {
 });
 
 describe("option validation", () => {
-    it("requires patchHeader, since the digest is written after the payload", async () => {
-        const reason = await reasonOf(
-            writeBackupContainer(Readable.from([ fakeDatabase() ]), new MemorySink(), {} as never)
-        );
-
-        expect(reason).toBe("invalid-options");
-    });
-
-    it.each([
-        [ "a negative plaintext size", { plaintextSize: -1 }, "invalid-options" ],
-        [ "a fractional plaintext size", { plaintextSize: 1.5 }, "invalid-options" ],
-        [
-            "scrypt parameters out of bounds",
-            { passphrase: PASSPHRASE, scrypt: { log2N: 30, r: 8, p: 1 } },
-            "invalid-kdf-params"
-        ],
-        [
-            "a scrypt cost above the writer ceiling",
-            { passphrase: PASSPHRASE, maxKdfMemoryBytes: 1024 },
-            "invalid-kdf-params"
-        ]
-    ])("rejects %s", async (_label, options, reason) => {
-        expect(await reasonOf(writeToBuffer(fakeDatabase(), options))).toBe(reason);
-    });
-
-    it("refuses a key derivation the reader considers too expensive", async () => {
-        const written = await writeToBuffer(
-            fakeDatabase(),
-            { passphrase: PASSPHRASE, scrypt: FAST_SCRYPT }
-        );
-
-        expect(await failureOf(written.bytes, { passphrase: PASSPHRASE, maxKdfMemoryBytes: 1024 }))
-            .toBe("invalid-kdf-params");
+    it("rejects a plaintext size that is not a non-negative safe integer", async () => {
+        expect(await reasonOf(writeToBuffer(fakeDatabase(), { plaintextSize: -1 })))
+            .toBe("invalid-options");
     });
 });
 
-describe("errors", () => {
-    it("carries a machine-readable reason and a plain English message", async () => {
-        try {
-            await readFromBuffer(Buffer.alloc(300, 9));
-            expect.unreachable("should have thrown");
-        } catch (error) {
-            expect(error).toMatchObject({
-                name: "BackupContainerError",
-                reason: "not-a-container"
-            });
-            expect((error as Error).message).toMatch(/container magic/);
-        }
-    });
+describe("forward-only writing", () => {
+    const FORWARD: WriteOptions = { passphrase: PASSPHRASE, scrypt: FAST_SCRYPT };
 
-    it("lets a destination error through untranslated", async () => {
-        const written = await writeToBuffer(fakeDatabase());
-        const failing = new MemorySink();
-        failing._write = (_chunk, _encoding, callback) =>
-            callback(new Error("ENOSPC: no space left on device"));
-
-        const read = readBackupContainer(Readable.from([ written.bytes ]), failing);
-
-        await expect(read).rejects.toThrow(/ENOSPC/);
-    });
-});
-
-describe("streamed containers", () => {
-    const STREAMED: WriteOptions = { streamed: true, passphrase: PASSPHRASE, scrypt: FAST_SCRYPT };
-
-    it("writes front to back, sized exactly as stated, and reads back on both runtimes", async () => {
+    it("is sized exactly as derived, and reads back on both runtimes", async () => {
         const database = fakeDatabase(64 * 1024);
-        const written = await writeToBuffer(database, { ...STREAMED, plaintextSize: database.length });
+        const written = await writeToBuffer(database, { ...FORWARD, plaintextSize: database.length });
 
-        // No patch was asked of the destination, and none was needed.
-        expect(written.patchedAt).toEqual([]);
-        expect(written.bytes.length).toBe(streamedContainerSize(database.length, true));
-        // The digest field stays zeros, which is what "no digest" looks like in the header.
-        expect(written.bytes.subarray(HEADER_BYTES_ENCRYPTED - 32, HEADER_BYTES_ENCRYPTED)
-            .every((byte) => byte === 0)).toBe(true);
+        // Nothing was written back to: what the sink received in order is the whole file.
+        expect(written.bytes.length).toBe(containerSize(database.length, true));
         expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
-            .toMatchObject({ encrypted: true, streamed: true, compressed: false });
+            .toMatchObject({ encrypted: true, compressed: false });
 
         const read = await readFromBuffer(written.bytes, { passphrase: PASSPHRASE });
         expect(read.bytes.equals(database)).toBe(true);
@@ -519,29 +460,30 @@ describe("streamed containers", () => {
 
     it("sizes a payload that is an exact multiple of the frame size, empty final frame included", async () => {
         const database = fakeDatabase(FRAME_SIZE);
-        const written = await writeToBuffer(database, STREAMED);
+        const written = await writeToBuffer(database, FORWARD);
 
-        expect(written.bytes.length).toBe(streamedContainerSize(FRAME_SIZE, true));
+        expect(written.bytes.length).toBe(containerSize(FRAME_SIZE, true));
         const read = await readFromBuffer(written.bytes, { passphrase: PASSPHRASE });
         expect(read.bytes.equals(database)).toBe(true);
     });
 
-    it("still catches tampering: the frames authenticate what the digest no longer covers", async () => {
+    it("catches tampering through the frames as well as the digest", async () => {
         const database = fakeDatabase(64 * 1024);
-        const written = await writeToBuffer(database, STREAMED);
+        const written = await writeToBuffer(database, FORWARD);
 
         const tampered = flipByte(written.bytes, HEADER_BYTES_ENCRYPTED + 4 + 100);
         expect(await failureOf(tampered, { passphrase: PASSPHRASE })).toBe("damaged-payload");
     });
 
-    it("writes and reads one without a passphrase, held together by its recorded size", async () => {
+    it("writes and reads a container with neither compression nor encryption", async () => {
+        // The case with nothing else standing behind it: the trailer's digest is the whole of its
+        // integrity, and it is there because no writer has to seek to produce one any more.
         const database = fakeDatabase(64 * 1024);
-        const written = await writeToBuffer(database, { streamed: true, plaintextSize: database.length });
+        const written = await writeToBuffer(database, { plaintextSize: database.length });
 
-        expect(written.patchedAt).toEqual([]);
-        expect(written.bytes.length).toBe(streamedContainerSize(database.length, false));
+        expect(written.bytes.length).toBe(containerSize(database.length, false));
         expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
-            .toMatchObject({ encrypted: false, streamed: true, compressed: false });
+            .toMatchObject({ encrypted: false, compressed: false });
 
         expect((await readFromBuffer(written.bytes)).bytes.equals(database)).toBe(true);
         expect((await readFromBufferWeb(written.bytes)).bytes.equals(database)).toBe(true);
@@ -549,16 +491,18 @@ describe("streamed containers", () => {
 
     it("catches a truncated unencrypted one, which is what a broken download leaves", async () => {
         const database = fakeDatabase(64 * 1024);
-        const written = await writeToBuffer(database, { streamed: true, plaintextSize: database.length });
+        const written = await writeToBuffer(database, { plaintextSize: database.length });
 
-        // The digest is gone, so the recorded size is what stands between a half-written
-        // download and a restore that trusts it.
+        // Cutting the end takes the trailer with it, so what is left cannot even claim a digest.
         expect(await failureOf(written.bytes.subarray(0, written.bytes.length - 1024)))
-            .toBe("size-mismatch");
+            .toBe("digest-mismatch");
     });
 
-    it("refuses to write an unencrypted streamed container that states no size", async () => {
-        expect(await reasonOf(writeToBuffer(fakeDatabase(), { streamed: true })))
-            .toBe("invalid-options");
+    it("records the length it actually wrote, whatever it was told in advance", async () => {
+        const database = fakeDatabase(64 * 1024);
+        // Told nothing: the trailer still states the size, counted as the payload went past.
+        const written = await writeToBuffer(database, {});
+
+        expect((await readFromBuffer(written.bytes)).result.bytesWritten).toBe(database.length);
     });
 });

--- a/packages/trilium-backup-container/src/container.spec.ts
+++ b/packages/trilium-backup-container/src/container.spec.ts
@@ -9,6 +9,7 @@ import {
     HEADER_BYTES_ENCRYPTED,
     HEADER_BYTES_PLAIN,
     containerSize,
+    SCRYPT_DEFAULTS,
     TRAILER_BYTES,
     TAG_BYTES
 } from "./format.js";
@@ -562,5 +563,42 @@ describe("forward-only writing", () => {
         const written = await writeToBuffer(database, {});
 
         expect((await readFromBuffer(written.bytes)).result.bytesWritten).toBe(database.length);
+    });
+});
+
+describe("what the trailer is holding the file to", () => {
+    it("refuses a payload that is not the length the trailer counted", async () => {
+        const database = fakeDatabase(9_000);
+        const written = await writeToBuffer(database, { plaintextSize: database.length });
+
+        // The size field alone, leaving the digest beside it intact: this is the check that stands
+        // on its own, rather than the one the digest would have caught anyway.
+        const lying = Buffer.from(written.bytes);
+        lying.writeBigUInt64LE(8_000n, lying.length - 8);
+
+        expect(await failureOf(lying)).toBe("size-mismatch");
+    });
+
+    it("reads a container whose payload is shorter than its own trailer", async () => {
+        // The edge the rolling window exists for: with nothing but a trailer left to look at, the
+        // reader has to hold all of it back rather than emit any of it as payload.
+        const written = await writeToBuffer(Buffer.alloc(0));
+
+        expect(written.bytes).toHaveLength(containerSize(0, false));
+
+        const read = await readFromBuffer(written.bytes, { requireSqliteHeader: false });
+        expect(read.bytes).toHaveLength(0);
+    });
+
+});
+
+describe("the cost of a key nobody chose", () => {
+    it("derives at the recommended cost when the caller does not say", async () => {
+        // Every other test here asks for a cheap derivation, which leaves the default untried; it
+        // is the one real users get, and the one whose bounds a reader checks against.
+        const written = await writeToBuffer(fakeDatabase(4096), { passphrase: PASSPHRASE });
+
+        expect([ ...written.bytes.subarray(41, 44) ])
+            .toEqual([ SCRYPT_DEFAULTS.log2N, SCRYPT_DEFAULTS.r, SCRYPT_DEFAULTS.p ]);
     });
 });

--- a/packages/trilium-backup-container/src/container.spec.ts
+++ b/packages/trilium-backup-container/src/container.spec.ts
@@ -13,7 +13,7 @@ import {
     TAG_BYTES
 } from "./format.js";
 import { readBackupContainer, writeBackupContainer } from "./node-streams.js";
-import { peekBackupContainer } from "./read.js";
+import { getInfo } from "./read.js";
 import {
     chunked,
     fakeDatabase,
@@ -27,7 +27,7 @@ import {
     type WriteOptions,
     writeToBuffer
 } from "./test-helpers.js";
-type PeekCase = [string, WriteOptions, { compressed: boolean; encrypted: boolean }];
+type PeekCase = [string, WriteOptions, { isCompressed: boolean; isEncrypted: boolean }];
 
 const PASSPHRASE = "correct horse battery staple";
 const FRAME_OVERHEAD = 4 + TAG_BYTES;
@@ -296,19 +296,19 @@ describe("damage and tampering", () => {
     });
 });
 
-describe("peeking at a container", () => {
+describe("describing a container for a listing", () => {
     it.each([
-        [ "plain", {}, { compressed: false, encrypted: false } ],
-        [ "compressed", { compress: true }, { compressed: true, encrypted: false } ],
+        [ "plain", {}, { isCompressed: false, isEncrypted: false } ],
+        [ "compressed", { compress: true }, { isCompressed: true, isEncrypted: false } ],
         [
             "encrypted",
             { passphrase: PASSPHRASE, scrypt: FAST_SCRYPT },
-            { compressed: false, encrypted: true }
+            { isCompressed: false, isEncrypted: true }
         ],
         [
             "both",
             { compress: true, passphrase: PASSPHRASE, scrypt: FAST_SCRYPT },
-            { compressed: true, encrypted: true }
+            { isCompressed: true, isEncrypted: true }
         ]
     ] as PeekCase[])("reports a %s container from its first bytes alone", async (
         _label,
@@ -321,30 +321,88 @@ describe("peeking at a container", () => {
             { ...options, plaintextSize: database.length }
         );
 
-        // Only the fixed header, and no passphrase, which is the whole point of the peek.
-        expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES))).toEqual({
+        // Only the fixed header, and no passphrase, which is the whole point of describing one.
+        expect(getInfo(written.bytes.subarray(0, FIXED_HEADER_BYTES))).toEqual({
+            isValid: true,
+            isSupported: true,
             version: 1,
-            plaintextSize: 9_000,
-            timestamp: expect.any(Number),
+            size: 9_000,
+            creationTimestamp: expect.any(Number),
             ...expected
         });
     });
 
-    it("reports an unrecorded plaintext size as zero rather than guessing", async () => {
-        const written = await writeToBuffer(fakeDatabase(4096), { compress: true });
+    it("dates the backup from the container, not from the file it sits in", async () => {
+        const taken = Date.UTC(2026, 1, 3, 4, 5, 6);
+        const written = await writeToBuffer(fakeDatabase(4096), { timestamp: taken });
 
-        expect(peekBackupContainer(written.bytes)?.plaintextSize).toBe(0);
+        const info = getInfo(written.bytes);
+
+        expect(info).toMatchObject({ isValid: true, isSupported: true });
+        expect(info.isValid && info.isSupported && info.creationTimestamp).toBe(taken);
+    });
+
+    it("reports an unrecorded size as zero rather than guessing", async () => {
+        const written = await writeToBuffer(fakeDatabase(4096), { compress: true });
+        const info = getInfo(written.bytes);
+
+        expect(info.isValid && info.isSupported && info.size).toBe(0);
+    });
+
+    it.each([
+        [ "an ArrayBuffer", (head: Uint8Array) => copyOf(head, 0) ],
+        [ "a view over one", (head: Uint8Array) => new DataView(copyOf(head, 0)) ],
+        // The one an offset-blind reader gets silently wrong, since the bytes it wants are there.
+        [
+            "a view starting partway into one",
+            (head: Uint8Array) => new DataView(copyOf(head, 8), 8)
+        ]
+    ])("takes the head as %s, since callers hold it differently", async (_label, wrap) => {
+        const written = await writeToBuffer(fakeDatabase(4096), { plaintextSize: 4096 });
+        const head = written.bytes.subarray(0, FIXED_HEADER_BYTES);
+
+        expect(getInfo(wrap(head))).toEqual(getInfo(head));
     });
 
     it.each([
         [ "fewer bytes than a header", Buffer.alloc(20) ],
         [ "something that is not a container", Buffer.alloc(64, 9) ],
-        [ "a version it does not know", tamper((bytes) => bytes.writeUInt8(2, 20)) ],
-        [ "a reserved flag bit", tamper((bytes) => bytes.writeUInt8(0b100, 29)) ]
-    ])("answers null for %s, so one bad file cannot derail a listing", (_label, bytes) => {
-        expect(peekBackupContainer(bytes)).toBeNull();
+        [ "an empty file", Buffer.alloc(0) ]
+    ])("says %s is not a backup at all, so one foreign file cannot derail a listing", (
+        _label,
+        bytes
+    ) => {
+        expect(getInfo(bytes)).toEqual({ isValid: false });
+    });
+
+    it.each([
+        [ "a version written after this build", (bytes: Buffer) => bytes.writeUInt8(2, 20), 2 ],
+        [ "a version nothing could have written", (bytes: Buffer) => bytes.writeUInt8(0, 20), 0 ],
+        [ "a reserved flag bit", (bytes: Buffer) => bytes.writeUInt8(0b100, 29), 1 ],
+        [ "a header that does not measure up", (bytes: Buffer) => bytes.writeUInt16LE(64, 30), 1 ]
+    ])("owns %s as a backup it cannot open, rather than disowning it", (
+        _label,
+        mutate,
+        version
+    ) => {
+        // The difference a listing lives on: "not a backup" and "a backup this build is too old
+        // for" are the same null to a reader that only answers yes or no.
+        expect(getInfo(tamper(mutate))).toEqual({ isValid: true, isSupported: false, version });
     });
 });
+
+/**
+ * The bytes in an `ArrayBuffer` of their own, which a `Buffer` never has: Node allocates those out
+ * of a shared pool, so `.buffer` on one is most of the heap and starts nowhere near the bytes.
+ *
+ * @param offset how far into the buffer to put them, so a view at a non-zero offset can be built.
+ */
+function copyOf(bytes: Uint8Array, offset: number): ArrayBuffer {
+    const buffer = new ArrayBuffer(offset + bytes.length);
+    new Uint8Array(buffer).set(bytes, offset);
+
+    return buffer;
+}
 
 function tamper(mutate: (bytes: Buffer) => void): Buffer {
     const header = Buffer.alloc(FIXED_HEADER_BYTES);
@@ -448,8 +506,8 @@ describe("forward-only writing", () => {
 
         // Nothing was written back to: what the sink received in order is the whole file.
         expect(written.bytes.length).toBe(containerSize(database.length, true));
-        expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
-            .toMatchObject({ encrypted: true, compressed: false });
+        expect(getInfo(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
+            .toMatchObject({ isEncrypted: true, isCompressed: false });
 
         const read = await readFromBuffer(written.bytes, { passphrase: PASSPHRASE });
         expect(read.bytes.equals(database)).toBe(true);
@@ -482,8 +540,8 @@ describe("forward-only writing", () => {
         const written = await writeToBuffer(database, { plaintextSize: database.length });
 
         expect(written.bytes.length).toBe(containerSize(database.length, false));
-        expect(peekBackupContainer(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
-            .toMatchObject({ encrypted: false, compressed: false });
+        expect(getInfo(written.bytes.subarray(0, FIXED_HEADER_BYTES)))
+            .toMatchObject({ isEncrypted: false, isCompressed: false });
 
         expect((await readFromBuffer(written.bytes)).bytes.equals(database)).toBe(true);
         expect((await readFromBufferWeb(written.bytes)).bytes.equals(database)).toBe(true);

--- a/packages/trilium-backup-container/src/cross-backend.spec.ts
+++ b/packages/trilium-backup-container/src/cross-backend.spec.ts
@@ -3,7 +3,7 @@ import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { webBackend } from "./backend-web.js";
-import { FRAME_SIZE, HEADER_BYTES_PLAIN } from "./format.js";
+import { FRAME_SIZE, HEADER_BYTES_PLAIN, TRAILER_BYTES } from "./format.js";
 import {
     failureOfWeb,
     fakeDatabase,
@@ -119,7 +119,7 @@ describe("web gzip canonical form", () => {
     it("normalises MTIME and the OS byte whatever the platform compressor emits", async () => {
         const database = fakeDatabase(5_000);
         const written = await writeToBufferWeb(database, { compress: true });
-        const payload = written.bytes.subarray(HEADER_BYTES_PLAIN);
+        const payload = written.bytes.subarray(HEADER_BYTES_PLAIN, -TRAILER_BYTES);
 
         expect(payload.readUInt16BE(0)).toBe(0x1f8b);
         expect(payload.readUInt32LE(4)).toBe(0);           // MTIME, so no timestamp leaks
@@ -144,7 +144,7 @@ describe("web failure reasons", () => {
 
     it("recovers with skipVerifier when only the verifier tag is damaged", async () => {
         const written = await encrypted();
-        const damaged = flipByte(written.bytes, 65);   // inside the verifier tag, bytes 60 to 75
+        const damaged = flipByte(written.bytes, 73);   // inside the verifier tag, bytes 68 to 83
 
         const recovered = await readFromBufferWeb(
             damaged,
@@ -176,17 +176,15 @@ describe("web failure reasons", () => {
         // Corrupt the deflate data, then repair the digest so the failure can only come from the
         // decoder.
         const damaged = flipByte(written.bytes, HEADER_BYTES_PLAIN + 30);
-        createHash("sha256").update(damaged.subarray(HEADER_BYTES_PLAIN)).digest().copy(
-            damaged,
-            HEADER_BYTES_PLAIN - 32
-        );
+        createHash("sha256").update(damaged.subarray(HEADER_BYTES_PLAIN, -TRAILER_BYTES)).digest()
+            .copy(damaged, damaged.length - TRAILER_BYTES);
 
         expect(await failureOfWeb(damaged)).toBe("damaged-payload");
     });
 
     it("surfaces a digest mismatch through the decompressor untranslated", async () => {
         const written = await writeToBuffer(fakeDatabase(50_000), { compress: true });
-        const damaged = flipByte(written.bytes, HEADER_BYTES_PLAIN - 5);   // inside the digest
+        const damaged = flipByte(written.bytes, written.bytes.length - TRAILER_BYTES + 5);   // in the digest
 
         expect(await failureOfWeb(damaged)).toBe("digest-mismatch");
     });

--- a/packages/trilium-backup-container/src/cross-backend.spec.ts
+++ b/packages/trilium-backup-container/src/cross-backend.spec.ts
@@ -71,9 +71,12 @@ describe("cross-backend round trips", () => {
 
     it("writes byte-identical plain containers on both backends", async () => {
         const database = fakeDatabase(9_000);
+        // Stated rather than taken from the clock, which is the one field two writes are entitled
+        // to disagree on: a millisecond between them would fail this for the wrong reason.
+        const shared = { plaintextSize: database.length, timestamp: Date.UTC(2026, 0, 2, 3, 4, 5) };
 
-        const node = await writeToBuffer(database, { plaintextSize: database.length });
-        const web = await writeToBufferWeb(database, { plaintextSize: database.length });
+        const node = await writeToBuffer(database, shared);
+        const web = await writeToBufferWeb(database, shared);
 
         expect(web.bytes.equals(node.bytes)).toBe(true);
     });

--- a/packages/trilium-backup-container/src/file-destination.spec.ts
+++ b/packages/trilium-backup-container/src/file-destination.spec.ts
@@ -19,7 +19,7 @@ describe("file destination", () => {
         await rm(directory, { recursive: true, force: true });
     });
 
-    it("writes to a file, patches the digest, and reads back byte for byte", async () => {
+    it("writes to a file in one pass and reads back byte for byte", async () => {
         const database = fakeDatabase(3 * 1024 * 1024);
         const source = join(directory, "document.db");
         const partial = join(directory, "backup.part");
@@ -32,19 +32,10 @@ describe("file destination", () => {
             compress: true,
             passphrase: "file test",
             scrypt: FAST_SCRYPT,
-            plaintextSize: (await stat(source)).size,
-            patchHeader: async (offset, data) => {
-                const handle = await open(partial, "r+");
-                try {
-                    await handle.write(data, 0, data.length, offset);
-                    await handle.sync();
-                } finally {
-                    await handle.close();
-                }
-            }
+            plaintextSize: (await stat(source)).size
         });
 
-        expect(result).toMatchObject({ headerLength: 108, compressed: true, encrypted: true });
+        expect(result).toMatchObject({ headerLength: 84, compressed: true, encrypted: true });
 
         await rename(partial, container);
         expect((await stat(container)).size).toBeLessThan(database.length);

--- a/packages/trilium-backup-container/src/format.spec.ts
+++ b/packages/trilium-backup-container/src/format.spec.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import { BackupContainerError } from "./errors.js";
 import {
     authenticatedHeaderEnd,
+    containerSize,
     type ContainerHeader,
     decodeFixedHeader,
     decodeHeader,
+    decodeTrailer,
     DEFAULT_MAX_HEADER_BYTES,
-    digestOffset,
     encodeHeader,
+    encodeTrailer,
     FIXED_HEADER_BYTES,
     HEADER_BYTES_ENCRYPTED,
     HEADER_BYTES_PLAIN,
@@ -16,20 +18,22 @@ import {
     nonceFor,
     SQLITE_MAGIC,
     scryptMemoryBytes,
+    TRAILER_BYTES,
     validateScryptParams,
     validateSqliteHeader
 } from "./format.js";
 
+const TIMESTAMP = 1_700_000_000_000;
+
 function plainHeader(overrides: Partial<ContainerHeader> = {}): ContainerHeader {
     return {
         version: 1,
+        timestamp: TIMESTAMP,
         compressed: true,
         encrypted: false,
-        streamed: false,
         plaintextSize: 4096,
         headerLength: HEADER_BYTES_PLAIN,
         encryption: null,
-        digest: Buffer.alloc(32, 7),
         ...overrides
     };
 }
@@ -37,6 +41,7 @@ function plainHeader(overrides: Partial<ContainerHeader> = {}): ContainerHeader 
 function encryptedHeader(): ContainerHeader {
     return {
         version: 1,
+        timestamp: TIMESTAMP,
         compressed: false,
         encrypted: true,
         plaintextSize: 123456789,
@@ -49,8 +54,7 @@ function encryptedHeader(): ContainerHeader {
             salt: Buffer.alloc(16, 1),
             noncePrefix: Buffer.alloc(8, 2),
             verifierTag: Buffer.alloc(16, 3)
-        },
-        digest: Buffer.alloc(32, 4)
+        }
     };
 }
 
@@ -58,36 +62,36 @@ describe("header layout", () => {
     it("round-trips an unencrypted header and matches the documented offsets", () => {
         const bytes = Buffer.from(encodeHeader(plainHeader()));
 
-        expect(bytes).toHaveLength(64);
+        expect(bytes).toHaveLength(40);
         expect(bytes.subarray(0, 20).toString("ascii")).toBe("Trilium Notes Backup");
         expect(bytes.readUInt8(20)).toBe(1);
-        expect(bytes.readUInt8(21)).toBe(0b01);
-        expect(bytes.readUInt16LE(22)).toBe(64);
-        expect(bytes.readBigUInt64LE(24)).toBe(4096n);
-        expect(digestOffset(64)).toBe(32);
+        expect(bytes.readBigUInt64LE(21)).toBe(BigInt(TIMESTAMP));
+        expect(bytes.readUInt8(29)).toBe(0b01);
+        expect(bytes.readUInt16LE(30)).toBe(40);
+        expect(bytes.readBigUInt64LE(32)).toBe(4096n);
 
         const decoded = decodeHeader(bytes, DEFAULT_MAX_HEADER_BYTES);
         expect(decoded).toMatchObject({
             version: 1,
+            timestamp: TIMESTAMP,
             compressed: true,
             encrypted: false,
             plaintextSize: 4096
         });
         expect(decoded.encryption).toBeNull();
-        expect(Buffer.from(decoded.digest).equals(Buffer.alloc(32, 7))).toBe(true);
     });
 
-    it("round-trips an encrypted header, with the tag and digest as the last two fields", () => {
+    it("round-trips an encrypted header, with the verifier tag as its last field", () => {
         const header = encryptedHeader();
         const bytes = Buffer.from(encodeHeader(header));
 
-        expect(bytes).toHaveLength(108);
-        expect(bytes.readUInt8(21)).toBe(0b10);
-        expect(bytes.readUInt8(32)).toBe(KDF_SCRYPT);
-        const params = [ bytes.readUInt8(33), bytes.readUInt8(34), bytes.readUInt8(35) ];
+        expect(bytes).toHaveLength(84);
+        expect(bytes.readUInt8(29)).toBe(0b10);
+        expect(bytes.readUInt8(40)).toBe(KDF_SCRYPT);
+        const params = [ bytes.readUInt8(41), bytes.readUInt8(42), bytes.readUInt8(43) ];
         expect(params).toEqual([ 17, 8, 1 ]);
-        expect(authenticatedHeaderEnd(108)).toBe(60);
-        expect(digestOffset(108)).toBe(76);
+        // Everything up to the tag is authenticated, the timestamp with it.
+        expect(authenticatedHeaderEnd(84)).toBe(68);
 
         const decoded = decodeHeader(bytes, DEFAULT_MAX_HEADER_BYTES);
         expect(decoded.encryption).toMatchObject({ kdfId: KDF_SCRYPT, log2N: 17, r: 8, p: 1 });
@@ -98,13 +102,53 @@ describe("header layout", () => {
         expect(decoded.plaintextSize).toBe(123456789);
     });
 
-    it("treats an unrepresentable plaintext size as unknown, so it can never widen a bound", () => {
+    it("treats an unrepresentable plaintext size or timestamp as unknown", () => {
+        // Neither may widen a bound or be shown as a date, so both read as "not stated".
         const bytes = Buffer.from(encodeHeader(plainHeader()));
-        bytes.writeBigUInt64LE(2n ** 63n, 24);
+        bytes.writeBigUInt64LE(2n ** 63n, 32);
+        bytes.writeBigUInt64LE(2n ** 63n, 21);
 
-        expect(decodeHeader(bytes, DEFAULT_MAX_HEADER_BYTES).plaintextSize).toBe(0);
+        const decoded = decodeHeader(bytes, DEFAULT_MAX_HEADER_BYTES);
+        expect(decoded.plaintextSize).toBe(0);
+        expect(decoded.timestamp).toBe(0);
+    });
+});
+
+describe("trailer", () => {
+    it("round-trips the digest and the length the payload came to", () => {
+        const digest = Buffer.alloc(32, 9);
+        const bytes = Buffer.from(encodeTrailer({ digest, plaintextSize: 987654321 }));
+
+        expect(bytes).toHaveLength(TRAILER_BYTES);
+        expect(bytes).toHaveLength(40);
+
+        const decoded = decodeTrailer(bytes);
+        expect(Buffer.from(decoded.digest)).toEqual(digest);
+        expect(decoded.plaintextSize).toBe(987654321);
     });
 
+    it("refuses anything that is not exactly a trailer, which is what a short file leaves", () => {
+        expect(() => decodeTrailer(Buffer.alloc(TRAILER_BYTES - 1)))
+            .toThrow(expect.objectContaining({ reason: "truncated" }) as Error);
+    });
+});
+
+describe("derived container size", () => {
+    it("counts the header, the payload and the trailer", () => {
+        expect(containerSize(4096, false)).toBe(HEADER_BYTES_PLAIN + 4096 + TRAILER_BYTES);
+    });
+
+    it("counts every frame's length field and tag when encrypted, the empty final one included", () => {
+        // An exact multiple of the frame size still ends with an empty final frame.
+        const oneFrame = 1_048_576;
+        expect(containerSize(oneFrame, true))
+            .toBe(HEADER_BYTES_ENCRYPTED + oneFrame + 2 * 20 + TRAILER_BYTES);
+        expect(containerSize(oneFrame + 1, true))
+            .toBe(HEADER_BYTES_ENCRYPTED + oneFrame + 1 + 2 * 20 + TRAILER_BYTES);
+    });
+});
+
+describe("nonces", () => {
     it("builds a distinct 12-byte nonce per counter", () => {
         const prefix = Buffer.alloc(8, 9);
 
@@ -133,12 +177,12 @@ describe("fixed header validation", () => {
         [ "a newer version", (bytes: Buffer) => bytes.writeUInt8(2, 20), "unsupported-version" ],
         [
             "a reserved flag bit",
-            (bytes: Buffer) => bytes.writeUInt8(0b1000, 21),
+            (bytes: Buffer) => bytes.writeUInt8(0b100, 29),
             "unsupported-flags"
         ],
         [
             "a header length that does not match the flags",
-            (bytes: Buffer) => bytes.writeUInt16LE(65, 22),
+            (bytes: Buffer) => bytes.writeUInt16LE(41, 30),
             "invalid-header-length"
         ]
     ])("rejects %s", (_label, mutate, reason) => {
@@ -146,7 +190,7 @@ describe("fixed header validation", () => {
     });
 
     it("rejects a header above the ceiling before anything else", () => {
-        expect(decode((bytes) => bytes.writeUInt16LE(4000, 22), 128)).toThrow(
+        expect(decode((bytes) => bytes.writeUInt16LE(4000, 30), 128)).toThrow(
             expect.objectContaining({ reason: "invalid-header-length" }) as Error
         );
     });
@@ -154,17 +198,17 @@ describe("fixed header validation", () => {
     it("accepts the exact length each flag combination requires", () => {
         const lengthOf = (header: ContainerHeader) =>
             decodeFixedHeader(
-                encodeHeader(header).subarray(0, 32),
+                encodeHeader(header).subarray(0, FIXED_HEADER_BYTES),
                 DEFAULT_MAX_HEADER_BYTES
             ).headerLength;
 
-        expect(lengthOf(plainHeader())).toBe(64);
-        expect(lengthOf(encryptedHeader())).toBe(108);
+        expect(lengthOf(plainHeader())).toBe(HEADER_BYTES_PLAIN);
+        expect(lengthOf(encryptedHeader())).toBe(HEADER_BYTES_ENCRYPTED);
     });
 
     it("rejects a KDF id it does not implement", () => {
         const bytes = Buffer.from(encodeHeader(encryptedHeader()));
-        bytes.writeUInt8(2, 32);
+        bytes.writeUInt8(2, 40);
 
         expect(() => decodeHeader(bytes, DEFAULT_MAX_HEADER_BYTES)).toThrow(
             expect.objectContaining({ reason: "unsupported-kdf" }) as Error

--- a/packages/trilium-backup-container/src/format.ts
+++ b/packages/trilium-backup-container/src/format.ts
@@ -18,29 +18,32 @@ export const FORMAT_VERSION = 1;
 
 export const FLAG_COMPRESSED = 0b0000_0001;
 export const FLAG_ENCRYPTED = 0b0000_0010;
-/**
- * Written front to back, with no payload digest: the destination could not be revisited to patch
- * one in — a download already on its way to the user, for instance.
- *
- * What stands in for the digest depends on the other flags. Encrypted, every frame carries its own
- * authentication tag, which covers each payload byte. Unencrypted, the recorded plaintext size is
- * the check: the reader refuses output that does not measure exactly that, which is what a
- * truncated download looks like. A streamed container therefore always records its size.
- */
-export const FLAG_STREAMED = 0b0000_0100;
-export const FLAG_RESERVED = 0b1111_1000;
+export const FLAG_RESERVED = 0b1111_1100;
 
-export const FIXED_HEADER_BYTES = 32;
+export const FIXED_HEADER_BYTES = 40;
 export const DIGEST_BYTES = 32;
 export const TAG_BYTES = 16;
 export const SALT_BYTES = 16;
 export const NONCE_PREFIX_BYTES = 8;
 export const NONCE_BYTES = 12;
 export const KEY_BYTES = 32;
+export const TIMESTAMP_BYTES = 8;
+export const SIZE_BYTES = 8;
 
-/** Header length is fixed per flag combination in version 1, and readers require equality. */
-export const HEADER_BYTES_PLAIN = 64;
-export const HEADER_BYTES_ENCRYPTED = 108;
+/** Header length is fixed per flag combination, and readers require equality. */
+export const HEADER_BYTES_PLAIN = 40;
+export const HEADER_BYTES_ENCRYPTED = 84;
+
+/**
+ * What follows the payload: the digest over it, and the length it actually came to.
+ *
+ * Both are only knowable once the payload has been written, which is why they sit at the end rather
+ * than in the header. Nothing in a container therefore has to be written back to, so any writer can
+ * produce one in a single forward pass, and every container carries a digest whatever its flags
+ * say, including the plain uncompressed unencrypted one, which would otherwise have nothing at all
+ * standing behind its contents.
+ */
+export const TRAILER_BYTES = DIGEST_BYTES + SIZE_BYTES;
 
 /** Default ceiling on the header, applied before anything is allocated or sought. */
 export const DEFAULT_MAX_HEADER_BYTES = 4096;
@@ -92,18 +95,38 @@ export interface EncryptionHeader extends ScryptParams {
 
 export interface ContainerHeader {
     version: number;
+    /**
+     * When the backup was taken, in milliseconds since the Unix epoch, or `0` when not recorded.
+     *
+     * Stated in the clear so that a directory of backups can be dated without opening any of them,
+     * and without depending on a filesystem timestamp that copying does not preserve.
+     */
+    timestamp: number;
     compressed: boolean;
     encrypted: boolean;
-    /** Written front to back, so the digest field holds zeros. See {@link FLAG_STREAMED}. */
-    streamed: boolean;
     /**
      * Size of the wrapped database before compression, or 0 when unknown. A hint, never an
-     * instruction.
+     * instruction: the authoritative figure is the one the trailer records once the payload is
+     * written. This one is here for what has to be known in advance, such as the length of a
+     * download or a progress bar to draw against.
      */
     plaintextSize: number;
     headerLength: number;
     encryption: EncryptionHeader | null;
+}
+
+/**
+ * What follows the payload, once there is a payload to describe. See {@link TRAILER_BYTES}.
+ *
+ * Not covered by anything the header authenticates, for the same reason the digest never was: it is
+ * written after the fact. In an encrypted container the frames already make tampering detectable,
+ * and here the digest does what it has always done, which is catch bit rot and truncation.
+ */
+export interface ContainerTrailer {
+    /** SHA-256 over the payload exactly as stored. */
     digest: Uint8Array;
+    /** The plaintext length as counted while writing, which the reader holds the output to. */
+    plaintextSize: number;
 }
 
 /** Header length implied by the flags, which readers require exactly. */
@@ -114,17 +137,12 @@ export function headerLengthFor(encrypted: boolean): number {
 /**
  * End of the span that the verifier tag and every frame authenticate.
  *
- * The verifier tag and the payload digest are the last two fields of the header and are both
- * written after the fact, so neither can be inside what the header authenticates. Stopping here
- * also keeps a bit flip in the verifier tag from invalidating every frame in the file.
+ * The verifier tag is the last field of the header and is written once the key exists, so it cannot
+ * be inside what it authenticates. Stopping here also keeps a bit flip in the verifier tag from
+ * invalidating every frame in the file. Everything before it, the timestamp included, is covered.
  */
 export function authenticatedHeaderEnd(headerLength: number): number {
-    return headerLength - TAG_BYTES - DIGEST_BYTES;
-}
-
-/** Offset of the payload digest, always the last 32 bytes of the header. */
-export function digestOffset(headerLength: number): number {
-    return headerLength - DIGEST_BYTES;
+    return headerLength - TAG_BYTES;
 }
 
 /** Memory a scrypt derivation needs, which is what the reader ceiling is applied to. */
@@ -140,43 +158,65 @@ export function nonceFor(noncePrefix: Uint8Array, counter: number): Uint8Array {
     return nonce;
 }
 
-/**
- * Serialises a header. The digest is written as supplied, so a writer passes zeros and patches
- * later.
- */
+/** Serialises a header. Every field is known before the payload, so nothing is patched in later. */
 export function encodeHeader(header: ContainerHeader): Uint8Array {
     const buffer = new Uint8Array(header.headerLength);
 
     buffer.set(MAGIC, 0);
     buffer[MAGIC.length] = header.version;
+    writeU64LE(buffer, 21, BigInt(header.timestamp));
     const compressed = header.compressed ? FLAG_COMPRESSED : 0;
     const encrypted = header.encrypted ? FLAG_ENCRYPTED : 0;
-    const streamed = header.streamed ? FLAG_STREAMED : 0;
-    buffer[21] = compressed | encrypted | streamed;
-    writeU16LE(buffer, 22, header.headerLength);
-    writeU64LE(buffer, 24, BigInt(header.plaintextSize));
+    buffer[29] = compressed | encrypted;
+    writeU16LE(buffer, 30, header.headerLength);
+    writeU64LE(buffer, 32, BigInt(header.plaintextSize));
 
     if (header.encryption) {
         const { kdfId, log2N, r, p, salt, noncePrefix, verifierTag } = header.encryption;
-        buffer[32] = kdfId;
-        buffer[33] = log2N;
-        buffer[34] = r;
-        buffer[35] = p;
-        buffer.set(salt, 36);
-        buffer.set(noncePrefix, 52);
-        buffer.set(verifierTag, 60);
+        buffer[40] = kdfId;
+        buffer[41] = log2N;
+        buffer[42] = r;
+        buffer[43] = p;
+        buffer.set(salt, 44);
+        buffer.set(noncePrefix, 60);
+        buffer.set(verifierTag, 68);
     }
-
-    buffer.set(header.digest, digestOffset(header.headerLength));
 
     return buffer;
 }
 
+/** Serialises the trailer, which is written once the payload is complete. */
+export function encodeTrailer(trailer: ContainerTrailer): Uint8Array {
+    const buffer = new Uint8Array(TRAILER_BYTES);
+
+    buffer.set(trailer.digest, 0);
+    writeU64LE(buffer, DIGEST_BYTES, BigInt(trailer.plaintextSize));
+
+    return buffer;
+}
+
+/** Parses the trailer out of exactly {@link TRAILER_BYTES} bytes. */
+export function decodeTrailer(buffer: Uint8Array): ContainerTrailer {
+    if (buffer.length !== TRAILER_BYTES) {
+        throw new BackupContainerError(
+            "truncated",
+            `Trailer is ${buffer.length} bytes, expected ${TRAILER_BYTES}.`
+        );
+    }
+
+    const plaintextSize = readU64LE(buffer, DIGEST_BYTES);
+
+    return {
+        digest: buffer.subarray(0, DIGEST_BYTES),
+        plaintextSize: plaintextSize > BigInt(Number.MAX_SAFE_INTEGER) ? 0 : Number(plaintextSize)
+    };
+}
+
 export interface FixedHeader {
     version: number;
+    timestamp: number;
     compressed: boolean;
     encrypted: boolean;
-    streamed: boolean;
     plaintextSize: number;
     headerLength: number;
 }
@@ -207,7 +247,7 @@ export function decodeFixedHeader(buffer: Uint8Array, maxHeaderBytes: number): F
         );
     }
 
-    const flags = buffer[21];
+    const flags = buffer[29];
     if (flags & FLAG_RESERVED) {
         throw new BackupContainerError(
             "unsupported-flags",
@@ -215,9 +255,8 @@ export function decodeFixedHeader(buffer: Uint8Array, maxHeaderBytes: number): F
         );
     }
     const encrypted = (flags & FLAG_ENCRYPTED) !== 0;
-    const streamed = (flags & FLAG_STREAMED) !== 0;
 
-    const headerLength = readU16LE(buffer, 22);
+    const headerLength = readU16LE(buffer, 30);
     if (headerLength > maxHeaderBytes) {
         throw new BackupContainerError(
             "invalid-header-length",
@@ -233,37 +272,40 @@ export function decodeFixedHeader(buffer: Uint8Array, maxHeaderBytes: number): F
     }
 
     // A hint that may only ever tighten a bound, so an unrepresentable value is the same as
-    // "unknown".
-    const plaintextSize = readU64LE(buffer, 24);
+    // "unknown". The same goes for a date nothing could have produced.
+    const plaintextSize = readU64LE(buffer, 32);
+    const timestamp = readU64LE(buffer, 21);
 
     return {
         version,
+        timestamp: timestamp > BigInt(Number.MAX_SAFE_INTEGER) ? 0 : Number(timestamp),
         compressed: (flags & FLAG_COMPRESSED) !== 0,
         encrypted,
-        streamed,
         plaintextSize: plaintextSize > BigInt(Number.MAX_SAFE_INTEGER) ? 0 : Number(plaintextSize),
         headerLength
     };
 }
 
 /**
- * Exact byte length of a streamed, uncompressed container wrapping `plaintextSize` bytes.
+ * Exact byte length of an uncompressed container wrapping `plaintextSize` bytes.
  *
- * Encrypted, that is the header, the payload, and the length field and tag around every frame —
- * including the final frame, which is empty when the payload is an exact multiple of the frame
- * size. Unencrypted, the payload is written as it stands and only the header precedes it.
+ * Encrypted, that is the header, the payload, the length field and tag around every frame including
+ * the final one, which is empty when the payload is an exact multiple of the frame size, and the
+ * trailer. Unencrypted, the payload is written as it stands between the header and the trailer.
  *
- * Exactness is the point: a download that states its size correctly is one the browser can draw a
- * progress bar for.
+ * Exactness is the point twice over: a download that states its size correctly is one the browser
+ * can draw a progress bar for, and a file that does not measure this much is one a reader can
+ * refuse before reading any of it. Compression breaks the derivation, since the payload is then
+ * shorter than the plaintext by a ratio nothing states in advance.
  */
-export function streamedContainerSize(plaintextSize: number, encrypted: boolean): number {
+export function containerSize(plaintextSize: number, encrypted: boolean): number {
     if (!encrypted) {
-        return HEADER_BYTES_PLAIN + plaintextSize;
+        return HEADER_BYTES_PLAIN + plaintextSize + TRAILER_BYTES;
     }
 
     const frames = Math.floor(plaintextSize / FRAME_SIZE) + 1;
 
-    return HEADER_BYTES_ENCRYPTED + plaintextSize + frames * (4 + TAG_BYTES);
+    return HEADER_BYTES_ENCRYPTED + plaintextSize + frames * (4 + TAG_BYTES) + TRAILER_BYTES;
 }
 
 /**
@@ -275,7 +317,7 @@ export function decodeHeader(buffer: Uint8Array, maxHeaderBytes: number): Contai
 
     let encryption: EncryptionHeader | null = null;
     if (fixed.encrypted) {
-        const kdfId = buffer[32];
+        const kdfId = buffer[40];
         if (kdfId !== KDF_SCRYPT) {
             throw new BackupContainerError(
                 "unsupported-kdf",
@@ -285,20 +327,16 @@ export function decodeHeader(buffer: Uint8Array, maxHeaderBytes: number): Contai
 
         encryption = {
             kdfId,
-            log2N: buffer[33],
-            r: buffer[34],
-            p: buffer[35],
-            salt: buffer.subarray(36, 52),
-            noncePrefix: buffer.subarray(52, 60),
-            verifierTag: buffer.subarray(60, 76)
+            log2N: buffer[41],
+            r: buffer[42],
+            p: buffer[43],
+            salt: buffer.subarray(44, 60),
+            noncePrefix: buffer.subarray(60, 68),
+            verifierTag: buffer.subarray(68, 84)
         };
     }
 
-    return {
-        ...fixed,
-        encryption,
-        digest: buffer.subarray(digestOffset(fixed.headerLength), fixed.headerLength)
-    };
+    return { ...fixed, encryption };
 }
 
 /**

--- a/packages/trilium-backup-container/src/index.ts
+++ b/packages/trilium-backup-container/src/index.ts
@@ -57,7 +57,11 @@ export {
     SCRYPT_BOUNDS,
     SCRYPT_DEFAULTS,
     type ScryptParams,
-    streamedContainerSize
+    containerSize,
+    type ContainerTrailer,
+    decodeTrailer,
+    encodeTrailer,
+    TRAILER_BYTES
 } from "./format.js";
 export { readBackupContainer, writeBackupContainer } from "./node-streams.js";
 export {
@@ -73,7 +77,6 @@ export {
     type ReadBackupContainerResult
 } from "./read.js";
 export {
-    type PatchHeader,
     type WriteBackupContainerOptions,
     type WriteBackupContainerResult
 } from "./write.js";

--- a/packages/trilium-backup-container/src/index.ts
+++ b/packages/trilium-backup-container/src/index.ts
@@ -13,22 +13,12 @@
  *
  * @example Writing an encrypted, compressed container
  * ```ts
+ * // One forward pass, so the destination is never written back to: write to a temporary name and
+ * // rename on success, and a partial file never looks finished.
  * await writeBackupContainer(createReadStream(source), createWriteStream(partial), {
  *     compress: true,
  *     passphrase,
- *     plaintextSize: (await stat(source)).size,
- *     // Reopening to patch keeps this simple. Do not hand the payload stream a FileHandle with
- *     // `autoClose: false` and patch through that handle: its `close()` then waits forever on a
- *     // stream that never emits `close`.
- *     patchHeader: async (offset, data) => {
- *         const handle = await open(partial, "r+");
- *         try {
- *             await handle.write(data, 0, data.length, offset);
- *             await handle.sync();
- *         } finally {
- *             await handle.close();
- *         }
- *     }
+ *     plaintextSize: (await stat(source)).size
  * });
  * await rename(partial, final);
  * ```
@@ -40,6 +30,14 @@
  *     fs.createWriteStream(database),
  *     { passphrase, onProgress: (progress) => report(Math.round(progress * 100)) }
  * );
+ * ```
+ *
+ * @example Listing a directory of them, opening none
+ * ```ts
+ * const info = getInfo(await read(path, FIXED_HEADER_BYTES));
+ * if (info.isValid && info.isSupported) {
+ *     rows.push({ path, taken: info.creationTimestamp, size: info.size });
+ * }
  * ```
  *
  * @module
@@ -70,11 +68,13 @@ export {
     type ProgressOptions
 } from "./progress.js";
 export {
-    type BackupContainerInfo,
+    type BackupContainerSummary,
+    type ContainerHead,
     DEFAULT_MAX_OUTPUT_BYTES,
-    peekBackupContainer,
+    getInfo,
     type ReadBackupContainerOptions,
-    type ReadBackupContainerResult
+    type ReadBackupContainerResult,
+    type SupportedBackupContainer
 } from "./read.js";
 export {
     type WriteBackupContainerOptions,

--- a/packages/trilium-backup-container/src/internals.spec.ts
+++ b/packages/trilium-backup-container/src/internals.spec.ts
@@ -121,3 +121,60 @@ describe("compressed payload damage", () => {
         expect(reason).toMatch(/no reason: Error: EIO/);
     });
 });
+
+describe("the node zlib plumbing", () => {
+    it("tears the stream down when the source it is fed fails partway", async () => {
+        let sourceClosed = false;
+        const poisoned = (async function* (): AsyncGenerator<Uint8Array> {
+            try {
+                yield fakeDatabase(1024);
+                // Not a byte chunk at all, which zlib refuses mid-write.
+                yield {} as unknown as Uint8Array;
+            } finally {
+                sourceClosed = true;
+            }
+        })();
+
+        const failure = await collect(nodeBackend.gzip(poisoned, 6)).catch((thrown) => thrown);
+
+        // Untranslated: a compressor that was handed nonsense is not a damaged payload.
+        expect(failure).toBeInstanceOf(Error);
+        expect(isBackupContainerError(failure)).toBe(false);
+        // The half that reads has to end too, or a failed backup leaves the database being read.
+        expect(sourceClosed).toBe(true);
+    });
+
+    it("stops feeding a stream the reader has walked away from", async () => {
+        let sourceClosed = false;
+        const source = (async function* (): AsyncGenerator<Uint8Array> {
+            try {
+                // More than the stream will buffer, so the writing half is still mid-flight when
+                // the reader leaves rather than already done.
+                for (let sent = 0; sent < 32; sent++) {
+                    yield fakeDatabase(256 * 1024);
+                }
+            } finally {
+                sourceClosed = true;
+            }
+        })();
+
+        for await (const chunk of nodeBackend.gzip(source, 6)) {
+            expect(chunk.length).toBeGreaterThan(0);
+            break;
+        }
+
+        // A reader is entitled to take one chunk and go. What must not happen is the database
+        // going on being read into a stream that was torn down behind it.
+        await new Promise((resolve) => setImmediate(resolve));
+        expect(sourceClosed).toBe(true);
+    });
+});
+
+async function collect(source: AsyncIterable<Uint8Array>): Promise<Buffer> {
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of source) {
+        chunks.push(chunk);
+    }
+
+    return Buffer.concat(chunks);
+}

--- a/packages/trilium-backup-container/src/internals.spec.ts
+++ b/packages/trilium-backup-container/src/internals.spec.ts
@@ -6,7 +6,7 @@ import { nodeBackend } from "./backend-node.js";
 import { deriveContainerKey } from "./backend.js";
 import { ByteReader } from "./byte-reader.js";
 import { BackupContainerError, isBackupContainerError } from "./errors.js";
-import { FRAME_SIZE, HEADER_BYTES_PLAIN } from "./format.js";
+import { FRAME_SIZE, HEADER_BYTES_PLAIN, TRAILER_BYTES } from "./format.js";
 import {
     fakeDatabase,
     failureOf,
@@ -93,19 +93,18 @@ describe("compressed payload damage", () => {
     it("reports a broken gzip stream as a damaged payload, not as a digest mismatch", async () => {
         const written = await writeToBuffer(fakeDatabase(50_000), { compress: true });
 
-        // Corrupt the deflate data, then repair the digest so the failure can only come from zlib.
+        // Corrupt the deflate data, then repair the trailer's digest over it, so the failure can
+        // only come from zlib.
         const damaged = flipByte(written.bytes, HEADER_BYTES_PLAIN + 30);
-        createHash("sha256").update(damaged.subarray(HEADER_BYTES_PLAIN)).digest().copy(
-            damaged,
-            HEADER_BYTES_PLAIN - 32
-        );
+        createHash("sha256").update(damaged.subarray(HEADER_BYTES_PLAIN, -TRAILER_BYTES)).digest()
+            .copy(damaged, damaged.length - TRAILER_BYTES);
 
         expect(await failureOf(damaged)).toBe("damaged-payload");
     });
 
     it("surfaces a digest mismatch through the decompressor untranslated", async () => {
         const written = await writeToBuffer(fakeDatabase(50_000), { compress: true });
-        const damaged = flipByte(written.bytes, HEADER_BYTES_PLAIN - 5);   // inside the digest
+        const damaged = flipByte(written.bytes, written.bytes.length - TRAILER_BYTES + 5);   // in the digest
 
         expect(await failureOf(damaged)).toBe("digest-mismatch");
     });

--- a/packages/trilium-backup-container/src/progress.spec.ts
+++ b/packages/trilium-backup-container/src/progress.spec.ts
@@ -117,7 +117,12 @@ describe("reading", () => {
 
         await readFromBuffer(written.bytes, { onProgress, progressIntervalMs: 0 });
 
-        expect(reports).toEqual([ 0.5, 1, 1 ]);
+        // Not exact fractions: an unencrypted payload is emitted a trailer's length behind the
+        // input, since that much is held back until the input ends and it can be told apart from
+        // the payload. What has to hold is that it climbs and arrives.
+        expect(reports.at(-1)).toBe(1);
+        expect(reports).toEqual([ ...reports ].sort((left, right) => left - right));
+        expect(reports[0]).toBeCloseTo(0.5, 3);
     });
 
     it.each(FORMATS)("measures the database coming out of a %s container", async (
@@ -198,16 +203,21 @@ describe("reading", () => {
         const database = fakeDatabase(2 * FRAME_SIZE);
         const written = await writeToBuffer(database, { plaintextSize: database.length });
 
-        // Claim a third more than the container actually holds, which is only caught at the end.
+        // Claim a third more than the container actually holds, which is only caught at the end,
+        // where the header's figure meets the one the trailer counted.
         const lying = Buffer.from(written.bytes);
-        lying.writeBigUInt64LE(BigInt(3 * FRAME_SIZE), 24);
+        lying.writeBigUInt64LE(BigInt(3 * FRAME_SIZE), 32);
 
         const failure = await reasonOf(
             readFromBuffer(lying, { onProgress, progressIntervalMs: 0 })
         );
 
         expect(failure).toBe("size-mismatch");
-        expect(reports).toEqual([ 1 / 3, 2 / 3 ]);
+        // Climbs towards the size it was told and stops where the payload really ended, which is
+        // the point: completion is never reported for a database that did not measure up.
+        expect(reports[0]).toBeCloseTo(1 / 3, 3);
+        expect(reports.at(-1)).toBeCloseTo(2 / 3, 3);
+        expect(reports).not.toContain(1);
     });
 
     it("stops reporting when the destination fails, without reporting completion after it", async () => {

--- a/packages/trilium-backup-container/src/read.ts
+++ b/packages/trilium-backup-container/src/read.ts
@@ -60,42 +60,105 @@ export interface ReadBackupContainerOptions extends ProgressOptions {
     requireSqliteHeader?: boolean;
 }
 
-/** What a container says about itself, before any of its payload is read. */
-export interface BackupContainerInfo {
+/** The head of a container, however the caller happens to be holding it. */
+export type ContainerHead = ArrayBuffer | ArrayBufferView;
+
+/**
+ * What a container says about itself, before any of its payload is read.
+ *
+ * Three answers rather than two, because "not a backup" and "a backup this build is too old to
+ * open" call for entirely different things to be said to the user, and the fields below only exist
+ * for the third: a version whose layout this module does not implement is one whose flags and sizes
+ * it would only be guessing at.
+ */
+export type BackupContainerSummary =
+    /** Not a container at all: whatever else this file is, it did not come from here. */
+    | { isValid: false }
+    /** One of ours, but past what this module implements: nothing beyond the version is known. */
+    | { isValid: true; isSupported: false; version: number }
+    | SupportedBackupContainer;
+
+/** A container this module can act on, which is the only case any of these fields is known in. */
+export interface SupportedBackupContainer {
+    isValid: true;
+    isSupported: true;
     version: number;
-    compressed: boolean;
-    encrypted: boolean;
+    /**
+     * Size of the database inside, before compression, or 0 where the writer did not record it. Not
+     * the size of the file, which is this plus the wrapping and, once compressed, less than this by
+     * an amount nothing states in advance.
+     */
+    size: number;
     /** When the backup was taken, in milliseconds since the Unix epoch, or 0 when not recorded. */
-    timestamp: number;
-    /** Size of the wrapped database before compression, or 0 when the writer did not record it. */
-    plaintextSize: number;
+    creationTimestamp: number;
+    isCompressed: boolean;
+    isEncrypted: boolean;
 }
 
 /**
  * Identifies a container from its first {@link FIXED_HEADER_BYTES} bytes, without touching the
  * payload and without the passphrase: what a container is, is stated in the clear.
  *
- * Returns `null` for anything this reader does not recognise, so that listing a directory of
- * backups is never derailed by one damaged or foreign file.
+ * Built for listing a directory of them, so it is O(1) over a view of what it is given, copies
+ * nothing, and never throws: one damaged or foreign file among a hundred costs the listing a row,
+ * not the listing.
+ *
+ * @param head at least {@link FIXED_HEADER_BYTES} bytes from offset 0 of the file. Anything longer
+ *             is fine and nothing past those bytes is read, so a caller holding the whole file may
+ *             pass it as it stands.
+ * @param maxHeaderBytes ceiling above which a header is not worth describing.
  */
-export function peekBackupContainer(
-    head: Uint8Array,
+export function getInfo(
+    head: ContainerHead,
     maxHeaderBytes: number = DEFAULT_MAX_HEADER_BYTES
-): BackupContainerInfo | null {
-    if (head.length < FIXED_HEADER_BYTES) {
-        return null;
+): BackupContainerSummary {
+    const bytes = asBytes(head);
+
+    // Settled here rather than by catching what the decoder throws, because this is the rejection
+    // that happens in bulk: a folder of backups is also a folder of everything else the user keeps
+    // there, and each of those should cost a comparison rather than an exception.
+    const isContainer = bytes.length >= FIXED_HEADER_BYTES
+        && bytesEqual(bytes.subarray(0, MAGIC.length), MAGIC);
+    if (!isContainer) {
+        return { isValid: false };
     }
 
+    // Past the magic, so this field is where the format has always promised to keep it, which is
+    // the one thing that stays true of a version written after this module.
+    const version = bytes[MAGIC.length];
+
     try {
-        const { version, timestamp, compressed, encrypted, plaintextSize } = decodeFixedHeader(
-            head.subarray(0, FIXED_HEADER_BYTES),
+        const { timestamp, compressed, encrypted, plaintextSize } = decodeFixedHeader(
+            bytes.subarray(0, FIXED_HEADER_BYTES),
             maxHeaderBytes
         );
 
-        return { version, timestamp, compressed, encrypted, plaintextSize };
+        return {
+            isValid: true,
+            isSupported: true,
+            version,
+            size: plaintextSize,
+            creationTimestamp: timestamp,
+            isCompressed: compressed,
+            isEncrypted: encrypted
+        };
     } catch {
-        return null;
+        // Every remaining way the head can be refused says the same thing to a listing: ours, and
+        // not for this build to open. A version it does not implement and a header that does not
+        // measure what this version requires are both answered by pointing at the version.
+        return { isValid: true, isSupported: false, version };
     }
+}
+
+/** Views whatever the caller holds as bytes, copying none of them. */
+function asBytes(head: ContainerHead): Uint8Array {
+    if (head instanceof Uint8Array) {
+        return head;
+    }
+
+    return ArrayBuffer.isView(head)
+        ? new Uint8Array(head.buffer, head.byteOffset, head.byteLength)
+        : new Uint8Array(head);
 }
 
 export interface ReadBackupContainerResult {

--- a/packages/trilium-backup-container/src/read.ts
+++ b/packages/trilium-backup-container/src/read.ts
@@ -247,6 +247,9 @@ export async function readContainer(
     // The payload readers always leave one behind or throw, so this is a guard on their contract
     // rather than on the file.
     const trailer = found.trailer;
+    /* v8 ignore next 3 -- no input reaches it: both readers end by decoding a trailer, which either
+       assigns this or throws `truncated` itself. It stands so a reader added later cannot return
+       having quietly skipped the digest. */
     if (!trailer) {
         throw new BackupContainerError("truncated", "The container ended without a trailer.");
     }

--- a/packages/trilium-backup-container/src/read.ts
+++ b/packages/trilium-backup-container/src/read.ts
@@ -10,10 +10,12 @@ import { BackupContainerError } from "./errors.js";
 import {
     authenticatedHeaderEnd,
     type ContainerHeader,
+    type ContainerTrailer,
     DEFAULT_MAX_HEADER_BYTES,
     DEFAULT_MAX_KDF_MEMORY_BYTES,
     decodeFixedHeader,
     decodeHeader,
+    decodeTrailer,
     encodeHeader,
     type EncryptionHeader,
     FIXED_HEADER_BYTES,
@@ -24,6 +26,7 @@ import {
     nonceFor,
     SQLITE_HEADER_BYTES,
     TAG_BYTES,
+    TRAILER_BYTES,
     validateScryptParams,
     validateSqliteHeader,
     VERIFIER_COUNTER
@@ -62,8 +65,8 @@ export interface BackupContainerInfo {
     version: number;
     compressed: boolean;
     encrypted: boolean;
-    /** Written front to back with no payload digest; the frames alone carry the integrity. */
-    streamed: boolean;
+    /** When the backup was taken, in milliseconds since the Unix epoch, or 0 when not recorded. */
+    timestamp: number;
     /** Size of the wrapped database before compression, or 0 when the writer did not record it. */
     plaintextSize: number;
 }
@@ -84,12 +87,12 @@ export function peekBackupContainer(
     }
 
     try {
-        const { version, compressed, encrypted, streamed, plaintextSize } = decodeFixedHeader(
+        const { version, timestamp, compressed, encrypted, plaintextSize } = decodeFixedHeader(
             head.subarray(0, FIXED_HEADER_BYTES),
             maxHeaderBytes
         );
 
-        return { version, compressed, encrypted, streamed, plaintextSize };
+        return { version, timestamp, compressed, encrypted, plaintextSize };
     } catch {
         return null;
     }
@@ -165,9 +168,10 @@ export async function readContainer(
     const progress = createProgressReporter(header.plaintextSize, options);
     const guard = new OutputGuard(ceiling, options.requireSqliteHeader !== false, progress);
 
+    const found: FoundTrailer = { trailer: null };
     const payload = header.encryption && key !== null
-        ? readFrames(reader, header, header.encryption, key, backend)
-        : readPlainPayload(reader, header, backend);
+        ? readFrames(reader, header, header.encryption, key, backend, found)
+        : readPlainPayload(reader, backend, found);
 
     const unwrapped = header.compressed ? backend.gunzip(payload) : payload;
     for await (const chunk of unwrapped) {
@@ -177,10 +181,26 @@ export async function readContainer(
     guard.finish();
     await output.end();
 
-    if (header.plaintextSize > 0 && guard.bytesWritten !== header.plaintextSize) {
+    // The payload readers always leave one behind or throw, so this is a guard on their contract
+    // rather than on the file.
+    const trailer = found.trailer;
+    if (!trailer) {
+        throw new BackupContainerError("truncated", "The container ended without a trailer.");
+    }
+
+    // The trailer's size is the authoritative one, counted as the payload was written rather than
+    // promised in advance, and it is what an unencrypted container leans on to notice truncation.
+    if (guard.bytesWritten !== trailer.plaintextSize) {
         throw new BackupContainerError(
             "size-mismatch",
-            `Output is ${guard.bytesWritten} bytes, header records ${header.plaintextSize}.`
+            `Output is ${guard.bytesWritten} bytes, the container records ${trailer.plaintextSize}.`
+        );
+    }
+    // Both stated the size, and they disagree: whichever is wrong, the file is not intact.
+    if (header.plaintextSize > 0 && header.plaintextSize !== trailer.plaintextSize) {
+        throw new BackupContainerError(
+            "size-mismatch",
+            `Header records ${header.plaintextSize} bytes, the trailer ${trailer.plaintextSize}.`
         );
     }
 
@@ -325,11 +345,11 @@ async function* readFrames(
     header: ContainerHeader,
     encryption: EncryptionHeader,
     key: unknown,
-    backend: ContainerBackend
+    backend: ContainerBackend,
+    found: FoundTrailer
 ): AsyncGenerator<Uint8Array> {
     const aad = aadOf(header);
-    // A streamed container records no digest, so hashing towards one would only slow the restore.
-    const hash = header.streamed ? null : backend.createSha256();
+    const hash = backend.createSha256();
     let counter = 0;
 
     for (;;) {
@@ -349,11 +369,9 @@ async function* readFrames(
 
         const ciphertext = await reader.readExactly(length);
         const tag = await reader.readExactly(TAG_BYTES);
-        if (hash) {
-            hash.update(lengthField);
-            hash.update(ciphertext);
-            hash.update(tag);
-        }
+        hash.update(lengthField);
+        hash.update(ciphertext);
+        hash.update(tag);
 
         const plaintext = await backend.gcmOpen(
             key,
@@ -376,40 +394,61 @@ async function* readFrames(
         counter++;
     }
 
+    // The frames say where they end, so the trailer is simply what follows the final one.
+    found.trailer = decodeTrailer(await reader.readExactly(TRAILER_BYTES));
+
     if (!(await reader.atEof())) {
         throw new BackupContainerError(
             "trailing-data",
-            `Bytes follow the final frame at offset ${reader.consumed}.`
+            `Bytes follow the trailer at offset ${reader.consumed}.`
         );
     }
 
-    if (hash) {
-        verifyDigest(hash.digest(), header.digest);
-    }
+    verifyDigest(hash.digest(), found.trailer.digest);
 }
 
-/** Yields the payload of an unencrypted container, which runs to end of file. */
+/**
+ * Yields the payload of an unencrypted container, which runs to the trailer.
+ *
+ * Nothing announces where that is, so the last {@link TRAILER_BYTES} bytes are held back as they go
+ * past and whatever is still held when the input ends is the trailer. That keeps the reader
+ * forward-only: it never has to know the file's length, let alone seek to it, which is what lets the
+ * same code read a file, a download and a stream that is still arriving.
+ */
 async function* readPlainPayload(
     reader: ByteReader,
-    header: ContainerHeader,
-    backend: ContainerBackend
+    backend: ContainerBackend,
+    found: FoundTrailer
 ): AsyncGenerator<Uint8Array> {
-    // A streamed container records no digest, so hashing towards one would only slow the restore.
-    // What it records instead is its size, which `readContainer` holds the output to.
-    const hash = header.streamed ? null : backend.createSha256();
+    const hash = backend.createSha256();
+    let held = EMPTY;
 
     for (;;) {
         const chunk = await reader.readUpTo(FRAME_SIZE);
         if (chunk.length === 0) {
             break;
         }
-        hash?.update(chunk);
-        yield chunk;
+
+        const pending = held.length === 0 ? chunk : concatBytes(held, chunk);
+        if (pending.length <= TRAILER_BYTES) {
+            // Copied, since it has to outlive the reader's own view of these bytes.
+            held = pending.slice();
+            continue;
+        }
+
+        const payload = pending.subarray(0, pending.length - TRAILER_BYTES);
+        held = pending.slice(pending.length - TRAILER_BYTES);
+        hash.update(payload);
+        yield payload;
     }
 
-    if (hash) {
-        verifyDigest(hash.digest(), header.digest);
-    }
+    found.trailer = decodeTrailer(held);
+    verifyDigest(hash.digest(), found.trailer.digest);
+}
+
+/** Where a payload reader leaves the trailer it consumed, for the caller that checks it. */
+interface FoundTrailer {
+    trailer: ContainerTrailer | null;
 }
 
 function verifyDigest(actual: Uint8Array, expected: Uint8Array): void {

--- a/packages/trilium-backup-container/src/test-helpers.ts
+++ b/packages/trilium-backup-container/src/test-helpers.ts
@@ -52,34 +52,29 @@ export function chunked(data: Buffer, chunkSize: number): Readable {
 export interface WrittenContainer {
     bytes: Buffer;
     result: WriteBackupContainerResult;
-    patchedAt: number[];
 }
 
-export type WriteOptions = Omit<WriteBackupContainerOptions, "patchHeader">;
+export type WriteOptions = WriteBackupContainerOptions;
 
-/** Writes a container in memory, applying the digest patch the way a file destination would. */
+/**
+ * Writes a container in memory.
+ *
+ * Nothing is written back to: a container is produced in one forward pass, so what the sink
+ * received in order is the whole file.
+ */
 export async function writeToBuffer(
     input: Buffer | Readable,
     options: WriteOptions = {}
 ): Promise<WrittenContainer> {
     const sink = new MemorySink();
-    const patches: { offset: number; data: Buffer }[] = [];
 
     const result = await writeBackupContainer(
         Buffer.isBuffer(input) ? Readable.from([ input ]) : input,
         sink,
-        {
-            ...options,
-            patchHeader: (offset, data) => { patches.push({ offset, data: Buffer.from(data) }); }
-        }
+        options
     );
 
-    const bytes = sink.toBuffer();
-    for (const patch of patches) {
-        patch.data.copy(bytes, patch.offset);
-    }
-
-    return { bytes, result, patchedAt: patches.map((patch) => patch.offset) };
+    return { bytes: sink.toBuffer(), result };
 }
 
 export interface ReadContainer {
@@ -103,23 +98,14 @@ export async function writeToBufferWeb(
     options: WriteOptions = {}
 ): Promise<WrittenContainer> {
     const collector = webCollector();
-    const patches: { offset: number; data: Buffer }[] = [];
 
     const result = await writeBackupContainerWeb(
         Buffer.isBuffer(input) ? webSource(input) : input,
         collector.stream,
-        {
-            ...options,
-            patchHeader: (offset, data) => { patches.push({ offset, data: Buffer.from(data) }); }
-        }
+        options
     );
 
-    const bytes = collector.toBuffer();
-    for (const patch of patches) {
-        patch.data.copy(bytes, patch.offset);
-    }
-
-    return { bytes, result, patchedAt: patches.map((patch) => patch.offset) };
+    return { bytes: collector.toBuffer(), result };
 }
 
 /** The web counterpart of {@link readFromBuffer}. */

--- a/packages/trilium-backup-container/src/web.ts
+++ b/packages/trilium-backup-container/src/web.ts
@@ -35,7 +35,11 @@ export {
     SCRYPT_BOUNDS,
     SCRYPT_DEFAULTS,
     type ScryptParams,
-    streamedContainerSize
+    containerSize,
+    type ContainerTrailer,
+    decodeTrailer,
+    encodeTrailer,
+    TRAILER_BYTES
 } from "./format.js";
 export {
     DEFAULT_PROGRESS_INTERVAL_MS,
@@ -51,7 +55,6 @@ export {
 } from "./read.js";
 export { readBackupContainer, writeBackupContainer } from "./web-streams.js";
 export {
-    type PatchHeader,
     type WriteBackupContainerOptions,
     type WriteBackupContainerResult
 } from "./write.js";

--- a/packages/trilium-backup-container/src/web.ts
+++ b/packages/trilium-backup-container/src/web.ts
@@ -47,11 +47,13 @@ export {
     type ProgressOptions
 } from "./progress.js";
 export {
-    type BackupContainerInfo,
+    type BackupContainerSummary,
+    type ContainerHead,
     DEFAULT_MAX_OUTPUT_BYTES,
-    peekBackupContainer,
+    getInfo,
     type ReadBackupContainerOptions,
-    type ReadBackupContainerResult
+    type ReadBackupContainerResult,
+    type SupportedBackupContainer
 } from "./read.js";
 export { readBackupContainer, writeBackupContainer } from "./web-streams.js";
 export {

--- a/packages/trilium-backup-container/src/write.ts
+++ b/packages/trilium-backup-container/src/write.ts
@@ -10,9 +10,8 @@ import {
     authenticatedHeaderEnd,
     type ContainerHeader,
     DEFAULT_MAX_KDF_MEMORY_BYTES,
-    DIGEST_BYTES,
-    digestOffset,
     encodeHeader,
+    encodeTrailer,
     FORMAT_VERSION,
     FRAME_FINAL_FLAG,
     FRAME_SIZE,
@@ -33,29 +32,14 @@ import { createProgressReporter, type ProgressOptions, type ProgressReporter } f
 
 const EMPTY = new Uint8Array(0);
 
-/**
- * Writes `data` at an absolute offset in the destination that is already being streamed to.
- *
- * The payload digest is only known once the payload has been written, so it is patched into the
- * header afterwards. A destination that cannot be written out of order cannot hold this format.
- */
-export type PatchHeader = (offset: number, data: Uint8Array) => Promise<void> | void;
-
 export interface WriteBackupContainerOptions extends ProgressOptions {
     /**
-     * Patches the payload digest into the header once the payload is complete. Required, except
-     * for a {@link streamed} container, which records no digest and never writes backwards.
-     */
-    patchHeader?: PatchHeader;
-    /**
-     * Write front to back, recording no payload digest â€” for a destination that cannot be
-     * revisited, such as a download already on its way to the user.
+     * When the backup was taken, in milliseconds since the Unix epoch. Defaults to now.
      *
-     * Encrypted, the GCM frame tags stand in for the digest. Unencrypted, {@link
-     * WriteBackupContainerOptions.plaintextSize} does, so it is required: without either, nothing
-     * about the payload could be checked.
+     * Taken as an option rather than read here so that a caller can record when the database was
+     * actually copied, which for a backup written from a snapshot is not when this ran.
      */
-    streamed?: boolean;
+    timestamp?: number;
     /** Compress the payload with gzip. */
     compress?: boolean;
     /** Encrypt the payload. Encryption is on exactly when a passphrase is given. */
@@ -106,21 +90,6 @@ export async function writeContainer(
     backend: ContainerBackend,
     options: WriteBackupContainerOptions
 ): Promise<WriteBackupContainerResult> {
-    const streamed = options.streamed === true;
-    if (streamed && options.passphrase === undefined && !(options.plaintextSize ?? 0)) {
-        throw new BackupContainerError(
-            "invalid-options",
-            "A streamed container that is not encrypted must record its plaintext size: with "
-                + "neither that nor frame tags, nothing about the payload could be checked."
-        );
-    }
-    if (!streamed && typeof options.patchHeader !== "function") {
-        throw new BackupContainerError(
-            "invalid-options",
-            "patchHeader is required to write the payload digest."
-        );
-    }
-
     const plaintextSize = options.plaintextSize ?? 0;
     if (!Number.isSafeInteger(plaintextSize) || plaintextSize < 0) {
         throw new BackupContainerError(
@@ -137,13 +106,12 @@ export async function writeContainer(
     // final.
     const header: ContainerHeader = {
         version: FORMAT_VERSION,
+        timestamp: options.timestamp ?? Date.now(),
         compressed,
         encrypted,
-        streamed,
         plaintextSize,
         headerLength: headerLengthFor(encrypted),
-        encryption: null,
-        digest: new Uint8Array(DIGEST_BYTES)
+        encryption: null
     };
 
     let key: unknown = null;
@@ -180,7 +148,10 @@ export async function writeContainer(
     await output.write(headerBytes);
 
     // input -> gzip -> frames -> digest -> output, with the stages the flags call for.
-    let payload = input;
+    // Counted at the input, before any of them, so the trailer records the database's own length
+    // rather than whatever the payload compressed or framed to.
+    const plaintext = { bytes: 0 };
+    let payload: ByteSource = countBytes(input, plaintext);
     if (progress) {
         payload = tapProgress(payload, progress);
     }
@@ -198,17 +169,16 @@ export async function writeContainer(
         payloadBytes += chunk.length;
         await output.write(chunk);
     }
+
+    // The trailer is the last thing in the file, and the only part that could not be written until
+    // now. Written before the sink is closed, so a destination that can only be appended to still
+    // ends up holding a complete container.
+    const digest = hash.digest();
+    await output.write(encodeTrailer({ digest, plaintextSize: plaintext.bytes }));
     await output.end();
 
-    const digest = hash.digest();
-    // A streamed container keeps the zeros: its frames authenticate themselves, and there is no
-    // going back to the header of a destination already streamed away.
-    if (!streamed) {
-        await options.patchHeader?.(digestOffset(header.headerLength), digest);
-    }
-
-    // After the patch rather than after the payload: the container is not written until the digest
-    // is in its header.
+    // After the trailer rather than after the payload: the container is not written until what
+    // vouches for it is.
     progress?.complete();
 
     return {
@@ -232,6 +202,14 @@ async function* tapProgress(source: ByteSource, progress: ProgressReporter): Byt
     for await (const chunk of source) {
         bytes += chunk.length;
         progress.at(bytes);
+        yield chunk;
+    }
+}
+
+/** Counts what passes through, so the trailer can state a length nobody had to be told. */
+async function* countBytes(source: ByteSource, counted: { bytes: number }): ByteSource {
+    for await (const chunk of source) {
+        counted.bytes += chunk.length;
         yield chunk;
     }
 }

--- a/packages/trilium-backup-container/src/write.ts
+++ b/packages/trilium-backup-container/src/write.ts
@@ -74,13 +74,14 @@ export interface WriteBackupContainerResult {
  * Wraps a database into a container. This is the runtime-neutral core; the Node and web entry
  * points wrap it with their stream types and their backend.
  *
- * The header is written first with a zeroed digest, then the payload streams through gzip and the
- * frame encryptor as configured, and finally the digest is patched into the header.
+ * The header is written first and never returned to, then the payload streams through gzip and the
+ * frame encryptor as configured, and finally the trailer records the digest and the length the
+ * payload came to. One forward pass, so the destination need not be seekable.
  *
  * @param input the database bytes.
  * @param output the destination, which is ended by this call.
  * @param backend the platform's crypto and compression primitives.
- * @param options see {@link WriteBackupContainerOptions}; `patchHeader` is required.
+ * @param options see {@link WriteBackupContainerOptions}.
  * @returns what was written, see {@link WriteBackupContainerResult}.
  * @throws BackupContainerError with `reason` set, see {@link BackupContainerErrorReason}.
  */

--- a/packages/trilium-backup-container/vite.config.ts
+++ b/packages/trilium-backup-container/vite.config.ts
@@ -16,11 +16,14 @@ export default defineConfig(() => ({
             [ "junit", { outputFile: "./test-output/vitest/junit.xml", addFileAttribute: true } ]
         ],
         coverage: {
+            // Every line, and every branch that any input can reach. What no input reaches carries
+            // a `v8 ignore` naming the caller that makes it unreachable, so the exceptions are
+            // read and argued rather than absorbed into a percentage.
             thresholds: {
-                lines: 99,
+                lines: 100,
                 functions: 100,
-                branches: 98,
-                statements: 99
+                branches: 100,
+                statements: 100
             },
             reportsDirectory: "./test-output/vitest/coverage",
             provider: "v8" as const,


### PR DESCRIPTION
Restoring a backup in the browser now works on the devices where it previously did not: very large backups on low-memory Android phones, which were being cut short partway through and reported as damaged, and any backup on iOS Safari, where switching away from Trilium during a restore ended it. When a restore does fail, the screen now says which of several quite different things went wrong instead of giving one message for all of them, and it no longer claims your database was replaced when it was never touched. Restoring also brings the backup password with it, so an instance restored from another database's backup stops encrypting its own backups with a password that will not open them. Taking a backup in the browser is faster and shows how far it has got, which matters most on a phone, where the browser keeps its own download progress hidden behind the notification shade. Finally, the list of existing backups now says when one of the files in it cannot be read at all, rather than presenting it as a backup like any other.

## Restoring a backup in the browser

- Read the backup file in 4 MiB slices instead of one `Blob.stream()` read that a low-memory device can end early without an error.
- Take the OPFS access handles back and run the step again when the browser closed them, which is what WebKit does whenever it suspends the page.
- Keep the candidate database when the pointer already names it, instead of deleting the database the restore has just installed.
- Write the pointer inside the rollback's reach, so a half-written pointer cannot leave a start finding neither database.
- Report a driver failure during the check as `check-failed` instead of declaring the backup damaged.
- Default an unrecognised failure to `restore-failed` instead of `swap-failed`, which told the user their database had been replaced and put back.
- Refuse a container the file is too small to hold, before a minute of work goes into it.
- Add error messages for `swap-failed-reload`, `check-failed`, `restore-failed` and `backup-incomplete`.
- Say "You will be shortly redirected to the application." on the transitional screen, which was printing the raw key `setup.restore-stage-done`.
- Add a test tying the set of stage labels to the stages a restore can report.

## The backup password after a restore

- Adopt the password that opened the restored backup as the instance's stored backup passphrase.
- Clear the stored passphrase when the restored backup brought none, since it belongs to a database that is no longer there.
- Skip the confirmation dialog the options screen shows, the password having been typed moments earlier for this database.
- Log both outcomes, naming neither the password nor any path.
- Never fail a restore over a keyring that will not answer, the database being in place and open by that point.

## Backup container format

- Move the payload digest and the plaintext length into a trailer after the payload.
- Remove the streamed flag, every container now being written in a single forward pass.
- Remove `patchHeader`, so writing a container no longer needs a seekable destination.
- Verify the digest on every container, including an uncompressed unencrypted one, which previously had nothing standing behind its contents.
- Record a creation timestamp in the header, in milliseconds since the Unix epoch, so a directory of backups can be dated without opening any of them.
- Shrink the header from 64 to 40 bytes plain and from 108 to 84 encrypted.
- Rename `streamedContainerSize` to `containerSize`.
- Keep the version byte at 1, the format not having shipped.

## Reading a container without opening it

- Add `getInfo(head)`, which describes a container from its first 40 bytes without the passphrase and without touching the payload.
- Accept an `ArrayBuffer`, a `Uint8Array`, a `Buffer` or any view, honouring a non-zero `byteOffset` and copying nothing.
- Distinguish a file that is not a backup from a backup this build is too old to open, which the previous `peekBackupContainer` collapsed into one null.
- Check the magic directly rather than by catching what the decoder throws, so rejecting a folder of non-backups costs no exceptions.
- Replace `peekBackupContainer` and `BackupContainerInfo` at their three call sites.

## The list of existing backups

- Mark a `.tnbackup` whose header will not parse as "Invalid backup file", in the options list and on the restore screen alike.
- Mark one written by a newer Trilium as "Unsupported backup file format version".
- Judge a file shorter than a header on the bytes it actually held rather than on the buffer it was read into.

## Taking a backup in the browser

- Read the database in one statement per batch of 512 pages, replacing one query per page, which for a multi-gigabyte database was over a million round trips into WebAssembly.
- Show the percentage and the byte count under "Downloading…" on the backup screen.
- Report the download's progress from the worker through to the page.
- Log where a backup's time went, split between reads, waiting on the download, and hashing.
- Give `formatSize` an optional decimals argument, so a counter that is still climbing keeps its trailing zeros and stops shifting the line.
- Add TiB to `formatSize`, which returned "3 undefined" above 1 TiB.

## Tests and tooling

- Raise the backup container package to 100% statement, branch, function and line coverage, and hold it there.
- Replace the hand-rolled scrypt promise wrapper with `promisify`, removing two branches no input could reach.
- Pin the timestamp in the cross-backend byte-identity test, which the new header field had made flaky.
