### PR TITLE
feat(ocr): support protected notes end to end

### DIFF
--- a/apps/client/src/widgets/ribbon/NoteActions.tsx
+++ b/apps/client/src/widgets/ribbon/NoteActions.tsx
@@ -199,7 +199,7 @@ export function NoteContextMenu({ note, noteContext, itemsAtStart, itemsNearNote
                     <CommandItem icon="bx bx-collapse-alt" text={t("compress-images")}
                         disabled={isInOptionsOrHelp}
                         command={() => void showImageCompressionDialog({ type: "note", noteId: note.noteId })} />
-                    <CommandItem command="showNoteOCRText" icon="bx bx-text" disabled={!["image", "file"].includes(noteType)} text={t("note_actions.view_ocr_text")} />
+                    <CommandItem command="showNoteOCRText" icon="bx bx-text" disabled={!["image", "file"].includes(noteType) || !isContentAvailable} text={t("note_actions.view_ocr_text")} />
                     {(syncServerHost && isElectron) &&
                         <CommandItem command="openNoteOnServer" icon="bx bx-world" disabled={!syncServerHost} text={t("note_actions.open_note_on_server")} />
                     }

--- a/apps/client/src/widgets/ribbon/NoteActions.tsx
+++ b/apps/client/src/widgets/ribbon/NoteActions.tsx
@@ -340,6 +340,7 @@ function DevelopmentActions({ note, noteContext }: { note: FNote, noteContext?: 
             <FormListHeader text="Development Actions" />
             <FormListItem
                 icon="bx bx-printer"
+                disabled={!note.isContentAvailable()}
                 onClick={() => window.open(`/?print=#root/${note.noteId}`, "_blank")}
             >Open print page</FormListItem>
             <FormListItem

--- a/apps/client/src/widgets/ribbon/NoteActions.tsx
+++ b/apps/client/src/widgets/ribbon/NoteActions.tsx
@@ -197,7 +197,7 @@ export function NoteContextMenu({ note, noteContext, itemsAtStart, itemsNearNote
                     {/* Always the note-level dialog, an image note included: it has children of its
                         own, and reaching them is what makes this "images" and not "image". */}
                     <CommandItem icon="bx bx-collapse-alt" text={t("compress-images")}
-                        disabled={isInOptionsOrHelp}
+                        disabled={isInOptionsOrHelp || !isContentAvailable}
                         command={() => void showImageCompressionDialog({ type: "note", noteId: note.noteId })} />
                     <CommandItem command="showNoteOCRText" icon="bx bx-text" disabled={!["image", "file"].includes(noteType) || !isContentAvailable} text={t("note_actions.view_ocr_text")} />
                     {(syncServerHost && isElectron) &&

--- a/apps/server/src/routes/api/ocr.spec.ts
+++ b/apps/server/src/routes/api/ocr.spec.ts
@@ -1,6 +1,6 @@
-import { cls, note_service as noteService } from "@triliumnext/core";
+import { becca, cls, note_service as noteService } from "@triliumnext/core";
 import type { Request } from "express";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Only the OCR engine is mocked — becca/sql run against the real in-memory DB.
 const ocrState = vi.hoisted(() => ({
@@ -18,12 +18,16 @@ vi.mock("../../services/ocr/ocr_service.js", () => ({
     }
 }));
 
+import ocrService from "../../services/ocr/ocr_service.js";
+import sql from "../../services/sql.js";
 import ocrRoutes from "./ocr.js";
 
 let noteId: string;
 let attachmentId: string;
 
 describe("OCR API", () => {
+    beforeEach(() => vi.clearAllMocks());
+
     beforeAll(() => {
         cls.init(() => {
             const { note } = noteService.createNewNote({ parentNoteId: "root", title: "OCR note", type: "text", content: "hi" });
@@ -49,6 +53,22 @@ describe("OCR API", () => {
             const result = await ocrRoutes.processNoteOCR({ params: { noteId }, body: { language: "eng" } } as unknown as Request<{ noteId: string }>);
             expect(result).toMatchObject({ success: true, result: { text: "hello" } });
         });
+
+        it("names the locked vault rather than blaming the note's format", async () => {
+            const note = becca.getNoteOrThrow(noteId);
+            note.isProtected = true;
+            // The engine would skip this note, which the route cannot tell from an unsupported one.
+            ocrState.noteResult = null;
+
+            try {
+                const result = await ocrRoutes.processNoteOCR({ params: { noteId }, body: {} } as unknown as Request<{ noteId: string }>);
+
+                expect(result).toEqual([400, { success: false, message: "Note is protected and the protected session is not available" }]);
+                expect(ocrService.processNoteOCR).not.toHaveBeenCalled();
+            } finally {
+                note.isProtected = false;
+            }
+        });
     });
 
     describe("processAttachmentOCR", () => {
@@ -65,6 +85,23 @@ describe("OCR API", () => {
             ocrState.attachmentResult = { text: "ocr" };
             expect(await ocrRoutes.processAttachmentOCR({ params: { attachmentId }, body: {} } as unknown as Request<{ attachmentId: string }>))
                 .toMatchObject({ success: true });
+        });
+
+        it("names the locked vault rather than blaming the attachment's format", async () => {
+            // becca builds an attachment from SQL on every lookup rather than caching it like a note,
+            // so the flag has to be set where the route will read it back from.
+            const setProtected = (value: number) =>
+                sql.execute("UPDATE attachments SET isProtected = ? WHERE attachmentId = ?", [value, attachmentId]);
+
+            setProtected(1);
+            try {
+                const result = await ocrRoutes.processAttachmentOCR({ params: { attachmentId }, body: {} } as unknown as Request<{ attachmentId: string }>);
+
+                expect(result).toEqual([400, { success: false, message: "Attachment is protected and the protected session is not available" }]);
+                expect(ocrService.processAttachmentOCR).not.toHaveBeenCalled();
+            } finally {
+                setProtected(0);
+            }
         });
     });
 

--- a/apps/server/src/routes/api/ocr.ts
+++ b/apps/server/src/routes/api/ocr.ts
@@ -62,6 +62,10 @@ async function processNoteOCR(req: Request<{ noteId: string }>): Promise<OCRProc
         return [404, { success: false, message: 'Note not found' }];
     }
 
+    if (!note.isContentAvailable()) {
+        return [400, { success: false, message: 'Note is protected and the protected session is not available' }];
+    }
+
     const result = await ocrService.processNoteOCR(noteId, { language, forceReprocess });
     if (!result) {
         return [400, { success: false, message: 'Note is not an image or has unsupported format' }];
@@ -124,6 +128,10 @@ async function processAttachmentOCR(req: Request<{ attachmentId: string }>): Pro
     const attachment = becca.getAttachment(attachmentId);
     if (!attachment) {
         return [404, { success: false, message: 'Attachment not found' }];
+    }
+
+    if (!attachment.isContentAvailable()) {
+        return [400, { success: false, message: 'Attachment is protected and the protected session is not available' }];
     }
 
     const result = await ocrService.processAttachmentOCR(attachmentId, { language, forceReprocess });

--- a/apps/server/src/services/binary.spec.ts
+++ b/apps/server/src/services/binary.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { asBuffer } from "./binary.js";
+
+describe("asBuffer", () => {
+    it("returns a Buffer holding the same bytes", () => {
+        const bytes = Uint8Array.from([1, 2, 3, 254, 255]);
+
+        const result = asBuffer(bytes);
+
+        expect(Buffer.isBuffer(result)).toBe(true);
+        expect([...result]).toEqual([1, 2, 3, 254, 255]);
+    });
+
+    it("shares memory with the source rather than copying it", () => {
+        const bytes = Uint8Array.from([1, 2, 3]);
+
+        const result = asBuffer(bytes);
+        bytes[0] = 42;
+
+        // A copy would still read 1 here. The whole point of this helper is that it does not copy.
+        expect(result[0]).toBe(42);
+    });
+
+    it("scopes the view to a subarray, not its backing buffer", () => {
+        const backing = Uint8Array.from([1, 2, 3, 4, 5, 6]);
+        const slice = backing.subarray(2, 5);
+
+        const result = asBuffer(slice);
+
+        expect(result.byteLength).toBe(3);
+        expect([...result]).toEqual([3, 4, 5]);
+    });
+
+    it("passes a Buffer through as it came", () => {
+        const buffer = Buffer.from([7, 8, 9]);
+
+        expect(asBuffer(buffer)).toBe(buffer);
+    });
+
+    it("handles an empty input", () => {
+        const result = asBuffer(new Uint8Array(0));
+
+        expect(Buffer.isBuffer(result)).toBe(true);
+        expect(result.byteLength).toBe(0);
+    });
+});

--- a/apps/server/src/services/binary.ts
+++ b/apps/server/src/services/binary.ts
@@ -1,0 +1,28 @@
+/**
+ * Byte helpers for server-side code, where `Buffer` is always available.
+ *
+ * Deliberately dependency-free. The image codec reaches for this, and the codec is loaded by a worker
+ * that must not have to stand up half a server to host it — so nothing here may import Trilium.
+ *
+ * The browser-facing counterparts live in `@triliumnext/core`'s `services/utils/binary.ts`, which
+ * cannot offer these: standalone runs core in a worker with no `Buffer` to convert to.
+ */
+
+/**
+ * The same bytes as a `Buffer`, over the same memory.
+ *
+ * `Buffer.from(uint8Array)` duplicates what it is given, and the libraries this server hands bytes to
+ * each want a `Buffer` — so an image was being copied whole several times on its way through, for
+ * readers that only ever read. On a run over a tree that is a second copy of every photograph in it,
+ * allocated and thrown away again, which costs more in collection than the copying does outright.
+ *
+ * `byteOffset`/`byteLength` keep the view scoped to the caller's slice, never the surrounding backing
+ * buffer. A `Buffer` is already one and is returned as it came.
+ */
+export function asBuffer(bytes: Uint8Array): Buffer {
+    if (Buffer.isBuffer(bytes)) {
+        return bytes;
+    }
+
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}

--- a/apps/server/src/services/image_codec.ts
+++ b/apps/server/src/services/image_codec.ts
@@ -20,6 +20,8 @@ import isSvg from "is-svg";
 import { Jimp } from "jimp";
 import * as UPNG from "upng-js";
 
+import { asBuffer } from "./binary.js";
+
 /**
  * Where a line the codec wants written goes. Dropped by default, since nothing here needs it.
  *
@@ -208,18 +210,6 @@ export function decodeCostOf({ width, height }: InspectedImage): number | null {
  */
 export function decodeImage(buffer: Uint8Array, budgetMb: number = DECODE_MEMORY_MB) {
     return Jimp.fromBuffer(asBuffer(buffer), { "image/jpeg": { maxMemoryUsageInMB: budgetMb } });
-}
-
-/**
- * The same bytes as a `Buffer`, over the same memory.
- *
- * `Buffer.from(uint8Array)` duplicates what it is given, and the libraries below each want one —
- * so an image was being copied whole several times on its way through, for readers that only ever
- * read. On a run over a tree that is a second copy of every photograph in it, allocated and thrown
- * away again, which costs more in collection than the copying does outright.
- */
-export function asBuffer(bytes: Uint8Array): Buffer {
-    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 }
 
 /** What {@link decodeImage} hands back, for the helpers that work on a decoded image. */

--- a/apps/server/src/services/ocr/ocr_service.spec.ts
+++ b/apps/server/src/services/ocr/ocr_service.spec.ts
@@ -40,7 +40,9 @@ const mockBecca = {
 };
 
 const mockBlobService = {
-    calculateContentHash: vi.fn().mockReturnValue('hash123')
+    calculateContentHash: vi.fn().mockReturnValue('hash123'),
+    // Stands in for the real encryption: distinguishable from the plain text, and reversible by eye.
+    encryptTextRepresentation: vi.fn((text: string, isProtected: boolean) => (isProtected ? `encrypted(${text})` : text))
 };
 
 const mockEntityChangesService = {
@@ -237,15 +239,15 @@ describe('OCRService', () => {
     });
 
     describe('storeOCRResult', () => {
-        it('should store OCR result in blob successfully', () => {
-            const ocrResult = {
-                text: 'Sample text',
-                confidence: 0.95,
-                extractedAt: '2025-06-10T10:00:00.000Z',
-                language: 'eng'
-            };
+        const ocrResult = {
+            text: 'Sample text',
+            confidence: 0.95,
+            extractedAt: '2025-06-10T10:00:00.000Z',
+            language: 'eng'
+        };
 
-            ocrService.storeOCRResult('blob123', ocrResult);
+        it('should store OCR result in blob successfully', () => {
+            ocrService.storeOCRResult('blob123', ocrResult, false);
 
             expect(mockSql.execute).toHaveBeenCalledWith(
                 expect.stringContaining('UPDATE blobs SET textRepresentation = ?'),
@@ -253,15 +255,18 @@ describe('OCRService', () => {
             );
         });
 
-        it('should handle undefined blobId gracefully', () => {
-            const ocrResult = {
-                text: 'Sample text',
-                confidence: 0.95,
-                extractedAt: '2025-06-10T10:00:00.000Z',
-                language: 'eng'
-            };
+        it('encrypts the text before storing it on a protected blob', () => {
+            ocrService.storeOCRResult('blob123', ocrResult, true);
 
-            ocrService.storeOCRResult(undefined, ocrResult);
+            expect(mockBlobService.encryptTextRepresentation).toHaveBeenCalledWith('Sample text', true);
+            expect(mockSql.execute).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE blobs SET textRepresentation = ?'),
+                ['encrypted(Sample text)', 'blob123']
+            );
+        });
+
+        it('should handle undefined blobId gracefully', () => {
+            ocrService.storeOCRResult(undefined, ocrResult, false);
 
             expect(mockSql.execute).not.toHaveBeenCalled();
             expect(mockLog.error).toHaveBeenCalledWith('Cannot store OCR result: blobId is undefined');
@@ -273,15 +278,17 @@ describe('OCRService', () => {
                 throw error;
             });
 
-            const ocrResult = {
-                text: 'Sample text',
-                confidence: 0.95,
-                extractedAt: '2025-06-10T10:00:00.000Z',
-                language: 'eng'
-            };
-
-            expect(() => ocrService.storeOCRResult('blob123', ocrResult)).toThrow('Database error');
+            expect(() => ocrService.storeOCRResult('blob123', ocrResult, false)).toThrow('Database error');
             expect(mockLog.error).toHaveBeenCalledWith('Failed to store OCR result for blob blob123: Error: Database error');
+        });
+
+        it('propagates an encryption failure instead of storing the text unencrypted', () => {
+            mockBlobService.encryptTextRepresentation.mockImplementationOnce(() => {
+                throw new Error('Cannot encrypt the text representation since protected session is not available.');
+            });
+
+            expect(() => ocrService.storeOCRResult('blob123', ocrResult, true)).toThrow('Cannot encrypt');
+            expect(mockSql.execute).not.toHaveBeenCalled();
         });
     });
 
@@ -291,6 +298,8 @@ describe('OCRService', () => {
             type: 'image',
             mime: 'image/jpeg',
             blobId: 'blob123',
+            isProtected: false,
+            isContentAvailable: vi.fn(),
             getContent: vi.fn(),
             getLabelValue: vi.fn().mockReturnValue(null)
         };
@@ -298,6 +307,8 @@ describe('OCRService', () => {
         beforeEach(() => {
             mockBecca.getNote.mockReturnValue(mockNote);
             mockNote.getContent.mockReturnValue(Buffer.from('fake-image-data'));
+            mockNote.isContentAvailable.mockReturnValue(true);
+            mockNote.isProtected = false;
             mockNote.mime = 'image/jpeg';
         });
 
@@ -385,14 +396,52 @@ describe('OCRService', () => {
             expect(mockLog.info).toHaveBeenCalledWith('OCR already exists for note note123, skipping');
         });
 
-        it('should throw when content is not a Buffer', async () => {
-            mockNote.getContent.mockReturnValue('not a buffer');
+        it('should throw when the content holds no recognisable bytes', async () => {
+            // String content has no binary form, and an empty buffer has nothing to recognise.
+            for (const content of ['not a buffer', Buffer.alloc(0), new Uint8Array(0)]) {
+                mockNote.getContent.mockReturnValue(content);
 
-            await expect(ocrService.processNoteOCR('note123')).rejects.toThrow(
-                'Cannot get content for note note123'
-            );
+                await expect(ocrService.processNoteOCR('note123')).rejects.toThrow(
+                    'Cannot get content for note note123'
+                );
+            }
+
             expect(mockLog.error).toHaveBeenCalledWith(
                 expect.stringContaining('Failed to process OCR for note note123')
+            );
+        });
+
+        it('recognises a protected note and stores the extracted text encrypted', async () => {
+            mockNote.isProtected = true;
+            mockSql.getRow.mockReturnValue(null);
+            // Decryption hands back a plain Uint8Array rather than a Buffer — the same bytes, and they
+            // must reach the processor rather than being rejected as unreadable content.
+            mockNote.getContent.mockReturnValue(Uint8Array.from(Buffer.from('decrypted-image-data')));
+            mockWorker.recognize.mockResolvedValue({
+                data: { text: 'Secret text', confidence: 90, words: [] }
+            });
+
+            const result = await ocrService.processNoteOCR('note123');
+
+            expect(result?.text).toBe('Secret text');
+            expect(mockBlobService.encryptTextRepresentation).toHaveBeenCalledWith('Secret text', true);
+            expect(mockSql.execute).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE blobs SET textRepresentation = ?'),
+                ['encrypted(Secret text)', 'blob123']
+            );
+        });
+
+        it('skips a protected note when no protected session is available', async () => {
+            mockNote.isProtected = true;
+            mockNote.isContentAvailable.mockReturnValue(false);
+
+            const result = await ocrService.processNoteOCR('note123');
+
+            expect(result).toBeNull();
+            expect(mockNote.getContent).not.toHaveBeenCalled();
+            expect(mockSql.execute).not.toHaveBeenCalled();
+            expect(mockLog.info).toHaveBeenCalledWith(
+                'note note123 is protected and no protected session is available, skipping OCR'
             );
         });
 
@@ -431,6 +480,8 @@ describe('OCRService', () => {
             role: 'image',
             mime: 'image/png',
             blobId: 'blob456',
+            isProtected: false,
+            isContentAvailable: vi.fn(),
             getContent: vi.fn()
         };
 
@@ -438,6 +489,8 @@ describe('OCRService', () => {
             mockBecca.getAttachment.mockReturnValue(mockAttachment);
             mockBecca.getNote.mockReturnValue({ getLabelValue: vi.fn().mockReturnValue(null) });
             mockAttachment.getContent.mockReturnValue(Buffer.from('fake-image-data'));
+            mockAttachment.isContentAvailable.mockReturnValue(true);
+            mockAttachment.isProtected = false;
         });
 
         it('should process attachment OCR successfully', async () => {
@@ -466,6 +519,36 @@ describe('OCRService', () => {
 
             expect(result).toBe(null);
             expect(mockLog.error).toHaveBeenCalledWith('Attachment nonexistent not found');
+        });
+
+        it('recognises a protected attachment and stores the extracted text encrypted', async () => {
+            mockAttachment.isProtected = true;
+            mockSql.getRow.mockReturnValue(null);
+            mockAttachment.getContent.mockReturnValue(Uint8Array.from(Buffer.from('decrypted-image-data')));
+            mockWorker.recognize.mockResolvedValue({
+                data: { text: 'Secret attachment text', confidence: 92, words: [] }
+            });
+
+            const result = await ocrService.processAttachmentOCR('attach123');
+
+            expect(result?.text).toBe('Secret attachment text');
+            expect(mockSql.execute).toHaveBeenCalledWith(
+                expect.stringContaining('UPDATE blobs SET textRepresentation = ?'),
+                ['encrypted(Secret attachment text)', 'blob456']
+            );
+        });
+
+        it('skips a protected attachment when no protected session is available', async () => {
+            mockAttachment.isProtected = true;
+            mockAttachment.isContentAvailable.mockReturnValue(false);
+
+            const result = await ocrService.processAttachmentOCR('attach123');
+
+            expect(result).toBeNull();
+            expect(mockAttachment.getContent).not.toHaveBeenCalled();
+            expect(mockLog.info).toHaveBeenCalledWith(
+                'attachment attach123 is protected and no protected session is available, skipping OCR'
+            );
         });
     });
 

--- a/apps/server/src/services/ocr/ocr_service.spec.ts
+++ b/apps/server/src/services/ocr/ocr_service.spec.ts
@@ -35,18 +35,16 @@ const mockSql = {
 
 const mockBecca = {
     getNote: vi.fn(),
-    getAttachment: vi.fn(),
-    getBlob: vi.fn()
+    getAttachment: vi.fn()
 };
 
 const mockBlobService = {
-    calculateContentHash: vi.fn().mockReturnValue('hash123'),
     // Stands in for the real encryption: distinguishable from the plain text, and reversible by eye.
     encryptTextRepresentation: vi.fn((text: string, isProtected: boolean) => (isProtected ? `encrypted(${text})` : text))
 };
 
 const mockEntityChangesService = {
-    putEntityChange: vi.fn()
+    putBlobEntityChange: vi.fn()
 };
 
 vi.mock('../sql.js', () => ({
@@ -85,14 +83,6 @@ beforeEach(async () => {
     mockSql.getRow.mockReturnValue(null);
     mockSql.getRows.mockReturnValue([]);
     mockSql.getColumn.mockReturnValue([]);
-
-    // Mock getBlob for putBlobEntityChange
-    mockBecca.getBlob.mockReturnValue({
-        blobId: 'blob123',
-        content: Buffer.from('data'),
-        textRepresentation: null,
-        utcDateModified: '2025-01-01'
-    });
 
     mockTesseract.createWorker.mockImplementation(async () => {
         return mockWorker;
@@ -459,9 +449,8 @@ describe('OCRService', () => {
             (mockNote as any).blobId = 'blob123';
         });
 
-        it('skips storing the blob entity change when blob is missing', async () => {
+        it('has the stored blob re-hashed for sync, since the text is not part of its identity', async () => {
             mockSql.getRow.mockReturnValue(null);
-            mockBecca.getBlob.mockReturnValue(null);
             mockWorker.recognize.mockResolvedValue({
                 data: { text: 'text', confidence: 90, words: [] }
             });
@@ -469,7 +458,7 @@ describe('OCRService', () => {
             const result = await ocrService.processNoteOCR('note123');
 
             expect(result?.text).toBe('text');
-            expect(mockEntityChangesService.putEntityChange).not.toHaveBeenCalled();
+            expect(mockEntityChangesService.putBlobEntityChange).toHaveBeenCalledWith('blob123');
         });
     });
 

--- a/apps/server/src/services/ocr/ocr_service.ts
+++ b/apps/server/src/services/ocr/ocr_service.ts
@@ -1,6 +1,7 @@
 import { getTesseractCode } from '@triliumnext/commons';
 import { becca, blob as blobService, entity_changes as entityChangesService, getLog, options } from '@triliumnext/core';
 
+import { asBuffer } from '../image_codec.js';
 import sql from '../sql.js';
 import { FileProcessor } from './processors/file_processor.js';
 import { ImageProcessor } from './processors/image_processor.js';
@@ -135,6 +136,8 @@ class OCRService {
             category: note.type,
             mime: note.mime,
             blobId: note.blobId,
+            isProtected: !!note.isProtected,
+            isContentAvailable: note.isContentAvailable(),
             languageNoteId: noteId,
             getContent: () => note.getContent()
         }, options);
@@ -156,6 +159,8 @@ class OCRService {
             category: attachment.role,
             mime: attachment.mime,
             blobId: attachment.blobId,
+            isProtected: !!attachment.isProtected,
+            isContentAvailable: attachment.isContentAvailable(),
             languageNoteId: attachment.ownerId,
             getContent: () => attachment.getContent()
         }, options);
@@ -170,10 +175,12 @@ class OCRService {
         category: string;
         mime: string;
         blobId: string | undefined;
+        isProtected: boolean;
+        isContentAvailable: boolean;
         languageNoteId: string;
         getContent: () => string | Uint8Array;
     }, options: OCRProcessingOptions = {}): Promise<OCRResult | null> {
-        const { entityId, entityType, category, mime, blobId, languageNoteId } = entity;
+        const { entityId, entityType, category, mime, blobId, isProtected, isContentAvailable, languageNoteId } = entity;
 
         if (!['image', 'file'].includes(category)) {
             getLog().info(`${entityType} ${entityId} is not an image or file, skipping OCR`);
@@ -190,16 +197,23 @@ class OCRService {
             return null;
         }
 
+        // Without the key the content is not readable, so there is nothing to recognise. This is an
+        // ordinary skip rather than a failure: the entity is picked up again once the vault is open.
+        if (!isContentAvailable) {
+            getLog().info(`${entityType} ${entityId} is protected and no protected session is available, skipping OCR`);
+            return null;
+        }
+
         try {
-            const content = entity.getContent();
-            if (!content || !(content instanceof Buffer)) {
+            const content = toBinaryContent(entity.getContent());
+            if (!content) {
                 throw new Error(`Cannot get content for ${entityType} ${entityId}`);
             }
 
             const language = this.resolveOcrLanguage(languageNoteId, options.language);
             const ocrResult = await this.extractTextFromFile(content, mime, { ...options, language });
 
-            this.storeOCRResult(blobId, ocrResult);
+            this.storeOCRResult(blobId, ocrResult, isProtected);
 
             return ocrResult;
         } catch (error) {
@@ -209,19 +223,24 @@ class OCRService {
     }
 
     /**
-     * Store OCR result in blob
+     * Store OCR result in blob.
+     *
+     * The text is encrypted for a protected entity, since it is a readable rendering of content that
+     * is itself only stored encrypted.
      */
-    storeOCRResult(blobId: string | undefined, ocrResult: OCRResult): void {
+    storeOCRResult(blobId: string | undefined, ocrResult: OCRResult, isProtected: boolean): void {
         if (!blobId) {
             getLog().error('Cannot store OCR result: blobId is undefined');
             return;
         }
 
         try {
+            const textRepresentation = blobService.encryptTextRepresentation(ocrResult.text, isProtected);
+
             sql.execute(`
                 UPDATE blobs SET textRepresentation = ?
                 WHERE blobId = ?
-            `, [ocrResult.text, blobId]);
+            `, [textRepresentation, blobId]);
 
             this.putBlobEntityChange(blobId);
 
@@ -463,3 +482,21 @@ class OCRService {
 }
 
 export default new OCRService();
+
+/**
+ * Narrows an entity's content to the `Buffer` the processors take, or null when there are no bytes to
+ * recognise — a string has no binary form, and neither does an empty buffer.
+ *
+ * The conversion matters because the two kinds of content arrive differently typed. Unprotected
+ * content is already a `Buffer`: better-sqlite3 returns one for a BLOB column and nothing rewraps it
+ * on the way through Becca. Protected content is decrypted on the way out, and the decryption builds
+ * its result with `new Uint8Array(...)`, which is not a `Buffer` — so testing for one rejected every
+ * protected image as unreadable. Same bytes either way, so wrap rather than reject.
+ */
+function toBinaryContent(content: string | Uint8Array): Buffer | null {
+    if (typeof content === "string" || content.byteLength === 0) {
+        return null;
+    }
+
+    return asBuffer(content);
+}

--- a/apps/server/src/services/ocr/ocr_service.ts
+++ b/apps/server/src/services/ocr/ocr_service.ts
@@ -1,7 +1,7 @@
 import { getTesseractCode } from '@triliumnext/commons';
 import { becca, blob as blobService, entity_changes as entityChangesService, getLog, options } from '@triliumnext/core';
 
-import { asBuffer } from '../image_codec.js';
+import { asBuffer } from '../binary.js';
 import sql from '../sql.js';
 import { FileProcessor } from './processors/file_processor.js';
 import { ImageProcessor } from './processors/image_processor.js';

--- a/apps/server/src/services/ocr/ocr_service.ts
+++ b/apps/server/src/services/ocr/ocr_service.ts
@@ -242,7 +242,7 @@ class OCRService {
                 WHERE blobId = ?
             `, [textRepresentation, blobId]);
 
-            this.putBlobEntityChange(blobId);
+            entityChangesService.putBlobEntityChange(blobId);
 
             getLog().info(`Stored OCR result for blob ${blobId}`);
         } catch (error) {
@@ -382,28 +382,6 @@ class OCRService {
     /**
      * Get processor for a given MIME type
      */
-    /**
-     * Notifies the sync system that a blob has changed, without modifying the blob's identity.
-     */
-    private putBlobEntityChange(blobId: string): void {
-        const blob = becca.getBlob({ blobId });
-        if (!blob || !blob.blobId) return;
-
-        const hash = blobService.calculateContentHash({
-            blobId: blob.blobId,
-            content: blob.content,
-            textRepresentation: blob.textRepresentation
-        });
-        entityChangesService.putEntityChange({
-            entityName: "blobs",
-            entityId: blobId,
-            hash,
-            isErased: false,
-            utcDateChanged: blob.utcDateModified,
-            isSynced: true
-        });
-    }
-
     private getProcessorForMimeType(mimeType: string): FileProcessor | null {
         for (const processor of this.processors.values()) {
             if (processor.canProcess(mimeType)) {

--- a/apps/server/src/services/ocr/processors/image_processor.spec.ts
+++ b/apps/server/src/services/ocr/processors/image_processor.spec.ts
@@ -60,6 +60,31 @@ afterEach(() => {
 
 const buffer = Buffer.from('fake-image');
 
+/**
+ * A recognition result in the shape tesseract.js actually answers with when the `blocks` output
+ * format is requested: the words are nested under blocks → paragraphs → lines, and there is no
+ * top-level `words` array to read them from.
+ */
+function pageWithLines(confidence: number, lines: [ text: string, confidence: number ][][]) {
+    return {
+        text: lines.map(line => line.map(([ text ]) => text).join(' ')).join('\n'),
+        confidence,
+        blocks: [ {
+            paragraphs: [ {
+                lines: lines.map(line => ({
+                    text: line.map(([ text ]) => text).join(' '),
+                    words: line.map(([ text, wordConfidence ]) => ({ text, confidence: wordConfidence }))
+                }))
+            } ]
+        } ]
+    };
+}
+
+/** What a recognition with no readable text answers with: text, a score, and `blocks: null`. */
+function pageWithoutBlocks(text: string, confidence: number) {
+    return { text, confidence, blocks: null };
+}
+
 describe('ImageProcessor', () => {
     it('reports the MIME types it can process', () => {
         const processor = new ImageProcessor();
@@ -76,7 +101,7 @@ describe('ImageProcessor', () => {
     it('extracts text and returns it untrimmed-confidence when no threshold is set', async () => {
         const processor = new ImageProcessor();
         mockWorker.recognize.mockResolvedValue({
-            data: { text: '  hello world  ', confidence: 88, words: [] }
+            data: { text: '  hello world  ', confidence: 88, blocks: null }
         });
 
         const result = await processor.extractText(buffer, { language: 'eng' });
@@ -92,10 +117,21 @@ describe('ImageProcessor', () => {
         );
     });
 
+    it('asks tesseract for the per-word breakdown the confidence filter needs', async () => {
+        const processor = new ImageProcessor();
+        mockWorker.recognize.mockResolvedValue({ data: pageWithLines(80, [ [ [ 'x', 80 ] ] ]) });
+
+        await processor.extractText(buffer, { language: 'eng' });
+
+        // Without this output format the result carries the plain text alone, and every image is
+        // judged by its mean confidence instead of word by word.
+        expect(mockWorker.recognize).toHaveBeenCalledWith(buffer, {}, { blocks: true });
+    });
+
     it('defaults the language to eng when none is supplied', async () => {
         const processor = new ImageProcessor();
         mockWorker.recognize.mockResolvedValue({
-            data: { text: 'x', confidence: 50, words: [] }
+            data: pageWithLines(50, [ [ [ 'x', 50 ] ] ])
         });
 
         await processor.extractText(buffer);
@@ -106,7 +142,7 @@ describe('ImageProcessor', () => {
     it('reuses the worker for the same language and recreates it when the language changes', async () => {
         const processor = new ImageProcessor();
         mockWorker.recognize.mockResolvedValue({
-            data: { text: 'a', confidence: 50, words: [] }
+            data: pageWithLines(50, [ [ [ 'a', 50 ] ] ])
         });
 
         await processor.extractText(buffer, { language: 'eng' });
@@ -122,7 +158,7 @@ describe('ImageProcessor', () => {
     it('invokes the recognizing-text logger callback', async () => {
         const processor = new ImageProcessor();
         mockWorker.recognize.mockResolvedValue({
-            data: { text: 'a', confidence: 50, words: [] }
+            data: pageWithLines(50, [ [ [ 'a', 50 ] ] ])
         });
 
         await processor.extractText(buffer, { language: 'eng' });
@@ -139,7 +175,7 @@ describe('ImageProcessor', () => {
     it('passes an errorHandler that logs worker errors instead of rethrowing them', async () => {
         const processor = new ImageProcessor();
         mockWorker.recognize.mockResolvedValue({
-            data: { text: 'a', confidence: 50, words: [] }
+            data: pageWithLines(50, [ [ [ 'a', 50 ] ] ])
         });
 
         await processor.extractText(buffer, { language: 'eng' });
@@ -166,36 +202,58 @@ describe('ImageProcessor', () => {
     });
 
     describe('confidence filtering', () => {
-        it('keeps only words above the configured threshold', async () => {
+        it('keeps the words above the threshold on the lines they were read on', async () => {
             mockOptions.getOption.mockReturnValue('0.8');
             const processor = new ImageProcessor();
             mockWorker.recognize.mockResolvedValue({
-                data: {
-                    text: 'good bad good',
-                    confidence: 70,
-                    words: [
-                        { text: 'good', confidence: 90 },
-                        { text: 'bad', confidence: 50 },
-                        { text: 'good', confidence: 95 }
-                    ]
-                }
+                data: pageWithLines(70, [
+                    [ [ 'good', 90 ], [ 'bad', 50 ] ],
+                    [ [ 'also', 95 ], [ 'good', 85 ] ]
+                ])
             });
 
             const result = await processor.extractText(buffer, { language: 'eng' });
 
-            expect(result.text).toBe('good good');
-            expect(result.confidence).toBeCloseTo((0.9 + 0.95) / 2);
+            expect(result.text).toBe('good\nalso good');
+            expect(result.confidence).toBeCloseTo((0.9 + 0.95 + 0.85) / 3);
         });
 
-        it('returns empty confidence when no words pass the threshold', async () => {
+        it('keeps well-read words on an image whose mean confidence is below the threshold', async () => {
+            // The mean is dragged under the line by the marks Tesseract misread as text, which is
+            // exactly what the per-word filter is for — judging the image by that mean instead
+            // would throw away every word on it.
+            mockOptions.getOption.mockReturnValue('0.75');
+            const processor = new ImageProcessor();
+            mockWorker.recognize.mockResolvedValue({
+                data: pageWithLines(60, [ [ [ 'Invoice', 96 ], [ '®', 0 ], [ 'total', 94 ] ] ])
+            });
+
+            const result = await processor.extractText(buffer, { language: 'eng' });
+
+            expect(result.text).toBe('Invoice total');
+        });
+
+        it('leaves no blank line where every word of one was dropped', async () => {
+            mockOptions.getOption.mockReturnValue('0.8');
+            const processor = new ImageProcessor();
+            mockWorker.recognize.mockResolvedValue({
+                data: pageWithLines(70, [
+                    [ [ 'kept', 90 ] ],
+                    [ [ 'noise', 10 ] ],
+                    [ [ 'also-kept', 90 ] ]
+                ])
+            });
+
+            const result = await processor.extractText(buffer, { language: 'eng' });
+
+            expect(result.text).toBe('kept\nalso-kept');
+        });
+
+        it('returns empty text and no confidence when no word passes the threshold', async () => {
             mockOptions.getOption.mockReturnValue('0.99');
             const processor = new ImageProcessor();
             mockWorker.recognize.mockResolvedValue({
-                data: {
-                    text: 'low',
-                    confidence: 10,
-                    words: [{ text: 'low', confidence: 10 }]
-                }
+                data: pageWithLines(10, [ [ [ 'low', 10 ] ] ])
             });
 
             const result = await processor.extractText(buffer, { language: 'eng' });
@@ -204,24 +262,11 @@ describe('ImageProcessor', () => {
             expect(result.confidence).toBe(0);
         });
 
-        it('handles an empty word array with a threshold set', async () => {
+        it('falls back to overall confidence when nothing was broken down into words', async () => {
             mockOptions.getOption.mockReturnValue('0.5');
             const processor = new ImageProcessor();
             mockWorker.recognize.mockResolvedValue({
-                data: { text: 'ignored', confidence: 80, words: [] }
-            });
-
-            const result = await processor.extractText(buffer, { language: 'eng' });
-
-            expect(result.text).toBe('');
-            expect(result.confidence).toBe(0);
-        });
-
-        it('falls back to overall confidence when there is no word-level data', async () => {
-            mockOptions.getOption.mockReturnValue('0.5');
-            const processor = new ImageProcessor();
-            mockWorker.recognize.mockResolvedValue({
-                data: { text: '  whole text  ', confidence: 80, words: undefined }
+                data: pageWithoutBlocks('  whole text  ', 80)
             });
 
             const result = await processor.extractText(buffer, { language: 'eng' });
@@ -234,7 +279,7 @@ describe('ImageProcessor', () => {
             mockOptions.getOption.mockReturnValue('0.9');
             const processor = new ImageProcessor();
             mockWorker.recognize.mockResolvedValue({
-                data: { text: 'whole text', confidence: 40, words: undefined }
+                data: pageWithoutBlocks('whole text', 40)
             });
 
             const result = await processor.extractText(buffer, { language: 'eng' });
@@ -250,7 +295,7 @@ describe('ImageProcessor', () => {
             mockOptions.getOption.mockReturnValue(null);
             const processor = new ImageProcessor();
             mockWorker.recognize.mockResolvedValue({
-                data: { text: 'kept', confidence: 30, words: [{ text: 'kept', confidence: 30 }] }
+                data: pageWithLines(30, [ [ [ 'kept', 30 ] ] ])
             });
 
             const result = await processor.extractText(buffer, { language: 'eng' });

--- a/apps/server/src/services/ocr/processors/image_processor.ts
+++ b/apps/server/src/services/ocr/processors/image_processor.ts
@@ -35,12 +35,15 @@ export class ImageProcessor extends FileProcessor {
 
     async extractText(buffer: Buffer, options: OCRProcessingOptions = {}): Promise<OCRResult> {
         const language = options.language || "eng";
-        await this.ensureWorker(language);
+        const worker = await this.ensureWorker(language);
 
         try {
             getLog().info(`Starting image OCR text extraction (language: ${language})...`);
 
-            const result = await this.worker!.recognize(buffer);
+            // The per-word breakdown the confidence filter runs on is an opt-in output format:
+            // by default `recognize` answers with the plain text and nothing else, leaving the
+            // filter with only the whole image's mean confidence to judge by.
+            const result = await worker.recognize(buffer, {}, { blocks: true });
 
             // Filter text based on minimum confidence threshold
             const { filteredText, overallConfidence } = this.filterTextByConfidence(result.data);
@@ -66,12 +69,12 @@ export class ImageProcessor extends FileProcessor {
     }
 
     /**
-     * Ensures a Tesseract worker is ready for the given language.
+     * Ensures a Tesseract worker is ready for the given language, and hands it back.
      * Creates a new worker if none exists or if the language has changed.
      */
-    private async ensureWorker(language: string): Promise<void> {
+    private async ensureWorker(language: string): Promise<Tesseract.Worker> {
         if (this.worker && this.currentLanguage === language) {
-            return;
+            return this.worker;
         }
 
         if (this.worker) {
@@ -97,13 +100,20 @@ export class ImageProcessor extends FileProcessor {
             }
         });
         this.currentLanguage = language;
+        return this.worker;
     }
 
 
     /**
-     * Filter text based on minimum confidence threshold
+     * Filter text based on minimum confidence threshold.
+     *
+     * Word by word, because the words Tesseract is least sure of are usually not words at all —
+     * a border read as punctuation, a speck read as a comma — and it is those that drag the mean
+     * for the image down. Judging the image by that mean throws away every well-read word on it
+     * along with them, so what is kept is decided per word and reassembled line by line, leaving
+     * the text laid out as it is on the picture.
      */
-    private filterTextByConfidence(data: any): { filteredText: string; overallConfidence: number } {
+    private filterTextByConfidence(data: Tesseract.Page): { filteredText: string; overallConfidence: number } {
         const minConfidence = this.getMinConfidenceThreshold();
 
         // If no minimum confidence set, return original text
@@ -114,21 +124,11 @@ export class ImageProcessor extends FileProcessor {
             };
         }
 
-        const filteredWords: string[] = [];
-        const validConfidences: number[] = [];
+        const lines = getRecognizedLines(data);
 
-        // Tesseract provides word-level data
-        if (data.words && Array.isArray(data.words)) {
-            for (const word of data.words) {
-                const wordConfidence = word.confidence / 100; // Convert to decimal
-
-                if (wordConfidence >= minConfidence) {
-                    filteredWords.push(word.text);
-                    validConfidences.push(wordConfidence);
-                }
-            }
-        } else {
-            // Fallback: if word-level data not available, use overall confidence
+        // Nothing was broken down into words — an image nothing could be read from. There is only
+        // the one score to go by, so the text stands or falls as a whole.
+        if (lines.length === 0) {
             const overallConfidence = data.confidence / 100;
             if (overallConfidence >= minConfidence) {
                 return {
@@ -143,14 +143,38 @@ export class ImageProcessor extends FileProcessor {
             };
         }
 
+        const keptLines: string[] = [];
+        const keptConfidences: number[] = [];
+        let totalWords = 0;
+
+        for (const line of lines) {
+            const keptWords: string[] = [];
+
+            for (const word of line.words ?? []) {
+                totalWords++;
+                const wordConfidence = word.confidence / 100; // Convert to decimal
+
+                if (wordConfidence >= minConfidence) {
+                    keptWords.push(word.text);
+                    keptConfidences.push(wordConfidence);
+                }
+            }
+
+            // A line every word of which was dropped leaves no blank behind: the gap would read as
+            // spacing on the picture that isn't there.
+            if (keptWords.length > 0) {
+                keptLines.push(keptWords.join(' '));
+            }
+        }
+
         // Calculate average confidence of accepted words
-        const averageConfidence = validConfidences.length > 0
-            ? validConfidences.reduce((sum, conf) => sum + conf, 0) / validConfidences.length
+        const averageConfidence = keptConfidences.length > 0
+            ? keptConfidences.reduce((sum, conf) => sum + conf, 0) / keptConfidences.length
             : 0;
 
-        const filteredText = filteredWords.join(' ').trim();
+        const filteredText = keptLines.join('\n').trim();
 
-        getLog().info(`Filtered OCR text: ${filteredWords.length} words kept out of ${data.words?.length || 0} total words (min confidence: ${minConfidence})`);
+        getLog().info(`Filtered OCR text: ${keptConfidences.length} words kept out of ${totalWords} total words (min confidence: ${minConfidence})`);
 
         return {
             filteredText,
@@ -166,4 +190,17 @@ export class ImageProcessor extends FileProcessor {
         return parseFloat(minConfidence);
     }
 
+}
+
+/**
+ * The words Tesseract read, in the lines it read them on.
+ *
+ * They sit three levels down the page it describes, and that description is only present when the
+ * `blocks` output format was asked for — see {@link ImageProcessor.extractText}. Without it, and
+ * for an image nothing was read from, this is empty.
+ */
+function getRecognizedLines(data: Tesseract.Page): Tesseract.Line[] {
+    return (data.blocks ?? []).flatMap(
+        block => (block.paragraphs ?? []).flatMap(paragraph => paragraph.lines ?? [])
+    );
 }

--- a/apps/server/src/zip_provider.ts
+++ b/apps/server/src/zip_provider.ts
@@ -4,6 +4,8 @@ import fs from "fs";
 import type { Stream } from "stream";
 import * as yauzl from "yauzl";
 
+import { asBuffer } from "./services/binary.js";
+
 class NodejsZipArchive implements ZipArchive {
     readonly #archive: ArchiverZip;
     // Byte sizes of appended entries not yet written out, in FIFO order.
@@ -55,11 +57,8 @@ class NodejsZipArchive implements ZipArchive {
         if (this.#error) {
             throw this.#error;
         }
-        // Wrap the Uint8Array in a Buffer view sharing the same memory rather
-        // than copying it (Buffer.from(uint8array) would allocate a full copy).
-        // byteOffset/byteLength keep the view scoped to this slice, never the
-        // surrounding backing buffer. archiver only reads, so sharing is safe.
-        const payload = typeof content === "string" ? content : Buffer.from(content.buffer, content.byteOffset, content.byteLength);
+        // A Buffer view over the same memory rather than a copy; archiver only reads, so sharing is safe.
+        const payload = typeof content === "string" ? content : asBuffer(content);
         const size = typeof content === "string" ? Buffer.byteLength(content) : content.byteLength;
         this.#pendingSizes.push(size);
         this.#queuedBytes += size;
@@ -103,8 +102,7 @@ async function openZip(source: ZipSource) {
         // Wrap the bytes in a Buffer *view* (no copy); fall through to fromBuffer. A `path` source is
         // opened straight from disk so a multi-GB zip is never held in memory (and dodges fs.readFile's
         // ~2 GiB ceiling) — yauzl reads the central directory and each entry on demand from the fd.
-        const buf = Buffer.isBuffer(source) ? source : Buffer.from(source.buffer, source.byteOffset, source.byteLength);
-        return yauzl.fromBufferPromise(buf, options);
+        return yauzl.fromBufferPromise(asBuffer(source), options);
     }
     return yauzl.openPromise(source.path, options);
 }

--- a/packages/trilium-core/src/routes/api/ocr.spec.ts
+++ b/packages/trilium-core/src/routes/api/ocr.spec.ts
@@ -2,10 +2,15 @@ import type { TextRepresentationResponse } from "@triliumnext/commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import becca from "../../becca/becca.js";
+import blobService from "../../services/blob.js";
 import * as cls from "../../services/context.js";
+import protectedSessionService from "../../services/protected_session.js";
 import { getSql } from "../../services/sql/index.js";
+import { encodeUtf8 } from "../../services/utils/binary.js";
 import { createTextNote } from "../../test/api_fixtures";
 import { CoreApiTester } from "../../test/api_tester";
+
+const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
 
 /**
  * Drives the shared OCR read routes through {@link CoreApiTester} (no Express), so this spec runs
@@ -54,6 +59,27 @@ describe("OCR text API (core)", () => {
 
         const res = await api.get<TextRepresentationResponse>(`/api/ocr/attachments/${attachmentId}/text`);
         expect(res.body).toEqual({ success: true, text: "text on the scan", hasOcr: true });
+    });
+
+    it("decrypts a protected note's text, and withholds it when the session is closed", async () => {
+        const { noteId } = await createTextNote(api, { content: "<p>a protected scan</p>" });
+        const note = becca.getNoteOrThrow(noteId);
+        note.isProtected = true;
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        try {
+            // Stored the way the OCR service stores it, so this covers both halves of the round trip.
+            storeOcrText(note.blobId, blobService.encryptTextRepresentation("secret scanned text", true));
+
+            const unlocked = await api.get<TextRepresentationResponse>(`/api/ocr/notes/${noteId}/text`);
+            expect(unlocked.body).toEqual({ success: true, text: "secret scanned text", hasOcr: true });
+        } finally {
+            protectedSessionService.resetDataKey();
+        }
+
+        // Locked again: the stored ciphertext must not reach the client in place of the text.
+        const locked = await api.get<TextRepresentationResponse>(`/api/ocr/notes/${noteId}/text`);
+        expect(locked.body).toEqual({ success: true, text: "", hasOcr: false });
     });
 
     it("404s for a missing note or attachment", async () => {

--- a/packages/trilium-core/src/routes/api/ocr.ts
+++ b/packages/trilium-core/src/routes/api/ocr.ts
@@ -2,6 +2,7 @@ import type { TextRepresentationResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 
 import becca from "../../becca/becca.js";
+import blobService from "../../services/blob.js";
 import { getSql } from "../../services/sql/index.js";
 
 /** The `[status, body]` tuple the result handler turns into a 404. */
@@ -20,7 +21,7 @@ function getNoteOCRText(req: Request<{ noteId: string }>): TextRepresentationRes
         return [ 404, { success: false, message: "Note not found" } ];
     }
 
-    return getTextRepresentation(note.blobId);
+    return getTextRepresentation(note.blobId, !!note.isProtected);
 }
 
 /** The attachment counterpart of {@link getNoteOCRText}. */
@@ -30,11 +31,15 @@ function getAttachmentOCRText(req: Request<{ attachmentId: string }>): TextRepre
         return [ 404, { success: false, message: "Attachment not found" } ];
     }
 
-    return getTextRepresentation(attachment.blobId);
+    return getTextRepresentation(attachment.blobId, !!attachment.isProtected);
 }
 
-function getTextRepresentation(blobId: string | undefined): TextRepresentationResponse {
-    let ocrText: string | null = null;
+/**
+ * A protected entity's text is stored encrypted, so it is reported as absent rather than shown when
+ * there is no protected session to read it with — the same answer the note's own content gives.
+ */
+function getTextRepresentation(blobId: string | undefined, isProtected: boolean): TextRepresentationResponse {
+    let storedText: string | null = null;
 
     if (blobId) {
         const result = getSql().getRow<{
@@ -46,13 +51,15 @@ function getTextRepresentation(blobId: string | undefined): TextRepresentationRe
         `, [ blobId ]);
 
         if (result) {
-            ocrText = result.textRepresentation;
+            storedText = result.textRepresentation;
         }
     }
 
+    const ocrText = blobService.decryptTextRepresentation(storedText, isProtected);
+
     return {
         success: true,
-        text: ocrText || "",
+        text: ocrText,
         hasOcr: !!ocrText
     };
 }

--- a/packages/trilium-core/src/services/blob.spec.ts
+++ b/packages/trilium-core/src/services/blob.spec.ts
@@ -153,6 +153,50 @@ describe("blob", () => {
         });
     });
 
+    describe("decryptTextRepresentation", () => {
+        it("passes unprotected text through and reports absent text as empty", () => {
+            protectedSessionService.resetDataKey();
+
+            expect(blob.decryptTextRepresentation("extracted text", false)).toBe("extracted text");
+            expect(blob.decryptTextRepresentation(null, false)).toBe("");
+            expect(blob.decryptTextRepresentation(undefined, false)).toBe("");
+            expect(blob.decryptTextRepresentation("", true)).toBe("");
+        });
+
+        it("round-trips protected text through the encrypting counterpart", () => {
+            protectedSessionService.setDataKey(PROTECTED_KEY);
+            try {
+                const stored = blob.encryptTextRepresentation("text read out of a protected image", true);
+                expect(blob.decryptTextRepresentation(stored, true)).toBe("text read out of a protected image");
+            } finally {
+                protectedSessionService.resetDataKey();
+            }
+        });
+
+        it("withholds protected text when no protected session is available", () => {
+            protectedSessionService.setDataKey(PROTECTED_KEY);
+            const stored = blob.encryptTextRepresentation("secret", true);
+            protectedSessionService.resetDataKey();
+
+            // The ciphertext must never be handed back in place of the text.
+            expect(blob.decryptTextRepresentation(stored, true)).toBe("");
+        });
+
+        it("answers with nothing for text encrypted under a different key", () => {
+            const otherKey = encodeUtf8("fedcba9876543210"); // exactly 16 bytes
+            const foreign = dataEncryption.encrypt(otherKey, "written with another key");
+
+            protectedSessionService.setDataKey(PROTECTED_KEY);
+            try {
+                // Deciphers to garbage, so the checksum fails and decryptString throws.
+                expect(blob.decryptTextRepresentation(foreign, true)).toBe("");
+            } finally {
+                protectedSessionService.resetDataKey();
+            }
+        });
+
+    });
+
     describe("getBlobPojo", () => {
         it("throws NotFoundError when the entity does not exist", () => {
             expect(() => getContext().init(() => blob.getBlobPojo("notes", "doesNotExist123"))).toThrow(NotFoundError);

--- a/packages/trilium-core/src/services/blob.spec.ts
+++ b/packages/trilium-core/src/services/blob.spec.ts
@@ -125,6 +125,34 @@ describe("blob", () => {
         });
     });
 
+    describe("encryptTextRepresentation", () => {
+        it("passes unprotected text through untouched", () => {
+            protectedSessionService.resetDataKey();
+            expect(blob.encryptTextRepresentation("extracted text", false)).toBe("extracted text");
+        });
+
+        it("encrypts protected text with the data key", () => {
+            protectedSessionService.setDataKey(PROTECTED_KEY);
+            try {
+                const encrypted = blob.encryptTextRepresentation("text read out of a protected image", true);
+
+                // The stored value must not contain the readable text...
+                expect(encrypted).not.toContain("protected image");
+                // ...and must decrypt back to it with the data key.
+                const decrypted = dataEncryption.decrypt(PROTECTED_KEY, encrypted);
+                expect(decrypted).toBeInstanceOf(Uint8Array);
+                expect(decodeUtf8(decrypted as Uint8Array)).toBe("text read out of a protected image");
+            } finally {
+                protectedSessionService.resetDataKey();
+            }
+        });
+
+        it("throws rather than storing protected text when no protected session is available", () => {
+            protectedSessionService.resetDataKey();
+            expect(() => blob.encryptTextRepresentation("secret", true)).toThrow(/protected session is not available/);
+        });
+    });
+
     describe("getBlobPojo", () => {
         it("throws NotFoundError when the entity does not exist", () => {
             expect(() => getContext().init(() => blob.getBlobPojo("notes", "doesNotExist123"))).toThrow(NotFoundError);

--- a/packages/trilium-core/src/services/blob.ts
+++ b/packages/trilium-core/src/services/blob.ts
@@ -1,6 +1,7 @@
 import { BlobRow, EMPTY_BLOB_ID, NoteRow } from "@triliumnext/commons";
 import becca from "../becca/becca.js";
 import { NotFoundError } from "../errors";
+import { getLog } from "./log.js";
 import protectedSessionService from "./protected_session.js";
 import { getSql } from "./sql/index.js";
 import { decodeUtf8 } from "./utils/binary.js";
@@ -31,6 +32,10 @@ function getBlobPojo(entityName: string, entityId: string, opts?: { preview: boo
     } else {
         pojo.content = processContent(pojo.content, !!entity.isProtected, true) as string | Uint8Array;
     }
+
+    // The extracted text travels with the blob and is protected on the same terms as the content it
+    // was read out of, so it is decrypted (or withheld) on the same terms too.
+    pojo.textRepresentation = decryptTextRepresentation(pojo.textRepresentation, !!entity.isProtected) || null;
 
     return { ...pojo, isStubbed };
 }
@@ -132,6 +137,42 @@ function encryptTextRepresentation(textRepresentation: string, isProtected: bool
     return encrypted;
 }
 
+/**
+ * Reads OCR-extracted text back off a blob, for every consumer of `blobs.textRepresentation`.
+ *
+ * The counterpart of {@link encryptTextRepresentation}, and it mirrors what {@link processContent}
+ * does for `content`: decrypt when a protected session is available, and answer with nothing when it
+ * is not — so a locked note reports no extracted text rather than showing the ciphertext it stores.
+ * Text that will not decrypt is treated the same way, since no caller has anything better to do with
+ * it than a caller that has no key, and one unreadable blob should not fail the request around it.
+ *
+ * One inherited edge: a stored value whose length rules out ciphertext altogether takes
+ * dataEncryptionService's recovery path for zadam/trilium#510, which hands back what it was given —
+ * and only under Node, since that path is selected by a Node crypto error message. Nothing writes a
+ * value of that shape here ({@link encryptTextRepresentation} is the only writer and always emits real
+ * ciphertext), so this is noted rather than defended against.
+ */
+function decryptTextRepresentation(textRepresentation: string | null | undefined, isProtected: boolean): string {
+    if (!textRepresentation) {
+        return "";
+    }
+
+    if (!isProtected) {
+        return textRepresentation;
+    }
+
+    if (!protectedSessionService.isProtectedSessionAvailable()) {
+        return "";
+    }
+
+    try {
+        return protectedSessionService.decryptString(textRepresentation) || "";
+    } catch {
+        getLog().info("Cannot decrypt the text representation of a protected blob.");
+        return "";
+    }
+}
+
 function calculateContentHash({ blobId, content, textRepresentation }: Pick<BlobRow, "blobId" | "content" | "textRepresentation">) {
     const textRepresentationSegment = textRepresentation ? `|${textRepresentation}` : "";
     return hash(`${blobId}|${content.toString()}${textRepresentationSegment}`);
@@ -142,5 +183,6 @@ export default {
     getDeletedNoteBlobPojo,
     processContent,
     encryptTextRepresentation,
+    decryptTextRepresentation,
     calculateContentHash
 };

--- a/packages/trilium-core/src/services/blob.ts
+++ b/packages/trilium-core/src/services/blob.ts
@@ -105,6 +105,33 @@ function processContent(content: Uint8Array | string | null, isProtected: boolea
     return content;
 }
 
+/**
+ * Prepares OCR-extracted text for storage on a blob.
+ *
+ * The text is a readable copy of what the blob holds, so for a protected entity it has to be encrypted
+ * at rest exactly like the content it was derived from — otherwise protecting a note would hide the
+ * image while leaving everything written in it in the clear. The counterpart on the way out is
+ * {@link processContent}'s handling of `content`: decrypt when a session is available, blank otherwise.
+ *
+ * A blob's protection state is unambiguous even though the `blobs` table does not record it: a
+ * protected entity's blobId is hashed with an `_ENCRYPTED_` prefix (see
+ * `AbstractBeccaEntity.getUnencryptedContentForHashCalculation`), so a blob is never shared between a
+ * protected and an unprotected entity. Any one of its referencing entities therefore answers for all.
+ */
+function encryptTextRepresentation(textRepresentation: string, isProtected: boolean): string {
+    if (!isProtected) {
+        return textRepresentation;
+    }
+
+    const encrypted = protectedSessionService.encrypt(textRepresentation);
+
+    if (!encrypted) {
+        throw new Error("Cannot encrypt the text representation since protected session is not available.");
+    }
+
+    return encrypted;
+}
+
 function calculateContentHash({ blobId, content, textRepresentation }: Pick<BlobRow, "blobId" | "content" | "textRepresentation">) {
     const textRepresentationSegment = textRepresentation ? `|${textRepresentation}` : "";
     return hash(`${blobId}|${content.toString()}${textRepresentationSegment}`);
@@ -114,5 +141,6 @@ export default {
     getBlobPojo,
     getDeletedNoteBlobPojo,
     processContent,
+    encryptTextRepresentation,
     calculateContentHash
 };

--- a/packages/trilium-core/src/services/entity_changes.ts
+++ b/packages/trilium-core/src/services/entity_changes.ts
@@ -46,6 +46,34 @@ function putEntityChange(origEntityChange: EntityChange) {
     cls.putEntityChange(ec);
 }
 
+/**
+ * Re-records a blob's entity change from what is stored on it now, leaving the blob itself alone.
+ *
+ * A blob is identified by a hash of its content, so it is normally recorded once, when it is written,
+ * and never again. Its text representation is not part of that identity and is filled in afterwards —
+ * by OCR, or by carrying the text across a change of protection — which leaves the recorded hash
+ * describing a row that no longer matches, and sync comparing against something that was never stored.
+ */
+function putBlobEntityChange(blobId: string) {
+    const blob = getSql().getRowOrNull<Pick<BlobRow, "blobId" | "content" | "utcDateModified" | "textRepresentation">>(
+        /*sql*/`SELECT blobId, content, textRepresentation, utcDateModified FROM blobs WHERE blobId = ?`,
+        [blobId]
+    );
+
+    if (!blob) {
+        return;
+    }
+
+    putEntityChange({
+        entityName: "blobs",
+        entityId: blobId,
+        hash: blobService.calculateContentHash(blob),
+        isErased: false,
+        utcDateChanged: blob.utcDateModified,
+        isSynced: true // blobs are always synced
+    } as EntityChange);
+}
+
 function putNoteReorderingEntityChange(parentNoteId: string, componentId?: string) {
     putEntityChange({
         entityName: "note_reordering",
@@ -199,6 +227,7 @@ function recalculateMaxEntityChangeId() {
 }
 
 export default {
+    putBlobEntityChange,
     putNoteReorderingEntityChange,
     putEntityChangeForOtherInstances,
     putEntityChangeWithForcedChange,

--- a/packages/trilium-core/src/services/llm/tools/attachment_tools.spec.ts
+++ b/packages/trilium-core/src/services/llm/tools/attachment_tools.spec.ts
@@ -12,8 +12,13 @@ vi.mock("../../../becca/becca.js", async (importOriginal) => {
     return { default: { ...actual.default, getAttachment: getAttachmentMock, getBlob: getBlobMock } };
 });
 
+import blobService from "../../blob.js";
+import protectedSessionService from "../../protected_session.js";
+import { encodeUtf8 } from "../../utils/binary.js";
 import { attachmentTools } from "./attachment_tools.js";
 import type { ToolDefinition } from "./tool_registry.js";
+
+const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
 
 function getTool(name: string): ToolDefinition {
     for (const [n, def] of attachmentTools) {
@@ -87,6 +92,33 @@ describe("attachment_tools", () => {
                 source: "ocr",
                 content: "OCR extracted"
             });
+        });
+
+        it("decrypts a protected attachment's OCR text, and withholds it when locked", () => {
+            getAttachmentMock.mockReturnValue(stubAttachment({
+                hasStringContent: () => false,
+                mime: "image/png",
+                blobId: "blob1",
+                isProtected: true
+            }));
+
+            protectedSessionService.setDataKey(PROTECTED_KEY);
+            try {
+                getBlobMock.mockReturnValue({
+                    textRepresentation: blobService.encryptTextRepresentation("OCR extracted", true)
+                });
+                expect(getTool("get_attachment_content").execute({ attachmentId: "att1" })).toEqual({
+                    attachmentId: "att1",
+                    source: "ocr",
+                    content: "OCR extracted"
+                });
+            } finally {
+                protectedSessionService.resetDataKey();
+            }
+
+            // Locked: reported as unreadable rather than answered with the ciphertext.
+            expect(getTool("get_attachment_content").execute({ attachmentId: "att1" }))
+                .toEqual({ error: "Attachment has no readable text content" });
         });
 
         it("returns an error for binary attachments with no readable text (no blobId, or empty blob)", () => {

--- a/packages/trilium-core/src/services/llm/tools/attachment_tools.ts
+++ b/packages/trilium-core/src/services/llm/tools/attachment_tools.ts
@@ -6,6 +6,7 @@ import { unwrapStringOrBuffer } from "../../../services/utils/binary.js";
 import { z } from "zod";
 
 import becca from "../../../becca/becca.js";
+import blobService from "../../../services/blob.js";
 import { defineTools } from "./tool_registry.js";
 
 export const attachmentTools = defineTools({
@@ -54,11 +55,12 @@ export const attachmentTools = defineTools({
 
             // For binary attachments, try OCR/extracted text from the blob.
             const blob = attachment.blobId ? becca.getBlob({ blobId: attachment.blobId }) : null;
-            if (blob?.textRepresentation) {
+            const extractedText = blobService.decryptTextRepresentation(blob?.textRepresentation, !!attachment.isProtected);
+            if (extractedText) {
                 return {
                     attachmentId: attachment.attachmentId,
                     source: "ocr" as const,
-                    content: blob.textRepresentation
+                    content: extractedText
                 };
             }
 

--- a/packages/trilium-core/src/services/llm/tools/helpers.spec.ts
+++ b/packages/trilium-core/src/services/llm/tools/helpers.spec.ts
@@ -12,6 +12,9 @@ vi.mock("../../../becca/becca.js", async (importOriginal) => {
     return { default: { ...actual.default, getBlob: getBlobMock } };
 });
 
+import blobService from "../../blob.js";
+import protectedSessionService from "../../protected_session.js";
+import { encodeUtf8 } from "../../utils/binary.js";
 import {
     applyTextEdits,
     flag,
@@ -58,6 +61,8 @@ function docNoteStub(docName: string | null) {
     });
 }
 
+const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
+
 function attachmentStub(overrides: Partial<Record<string, unknown>> = {}): BAttachment {
     return {
         attachmentId: "a1",
@@ -97,6 +102,23 @@ describe("getNoteContentForLlm", () => {
         const note = noteStub({ type: "image", getContent: () => new Uint8Array([1, 2, 3]) });
         getBlobMock.mockReturnValue({ textRepresentation: "scanned words" });
         expect(getNoteContentForLlm(note)).toBe("[extracted text from image]\nscanned words");
+    });
+
+    it("decrypts a protected note's extracted text, and withholds it when locked", () => {
+        const note = noteStub({ type: "image", isProtected: true, getContent: () => new Uint8Array([1, 2, 3]) });
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        try {
+            getBlobMock.mockReturnValue({
+                textRepresentation: blobService.encryptTextRepresentation("scanned secret", true)
+            });
+            expect(getNoteContentForLlm(note)).toBe("[extracted text from image]\nscanned secret");
+        } finally {
+            protectedSessionService.resetDataKey();
+        }
+
+        // Locked, with the same blob still in hand: the model must not be fed the ciphertext.
+        expect(getNoteContentForLlm(note)).toBe("[binary content]");
     });
 
     it("falls back to a binary-content marker when no extracted text exists", () => {
@@ -203,6 +225,22 @@ describe("getAttachmentContentPreview", () => {
         getBlobMock.mockReturnValue({ textRepresentation: "ocr text" });
         const att = attachmentStub({ hasStringContent: () => false, mime: "image/png" });
         expect(getAttachmentContentPreview(att)).toBe("ocr text");
+    });
+
+    it("decrypts a protected attachment's extracted text, and withholds it when locked", () => {
+        const att = attachmentStub({ hasStringContent: () => false, mime: "image/png", isProtected: true });
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        try {
+            getBlobMock.mockReturnValue({
+                textRepresentation: blobService.encryptTextRepresentation("ocr secret", true)
+            });
+            expect(getAttachmentContentPreview(att)).toBe("ocr secret");
+        } finally {
+            protectedSessionService.resetDataKey();
+        }
+
+        expect(getAttachmentContentPreview(att)).toBeNull();
     });
 
     it("returns null when no readable text exists", () => {

--- a/packages/trilium-core/src/services/llm/tools/helpers.ts
+++ b/packages/trilium-core/src/services/llm/tools/helpers.ts
@@ -5,6 +5,7 @@
 import type BAttachment from "../../../becca/entities/battachment.js";
 import becca from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
+import blobService from "../../../services/blob.js";
 import markdownExport from "../../../services/export/markdown.js";
 import markdownImport from "../../../services/import/markdown.js";
 import { unwrapStringOrBuffer } from "../../../services/utils/binary.js";
@@ -66,8 +67,9 @@ export function getNoteContentForLlm(note: BNote) {
     if (typeof content !== "string") {
         // For binary content (images, files), use extracted text if available.
         const blob = note.blobId ? becca.getBlob({ blobId: note.blobId }) : null;
-        if (blob?.textRepresentation) {
-            return `[extracted text from ${note.type}]\n${blob.textRepresentation}`;
+        const extractedText = blobService.decryptTextRepresentation(blob?.textRepresentation, !!note.isProtected);
+        if (extractedText) {
+            return `[extracted text from ${note.type}]\n${extractedText}`;
         }
         return "[binary content]";
     }
@@ -184,7 +186,7 @@ export function getAttachmentContentPreview(att: BAttachment): string | null {
         text = unwrapStringOrBuffer(content);
     } else {
         const blob = att.blobId ? becca.getBlob({ blobId: att.blobId }) : null;
-        text = blob?.textRepresentation ?? null;
+        text = blobService.decryptTextRepresentation(blob?.textRepresentation, !!att.isProtected) || null;
     }
 
     if (!text) {

--- a/packages/trilium-core/src/services/notes.spec.ts
+++ b/packages/trilium-core/src/services/notes.spec.ts
@@ -1,15 +1,19 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import becca from "../becca/becca.js";
 import type BBranch from "../becca/entities/bbranch.js";
 import type BNote from "../becca/entities/bnote.js";
+import blobService from "./blob.js";
 import { disableEntityEvents, getContext } from "./context.js";
 import { getLog } from "./log.js";
 import noteService, { prepareTitle, saveLinks } from "./notes.js";
 import optionService from "./options.js";
+import protectedSessionService from "./protected_session.js";
 import { fakeRequestProvider } from "../test/request_provider.js";
 import { initRequest } from "./request.js";
 import { getSql } from "./sql/index.js";
+import TaskContext from "./task_context.js";
+import { encodeUtf8 } from "./utils/binary.js";
 
 /**
  * The pure link-extraction helpers (findBookmarks, findLlmChatLinks) and the
@@ -40,6 +44,70 @@ function createNote(parentNoteId: string, overrides: Partial<Parameters<typeof n
         })
     );
 }
+
+describe("OCR text across (un)protection", () => {
+    const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
+
+    /** The text as it is stored on the blob right now, without decrypting it. */
+    function storedText(blobId: string | undefined) {
+        return getSql().getValue<string | null>("SELECT textRepresentation FROM blobs WHERE blobId = ?", [blobId ?? ""]);
+    }
+
+    function setStoredText(blobId: string | undefined, text: string) {
+        getSql().execute("UPDATE blobs SET textRepresentation = ? WHERE blobId = ?", [text, blobId ?? ""]);
+    }
+
+    function protect(note: BNote, value: boolean) {
+        getContext().init(() =>
+            noteService.protectNoteRecursively(note, value, false, new TaskContext("spec-protect", "protectNotes", { protect: value }))
+        );
+    }
+
+    afterEach(() => protectedSessionService.resetDataKey());
+
+    it("carries a note's extracted text onto the blob the re-save produces, encrypting it", () => {
+        const { note } = createNote("root", { title: "spec-ocr-carry", content: "image-bytes-carry", type: "image", mime: "image/png" });
+        setStoredText(note.blobId, "text read out of the picture");
+        const unprotectedBlobId = note.blobId;
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        protect(note, true);
+
+        // A new blob, since protection is part of a blob's identity — and the text came with it.
+        expect(note.blobId).not.toBe(unprotectedBlobId);
+        expect(storedText(note.blobId)).not.toBe("text read out of the picture");
+        expect(blobService.decryptTextRepresentation(storedText(note.blobId), true)).toBe("text read out of the picture");
+
+        // And back again, readable without a key once the note no longer needs one.
+        protect(note, false);
+        expect(storedText(note.blobId)).toBe("text read out of the picture");
+    });
+
+    it("carries an attachment's extracted text too", () => {
+        const { note } = createNote("root", { title: "spec-ocr-carry-attachment" });
+        const attachment = getContext().init(() =>
+            note.saveAttachment({ role: "image", mime: "image/png", title: "scan.png", content: "attachment-bytes-carry" })
+        );
+        setStoredText(attachment.blobId, "text read out of the attachment");
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        protect(note, true);
+
+        const protectedAttachment = becca.getAttachmentOrThrow(attachment.attachmentId);
+        expect(protectedAttachment.isProtected).toBe(true);
+        expect(blobService.decryptTextRepresentation(storedText(protectedAttachment.blobId), true))
+            .toBe("text read out of the attachment");
+    });
+
+    it("leaves a note that never had extracted text without any", () => {
+        const { note } = createNote("root", { title: "spec-ocr-carry-none", content: "image-bytes-none", type: "image", mime: "image/png" });
+
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        protect(note, true);
+
+        expect(storedText(note.blobId)).toBeNull();
+    });
+});
 
 describe("notes service (real DB)", () => {
     beforeAll(() => {

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -10,6 +10,7 @@ import BNote from "../becca/entities/bnote.js";
 import { ValidationError } from "../errors.js";
 import { getLog } from "../services/log.js";
 import protectedSessionService from "../services/protected_session.js";
+import blobService from "./blob.js";
 import * as cls from "./context.js";
 import entityChangesService from "./entity_changes.js";
 import eventService from "./events.js";
@@ -414,9 +415,12 @@ function protectNote(note: BNote, protect: boolean) {
     try {
         if (protect !== note.isProtected) {
             const content = note.getContent();
+            const extractedText = readExtractedText(note.blobId, note.isProtected);
 
             note.isProtected = protect;
             note.setContent(content, { forceSave: true });
+
+            writeExtractedText(note.blobId, extractedText, protect);
         }
 
         revisionService.protectRevisions(note);
@@ -425,9 +429,12 @@ function protectNote(note: BNote, protect: boolean) {
             if (protect !== attachment.isProtected) {
                 try {
                     const content = attachment.getContent();
+                    const extractedText = readExtractedText(attachment.blobId, attachment.isProtected);
 
                     attachment.isProtected = protect;
                     attachment.setContent(content, { forceSave: true });
+
+                    writeExtractedText(attachment.blobId, extractedText, protect);
                 } catch (e) {
                     log.error(`Could not un/protect attachment '${attachment.attachmentId}'`);
 
@@ -440,6 +447,41 @@ function protectNote(note: BNote, protect: boolean) {
 
         throw e;
     }
+}
+
+/**
+ * The text OCR pulled out of a file, read off the blob holding it.
+ *
+ * (Un)protecting re-saves content that has not changed a byte, but a blob's identity takes its
+ * protection into account, so the re-save lands on a different row — one with no extracted text on it.
+ * The text describes the same file either way, so it is read here while the old state still says how
+ * it is stored, and put back by {@link writeExtractedText} once the new state does.
+ */
+function readExtractedText(blobId: string | undefined, isProtected: boolean | undefined): string {
+    if (!blobId) {
+        return "";
+    }
+
+    const row = getSql().getRowOrNull<{ textRepresentation: string | null }>(
+        /*sql*/`SELECT textRepresentation FROM blobs WHERE blobId = ?`,
+        [blobId]
+    );
+
+    return blobService.decryptTextRepresentation(row?.textRepresentation, !!isProtected);
+}
+
+/** Puts {@link readExtractedText}'s text back, on the blob the re-save produced and in its terms. */
+function writeExtractedText(blobId: string | undefined, extractedText: string, isProtected: boolean) {
+    if (!blobId || !extractedText) {
+        return;
+    }
+
+    getSql().execute(
+        /*sql*/`UPDATE blobs SET textRepresentation = ? WHERE blobId = ?`,
+        [blobService.encryptTextRepresentation(extractedText, isProtected), blobId]
+    );
+
+    entityChangesService.putBlobEntityChange(blobId);
 }
 
 export function checkImageAttachments(note: BNote, content: string) {

--- a/packages/trilium-core/src/services/search/expressions/ocr_content.spec.ts
+++ b/packages/trilium-core/src/services/search/expressions/ocr_content.spec.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import becca from "../../../becca/becca.js";
 import type BNote from "../../../becca/entities/bnote.js";
+import blobService from "../../blob.js";
 import { getContext } from "../../context.js";
 import noteService from "../../notes.js";
+import protectedSessionService from "../../protected_session.js";
 import { getSql } from "../../sql/index.js";
+import { encodeUtf8 } from "../../utils/binary.js";
 import NoteSet from "../note_set.js";
 import SearchContext from "../search_context.js";
 import OCRContentExpression from "./ocr_content.js";
+
+const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
 
 let counter = 0;
 
@@ -60,6 +65,28 @@ function createNoteWithOcrAttachment(ocrText: string): BNote {
     );
 
     setTextRepresentationForBlob(attachment.blobId!, ocrText);
+
+    return note;
+}
+
+/**
+ * As {@link createNoteWithOcrText}, for a note the query has to decrypt: the row is flagged protected
+ * and the text is stored encrypted, the way the OCR service stores it. Needs an open session.
+ */
+function createProtectedNoteWithOcrText(ocrText: string): BNote {
+    const note = createNoteWithOcrText(blobService.encryptTextRepresentation(ocrText, true));
+
+    getSql().execute("UPDATE notes SET isProtected = 1 WHERE noteId = ?", [note.noteId]);
+    note.isProtected = true;
+
+    return note;
+}
+
+/** The attachment counterpart: only the attachment row is flagged, which is what the query reads. */
+function createProtectedNoteWithOcrAttachment(ocrText: string): BNote {
+    const note = createNoteWithOcrAttachment(blobService.encryptTextRepresentation(ocrText, true));
+
+    getSql().execute("UPDATE attachments SET isProtected = 1 WHERE ownerId = ?", [note.noteId]);
 
     return note;
 }
@@ -198,5 +225,47 @@ describe("OCRContentExpression (real DB)", () => {
     it("renders a readable toString with the joined tokens", () => {
         const exp = new OCRContentExpression(["foo", "bar"]);
         expect(exp.toString()).toBe("OCRContent('foo', 'bar')");
+    });
+
+    describe("protected notes", () => {
+        beforeEach(() => protectedSessionService.setDataKey(PROTECTED_KEY));
+        afterEach(() => protectedSessionService.resetDataKey());
+
+        it("matches encrypted text on a note and on an attachment, with the same semantics as the query", () => {
+            const note = createProtectedNoteWithOcrText("Protected invoice total");
+            const viaAttachment = createProtectedNoteWithOcrAttachment("Protected scanned receipt");
+
+            expect(execute(new OCRContentExpression(["invoice"])).hasNote(note)).toBe(true);
+            expect(execute(new OCRContentExpression(["receipt"])).hasNote(viaAttachment)).toBe(true);
+
+            // Case-insensitive, as SQLite's LIKE is for the unprotected ones.
+            expect(execute(new OCRContentExpression(["INVOICE"])).hasNote(note)).toBe(true);
+
+            // And every token still has to be there.
+            expect(execute(new OCRContentExpression(["invoice", "receipt"])).hasNote(note)).toBe(false);
+        });
+
+        it("finds protected and unprotected notes in one search", () => {
+            const openly = createNoteWithOcrText("shared marker openly stored");
+            const encrypted = createProtectedNoteWithOcrText("shared marker under lock");
+
+            const result = execute(new OCRContentExpression(["marker"]));
+
+            expect(result.hasNote(openly)).toBe(true);
+            expect(result.hasNote(encrypted)).toBe(true);
+        });
+
+        it("cannot match a protected note once the session is closed", () => {
+            const note = createProtectedNoteWithOcrText("Protected passport number");
+
+            protectedSessionService.resetDataKey();
+
+            // Neither by the text it was made from, nor by anything in the stored ciphertext.
+            expect(execute(new OCRContentExpression(["passport"])).hasNote(note)).toBe(false);
+
+            const stored = getSql().getValue<string>(
+                "SELECT textRepresentation FROM blobs WHERE blobId = ?", [note.blobId ?? ""]);
+            expect(execute(new OCRContentExpression([stored.slice(0, 12)])).hasNote(note)).toBe(false);
+        });
     });
 });

--- a/packages/trilium-core/src/services/search/expressions/ocr_content.ts
+++ b/packages/trilium-core/src/services/search/expressions/ocr_content.ts
@@ -1,4 +1,6 @@
 import becca from "../../../becca/becca.js";
+import blobService from "../../blob.js";
+import protectedSessionService from "../../protected_session.js";
 import { getSql } from "../../sql/index.js";
 import NoteSet from "../note_set.js";
 import type SearchContext from "../search_context.js";
@@ -8,8 +10,10 @@ import Expression from "./expression.js";
  * Search expression for finding text within OCR-extracted content (textRepresentation)
  * from image notes and their attachments.
  *
- * Uses a single SQL query to find all noteIds whose own blob or attachment blobs
- * contain matching text, then intersects with the input note set.
+ * Unprotected text is matched by the database, which is what it is for. A protected note's text is
+ * stored encrypted and there is nothing in it for SQL to compare against, so those are read out and
+ * matched here instead — and only while a protected session is open, since otherwise they cannot be
+ * read at all.
  */
 export default class OCRContentExpression extends Expression {
     private tokens: string[];
@@ -41,38 +45,107 @@ export default class OCRContentExpression extends Expression {
     }
 
     /**
-     * Find all noteIds that have OCR text matching all tokens, in a single query.
+     * Find all noteIds that have OCR text matching all tokens.
      * Checks both the note's own blob and its attachment blobs.
      */
     private findNoteIdsWithMatchingOCR(): Set<string> {
         if (this.tokens.length === 0) return new Set();
 
-        // Build WHERE conditions: all tokens must appear in textRepresentation
+        const matchingNoteIds = new Set<string>();
+
+        this.collectUnprotectedMatches(matchingNoteIds);
+        this.collectProtectedMatches(matchingNoteIds);
+
+        return matchingNoteIds;
+    }
+
+    /** The stored text is the readable text, so all tokens must appear in it. */
+    private collectUnprotectedMatches(matchingNoteIds: Set<string>) {
         const likeConditions = this.tokens.map(() => `b.textRepresentation LIKE ?`).join(' AND ');
         const params = this.tokens.map(token => `%${token}%`);
-
-        // Find notes whose own blob matches
         const sql = getSql();
+
+        // Notes whose own blob matches.
         const noteIds = sql.getColumn<string>(`
             SELECT n.noteId
             FROM notes n
             JOIN blobs b ON n.blobId = b.blobId
             WHERE b.textRepresentation IS NOT NULL
               AND n.isDeleted = 0
+              AND n.isProtected = 0
               AND ${likeConditions}
         `, params);
 
-        // Find notes that own attachments whose blob matches
+        // Notes that own an attachment whose blob matches.
         const attachmentOwnerIds = sql.getColumn<string>(`
             SELECT a.ownerId
             FROM attachments a
             JOIN blobs b ON a.blobId = b.blobId
             WHERE b.textRepresentation IS NOT NULL
               AND a.isDeleted = 0
+              AND a.isProtected = 0
               AND ${likeConditions}
         `, params);
 
-        return new Set([...noteIds, ...attachmentOwnerIds]);
+        for (const noteId of [...noteIds, ...attachmentOwnerIds]) {
+            matchingNoteIds.add(noteId);
+        }
+    }
+
+    /**
+     * The same search over blobs whose text is encrypted, decrypting each one to compare it.
+     *
+     * Only rows that are protected are read, and their text is what OCR pulled out of one file
+     * rather than the file itself, so this stays far smaller than the note-content search that
+     * already works this way.
+     */
+    private collectProtectedMatches(matchingNoteIds: Set<string>) {
+        if (!protectedSessionService.isProtectedSessionAvailable()) {
+            return;
+        }
+
+        const sql = getSql();
+        const queries = [
+            /*sql*/`
+                SELECT n.noteId AS noteId, b.textRepresentation AS textRepresentation
+                FROM notes n
+                JOIN blobs b ON n.blobId = b.blobId
+                WHERE b.textRepresentation IS NOT NULL
+                  AND n.isDeleted = 0
+                  AND n.isProtected = 1`,
+            /*sql*/`
+                SELECT a.ownerId AS noteId, b.textRepresentation AS textRepresentation
+                FROM attachments a
+                JOIN blobs b ON a.blobId = b.blobId
+                WHERE b.textRepresentation IS NOT NULL
+                  AND a.isDeleted = 0
+                  AND a.isProtected = 1`
+        ];
+
+        for (const query of queries) {
+            for (const row of sql.iterateRows<{ noteId: string; textRepresentation: string }>(query)) {
+                if (matchingNoteIds.has(row.noteId)) {
+                    continue;
+                }
+
+                const text = blobService.decryptTextRepresentation(row.textRepresentation, true);
+
+                if (text && this.matchesAllTokens(text)) {
+                    matchingNoteIds.add(row.noteId);
+                }
+            }
+        }
+    }
+
+    /**
+     * The in-memory equivalent of the LIKE conditions above: every token must appear, ignoring case.
+     * Case folding is done on both sides, so unlike SQLite's LIKE this also holds outside ASCII. A
+     * token is compared literally, where LIKE would read `%` or `_` in one as a wildcard.
+     */
+    private matchesAllTokens(text: string): boolean {
+        const haystack = text.toLowerCase();
+
+        return this.tokens.every(token => haystack.includes(token.toLowerCase()));
     }
 
     toString(): string {

--- a/packages/trilium-core/src/services/search/services/search.spec.ts
+++ b/packages/trilium-core/src/services/search/services/search.spec.ts
@@ -5,7 +5,11 @@ import BBranch from "../../../becca/entities/bbranch.js";
 import SearchContext from "../search_context.js";
 import dateUtils from "../../utils/date.js";
 import becca from "../../../becca/becca.js";
+import protectedSessionService from "../../protected_session.js";
+import { encodeUtf8 } from "../../utils/binary.js";
 import { findNoteByTitle, note, NoteBuilder } from "../../../test/becca_mocking.js";
+
+const PROTECTED_KEY = encodeUtf8("0123456789abcdef"); // exactly 16 bytes
 
 describe("Search", () => {
     let rootNote: any;
@@ -870,6 +874,33 @@ describe("Search", () => {
 
         const snippet = searchService.extractContentSnippet(noteBuilder.note.noteId, [ "done" ]);
         expect(snippet).toBe("if a < b && b > c, then done");
+    });
+
+    it("takes a protected note's content as given, having already been decrypted on the way out", () => {
+        protectedSessionService.setDataKey(PROTECTED_KEY);
+        try {
+            const noteBuilder = note("Protected note");
+            noteBuilder.note.isProtected = true;
+            // What a real note hands back with a session open. Decrypting it a second time here would
+            // put it through the cipher as though it were still encrypted.
+            noteBuilder.note.getContent = () => "<p>secret body text</p>";
+            rootNote.child(noteBuilder);
+
+            expect(searchService.extractContentSnippet(noteBuilder.note.noteId, [ "secret" ]))
+                .toBe("secret body text");
+        } finally {
+            protectedSessionService.resetDataKey();
+        }
+    });
+
+    it("shows nothing of a protected note whose content the closed session withheld", () => {
+        const noteBuilder = note("Locked note");
+        noteBuilder.note.isProtected = true;
+        // A real note answers with nothing at all when it cannot be read.
+        noteBuilder.note.getContent = () => "";
+        rootNote.child(noteBuilder);
+
+        expect(searchService.extractContentSnippet(noteBuilder.note.noteId, [ "secret" ])).toBe("");
     });
 
     // FIXME: test what happens when we order without any filter criteria

--- a/packages/trilium-core/src/services/search/services/search.ts
+++ b/packages/trilium-core/src/services/search/services/search.ts
@@ -5,9 +5,9 @@ import striptags from "striptags";
 import becca from "../../../becca/becca.js";
 import becca_service from "../../../becca/becca_service.js";
 import type BNote from "../../../becca/entities/bnote.js";
+import blobService from "../../blob.js";
 import hoistedNoteService from "../../hoisted_note.js";
 import { getLog } from "../../log.js";
-import protectedSessionService from "../../protected_session.js";
 import scriptService from "../../script.js";
 import { isScriptingEnabled } from "../../scripting_guard.js";
 import { escapeHtml, escapeRegExp, unescapeHtml } from "../../utils/index.js";
@@ -472,28 +472,20 @@ function extractContentSnippet(noteId: string, searchTokens: string[], maxLength
         let content: string | undefined;
 
         if (["text", "code", "mermaid", "canvas", "mindMap", "llmChat"].includes(note.type)) {
+            // Protection is already accounted for: a note hands back its content decrypted, and hands
+            // back nothing at all when there is no session to decrypt it with.
             const raw = note.getContent();
             if (raw && typeof raw === "string") {
                 content = raw;
             }
         } else {
-            // For non-text notes (image, file), use OCR text representation
-            content = getTextRepresentationForNote(note) || undefined;
+            // For non-text notes (image, file), use OCR text representation. That one is stored as it
+            // sits on the blob, so it is the reader's job to decrypt it — or to withhold it.
+            content = blobService.decryptTextRepresentation(getTextRepresentationForNote(note), !!note.isProtected) || undefined;
         }
 
         if (!content) {
             return "";
-        }
-
-        // Handle protected notes
-        if (note.isProtected && protectedSessionService.isProtectedSessionAvailable()) {
-            try {
-                content = protectedSessionService.decryptString(content) || "";
-            } catch (e) {
-                return ""; // Can't decrypt, don't show content
-            }
-        } else if (note.isProtected) {
-            return ""; // Protected but no session available
         }
 
         // Strip HTML tags for text notes

--- a/packages/trilium-core/src/services/sql/sql.spec.ts
+++ b/packages/trilium-core/src/services/sql/sql.spec.ts
@@ -90,15 +90,12 @@ describe("SqlService (real DB)", () => {
             getSql().insert(table, { name: "b", val: 2 });
 
             expect(getSql().getValue<number>(`SELECT COUNT(*) FROM "${table}"`)).toBe(2);
-            // Distinct query strings: getColumn pluck-mode and getRows row-mode
-            // share the statement cache by query text, so reusing the exact same
-            // string would leave the cached statement stuck in pluck mode.
             expect(
-                getSql().getColumn<string>(`SELECT name FROM "${table}" /*col*/ ORDER BY val`)
+                getSql().getColumn<string>(`SELECT name FROM "${table}" ORDER BY val`)
             ).toEqual(["a", "b"]);
 
             const all = getSql().getRows<{ name: string }>(
-                `SELECT name FROM "${table}" /*rows*/ ORDER BY val`
+                `SELECT name FROM "${table}" ORDER BY val`
             );
             expect(all.map((r) => r.name)).toEqual(["a", "b"]);
 
@@ -112,6 +109,27 @@ describe("SqlService (real DB)", () => {
                 [2]
             );
             expect(single).toEqual({ name: "b" });
+        });
+
+        it("keeps a plucking reader from changing what the same query returns to a row reader", () => {
+            // The statement cache is keyed by query text and both pluck and raw stick to a statement
+            // once set, so a plucking read used to leave every later read of the byte-identical query
+            // returning bare values instead of rows — for the rest of the process, and wherever in the
+            // codebase that query happened to be repeated.
+            const table = createTempTable();
+            getSql().insert(table, { name: "a", val: 1 });
+            const query = `SELECT name FROM "${table}" WHERE val = ?`;
+
+            expect(getSql().getValue<string>(query, [1])).toBe("a");
+            expect(getSql().getRow<{ name: string }>(query, [1])).toEqual({ name: "a" });
+            expect(getSql().getRowOrNull<{ name: string }>(query, [1])).toEqual({ name: "a" });
+            expect(getSql().getRows<{ name: string }>(query, [1])).toEqual([{ name: "a" }]);
+
+            // ...and in the other order, so neither mode is merely winning by going first.
+            const reverse = `SELECT name FROM "${table}" WHERE val = ? /* reverse */`;
+            expect(getSql().getRows<{ name: string }>(reverse, [1])).toEqual([{ name: "a" }]);
+            expect(getSql().getColumn<string>(reverse, [1])).toEqual(["a"]);
+            expect(getSql().getRow<{ name: string }>(reverse, [1])).toEqual({ name: "a" });
         });
 
         it("getRowOrNull returns null when no rows match", () => {
@@ -159,15 +177,20 @@ describe("SqlService (real DB)", () => {
             expect(a).toBe(b);
         });
 
-        // Node's better-sqlite3 provider prepares a fresh statement object per
-        // cache key, so raw vs non-raw yield distinct instances. The WASM
-        // (sql.js) provider may hand back the same object for identical SQL, so
-        // this distinctness is a Node-provider impl detail, not a portable contract.
-        it.skipIf(isBrowserRuntime)("keeps raw and non-raw statements as distinct cache entries", () => {
-            const sql = getSql();
-            const plain = sql.stmt("SELECT 2");
-            const raw = sql.stmt("SELECT 2", true);
-            expect(plain).not.toBe(raw);
+        it("reads one query in every shape, whichever was asked for first", () => {
+            // Statements are shared and their output mode sticks, so the shape a read gets has to come
+            // from the read rather than from whatever the last one left behind. Keeping the modes in
+            // separate cache entries was not enough: the browser provider caches by query text too, and
+            // handed both entries the same statement.
+            const table = createTempTable();
+            getSql().insert(table, { name: "a", val: 1 });
+            const query = `SELECT name, val FROM "${table}"`;
+
+            expect(getSql().getColumn<string>(query)).toEqual(["a"]);
+            expect(getSql().getRawRows<[string, number]>(query)).toEqual([["a", 1]]);
+            expect(getSql().getRows<{ name: string; val: number }>(query)).toEqual([{ name: "a", val: 1 }]);
+            expect(getSql().getValue<string>(query)).toBe("a");
+            expect(getSql().getRow<{ name: string; val: number }>(query)).toEqual({ name: "a", val: 1 });
         });
     });
 

--- a/packages/trilium-core/src/services/sql/sql.ts
+++ b/packages/trilium-core/src/services/sql/sql.ts
@@ -7,6 +7,12 @@ const LOG_ALL_QUERIES = false;
 // smaller values can result in better performance due to better usage of statement cache
 const PARAM_LIMIT = 100;
 
+/**
+ * The output shapes a prepared statement can return: rows as objects, rows as arrays (`raw`), or the
+ * first column alone (`pluck`). Each sticks to the statement once set, so a reader always names one.
+ */
+type StatementMode = "row" | "raw" | "pluck";
+
 export interface SqlServiceParams {
     provider: DatabaseProvider;
     onTransactionRollback: () => void;
@@ -133,18 +139,32 @@ export class SqlService {
     /**
      * For the given SQL query, returns a prepared statement. For the same query (string comparison), the same statement is returned.
      *
+     * The statement carries its output mode, and the mode sticks to it: a `pluck()` or `raw()` set for
+     * one read stays set for every later read of the same query. Since the statement is shared — by
+     * this cache, and again by the browser provider's own — a read never inherits a mode. Every reader
+     * states the shape it wants through {@link applyMode()} instead.
+     *
      * @param sql the SQL query for which to return a prepared statement.
-     * @param isRaw indicates whether `.raw()` is going to be called on the prepared statement in order to return the raw rows (e.g. via {@link getRawRows()}). The reason is that the raw state is preserved in the saved statement and would break non-raw calls for the same query.
      * @returns the corresponding {@link Statement}.
      */
-    stmt(sql: string, isRaw?: boolean) {
-        const key = (isRaw ? `raw/${sql}` : sql);
-
-        if (!(key in this.statementCache)) {
-            this.statementCache[key] = this.dbConnection.prepare(sql);
+    stmt(sql: string) {
+        if (!(sql in this.statementCache)) {
+            this.statementCache[sql] = this.dbConnection.prepare(sql);
         }
 
-        return this.statementCache[key];
+        return this.statementCache[sql];
+    }
+
+    /**
+     * Puts a statement into the output mode a reader wants, turning the other modes off.
+     *
+     * Only for statements that return data: better-sqlite3 rejects both calls on one that does not.
+     */
+    private applyMode(statement: Statement, mode: StatementMode): Statement {
+        statement.raw(mode === "raw");
+        statement.pluck(mode === "pluck");
+
+        return statement;
     }
 
     /**
@@ -155,7 +175,7 @@ export class SqlService {
      * @returns - map of column name to column value
      */
     getRow<T>(query: string, params: Params = []): T {
-        return this.wrap(query, (s) => s.get(params)) as T;
+        return this.wrap(query, (s) => s.get(params), "row") as T;
     }
 
     getRowOrNull<T>(query: string, params: Params = []): T | null {
@@ -175,7 +195,7 @@ export class SqlService {
      * @returns single value
      */
     getValue<T>(query: string, params: Params = []): T {
-        return this.wrap(query, (s) => s.pluck().get(params)) as T;
+        return this.wrap(query, (s) => s.get(params), "pluck") as T;
     }
 
     getManyRows<T>(query: string, params: Params): T[] {
@@ -198,7 +218,7 @@ export class SqlService {
 
             const statement = curParams.length === PARAM_LIMIT ? this.stmt(curQuery) : this.dbConnection.prepare(curQuery);
 
-            const subResults = statement.all(curParamsObj);
+            const subResults = this.applyMode(statement, "row").all(curParamsObj);
             results = results.concat(subResults);
         }
 
@@ -213,11 +233,11 @@ export class SqlService {
      * @returns - array of all rows, each row is a map of column name to column value
      */
     getRows<T>(query: string, params: Params = []): T[] {
-        return this.wrap(query, (s) => s.all(params)) as T[];
+        return this.wrap(query, (s) => s.all(params), "row") as T[];
     }
 
     getRawRows<T extends {} | unknown[]>(query: string, params: Params = []): T[] {
-        return (this.wrap(query, (s) => s.raw().all(params), true) as T[]) || [];
+        return (this.wrap(query, (s) => s.all(params), "raw") as T[]) || [];
     }
 
     iterateRows<T>(query: string, params: Params = []): IterableIterator<T> {
@@ -225,7 +245,7 @@ export class SqlService {
             console.log(query);
         }
 
-        return this.stmt(query).iterate(params) as IterableIterator<T>;
+        return this.applyMode(this.stmt(query), "row").iterate(params) as IterableIterator<T>;
     }
 
     /**
@@ -254,7 +274,7 @@ export class SqlService {
      * @returns array of first column of all returned rows
      */
     getColumn<T>(query: string, params: Params = []): T[] {
-        return this.wrap(query, (s) => s.pluck().all(params)) as T[];
+        return this.wrap(query, (s) => s.all(params), "pluck") as T[];
     }
 
     /**
@@ -307,9 +327,10 @@ export class SqlService {
     }
 
     /**
-     * @param isRaw indicates whether `.raw()` is going to be called on the prepared statement in order to return the raw rows (e.g. via {@link getRawRows()}). The reason is that the raw state is preserved in the saved statement and would break non-raw calls for the same query.
+     * @param mode the output shape `func` reads the statement in. Omitted for a statement that returns
+     * no data, which cannot be put into a mode at all. See {@link stmt()} for why a reader names one.
      */
-    wrap(query: string, func: (statement: Statement) => unknown, isRaw?: boolean): unknown {
+    wrap(query: string, func: (statement: Statement) => unknown, mode?: StatementMode): unknown {
         const startTimestamp = Date.now();
         let result;
 
@@ -318,7 +339,9 @@ export class SqlService {
         }
 
         try {
-            result = func(this.stmt(query, isRaw));
+            const statement = this.stmt(query);
+
+            result = func(mode ? this.applyMode(statement, mode) : statement);
         } catch (e: any) {
             if (e.message.includes("The database connection is not open")) {
                 // this often happens on killing the app which puts these alerts in front of user


### PR DESCRIPTION
Closes #10976

OCR never ran on a protected note or attachment. For anyone who protects
their tree from the root down, the whole feature was dead — and the reason
it looked like a file problem is that the failure was reported as one.

This makes the feature work for protected content the whole way through:
extract, store, read back, search, and survive a change of protection.

## The original defect

Content reached the processors through an `instanceof Buffer` check, and a
protected note's content is never a `Buffer`: it is decrypted on the way
out, and the decryption builds its result with `new Uint8Array(...)`. So
every protected entity failed with `Cannot get content for ...`, whether or
not the vault was open, and — since nothing was stored — the batch
re-attempted and re-failed on every run.

## What changed

- **Extraction** wraps the decrypted bytes rather than rejecting them, and
  a protected entity with no session open is an ordinary skip with its own
  log line instead of a failure counted against the batch.
- **Storage** encrypts the extracted text when the entity is protected. It
  is a readable rendering of content that is only ever stored encrypted, so
  storing it as-is would have left everything written in a protected image
  sitting in the clear in `blobs.textRepresentation` — and syncing it.
- **Reading** decrypts on the same terms the note's own content is read on:
  while a session is open, nothing once it closes. Covers the OCR text
  routes, the blob POJO the client is served, and the three LLM tools that
  fall back to extracted text for binary content.
- **Search** matches protected notes by leaving the database the text it can
  read and comparing the rest decrypted in memory, the way note content is
  already matched. Both feed one result set.
- **Protect/unprotect** carries the text across. The re-save lands on a new
  blob row, so protecting an OCR'd image used to drop everything OCR had
  read out of it, and unprotecting dropped it again.
- **The UI** stops offering actions a locked vault cannot carry out: the OCR
  text dialog, the image-compression run, and the print page.

## Two fixes that are not about protection

Both were found by this work and are worth reading on their own.

**The confidence filter never ran.** It looked for `data.words`, which
tesseract.js 7 does not have — words sit under blocks → paragraphs → lines,
an opt-in output format `recognize` was never asked for. Every image fell
through to a fallback judging the whole page by its mean confidence, which
is dragged down by the marks Tesseract misreads as text: exactly what the
per-word filter exists to drop. At the shipped default threshold, a
screenshot reading 159 words (62 of them above 90%) scored a mean of 69% and
had all 747 characters discarded, reported to the reader as no text found.
It now yields 471 characters over 29 lines. The spec built `data.words` by
hand, so it asserted the intended behaviour on a shape the library never
produces.

**`pluck()` leaked between callers of the same query.** `getValue`/
`getColumn` set it on a cached statement and it sticks, so any later
`getRow` of a byte-identical query returned bare values instead of rows —
for the rest of the process, and wherever in the codebase that query
happened to be repeated. This was a known sharp edge: `sql.spec.ts` steered
around it with `/*col*/` and `/*rows*/` markers, and `stmt()` already kept
`raw()` in its own cache slot for the same reason. Extending the cache key
to pluck is not enough, because the browser provider caches by query text
too and hands both slots the same statement. A reader now states the shape
it wants on every call, and the cache is back to one entry per query.

**This one touches every query in the app**, so it is the part most worth a
careful look — and the reason to let CI run the full suite rather than trust
the targeted runs below.

## Testing

Targeted suites pass under both runtimes where the code is shared (server +
standalone): blob, notes, sql, search, the OCR expression, the OCR routes,
the LLM tools, the image processor, and the OCR service. The full
server/standalone sweep has not been run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)