### PR TITLE
feat(mermaid): persist the diagram display mode in the note content

### DIFF
--- a/packages/ckeditor5/src/plugins/mermaid/README.md
+++ b/packages/ckeditor5/src/plugins/mermaid/README.md
@@ -14,6 +14,14 @@ or both side by side. Load the `Mermaid` glue plugin; it pulls in `MermaidEditin
 | `mermaid_{preview,source_view,split_view}_command.ts` | Switch the widget's `displayMode` |
 | `utils.ts` | `debounce` for the source textarea, `checkIsOn` for button state |
 
+## The display mode is part of the content
+
+A diagram round-trips as `<pre spellcheck="false"><code class="language-mermaid">…</code></pre>`, with
+the picked mode persisted on the `<code>` as `data-trilium-display-mode` — the same treatment
+collapsed list items get with `data-trilium-collapsed`. The default (`split`) is left out, so a
+diagram nobody switched keeps producing exactly the content it did before; a missing or unknown
+value upcasts back to `split`.
+
 ## The mermaid library is not a dependency
 
 The plugin never imports mermaid. The host passes it in through editor config:

--- a/packages/ckeditor5/src/plugins/mermaid/mermaid_editing.spec.ts
+++ b/packages/ckeditor5/src/plugins/mermaid/mermaid_editing.spec.ts
@@ -84,6 +84,36 @@ describe( 'MermaidEditing', () => {
 						'<mermaid displayMode="split" source=""></mermaid>'
 					);
 				} );
+
+				it( 'restores the persisted display mode', () => {
+					for ( const mode of [ 'source', 'preview' ] ) {
+						editor.setData(
+							'<pre spellcheck="false">' +
+								`<code class="language-mermaid" data-trilium-display-mode="${ mode }">flowchart TB</code>` +
+							'</pre>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+							`<mermaid displayMode="${ mode }" source="flowchart TB"></mermaid>`
+						);
+					}
+				} );
+
+				it( 'falls back to the split mode for a missing or unknown display mode', () => {
+					// A diagram saved before the mode was persisted, and one carrying a mode this
+					// version has no widget state for (hand-edited or imported content).
+					for ( const attribute of [ '', ' data-trilium-display-mode="nonsense"' ] ) {
+						editor.setData(
+							'<pre spellcheck="false">' +
+								`<code class="language-mermaid"${ attribute }>flowchart TB</code>` +
+							'</pre>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+							'<mermaid displayMode="split" source="flowchart TB"></mermaid>'
+						);
+					}
+				} );
 			} );
 
 			describe( 'data downcast', () => {
@@ -114,6 +144,48 @@ describe( 'MermaidEditing', () => {
 						'<pre spellcheck="false">' +
 							'<code class="language-mermaid"></code>' +
 						'</pre>'
+					);
+				} );
+
+				it( 'persists a non-default display mode, and only that', () => {
+					// The default (split) stays out of the data so untouched diagrams keep
+					// producing the very same content.
+					setModelData( editor.model, '<mermaid displayMode="split" source="flowchart TB"></mermaid>' );
+
+					expect( editor.getData() ).to.equal(
+						'<pre spellcheck="false"><code class="language-mermaid">flowchart TB</code></pre>'
+					);
+
+					for ( const mode of [ 'source', 'preview' ] ) {
+						setModelData( editor.model, `<mermaid displayMode="${ mode }" source="flowchart TB"></mermaid>` );
+
+						expect( editor.getData() ).to.equal(
+							'<pre spellcheck="false">' +
+								`<code class="language-mermaid" data-trilium-display-mode="${ mode }">flowchart TB</code>` +
+							'</pre>'
+						);
+					}
+				} );
+
+				it( 'round-trips the mode a display-mode command switched to', () => {
+					editor.setData(
+						'<pre spellcheck="false">' +
+							'<code class="language-mermaid">flowchart TB</code>' +
+						'</pre>'
+					);
+
+					editor.execute( 'mermaidPreviewCommand' );
+
+					expect( editor.getData() ).to.equal(
+						'<pre spellcheck="false">' +
+							'<code class="language-mermaid" data-trilium-display-mode="preview">flowchart TB</code>' +
+						'</pre>'
+					);
+
+					editor.setData( editor.getData() );
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<mermaid displayMode="preview" source="flowchart TB"></mermaid>'
 					);
 				} );
 			} );

--- a/packages/ckeditor5/src/plugins/mermaid/mermaid_editing.ts
+++ b/packages/ckeditor5/src/plugins/mermaid/mermaid_editing.ts
@@ -17,6 +17,22 @@ const DEBOUNCE_TIME = 300;
 
 type DowncastConversionData = DowncastAttributeEvent["args"][0];
 
+/** The modes the widget can be shown in, i.e. the values of its `displayMode` model attribute. */
+const DISPLAY_MODES = [ 'source', 'split', 'preview' ] as const;
+
+type MermaidDisplayMode = typeof DISPLAY_MODES[ number ];
+
+const DEFAULT_DISPLAY_MODE: MermaidDisplayMode = 'split';
+
+/**
+ * Carries the mode the user picked into the note content, the way collapsed list items persist
+ * `data-trilium-collapsed`. It is written on the `<code>` element the widget already round-trips
+ * through, and only for a non-default mode — so a diagram left in split view keeps producing
+ * byte-identical content, and every consumer that keys off `code.language-mermaid` (the share
+ * view, markdown export, the importers) is unaffected.
+ */
+const DISPLAY_MODE_DATA_ATTRIBUTE = 'data-trilium-display-mode';
+
 export default class MermaidEditing extends Plugin {
 
 	private _config!: EditorConfig["mermaid"];
@@ -97,11 +113,18 @@ export default class MermaidEditing extends Plugin {
 		}
 
 		const targetViewPosition = mapper.toViewPosition( model.createPositionBefore( data.item as ModelItem ) );
+		const displayMode = readDisplayMode( data.item.getAttribute( 'displayMode' ) );
 		// For downcast we're using only language-mermaid class. We don't set class to `mermaid language-mermaid` as
 		// multiple markdown converters that we have seen are using only `language-mermaid` class and not `mermaid` alone.
-		const code = writer.createContainerElement( 'code', {
+		const codeAttributes: Record<string, string> = {
 			class: 'language-mermaid'
-		} ) as any;
+		};
+
+		if ( displayMode !== DEFAULT_DISPLAY_MODE ) {
+			codeAttributes[ DISPLAY_MODE_DATA_ATTRIBUTE ] = displayMode;
+		}
+
+		const code = writer.createContainerElement( 'code', codeAttributes ) as any;
 		const pre = writer.createContainerElement( 'pre', {
 			spellcheck: 'false'
 		} ) as any;
@@ -241,7 +264,7 @@ export default class MermaidEditing extends Plugin {
 
 		const mermaidElement = writer.createElement( 'mermaid', {
 			source: mermaidSource,
-			displayMode: 'split'
+			displayMode: readDisplayMode( viewCodeElement.getAttribute( DISPLAY_MODE_DATA_ATTRIBUTE ) )
 		} );
 
 		// Let's try to insert mermaid element.
@@ -287,4 +310,13 @@ export default class MermaidEditing extends Plugin {
 			document.getElementById( id )?.remove();
 		}
 	}
+}
+
+/**
+ * Narrows a persisted (or model-held) display mode to a known one, falling back to the default.
+ * Content can carry anything: an older note has no attribute at all, and a hand-edited or
+ * imported one can carry a value the widget has no mode for.
+ */
+function readDisplayMode( value: unknown ): MermaidDisplayMode {
+	return DISPLAY_MODES.includes( value as MermaidDisplayMode ) ? value as MermaidDisplayMode : DEFAULT_DISPLAY_MODE;
 }


### PR DESCRIPTION
Closes #7931

## What

An inline Mermaid diagram's view mode (source / split / preview) lived only in the CKEditor model, so it was lost on every reload — a diagram deliberately left in preview came back with the source textarea showing again.

This persists it into the note content, taking the same approach collapsible bullets use for `data-trilium-collapsed`.

## How

- **Data downcast** writes the model's `displayMode` onto the `<code>` element the widget already round-trips through, as `data-trilium-display-mode="source|preview"`.
- **Upcast** reads it back, instead of hard-coding `displayMode: 'split'`.
- A `readDisplayMode()` helper narrows whatever the content carries to a known mode, falling back to `split`.

Two deliberate choices:

- **The default is omitted.** A diagram nobody switched serializes byte-identically to before, so existing notes see no content churn and no spurious revisions.
- **It goes on the `<code>`, not the `<pre>`.** That keeps the round-trip inside the single element the upcast handler already inspects, and leaves the `<pre spellcheck="false"><code class="language-mermaid">` shape everything else keys off untouched — the share view, the client read-only renderer, markdown export, and the ENEX/Anytype importers. `data-*` is allowed on any element by the sanitizer, so it survives import too.

## Not included

Read-only and share rendering still always render the diagram, even for a note saved in source mode. The mode reads as an editing affordance there, and honoring it would change how already-published notes look. Easy to add later if wanted.

## Testing

Four new cases in `mermaid_editing.spec.ts`: upcast restores `source`/`preview`, falls back to `split` for a missing or unknown value, downcast writes only non-default modes, and a full round-trip through `mermaidPreviewCommand` → `getData()` → `setData()`.

All 111 Mermaid specs pass (`pnpm --filter ckeditor5 test src/plugins/mermaid`) and `pnpm typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)