### PR TITLE
fix(sync): stop an unreconcilable content hash divergence from syncing forever

### DIFF
--- a/apps/client/src/services/i18n.spec.ts
+++ b/apps/client/src/services/i18n.spec.ts
@@ -1,6 +1,7 @@
 import { MESSAGE_KEY_PREFIX, MESSAGE_OVERRIDES, slugify } from "@triliumnext/ckeditor5";
 import { dayjs, findDuplicateJsonKeys, findPluralKeyConflicts, LOCALES } from "@triliumnext/commons";
 import { readdirSync, readFileSync } from "fs";
+import i18next from "i18next";
 import { join } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -61,6 +62,21 @@ describe("i18n", () => {
                     pluralConflicts.map((c) => `  - "${c.path}" (plural form '_${c.suffix}')`).join("\n")}`
             ).toEqual([]);
         }
+    });
+
+    // i18next HTML-escapes interpolated values by default, so a value carrying a slash, an
+    // apostrophe or a quote reaches the user as `blobs&#x2F;9`. Almost everything we interpolate is
+    // rendered as text (a Preact child, a title attribute), where that escaping only produces
+    // gibberish, which is what the unescaped `{{- value}}` form is for. There is no way to tell
+    // from a catalog entry alone which one it should use, so this only covers the messages whose
+    // values are known to carry such characters.
+    it("interpolates values carrying special characters unescaped", async () => {
+        const catalog = JSON.parse(readFileSync(join(__dirname, "..", "translations", "en", "translation.json"), { encoding: "utf-8" }));
+        const i18n = i18next.createInstance();
+        await i18n.init({ lng: "en", resources: { en: { translation: catalog } } });
+
+        // Diverged sync sectors are formatted `entityName/sector`.
+        expect(i18n.t("ws.sync-hash-check-failed", { sectors: "blobs/9" })).toContain("blobs/9");
     });
 
     // The text editor localizes by passing the English text itself to the editor's translation

--- a/apps/client/src/services/ws.spec.ts
+++ b/apps/client/src/services/ws.spec.ts
@@ -84,7 +84,7 @@ describe("dispatchMessage", () => {
         await ws.dispatchMessage({ type: "reload-frontend", reason: "x" } as WebSocketMessage);
         expect(utilsCtrl.reloadFrontendApp).toHaveBeenCalledWith(expect.stringContaining("reload"));
 
-        await ws.dispatchMessage({ type: "sync-hash-check-failed" } as any);
+        await ws.dispatchMessage({ type: "sync-hash-check-failed", sectors: ["blobs/9"] } as any);
         await ws.dispatchMessage({ type: "consistency-checks-failed" } as any);
         expect(toast.showError).toHaveBeenCalledTimes(2);
 

--- a/apps/client/src/services/ws.spec.ts
+++ b/apps/client/src/services/ws.spec.ts
@@ -7,6 +7,7 @@ import { buildNote } from "../test/easy-froca";
 // and swap behaviour per test without re-mocking.
 const toast = vi.hoisted(() => ({
     showError: vi.fn(),
+    showErrorTitleAndMessage: vi.fn(),
     showMessage: vi.fn(),
     showPersistent: vi.fn(),
     closePersistent: vi.fn()
@@ -85,8 +86,10 @@ describe("dispatchMessage", () => {
         expect(utilsCtrl.reloadFrontendApp).toHaveBeenCalledWith(expect.stringContaining("reload"));
 
         await ws.dispatchMessage({ type: "sync-hash-check-failed", sectors: ["blobs/9"] } as any);
+        expect(toast.showErrorTitleAndMessage).toHaveBeenCalledTimes(1);
+
         await ws.dispatchMessage({ type: "consistency-checks-failed" } as any);
-        expect(toast.showError).toHaveBeenCalledTimes(2);
+        expect(toast.showError).toHaveBeenCalledTimes(1);
 
         await ws.dispatchMessage({ type: "api-log-messages", noteId: "n1", messages: ["a"] } as any);
         expect(appCtx.triggerEvent).toHaveBeenCalledWith("apiLogMessages", { noteId: "n1", messages: ["a"] });

--- a/apps/client/src/services/ws.ts
+++ b/apps/client/src/services/ws.ts
@@ -100,10 +100,14 @@ export async function dispatchMessage(message: WebSocketMessage) {
     } else if (messageType === "sync-hash-check-failed") {
         // Not auto-dismissed after the usual few seconds: syncing stays broken until the user acts,
         // and the backend only reports it once (it would otherwise recur with every sync attempt).
-        // The sector list is interpolated unescaped ({{- }}) — the toast renders its message as
-        // text, so i18next's HTML escaping would only turn the `entityName/sector` slash into a
+        // The sector list is interpolated unescaped ({{- }}) since the toast renders its message as
+        // text: i18next's HTML escaping would only turn the `entityName/sector` slash into a
         // literal `&#x2F;`.
-        toastService.showError(t("ws.sync-hash-check-failed", { sectors: (msg.sectors ?? []).join(", ") }), 50 * 60000);
+        toastService.showErrorTitleAndMessage(
+            t("ws.sync-hash-check-failed-title"),
+            t("ws.sync-hash-check-failed", { sectors: (msg.sectors ?? []).join(", ") }),
+            50 * 60000
+        );
     } else if (messageType === "consistency-checks-failed") {
         toastService.showError(t("ws.consistency-checks-failed"), 50 * 60000);
     } else if (messageType === "api-log-messages") {

--- a/apps/client/src/services/ws.ts
+++ b/apps/client/src/services/ws.ts
@@ -100,6 +100,9 @@ export async function dispatchMessage(message: WebSocketMessage) {
     } else if (messageType === "sync-hash-check-failed") {
         // Not auto-dismissed after the usual few seconds: syncing stays broken until the user acts,
         // and the backend only reports it once (it would otherwise recur with every sync attempt).
+        // The sector list is interpolated unescaped ({{- }}) — the toast renders its message as
+        // text, so i18next's HTML escaping would only turn the `entityName/sector` slash into a
+        // literal `&#x2F;`.
         toastService.showError(t("ws.sync-hash-check-failed", { sectors: (msg.sectors ?? []).join(", ") }), 50 * 60000);
     } else if (messageType === "consistency-checks-failed") {
         toastService.showError(t("ws.consistency-checks-failed"), 50 * 60000);

--- a/apps/client/src/services/ws.ts
+++ b/apps/client/src/services/ws.ts
@@ -98,7 +98,9 @@ export async function dispatchMessage(message: WebSocketMessage) {
     } else if (messageType === "frontend-update") {
         await executeFrontendUpdate(msg.data.entityChanges);
     } else if (messageType === "sync-hash-check-failed") {
-        toastService.showError(t("ws.sync-check-failed"), 60000);
+        // Not auto-dismissed after the usual few seconds: syncing stays broken until the user acts,
+        // and the backend only reports it once (it would otherwise recur with every sync attempt).
+        toastService.showError(t("ws.sync-hash-check-failed", { sectors: (msg.sectors ?? []).join(", ") }), 50 * 60000);
     } else if (messageType === "consistency-checks-failed") {
         toastService.showError(t("ws.consistency-checks-failed"), 50 * 60000);
     } else if (messageType === "api-log-messages") {

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2748,7 +2748,7 @@
     "backend_scripting_disabled_more_info": "More info"
   },
   "ws": {
-    "sync-check-failed": "Sync check failed!",
+    "sync-hash-check-failed": "Sync stopped: this database and the sync server disagree on {{sectors}} and re-syncing did not resolve it. See the logs for details.",
     "consistency-checks-failed": "Consistency checks failed! See logs for details.",
     "encountered-error": "Encountered error \"{{message}}\", check out the console.",
     "lost-websocket-connection-title": "Lost connection to the server",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2748,7 +2748,8 @@
     "backend_scripting_disabled_more_info": "More info"
   },
   "ws": {
-    "sync-hash-check-failed": "Sync stopped: this database and the sync server hold data that could not be reconciled by re-syncing it ({{- sectors}}). Syncing will keep failing until this is resolved — see the logs for details.",
+    "sync-hash-check-failed-title": "Sync stopped",
+    "sync-hash-check-failed": "This database and the sync server hold data that could not be reconciled by re-syncing it ({{- sectors}}).\n\nSyncing will keep failing until this is resolved. See the logs for details.",
     "consistency-checks-failed": "Consistency checks failed! See logs for details.",
     "encountered-error": "Encountered error \"{{message}}\", check out the console.",
     "lost-websocket-connection-title": "Lost connection to the server",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2748,7 +2748,7 @@
     "backend_scripting_disabled_more_info": "More info"
   },
   "ws": {
-    "sync-hash-check-failed": "Sync stopped: this database and the sync server disagree on {{sectors}} and re-syncing did not resolve it. See the logs for details.",
+    "sync-hash-check-failed": "Sync stopped: this database and the sync server hold data that could not be reconciled by re-syncing it ({{- sectors}}). Syncing will keep failing until this is resolved — see the logs for details.",
     "consistency-checks-failed": "Consistency checks failed! See logs for details.",
     "encountered-error": "Encountered error \"{{message}}\", check out the console.",
     "lost-websocket-connection-title": "Lost connection to the server",

--- a/packages/commons/src/lib/ws_api.ts
+++ b/packages/commons/src/lib/ws_api.ts
@@ -166,6 +166,16 @@ export type WebSocketMessage = AllTaskDefinitions | {
     type: "sync-pull-in-progress" | "sync-push-in-progress" | "sync-finished" | "sync-failed";
     lastSyncedPush: number;
 } | {
+    /**
+     * Syncing stopped because the content hashes of these sectors kept differing from the sync
+     * server's even after re-syncing them: the two databases hold data sync cannot reconcile. Unlike
+     * every other sync failure this one does not resolve itself by retrying, so it is surfaced to
+     * the user instead of only being logged.
+     */
+    type: "sync-hash-check-failed";
+    /** The diverged sectors, each as `entityName/sector` (e.g. `blobs/9`). */
+    sectors: string[];
+} | {
     type: "consistency-checks-failed"
 } | {
     /**

--- a/packages/trilium-core/src/services/content_hash.ts
+++ b/packages/trilium-core/src/services/content_hash.ts
@@ -5,9 +5,10 @@ import { hash } from "./utils/index.js";
 
 type SectorHash = Record<string, string>;
 
-interface FailedCheck {
+export interface FailedCheck {
     entityName: string;
-    sector: string[1];
+    /** Single character: the first character of the entity ID the sector groups by. */
+    sector: string;
 }
 
 /**

--- a/packages/trilium-core/src/services/entity_changes.spec.ts
+++ b/packages/trilium-core/src/services/entity_changes.spec.ts
@@ -213,6 +213,20 @@ describe("entity_changes service (real DB)", () => {
                 expect(before).not.toContain(id);
             }
         });
+
+        // A sector is re-queued precisely when the two sides disagree about its contents, which
+        // includes the case where the sync server has lost a change it once served. Keeping the
+        // server's instance ID on the re-queued row would leave that row unpushable (pushChanges
+        // skips it as "the server has this already") and the divergence unrepairable.
+        it("takes ownership of changes stamped with another instance, so they can be pushed again", () => {
+            const foreign = buildEntityChange({ entityId: "9foreignInstance", instanceId: "SOME_OTHER_INSTANCE" });
+            getContext().init(() => entityChangesService.putEntityChange(foreign));
+            expect(readRow("notes", foreign.entityId)?.instanceId).toBe("SOME_OTHER_INSTANCE");
+
+            getContext().init(() => entityChangesService.addEntityChangesForSector("notes", "9"));
+
+            expect(readRow("notes", foreign.entityId)?.instanceId).toBe(getInstanceId());
+        });
     });
 
     describe("fillAllEntityChanges", () => {

--- a/packages/trilium-core/src/services/entity_changes.ts
+++ b/packages/trilium-core/src/services/entity_changes.ts
@@ -24,6 +24,29 @@ function putEntityChangeWithForcedChange(origEntityChange: EntityChange) {
     putEntityChange(ec);
 }
 
+/**
+ * Re-queues an existing entity change so the next sync sends it to the rest of the cluster again.
+ *
+ * Beyond forcing a new change ID, this takes ownership of the row, and that is the point of it. A
+ * change carries the instance ID of wherever it came from, and both directions of the protocol use
+ * that to avoid echoing a change back to its origin: `pushChanges` skips changes stamped with the
+ * sync server's ID, and a server serving `/api/sync/changed` skips the ones stamped with the
+ * requesting client's. Either filter assumes the other side still holds what it once sent.
+ *
+ * A sector re-queue happens exactly when that assumption has already failed — the two sides disagree
+ * about the sector's contents, e.g. because the server purged a blob that briefly looked unreferenced
+ * while a push was still arriving, or because a peer was restored from an older backup. Keeping the
+ * original stamp would mean the only instance still holding the data refuses to send it, so the
+ * re-queue would produce a change nobody transmits and the sector could never converge. Stamping the
+ * local instance makes the row transmissible again; a receiver that turns out to have it already
+ * applies it as a no-op, since the hashes match.
+ */
+function requeueEntityChange(origEntityChange: EntityChange) {
+    const ec = { ...origEntityChange, changeId: null, instanceId: null };
+
+    putEntityChange(ec);
+}
+
 function putEntityChange(origEntityChange: EntityChange) {
     const ec = { ...origEntityChange };
 
@@ -114,7 +137,7 @@ function addEntityChangesForSector(entityName: string, sector: string) {
         }
 
         for (const ec of entityChanges) {
-            putEntityChangeWithForcedChange(ec);
+            requeueEntityChange(ec);
         }
     });
 
@@ -134,7 +157,7 @@ function addEntityChangesForDependingEntity(sector: string, tableName: string, p
     );
 
     for (const ec of dependingEntityChanges) {
-        putEntityChangeWithForcedChange(ec);
+        requeueEntityChange(ec);
     }
 
     return dependingEntityChanges.length;

--- a/packages/trilium-core/src/services/sync.spec.ts
+++ b/packages/trilium-core/src/services/sync.spec.ts
@@ -1,4 +1,4 @@
-import type { EntityChange } from "@triliumnext/commons";
+import type { EntityChange, EntityChangeRecord } from "@triliumnext/commons";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import entityConstructor from "../becca/entity_constructor.js";
@@ -41,11 +41,18 @@ interface FakeConfig {
 let config: FakeConfig = {};
 let changedIdx = 0;
 let checkIdx = 0;
-const requestLog: Array<{ method: string; url: string }> = [];
+const requestLog: Array<{ method: string; url: string; body?: ExecOpts["body"] }> = [];
+
+/** The entity IDs actually sent to the sync server, across every push of the run. */
+const pushedEntityIds = () => requestLog
+    .filter((r) => r.url.includes("/api/sync/update"))
+    // syncRequest always serializes the body itself, so a push body is a JSON string.
+    .flatMap((r) => (typeof r.body === "string" ? JSON.parse(r.body || "{}").entities ?? [] : []) as EntityChangeRecord[])
+    .map((record) => record.entityChange.entityId);
 
 const fakeRequest: RequestProvider = fakeRequestProvider({
     exec: (<T,>(opts: ExecOpts): Promise<T> => {
-        requestLog.push({ method: opts.method, url: opts.url });
+        requestLog.push({ method: opts.method, url: opts.url, body: opts.body });
         const url = opts.url;
         const reply = (value: unknown) => Promise.resolve(value as T);
 
@@ -288,6 +295,35 @@ describe("sync service", () => {
         expect(checksSpy).toHaveBeenCalled();
         expect(sectorSpy).toHaveBeenCalledWith("notes", "a");
         expect(requestLog.some((r) => r.url.includes("/api/sync/queue-sector/notes/a"))).toBe(true);
+    });
+
+    // The situation the sector re-queue exists for: the sync server no longer has a change this
+    // instance holds. Since the change originally came from the server it carries the server's
+    // instance ID, which is exactly what pushChanges filters out, so before the re-queue took
+    // ownership of the row the one copy left in the cluster could never be sent back (#11073).
+    it("pushes a diverged change the sync server has lost even though it came from there", async () => {
+        const blobId = "9lostByServer";
+        cls.init(() => {
+            const sql = getSql();
+            sql.execute("INSERT INTO blobs (blobId, content, dateModified, utcDateModified) VALUES (?, 'lost content', ?, ?)",
+                [blobId, dateUtils.utcNowDateTime(), dateUtils.utcNowDateTime()]);
+            sql.execute(`
+                INSERT INTO entity_changes (entityName, entityId, hash, isErased, changeId, componentId, instanceId, isSynced, utcDateChanged)
+                VALUES ('blobs', ?, 'lostHash', 0, 'lostChangeId', 'NA', 'REMOTE_INSTANCE', 1, ?)`,
+                [blobId, dateUtils.utcNowDateTime()]);
+            // Everything is pushed as far as sync is concerned, so only the re-queue can resend it.
+            options.setOption("lastSyncedPush", String(syncService.getMaxEntityChangeId()));
+        });
+
+        vi.spyOn(consistencyChecks, "runEntityChangesChecks").mockImplementation(() => {});
+        vi.mocked(contentHashService.checkContentHashes).mockReturnValueOnce([{ entityName: "blobs", sector: "9" }]);
+        config.check = [
+            { maxEntityChangeId: 0, entityHashes: { blobs: { 9: "diverged" } } },
+            { maxEntityChangeId: 0, entityHashes: {} }
+        ];
+
+        await expect(runSync()).resolves.toEqual({ success: true });
+        expect(pushedEntityIds()).toContain(blobId);
     });
 
     describe("unresolvable content hash divergence", () => {

--- a/packages/trilium-core/src/services/sync.spec.ts
+++ b/packages/trilium-core/src/services/sync.spec.ts
@@ -13,10 +13,11 @@ import { type ExecOpts, initRequest, type RequestProvider } from "./request.js";
 import { getSql } from "./sql/index.js";
 import setupService from "./setup.js";
 import sqlInit from "./sql_init.js";
-import syncService, { estimateEntityChangeRecordSize } from "./sync.js";
+import syncService, { estimateEntityChangeRecordSize, MAX_SECTOR_RESYNC_ATTEMPTS, MAX_SYNC_ROUNDS } from "./sync.js";
 import syncOptions from "./sync_options.js";
 import syncUpdateService from "./sync_update.js";
 import dateUtils from "./utils/date.js";
+import ws from "./ws.js";
 
 interface ChangesResponse {
     entityChanges: unknown[];
@@ -287,6 +288,70 @@ describe("sync service", () => {
         expect(checksSpy).toHaveBeenCalled();
         expect(sectorSpy).toHaveBeenCalledWith("notes", "a");
         expect(requestLog.some((r) => r.url.includes("/api/sync/queue-sector/notes/a"))).toBe(true);
+    });
+
+    describe("unresolvable content hash divergence", () => {
+        // A sector that keeps diverging after being re-queued used to spin the sync loop forever,
+        // re-pushing the same sector every round without ever converging (#11073).
+        beforeEach(() => {
+            vi.spyOn(consistencyChecks, "runEntityChangesChecks").mockImplementation(() => {});
+            vi.spyOn(entityChangesService, "addEntityChangesForSector").mockImplementation(() => {});
+        });
+
+        it("gives up on a sector that stays diverged and reports it as a sync error", async () => {
+            vi.mocked(contentHashService.checkContentHashes).mockReturnValue([{ entityName: "blobs", sector: "9" }]);
+            const notifySpy = vi.spyOn(ws, "syncHashCheckFailed").mockImplementation(() => {});
+
+            const result = await runSync();
+
+            expect(result).toMatchObject({ success: false, errorCode: "CONTENT_HASH_MISMATCH" });
+            expect(syncService.getLastSyncError()).toContain("blobs/9");
+            // The sector is re-queued on every attempt but the last, which only reports it.
+            expect(entityChangesService.addEntityChangesForSector).toHaveBeenCalledTimes(MAX_SECTOR_RESYNC_ATTEMPTS - 1);
+            expect(notifySpy).toHaveBeenCalledWith(["blobs/9"]);
+        });
+
+        it("notifies about the same divergence once, until a sync converges again", async () => {
+            vi.mocked(contentHashService.checkContentHashes).mockReturnValue([{ entityName: "notes", sector: "b" }]);
+            const notifySpy = vi.spyOn(ws, "syncHashCheckFailed").mockImplementation(() => {});
+
+            await expect(runSync()).resolves.toMatchObject({ success: false });
+            // The sync timer re-runs every minute; the toast must not come back with it.
+            await expect(runSync()).resolves.toMatchObject({ success: false });
+            expect(notifySpy).toHaveBeenCalledTimes(1);
+
+            vi.mocked(contentHashService.checkContentHashes).mockReturnValue([]);
+            await expect(runSync()).resolves.toEqual({ success: true });
+
+            // A divergence that comes back after a healthy sync is worth reporting again.
+            vi.mocked(contentHashService.checkContentHashes).mockReturnValue([{ entityName: "notes", sector: "b" }]);
+            await expect(runSync()).resolves.toMatchObject({ success: false });
+            expect(notifySpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("keeps repairing the sectors that can still be fixed", async () => {
+            // 'notes/c' is unfixable, 'notes/d' converges on its second attempt: giving up on the
+            // former must not cut the latter's repair short.
+            vi.mocked(contentHashService.checkContentHashes)
+                .mockReturnValueOnce([{ entityName: "notes", sector: "c" }, { entityName: "notes", sector: "d" }])
+                .mockReturnValue([{ entityName: "notes", sector: "c" }]);
+            vi.spyOn(ws, "syncHashCheckFailed").mockImplementation(() => {});
+
+            await expect(runSync()).resolves.toMatchObject({ success: false, errorCode: "CONTENT_HASH_MISMATCH" });
+
+            expect(entityChangesService.addEntityChangesForSector).toHaveBeenCalledWith("notes", "d");
+            expect(syncService.getLastSyncError()).toContain("notes/c");
+            expect(syncService.getLastSyncError()).not.toContain("notes/d");
+        });
+
+        it("stops a sync run that never converges instead of looping forever", async () => {
+            // The server always reports more changes than we have pulled, so every round is told to
+            // try again — the shape of an endless sync that isn't a hash divergence.
+            config.check = [{ maxEntityChangeId: 999_999_999, entityHashes: {} }];
+
+            await expect(runSync()).resolves.toMatchObject({ success: false, errorCode: "NOT_CONVERGING" });
+            expect(requestLog.filter((r) => r.url.endsWith("/api/sync/check")).length).toBe(MAX_SYNC_ROUNDS);
+        });
     });
 
     it("skips the content check while local pushes are still outstanding", async () => {

--- a/packages/trilium-core/src/services/sync.ts
+++ b/packages/trilium-core/src/services/sync.ts
@@ -4,7 +4,7 @@ import becca from "../becca/becca.js";
 import appInfo from "./app_info.js";
 import * as cls from "./context.js";
 import consistency_checks from "./consistency_checks.js";
-import contentHashService from "./content_hash.js";
+import contentHashService, { type FailedCheck } from "./content_hash.js";
 import dateUtils from "./utils/date.js";
 import entityChangesService from "./entity_changes.js";
 import { getLog } from "./log.js";
@@ -29,6 +29,37 @@ let proxyToggle = true;
 let outstandingPullCount = 0;
 let totalPullCount: number | null = null;
 let lastSyncError: string | null = null;
+
+/**
+ * How many times the same `(entityName, sector)` pair may fail the content-hash check within a
+ * single sync run before the divergence is treated as unresolvable.
+ *
+ * A failed check re-queues the sector on both sides, and one further round is all it takes for that
+ * to have its effect: everything either side holds for the sector is pushed and pulled again before
+ * the hashes are compared. The third attempt is slack for a check that raced a concurrent edit (the
+ * outstanding-push/pull guards close most, but not all, of that window). Past that, re-queuing the
+ * same sector can only produce the same mismatch — the two databases hold something sync is unable
+ * to reconcile (a blob erased on one side only, an entity the other side keeps rejecting as older,
+ * …) — and retrying it forever is what turned this into an endlessly spinning sync.
+ */
+export const MAX_SECTOR_RESYNC_ATTEMPTS = 3;
+
+/**
+ * Hard cap on the number of login/push/pull/check rounds a single sync run may take. Every repeated
+ * round is meant to be making progress — draining outstanding pulls or pushes, or re-queuing a
+ * diverged sector — so reaching this many rounds means something is cycling without converging.
+ * Bailing out reports it as a sync error rather than looping inside `sync()` forever; the sync
+ * timer starts a fresh run a minute later regardless.
+ */
+export const MAX_SYNC_ROUNDS = 50;
+
+/**
+ * The diverged sectors of the most recent unresolvable-divergence notification, so the same toast
+ * isn't raised for the rest of the session: sync retries every minute and a divergence sync cannot
+ * fix keeps failing every time. Cleared once a sync converges, so a divergence that returns later
+ * is reported again.
+ */
+let notifiedDivergedSectors: string | null = null;
 
 interface CheckResponse {
     maxEntityChangeId: number;
@@ -63,8 +94,21 @@ async function sync() {
             lastSyncError = null;
 
             let continueSync = false;
+            let rounds = 0;
+            // Attempts per `entityName:sector`, and the sectors that exhausted them. Both are
+            // per-run: a fresh sync run gets to try the whole repair sequence again.
+            const sectorAttempts = new Map<string, number>();
+            const unresolvableChecks: FailedCheck[] = [];
 
             do {
+                if (++rounds > MAX_SYNC_ROUNDS) {
+                    return reportSyncFailure(
+                        `Sync did not converge after ${MAX_SYNC_ROUNDS} rounds, giving up for now. `
+                        + `See the preceding log entries for what each round was still waiting on.`,
+                        "NOT_CONVERGING"
+                    );
+                }
+
                 const syncContext = await login();
 
                 await pushChanges(syncContext);
@@ -75,8 +119,19 @@ async function sync() {
 
                 await syncFinished(syncContext);
 
-                continueSync = await checkContentHash(syncContext);
+                const check = await checkContentHash(syncContext, sectorAttempts);
+
+                unresolvableChecks.push(...check.unresolvable);
+                continueSync = check.continueSync;
             } while (continueSync);
+
+            if (unresolvableChecks.length > 0) {
+                // Deliberately before setDbAsInitialized()/syncFinished(): this run did not
+                // converge, so it must not be reported (nor recorded) as a completed sync.
+                return reportUnresolvableDivergence(unresolvableChecks);
+            }
+
+            notifiedDivergedSectors = null;
 
             // A converged sync (everything pushed, everything pulled, content hashes verified)
             // is what makes an initial sync-from-server database usable. setup.triggerSync()
@@ -142,6 +197,47 @@ async function sync() {
  */
 function redactUrlHosts(message: string) {
     return message.replace(/(https?:\/\/)[^/\s]+/gi, "$1[redacted]");
+}
+
+/**
+ * Ends a sync run that cannot make progress: records the reason the same way a thrown sync error
+ * would (log + `lastSyncError` + a failed sync status), but without the proxy toggle, since nothing
+ * here points at the connection.
+ */
+function reportSyncFailure(message: string, errorCode: string) {
+    getLog().error(message);
+
+    lastSyncError = message;
+
+    ws.syncFailed();
+
+    return { success: false, errorCode, message };
+}
+
+/**
+ * Reports sectors whose content hash kept diverging after {@link MAX_SECTOR_RESYNC_ATTEMPTS}
+ * re-syncs. This is a state a user has to act on (the databases hold irreconcilable data, typically
+ * repaired by a consistency check or a full re-sync of the client), so on top of the recorded sync
+ * error it raises a toast — once per set of sectors, see {@link notifiedDivergedSectors}.
+ */
+function reportUnresolvableDivergence(failedChecks: FailedCheck[]) {
+    const sectors = failedChecks.map(({ entityName, sector }) => `${entityName}/${sector}`);
+    const result = reportSyncFailure(
+        `Content hash mismatch in ${sectors.join(", ")} could not be resolved by re-syncing the sector(s) `
+        + `${MAX_SECTOR_RESYNC_ATTEMPTS} times. The local database and the sync server hold data that sync `
+        + `cannot reconcile, so syncing stopped instead of retrying indefinitely.`,
+        "CONTENT_HASH_MISMATCH"
+    );
+
+    const notificationKey = sectors.join(",");
+
+    if (notifiedDivergedSectors !== notificationKey) {
+        notifiedDivergedSectors = notificationKey;
+
+        ws.syncHashCheckFailed(sectors);
+    }
+
+    return result;
 }
 
 /**
@@ -436,7 +532,16 @@ async function syncFinished(syncContext: SyncContext) {
     await syncRequest(syncContext, "POST", "/api/sync/finished");
 }
 
-async function checkContentHash(syncContext: SyncContext) {
+/**
+ * Compares the local content hashes against the sync server's and re-queues the sectors that
+ * differ, so the next round of the sync loop exchanges them again.
+ *
+ * `sectorAttempts` counts, across the rounds of one sync run, how often each sector has been found
+ * diverged; a sector that used up {@link MAX_SECTOR_RESYNC_ATTEMPTS} is not re-queued again and is
+ * returned in `unresolvable` instead (exactly once — its counter keeps rising while other sectors
+ * are still being repaired). `continueSync` reports whether another round can achieve anything.
+ */
+async function checkContentHash(syncContext: SyncContext, sectorAttempts: Map<string, number>): Promise<{ continueSync: boolean; unresolvable: FailedCheck[] }> {
     const resp = await syncRequest<CheckResponse>(syncContext, "GET", "/api/sync/check");
     if (!resp) {
         throw new Error("Got no response.");
@@ -448,7 +553,7 @@ async function checkContentHash(syncContext: SyncContext) {
     if (lastSyncedPullId < resp.maxEntityChangeId) {
         log.info(`There are some outstanding pulls (${lastSyncedPullId} vs. ${resp.maxEntityChangeId}), skipping content check.`);
 
-        return true;
+        return { continueSync: true, unresolvable: [] };
     }
 
     const notPushedSyncs = getSql().getValue("SELECT EXISTS(SELECT 1 FROM entity_changes WHERE isSynced = 1 AND id > ?)", [getLastSyncedPush()]);
@@ -456,25 +561,43 @@ async function checkContentHash(syncContext: SyncContext) {
     if (notPushedSyncs) {
         log.info(`There's ${notPushedSyncs} outstanding pushes, skipping content check.`);
 
-        return true;
+        return { continueSync: true, unresolvable: [] };
     }
 
-    const failedChecks = contentHashService.checkContentHashes(resp.entityHashes);
+    const retryable: FailedCheck[] = [];
+    const unresolvable: FailedCheck[] = [];
 
-    if (failedChecks.length > 0) {
+    for (const failedCheck of contentHashService.checkContentHashes(resp.entityHashes)) {
+        const key = `${failedCheck.entityName}:${failedCheck.sector}`;
+        const attempts = (sectorAttempts.get(key) ?? 0) + 1;
+
+        sectorAttempts.set(key, attempts);
+
+        if (attempts < MAX_SECTOR_RESYNC_ATTEMPTS) {
+            retryable.push(failedCheck);
+        } else if (attempts === MAX_SECTOR_RESYNC_ATTEMPTS) {
+            log.error(`Content hash check for ${failedCheck.entityName} sector ${failedCheck.sector} still fails after ${attempts} attempts, giving up on re-syncing it.`);
+
+            unresolvable.push(failedCheck);
+        }
+    }
+
+    if (retryable.length > 0) {
         // before re-queuing sectors, make sure the entity changes are correct
         consistency_checks.runEntityChangesChecks();
 
         await syncRequest(syncContext, "POST", `/api/sync/check-entity-changes`);
     }
 
-    for (const { entityName, sector } of failedChecks) {
+    for (const { entityName, sector } of retryable) {
         entityChangesService.addEntityChangesForSector(entityName, sector);
 
         await syncRequest(syncContext, "POST", `/api/sync/queue-sector/${entityName}/${sector}`);
     }
 
-    return failedChecks.length > 0;
+    // Sectors that are out of attempts are reported, not retried, so they must not keep the loop
+    // running — only sectors that were actually re-queued can be fixed by another round.
+    return { continueSync: retryable.length > 0, unresolvable };
 }
 
 const PAGE_SIZE = 1000000;

--- a/packages/trilium-core/src/services/ws.spec.ts
+++ b/packages/trilium-core/src/services/ws.spec.ts
@@ -158,6 +158,7 @@ describe("ws service (real DB)", () => {
         ws.syncPullInProgress();
         ws.syncFinished();
         ws.syncFailed();
+        ws.syncHashCheckFailed(["blobs/9"]);
         ws.reloadFrontend("because");
 
         const types = sentAll.map((m) => m.type);
@@ -166,10 +167,12 @@ describe("ws service (real DB)", () => {
             "sync-pull-in-progress",
             "sync-finished",
             "sync-failed",
+            "sync-hash-check-failed",
             "reload-frontend"
         ]));
         const pull = sentAll.find((m) => m.type === "sync-pull-in-progress");
         expect(pull).toMatchObject({ lastSyncedPush: 42 });
+        expect(sentAll.find((m) => m.type === "sync-hash-check-failed")).toMatchObject({ sectors: ["blobs/9"] });
     });
 
     it("sends a ping frontend-update when there are no pending entity changes", () => {

--- a/packages/trilium-core/src/services/ws.ts
+++ b/packages/trilium-core/src/services/ws.ts
@@ -200,6 +200,16 @@ function syncFailed() {
     sendMessageToAllClients({ type: "sync-failed", lastSyncedPush });
 }
 
+/**
+ * Tells the user that syncing has stopped because the given sectors kept diverging from the sync
+ * server's, which no amount of retrying will fix. The sync status icon only ever shows a generic
+ * failure (indistinguishable from an unreachable server), so this state — which needs the user to
+ * act — is raised as a notification of its own.
+ */
+function syncHashCheckFailed(sectors: string[]) {
+    sendMessageToAllClients({ type: "sync-hash-check-failed", sectors });
+}
+
 function reloadFrontend(reason: string) {
     sendMessageToAllClients({ type: "reload-frontend", reason });
 }
@@ -215,6 +225,7 @@ export default {
     syncPullInProgress,
     syncFinished,
     syncFailed,
+    syncHashCheckFailed,
     sendTransactionEntityChangesToAllClients,
     setLastSyncedPush,
     reloadFrontend


### PR DESCRIPTION
## The problem

A content hash mismatch that sync cannot reconcile made `sync()` loop forever inside its own `do/while`, holding the sync mutex, re-queuing the same sector every round:

```
Content hash check for blobs sector 9 FAILED. Local is mW9pBx1tLrETEYV6dFI4XbMzoGY=, remote is Ho70ikBqUgXtZWjbkrixAEINrlc=
Added sector 9 of 'blobs' (1247 entities) to the sync queue.
Sync QDI3G2eKXA: Pushing 1 sync changes in 76ms
```

Note the second and third lines: 1247 entities re-queued, **1** actually sent. The sector could never converge, and nothing in the UI said so — the sync just never finished.

## Root cause

An entity change carries the instance ID of wherever it came from, and both directions of the protocol use it to avoid echoing a change back to its origin: `pushChanges` skips changes stamped with the sync server's ID, and a server serving `/api/sync/changed` skips those stamped with the requesting client's. Both assume the other side still holds what it once sent.

A sector re-queue happens exactly when that assumption has already failed — the two sides disagree about the sector's contents, because a peer lost a change it once served (blobs are purged outright when they look unreferenced, a peer can be restored from an older backup, …). But `addEntityChangesForSector` preserved the stamp, so the one instance still holding the data refused to send it. The repair produced a change nobody transmitted, and the check failed identically on every subsequent round.

In the case that prompted this, of 1247 re-queued rows exactly one was transmissible; the single row the server was missing was the one row the client would never send.

## The fix

**`requeueEntityChange()` takes ownership of re-queued rows** (`entity_changes.ts`), clearing the instance ID alongside the change ID. This repairs both directions symmetrically — a server re-queuing a sector had the mirror-image bug, silently not returning the rows a given client had originally pushed. A receiver that already has the change applies it as a no-op, since the hashes match.

Note the cost: a re-queued sector is now transmitted in full rather than filtered down to the locally-owned rows. That is what the operation was always meant to do, it is bounded by the sector (~1/62 of an entity type), and it only happens on divergence.

**Bounded retries with a real error** (`sync.ts`). A sector that still diverges after `MAX_SECTOR_RESYNC_ATTEMPTS` (3) is no longer re-queued; the run ends with a `CONTENT_HASH_MISMATCH` sync error rather than looping. Sectors that can still be repaired keep being repaired in the same run, so giving up on one does not cut the others short. `MAX_SYNC_ROUNDS` (50) covers the outstanding-pull/push paths of the same loop, which could stall in the same way.

**The user is told.** A new `sync-hash-check-failed` WebSocket message raises a toast naming the diverged sectors — once per set, reset when a sync converges, since the sync timer would otherwise re-raise it every minute forever.

## Tests

The two new tests were written first and fail on `main` for the right reason:

```
sync.spec.ts    AssertionError: expected [] to include '9lostByServer'
entity_changes  AssertionError: expected 'SOME_OTHER_INSTANCE' to be '3nsO2Un0WqQ5'
```

- `entity_changes.spec.ts` — a re-queued sector restamps a change owned by another instance.
- `sync.spec.ts` — end to end with the real `addEntityChangesForSector`: a change the server has lost, stamped with the server's own instance ID, is pushed after the re-queue. Also covers giving up after three attempts, notify-once-until-converged, mixed resolvable/unresolvable sectors, and the round cap.
- `i18n.spec.ts` — the sector list renders unescaped (i18next would otherwise show `blobs&#x2F;9`).

Green under both runtimes (`server` and `standalone` both run the core specs), along with `consistency_checks`, `sync_update`, `content_hash`, `routes/api/sync` and `becca`. `pnpm typecheck` clean.

## Follow-up, not in this PR

`erase.ts`'s `setEntityChangesAsErased` uses the unchanged helper and may have the same defect for erasures — an erasure recorded on a change stamped with the server's ID would never be pushed. Left alone because erasure may be designed to happen independently on each instance, which I have not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)