### PR TITLE
docs: add Hostim to third-party cloud hosting

### DIFF
--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.html
@@ -17,6 +17,17 @@
 </ol>
 <p>PikaPods generally updates their Trilium instances to the latest version
   within a two-week interval after a new version is released.</p>
+<h3>Hostim</h3>
+<ol>
+  <li>Go to <a href="https://hostim.dev">hostim.dev</a> and sign up.</li>
+  <li>Open the <a href="https://console.hostim.dev/dashboard">dashboard</a>, create
+    a project and pick the “Trilium Notes” template.</li>
+  <li>Follow the on-screen instructions to set up your own cloud hosted instance.</li>
+</ol>
+<p>Hostim runs the official <code>triliumnext/trilium</code> Docker image with
+  the data directory on a persistent volume, and terminates HTTPS in front
+  of it. Instances are updated when you redeploy the app, which pulls the
+  current <code>latest</code> image.</p>
 <h2>Matching your version with the cloud instance</h2>
 <p>Please note that once you set up&nbsp;<a class="reference-link" href="#root/_help_cbkrhQjrkKrh">Synchronization</a>&nbsp;between
   a cloud instance and <a href="#root/_help_poXkQfguuA0U">desktop</a> clients, it's

--- a/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Server Installation/Third-party cloud hosting.md
@@ -17,6 +17,14 @@ As an alternative to [hosting your own Trilium instance](1.%20Installing%20the%2
 
 PikaPods generally updates their Trilium instances to the latest version within a two-week interval after a new version is released.
 
+### Hostim
+
+1.  Go to [hostim.dev](https://hostim.dev) and sign up.
+2.  Open the [dashboard](https://console.hostim.dev/dashboard), create a project and pick the “Trilium Notes” template.
+3.  Follow the on-screen instructions to set up your own cloud hosted instance.
+
+Hostim runs the official `triliumnext/trilium` Docker image with the data directory on a persistent volume, and terminates HTTPS in front of it. Instances are updated when you redeploy the app, which pulls the current `latest` image.
+
 ## Matching your version with the cloud instance
 
 Please note that once you set up <a class="reference-link" href="../Synchronization.md">Synchronization</a> between a cloud instance and [desktop](../Desktop%20Installation.md) clients, it's important that the version of the desktop application and the server match up.


### PR DESCRIPTION
Adds Hostim as a second entry under *Cloud instance providers*.

I maintain [Hostim](https://hostim.dev), a small EU container hosting platform, and we added a one-click Trilium template — so this is me adding our own entry. Happy to drop it or reword it however you prefer.

Same shape as the PikaPods entry above it: the official `triliumnext/trilium` image, `TRILIUM_DATA_DIR` on a persistent volume, HTTPS terminated in front, no forks or patches. Nothing to add to the disclaimer box either — no free credits, no revenue share — so I left it untouched. The intro line already says "two services", which now matches the list again.

Both the User Guide markdown and the paired in-app help HTML are updated, per `docs/Developer Guide/Developer Guide/Documentation.md`. No files added or moved and no images, so the meta file is untouched.