### PR TITLE
docs: update Evernote import doc link to new docs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Our documentation is available in multiple formats:
 * Scales well in both usability and performance upwards of 100 000 notes
 * Touch optimized [mobile frontend](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend) for smartphones and tablets
 * Built-in [dark theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote) and [Markdown import & export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html) and [Markdown import & export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for easy saving of web content
 * Customizable UI (sidebar buttons, user-defined widgets, ...)
 * [Metrics](https://docs.triliumnotes.org/user-guide/advanced-usage/metrics), along with a Grafana Dashboard.

--- a/docs/README-ZH_CN.md
+++ b/docs/README-ZH_CN.md
@@ -78,7 +78,7 @@ Trilium Notes 是一款免费且开源、跨平台的阶层式笔记应用程序
 * 即使笔记数量超过 10 万条，在易用性和性能方面仍能良好扩展
 * 为智能手机和平板电脑触控优化的[移动前端](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend)
 * 内置[暗色主题](https://docs.triliumnotes.org/user-guide/concepts/themes)，支持用户主题
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   导入以及 [Markdown
   导入与导出](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * 用于快速保存网页内容的 [Web

--- a/docs/README-ZH_TW.md
+++ b/docs/README-ZH_TW.md
@@ -80,7 +80,7 @@ Trilium Notes 是一款免費且開源、跨平台的階層式筆記應用程式
 * 為手機與平板最佳化的[行動前端](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend)
 * 內建[深色主題](https://docs.triliumnotes.org/user-guide/concepts/themes)，並支援自訂主題
 * [Evernote
-  匯入](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)與
+  匯入](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)與
   [Markdown
   匯入與匯出](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * 用於快速保存網頁內容的 [Web

--- a/docs/README-ar.md
+++ b/docs/README-ar.md
@@ -118,7 +118,7 @@ status](https://hosted.weblate.org/widget/trilium/svg-badge.svg)](https://hosted
 * [الوضع الداكن](https://docs.triliumnotes.org/user-guide/concepts/themes)
   المدمج، ودعم سمات المستخدم
 * [إيفيرنوت
-  (Evernote)](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  (Evernote)](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   و[استيراد وتصدير ملفات
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [أداة قص الويب](https://docs.triliumnotes.org/user-guide/setup/web-clipper)

--- a/docs/README-az.md
+++ b/docs/README-az.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-bg.md
+++ b/docs/README-bg.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-ca.md
+++ b/docs/README-ca.md
@@ -114,7 +114,7 @@ La nostra documentació està disponible en diversos formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-cs.md
+++ b/docs/README-cs.md
@@ -115,7 +115,7 @@ Naše dokumenatce je dostupná ve vícero formátech:
 * Vestavěný [tmavý
   motiv](https://docs.triliumnotes.org/user-guide/concepts/themes), podpora
   uživatelských motivů
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   a [import & export
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Webový výstřižek](https://docs.triliumnotes.org/user-guide/setup/web-clipper)

--- a/docs/README-de.md
+++ b/docs/README-de.md
@@ -116,7 +116,7 @@ Unsere Dokumentation ist verfügbar in mehreren Formaten:
 * Integriertes [dunkles
   Design](https://docs.triliumnotes.org/user-guide/concepts/themes),
   Unterstützung für benutzerdefinierte Designs
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   und [Markdown importieren und
   exportieren](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) zum

--- a/docs/README-el.md
+++ b/docs/README-el.md
@@ -120,7 +120,7 @@ status](https://hosted.weblate.org/widget/trilium/svg-badge.svg)](https://hosted
 * Ενσωματωμένο [σκούρο
   θέμα](https://docs.triliumnotes.org/user-guide/concepts/themes), υποστήριξη
   για θέματα χρήστη
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown εισαγωγή &
   εξαγωγή](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) για

--- a/docs/README-en_GB.md
+++ b/docs/README-en_GB.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-es.md
+++ b/docs/README-es.md
@@ -119,7 +119,7 @@ La documentación está disponible en varios formatos:
 * [Tema oscuro](https://docs.triliumnotes.org/user-guide/concepts/themes)
   integrado, con soporte para temas personalizados
 * Importación y exportación de
-  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   y
   [Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) para

--- a/docs/README-fa.md
+++ b/docs/README-fa.md
@@ -103,7 +103,7 @@ application with focus on building large personal knowledge bases.
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-fi.md
+++ b/docs/README-fi.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-fr.md
+++ b/docs/README-fr.md
@@ -118,7 +118,7 @@ Notre documentation est disponible sous plusieurs formats :
   optimisée pour le tactile sur smartphones et tablettes
 * [Thème sombre](https://docs.triliumnotes.org/user-guide/concepts/themes)
   intégré, prise en charge des thèmes utilisateur
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   et [Importation et exportation
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) pour

--- a/docs/README-ga.md
+++ b/docs/README-ga.md
@@ -121,7 +121,7 @@ Tá ár ndoiciméadacht ar fáil i bhformáidí éagsúla:
 * Téama dorcha
   ionsuite(https://docs.triliumnotes.org/user-guide/concepts/themes), tacaíocht
   do théamaí úsáideora
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   agus [Iompórtáil & Easpórtáil
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Gearrthóir

--- a/docs/README-hi.md
+++ b/docs/README-hi.md
@@ -116,7 +116,7 @@
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-hr.md
+++ b/docs/README-hr.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-hu.md
+++ b/docs/README-hu.md
@@ -114,7 +114,7 @@ Dokumentációink többféle formátumban is elérhetők:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-id.md
+++ b/docs/README-id.md
@@ -118,7 +118,7 @@ Dokumentasi kami tersedia dalam beberapa format:
 * [Tema gelap](https://docs.triliumnotes.org/user-guide/concepts/themes) bawaan,
   dukungan untuk tema pengguna
 * Impor & ekspor
-  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   dan
   [Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper)

--- a/docs/README-it.md
+++ b/docs/README-it.md
@@ -117,7 +117,7 @@ La nostra documentazione è disponibile in diversi formati:
 * Tema scuro integrato
   (https://docs.triliumnotes.org/user-guide/concepts/themes), supporto per temi
   utente
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   e [Importazione ed esportazione
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) per

--- a/docs/README-ja.md
+++ b/docs/README-ja.md
@@ -94,7 +94,7 @@ Trilium Notes
   [モバイルフロントエンド](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend)
 * 組み込みの
   [ダークテーマ](https://docs.triliumnotes.org/user-guide/concepts/themes)、ユーザーテーマのサポート
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   と
   [マークダウンのインポートとエクスポート](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) で

--- a/docs/README-ko.md
+++ b/docs/README-ko.md
@@ -98,7 +98,7 @@ Trilium Notes는 대규모 개인 지식 기반 구축에 중점을 둔 무료 �
   프런트엔드](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend)
 * 기본 제공 [다크 테마](https://docs.triliumnotes.org/user-guide/concepts/themes) 및 사용자
   테마 지원
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   및 [Markdown 가져오기 및
   내보내기](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * 웹 콘텐츠를 간편하게 저장하는 [웹

--- a/docs/README-md.md
+++ b/docs/README-md.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-mr.md
+++ b/docs/README-mr.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-nb_NO.md
+++ b/docs/README-nb_NO.md
@@ -113,7 +113,7 @@ Vår dokumentasjon er tilgjengelig i flere format:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-nl.md
+++ b/docs/README-nl.md
@@ -117,7 +117,7 @@ Onze documentatie is beschikbaar in meerdere formaten:
 * Ingebouwd [donker
   thema](https://docs.triliumnotes.org/user-guide/concepts/themes),
   ondersteuning voor gebruikera thema's
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   en [Markdown importeren &
   exporteren](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) om

--- a/docs/README-pl.md
+++ b/docs/README-pl.md
@@ -118,7 +118,7 @@ Nasza dokumentacja jest dostępna w wielu formatach:
 * Wbudowany [ciemny
   motyw](https://docs.triliumnotes.org/user-guide/concepts/themes) i wsparcie
   dla motywów użytkownika
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   oraz [import i eksport
   Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) do

--- a/docs/README-pt.md
+++ b/docs/README-pt.md
@@ -114,7 +114,7 @@ A nossa documentação está disponível em múltiplos formatos:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-pt_BR.md
+++ b/docs/README-pt_BR.md
@@ -115,7 +115,7 @@ Nossa documentação está disponível em vários formatos:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-ro.md
+++ b/docs/README-ro.md
@@ -119,7 +119,7 @@ Documentația este disponibilă în mai multe formate:
 * [Temă întunecată](https://docs.triliumnotes.org/user-guide/concepts/themes)
   predefinită, dar și suport pentru teme personalizate
 * Import și export pentru
-  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   și
   [Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper)

--- a/docs/README-ru.md
+++ b/docs/README-ru.md
@@ -115,7 +115,7 @@ Trilium Notes – это приложение для заметок с иера�
   смартфонов и планшетов
 * [Темная тема](https://docs.triliumnotes.org/user-guide/concepts/themes)
 * Импорт и экпорт
-  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   и данных в
   [markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
   формате

--- a/docs/README-sl.md
+++ b/docs/README-sl.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-sr.md
+++ b/docs/README-sr.md
@@ -113,7 +113,7 @@ Our documentation is available in multiple formats:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-sv.md
+++ b/docs/README-sv.md
@@ -112,7 +112,7 @@ Vår dokumentation är tillgänglig i flera format:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-tr.md
+++ b/docs/README-tr.md
@@ -111,7 +111,7 @@ Dokümantasyonumuz birden fazla formatta mevcuttur:
 * Built-in [dark
   theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for
   user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   and [Markdown import &
   export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for

--- a/docs/README-ug.md
+++ b/docs/README-ug.md
@@ -121,7 +121,7 @@ docs.triliumnotes.org](https://docs.triliumnotes.org/)**
 * ئىچىگە ئورۇنلاشتۇرۇلغان [قېنىق رەڭلىك
   تېما](https://docs.triliumnotes.org/user-guide/concepts/themes)
 * [Evernote دىن
-  ئەكىرىش](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  ئەكىرىش](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   ۋە [Markdown نى ئەكىرىش ھەم
   چىقىرىش](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * توردىكى مەزمۇنلارنى تېز ساقلاشقا ئىشلىتىلىدىغان [Web

--- a/docs/README-uk.md
+++ b/docs/README-uk.md
@@ -117,7 +117,7 @@ Trilium Notes — це безкоштовний кросплатформний �
 * Вбудована [темна
   тема](https://docs.triliumnotes.org/user-guide/concepts/themes), підтримка тем
   користувача
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   та [Markdown імпорт &
   експорт](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) для

--- a/docs/README-ur.md
+++ b/docs/README-ur.md
@@ -112,7 +112,7 @@ Trilium Notes ایک مفت اور اوپن سورس، کراس پلیٹ فار�
   اینڈ](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend)
 * بلٹ ان [ڈارک تھیم](https://docs.triliumnotes.org/user-guide/concepts/themes)،
   یوزر تھیمز کی سپورٹ
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   اور [Markdown امپورٹ اور
   ایکسپورٹ](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * ویب مواد آسانی سے محفوظ کرنے کے لیے [ویب

--- a/docs/README-vi.md
+++ b/docs/README-vi.md
@@ -118,7 +118,7 @@ Tài liệu của chúng tôi có sẵn ở nhiều định dạng:
   tối](https://docs.triliumnotes.org/user-guide/concepts/themes), hỗ trợ giao
   diện do người dùng tùy chỉnh
 * Hỗ trợ nhập, xuất cho
-  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote)
+  [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html)
   và
   [Markdown](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) để

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ Our documentation is available in multiple formats:
 * Scales well in both usability and performance upwards of 100 000 notes
 * Touch optimized [mobile frontend](https://docs.triliumnotes.org/user-guide/setup/mobile-frontend) for smartphones and tablets
 * Built-in [dark theme](https://docs.triliumnotes.org/user-guide/concepts/themes), support for user themes
-* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/evernote) and [Markdown import & export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
+* [Evernote](https://docs.triliumnotes.org/user-guide/concepts/import-export/import-from-apps/evernote.html) and [Markdown import & export](https://docs.triliumnotes.org/user-guide/concepts/import-export/markdown)
 * [Web Clipper](https://docs.triliumnotes.org/user-guide/setup/web-clipper) for easy saving of web content
 * Customizable UI (sidebar buttons, user-defined widgets, ...)
 * [Metrics](https://docs.triliumnotes.org/user-guide/advanced-usage/metrics), along with a Grafana Dashboard.


### PR DESCRIPTION
The README and all localized READMEs (41 files) link to `docs.triliumnotes.org/user-guide/concepts/import-export/evernote`, which returns 404. The docs site restructured and the page now lives at `user-guide/concepts/import-export/import-from-apps/evernote.html` (verified 200, linked from the live import-export index). Updated the link in every file.