### PR TITLE
fix(text editor): show todo hints only on hover

### DIFF
--- a/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.spec.ts
+++ b/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.spec.ts
@@ -380,7 +380,7 @@ describe("TodoListMultistateEditing", () => {
             // The manager creates handles lazily and shows nothing until a handle
             // pushes onto the visibility stack — so a freshly-rendered editor
             // has no popup, and every checkbox reports `null` for
-            // `Tooltip.getInstance` until it is hovered or the caret enters it.
+            // `Tooltip.getInstance` until it is hovered.
             const domRoot = editor.editing.view.getDomRoot();
             const input = domRoot?.querySelector<HTMLInputElement>('.todo-list__label input[type="checkbox"]');
             expect(input).not.toBeNull();
@@ -475,11 +475,8 @@ describe("TodoListMultistateEditing", () => {
             const currentInput = editor.editing.view.getDomRoot()?.querySelector<HTMLInputElement>('.todo-list__label input[type="checkbox"]');
             expect(currentInput).not.toBeNull();
             expect(currentInput).not.toBe(firstInput);
-            // Whether a popup is currently visible depends on where the caret
-            // is (`TODO_FIXTURE` places it inside the item, so the plugin's
-            // caret-driven flow can legitimately show the tooltip during the
-            // rebuild) — that's orthogonal to the "old-handle-disposed" invariant
-            // this test exists to verify.
+            // Popup visibility is orthogonal to the "old-handle-disposed"
+            // invariant this test exists to verify.
         });
 
         it("includes the state label when a configured state is set", () => {
@@ -535,9 +532,7 @@ describe("TodoListMultistateEditing", () => {
         });
     });
 
-    describe("caret-driven tooltip visibility", () => {
-        // Fixture: a plain paragraph then two todo items. The caret starts in the plain
-        // paragraph so we can move it into (and between) the todos to drive the listener.
+    describe("caret movement", () => {
         const CARET_FIXTURE = '<paragraph>plain[]</paragraph>' +
             '<paragraph listIndent="0" listItemId="t-a" listType="todo">A</paragraph>' +
             '<paragraph listIndent="0" listItemId="t-b" listType="todo">B</paragraph>';
@@ -552,155 +547,32 @@ describe("TodoListMultistateEditing", () => {
         beforeEach(async () => {
             editor = await createEditor({ taskStates: CUSTOM_STATES });
             setModelData(editor.model, CARET_FIXTURE);
-            // Real timers by default — the dwell-delay tests below opt into fake
-            // timers explicitly so they can advance past `TOOLTIP_DWELL_MS`
-            // without paying the wall-clock cost.
             vi.useFakeTimers({ shouldAdvanceTime: false });
         });
 
-        // Switch back to real timers between tests — Bootstrap's own transitions
-        // still run on real time, and leaving fake timers on can wedge cleanup.
-        function endFakeTimers(): void {
+        it("does not show a tooltip when the caret moves into, between, or within todo items", () => {
+            moveCaretTo(1);
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 5);
+            expect(livePopup()).toBeNull();
+
+            moveCaretTo(2);
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 5);
+            expect(livePopup()).toBeNull();
+
+            editor.model.change((writer) => {
+                writer.setSelection(writer.createPositionAt(getBlock(editor, 2), 1));
+            });
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 5);
+            expect(livePopup()).toBeNull();
+
             vi.runOnlyPendingTimers();
             vi.useRealTimers();
-        }
-
-        it("shows a tooltip on the correct source element after the dwell delay when the caret enters a todo <li>", () => {
-            expect(livePopup()).toBeNull();
-
-            moveCaretTo(1); // caret in todo A → schedules a delayed show
-            expect(livePopup()).toBeNull(); // still deferred
-
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            expect(livePopup()).not.toBeNull();
-
-            // The tooltip belongs to the caret's todo item — its aria link points
-            // back at the corresponding checkbox.
-            const source = document.querySelector<HTMLElement>(`[aria-describedby="${livePopup()?.id}"]`);
-            const targetLi = source?.closest("li");
-            expect(targetLi?.getAttribute("data-list-item-id")).toBe("t-a");
-
-            endFakeTimers();
-        });
-
-        it("hides the visible tooltip when the caret leaves any todo item", () => {
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            expect(livePopup()).not.toBeNull();
-
-            moveCaretTo(0); // back to the plain paragraph — the caret handle disposes
-            expect(livePopup()).toBeNull();
-
-            endFakeTimers();
-        });
-
-        it("switches the visible tooltip's source element when the caret moves between two todo items", () => {
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const firstSourceLi = document.querySelector<HTMLElement>(
-                `[aria-describedby="${livePopup()?.id}"]`
-            )?.closest("li");
-            expect(firstSourceLi?.getAttribute("data-list-item-id")).toBe("t-a");
-
-            moveCaretTo(2); // enter B — the caret handle rebinds to the new checkbox
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const secondSourceLi = document.querySelector<HTMLElement>(
-                `[aria-describedby="${livePopup()?.id}"]`
-            )?.closest("li");
-            expect(secondSourceLi?.getAttribute("data-list-item-id")).toBe("t-b");
-
-            endFakeTimers();
-        });
-
-        it("does not disturb the popup when the caret moves within the same todo item", () => {
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const before = livePopup();
-            expect(before).not.toBeNull();
-
-            // Move the caret to a different position WITHIN the same todo item.
-            editor.model.change((writer) => {
-                writer.setSelection(writer.createPositionAt(getBlock(editor, 1), 1));
-            });
-
-            // Same DOM popup element — no dispose/re-create dance.
-            expect(livePopup()).toBe(before);
-
-            endFakeTimers();
-        });
-
-        it("re-shows the tooltip immediately after a state change on the caret's item (no second dwell)", () => {
-            moveCaretTo(1); // caret in todo A
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            expect(livePopup()).not.toBeNull();
-
-            // 'doing' has isCompleted=false → the checkbox input stays the same
-            // DOM element. The plugin detects the state change on the caret's
-            // item and calls `handle.show()` (not showAfter), so the popup
-            // stays visible without any additional dwell wait.
-            editor.execute("setTaskState", { state: "doing" });
-            expect(livePopup()).not.toBeNull();
-
-            endFakeTimers();
-        });
-
-        it("recovers cleanly when the checkbox under the caret is replaced by a reconvert", () => {
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const domRoot = editor.editing.view.getDomRoot();
-            const oldInput = domRoot?.querySelector<HTMLInputElement>('.todo-list__label input[type="checkbox"]');
-
-            // Toggling the native checkbox reconverts the todo item — the DOM
-            // input is replaced. The plugin reaps the old hover handle and
-            // re-attaches its caret handle to the new input.
-            editor.execute("checkTodoList");
-            editor.editing.view.forceRender();
-
-            expect(oldInput?.isConnected).toBe(false);
-            // Moving the caret out must not throw despite the stale reference.
-            expect(() => moveCaretTo(0)).not.toThrow();
-
-            endFakeTimers();
-        });
-
-        it("keeps no tooltip visible when the caret has no todo ancestor", () => {
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            expect(livePopup()).not.toBeNull();
-
-            moveCaretTo(0); // plain paragraph → no todo ancestor → hide
-            expect(livePopup()).toBeNull();
-
-            endFakeTimers();
-        });
-
-        it("bails out safely when the position has no parent (defensive branch)", () => {
-            const selection = editor.model.document.selection;
-            const spy = vi.spyOn(selection, "getFirstPosition")
-                .mockReturnValueOnce(null as unknown as ReturnType<typeof selection.getFirstPosition>);
-            // Nudge the selection so `change:range` fires with the mocked getFirstPosition.
-            editor.model.change((writer) => {
-                writer.setSelection(writer.createPositionAt(getBlock(editor, 0), 0));
-            });
-            spy.mockRestore();
-        });
-
-        it("nulls the caret-shown reference on destroy", async () => {
-            moveCaretTo(1);
-            // No throw expected — destroy must clear internal state cleanly whether
-            // or not a caret-shown tooltip is currently tracked.
-            await editor.destroy();
-            expect(editor.state).toBe("destroyed");
-            // Recreate so the shared afterEach's destroy() does not double-destroy.
-            editor = await createEditor({ taskStates: CUSTOM_STATES });
         });
     });
 
     describe("hover-driven tooltip visibility", () => {
-        // Two todos so we can hover one while the caret sits in a plain
-        // paragraph — the caret and hover flows must be independently
-        // exercised, since the `ownedByCaret` check yields different results
-        // in each case.
+        // Two todos verify that the hover handle follows the pointer independently
+        // of the caret position.
         const HOVER_FIXTURE = '<paragraph>plain[]</paragraph>' +
             '<paragraph listIndent="0" listItemId="t-a" listType="todo">A</paragraph>' +
             '<paragraph listIndent="0" listItemId="t-b" listType="todo">B</paragraph>';
@@ -734,9 +606,7 @@ describe("TodoListMultistateEditing", () => {
             vi.useRealTimers();
         }
 
-        it("mouseenter on a checkbox not owned by the caret schedules a delayed show; mouseleave cancels it", () => {
-            // Caret in the plain paragraph — no todo owns the caret, so the
-            // hover flow is fully in charge of the hovered checkbox's tooltip.
+        it("mouseenter schedules a delayed show and mouseleave hides the tooltip", () => {
             moveCaretTo(0);
             const inputA = checkboxOfItem("t-a");
             expect(livePopup()).toBeNull();
@@ -758,46 +628,58 @@ describe("TodoListMultistateEditing", () => {
             endFakeTimers();
         });
 
-        it("mouseenter is a no-op when the caret is inside the hovered checkbox's item", () => {
-            // Caret is inside todo A → the caret handle already owns A's
-            // tooltip visibility. Hovering the same checkbox must not run the
-            // dwell-and-push cycle (the manager would flicker if it did).
+        it("mouseleave before the dwell delay cancels the pending show", () => {
+            const inputA = checkboxOfItem("t-a");
+
+            inputA.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS - 1);
+            inputA.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 2);
+
+            expect(livePopup()).toBeNull();
+            endFakeTimers();
+        });
+
+        it("shows on hover even when the caret is inside the hovered item", () => {
             moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const beforeHover = livePopup();
-            expect(beforeHover).not.toBeNull(); // caret drove this popup
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 2);
+            expect(livePopup()).toBeNull();
 
             const inputA = checkboxOfItem("t-a");
             inputA.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
-            // Advance well past the dwell — no NEW render, and no manager churn.
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS * 2);
-            // Same popup element — the caret handle's tooltip was never disturbed.
-            expect(livePopup()).toBe(beforeHover);
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
+            expect(livePopup()).not.toBeNull();
+
+            inputA.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+            expect(livePopup()).toBeNull();
 
             endFakeTimers();
         });
 
-        it("mouseleave is a no-op when the caret is inside the hovered checkbox's item", () => {
-            // The caret owns A's popup. Even if a mouseleave arrives (mouse
-            // sweeping across the checkbox during selection), the hover branch
-            // must not tear the popup down — the caret handle still wants it.
-            moveCaretTo(1);
-            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
-            const beforeLeave = livePopup();
-            expect(beforeLeave).not.toBeNull();
-
+        it("switches the visible tooltip when hovering a different checkbox", () => {
             const inputA = checkboxOfItem("t-a");
+            const inputB = checkboxOfItem("t-b");
+
+            inputA.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
+            expect(document.querySelector<HTMLElement>(
+                `[aria-describedby="${livePopup()?.id}"]`
+            )?.closest("li")?.getAttribute("data-list-item-id")).toBe("t-a");
+
             inputA.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
-            expect(livePopup()).toBe(beforeLeave);
+            inputB.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+            vi.advanceTimersByTime(TOOLTIP_DWELL_MS);
+            expect(document.querySelector<HTMLElement>(
+                `[aria-describedby="${livePopup()?.id}"]`
+            )?.closest("li")?.getAttribute("data-list-item-id")).toBe("t-b");
 
             endFakeTimers();
         });
     });
 
     describe("contentHintsEnabled config", () => {
-        // With hints off, neither the hover nor the caret flow should spawn
-        // a popup — the plugin's core editing behavior (state cycle, native
-        // toggle) must still work, but the on-screen hint is fully muted.
+        // With hints off, hover should not spawn a popup. The plugin's core editing
+        // behavior (state cycle, native toggle) must still work.
         beforeEach(async () => {
             editor = await createEditor({
                 taskStates: CUSTOM_STATES,

--- a/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.ts
+++ b/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.ts
@@ -6,7 +6,7 @@ import { ContentHintManager, type HintHandle } from "../../content_hint_manager.
 import { renderShortcut } from "../../shortcut.js";
 
 /**
- * Dwell delay before a hover or a stationary caret pops the checkbox tooltip.
+ * Dwell delay before hovering a checkbox pops its tooltip.
  * Long enough that brief flyovers don't spawn a tooltip, short enough that
  * intentional attention consistently produces one.
  */
@@ -38,38 +38,14 @@ export default class TodoListMultistateEditing extends Plugin {
         return [TodoList, ListEditing] as const;
     }
 
-    /**
-     * Shared content-hint stack. One hover handle per rendered checkbox plus
-     * one caret handle (moved between checkboxes as the caret does) push/pop
-     * against it — only the top of the stack is on screen at a time. See
-     * {@link ContentHintManager} for the rationale.
-     */
+    /** Shared content-hint stack, with one hover handle per rendered checkbox. */
     private _hintManager?: ContentHintManager;
 
     /** Hover-driven handle per rendered checkbox. Disposed when the checkbox detaches. */
     private readonly _hoverHandles = new Map<HTMLInputElement, HintHandle>();
 
-    /**
-     * Last known task state per rendered checkbox — used to detect content-changing
-     * events (Ctrl+Shift+Enter, native toggle) so the caret handle can force an
-     * immediate `show()` instead of a delayed one.
-     */
+    /** Last known task state per rendered checkbox, used to refresh hover content. */
     private readonly _knownState = new Map<HTMLInputElement, string | null>();
-
-    /** Caret-driven handle, if the caret is currently inside a todo item. */
-    private _caretHandle: HintHandle | null = null;
-
-    /** DOM checkbox the caret handle is currently attached to. */
-    private _caretInput: HTMLInputElement | null = null;
-
-    /**
-     * `data-list-item-id` of the todo item the caret is currently inside, or
-     * `null` when the caret isn't inside a todo item. Tracks the *conceptual*
-     * caret target so a mere DOM-node rebuild (Ctrl+Shift+Enter across the
-     * isCompleted boundary recreates the checkbox input) doesn't get treated
-     * as a fresh visit and delayed by the dwell timer.
-     */
-    private _caretItemId: string | null = null;
 
     /** State-name → definition, keyed for `buildTooltipTitle` calls. */
     private _stateByName!: Map<string, TaskStateDef>;
@@ -93,11 +69,7 @@ export default class TodoListMultistateEditing extends Plugin {
                     sanitize: false,
                     customClass: "text-editor-content-tooltip"
                 },
-                // Self-dismiss the tooltip 1s after the last relevant event (push,
-                // content update, top change). Anything that would legitimately
-                // keep the hint alive — hover crossing, caret movement, state
-                // change — pushes to the manager, so the timer resets and the
-                // popup stays. When events stop, it fades on its own.
+                // Self-dismiss the tooltip after the last relevant hover event.
                 autoHideAfterMs: 2000
             });
         }
@@ -175,19 +147,7 @@ export default class TodoListMultistateEditing extends Plugin {
                 if (!domRoot) {
                     return;
                 }
-                // Refresh handles first; the return value tells `_syncCaretTooltip`
-                // whether the caret's item changed state on this render (Ctrl+Shift+Enter,
-                // native toggle, etc.) so it can force an immediate `show()` instead
-                // of waiting out the dwell timer again.
-                const caretItemStateChanged = this._refreshHoverHandles(domRoot);
-                this._syncCaretTooltip({ forceShowIfSameTarget: caretItemStateChanged });
-            });
-
-            // Keyboard-only navigation into an <li> doesn't move DOM focus (the editable
-            // root keeps it), so the manager needs to be driven from model-selection
-            // changes to catch the keyboard-into-todo case.
-            this.listenTo(editor.model.document.selection, "change:range", () => {
-                this._syncCaretTooltip({ forceShowIfSameTarget: false });
+                this._refreshHoverHandles(domRoot);
             });
         }
 
@@ -258,10 +218,6 @@ export default class TodoListMultistateEditing extends Plugin {
     }
 
     override destroy() {
-        this._caretHandle?.dispose();
-        this._caretHandle = null;
-        this._caretInput = null;
-        this._caretItemId = null;
         for (const handle of this._hoverHandles.values()) {
             handle.dispose();
         }
@@ -276,20 +232,15 @@ export default class TodoListMultistateEditing extends Plugin {
      * Creates a handle + attaches mouseenter/mouseleave for each new checkbox,
      * disposes handles whose input was detached, and refreshes content on
      * inputs whose task state changed since the last render.
-     *
-     * Returns `true` iff the caret's own checkbox saw a state change on this
-     * render — the caller uses that to force `show()` its caret handle instead
-     * of waiting out the dwell timer (state change should reveal the tooltip
-     * immediately, per the "reappear on state change" spec).
      */
-    private _refreshHoverHandles(domRoot: HTMLElement): boolean {
+    private _refreshHoverHandles(domRoot: HTMLElement): void {
         const manager = this._hintManager;
         // The two callers that reach this method are gated on `hintsEnabled`
         // in `init()`, so `_hintManager` is set here in practice. The guard
         // keeps TypeScript happy and documents the contract.
         /* v8 ignore next 3 */
         if (!manager) {
-            return false;
+            return;
         }
         // Reap detached checkboxes.
         for (const input of Array.from(this._hoverHandles.keys())) {
@@ -297,17 +248,8 @@ export default class TodoListMultistateEditing extends Plugin {
                 this._hoverHandles.get(input)?.dispose();
                 this._hoverHandles.delete(input);
                 this._knownState.delete(input);
-                if (input === this._caretInput) {
-                    // Caret handle for a detached input; drop it — `_syncCaretTooltip`
-                    // will pick up the new one via `_findCaretCheckbox`.
-                    this._caretHandle?.dispose();
-                    this._caretHandle = null;
-                    this._caretInput = null;
-                }
             }
         }
-
-        let caretItemStateChanged = false;
 
         for (const input of domRoot.querySelectorAll<HTMLInputElement>(".todo-list__label input[type=\"checkbox\"]")) {
             const currentState = readTaskState(input);
@@ -318,23 +260,10 @@ export default class TodoListMultistateEditing extends Plugin {
             if (isNew) {
                 const handle = manager.createHandle(input, this._computeContent(input));
                 this._hoverHandles.set(input, handle);
-                // Cache the enclosing item's id — stable for this input's life, and we
-                // need it on every hover event to decide whether to yield to the caret.
-                /* v8 ignore next -- CKEditor's list plugin guarantees every
-                   `<li>` inside a rendered todo list carries `data-list-item-id`
-                   and the checkbox is nested inside that `<li>`. The `?.` /
-                   `?? null` fallbacks are defensive. */
-                const ownItemId = input.closest<HTMLElement>("li")?.getAttribute("data-list-item-id") ?? null;
-                // Hover on the checkbox whose item already has the caret is a no-op:
-                // the caret handle already owns that item's tooltip visibility, and
-                // running the dwell + push cycle on top of it only confuses the stack.
-                const ownedByCaret = () => ownItemId !== null && ownItemId === this._caretItemId;
                 input.addEventListener("mouseenter", () => {
-                    if (ownedByCaret()) return;
                     handle.showAfter(TOOLTIP_DWELL_MS);
                 });
                 input.addEventListener("mouseleave", () => {
-                    if (ownedByCaret()) return;
                     handle.hide();
                 });
             /* v8 ignore start -- taskState is scope:"item", so any state change
@@ -344,84 +273,8 @@ export default class TodoListMultistateEditing extends Plugin {
                ever stopped reconverting on scope:"item" attribute changes. */
             } else if (currentState !== previousState) {
                 this._hoverHandles.get(input)?.setContent(this._computeContent(input));
-                if (input === this._caretInput) {
-                    caretItemStateChanged = true;
-                }
             }
             /* v8 ignore stop */
-        }
-
-        return caretItemStateChanged;
-    }
-
-    /**
-     * Reconcile the caret handle against the current model caret target. Called
-     * on selection changes AND at the end of every render.
-     *
-     * The item-id vs input-identity distinction matters: a state change across
-     * the isCompleted boundary reconverts the todo item, giving us a new DOM
-     * checkbox even though the caret hasn't moved. We want the tooltip to
-     * reappear immediately in that case (per "reappear on state change"), not
-     * to be delayed as if the user just navigated in.
-     *
-     * Cases:
-     *   - Item unchanged, input unchanged, state unchanged → no-op.
-     *   - Item unchanged, input unchanged, state changed (`forceShowIfSameTarget`)
-     *     → refresh content, force immediate `show()`.
-     *   - Item unchanged, input replaced (isCompleted-boundary reconversion)
-     *     → rebuild handle on the new input, immediate `show()`.
-     *   - Item changed (user actually moved the caret) → new handle,
-     *     `showAfter(TOOLTIP_DWELL_MS)`, so drive-throughs don't spawn a tooltip.
-     */
-    private _syncCaretTooltip(options: { forceShowIfSameTarget: boolean }): void {
-        const manager = this._hintManager;
-        /* v8 ignore next 3 -- gated same as _refreshHoverHandles, see there. */
-        if (!manager) {
-            return;
-        }
-        const target = this._findCaretCheckbox();
-        const targetItemId = target?.closest<HTMLElement>("li")?.getAttribute("data-list-item-id") ?? null;
-        const itemChanged = targetItemId !== this._caretItemId;
-        const inputChanged = target !== this._caretInput;
-
-        if (!itemChanged) {
-            if (inputChanged) {
-                // Same conceptual item, but the DOM input was recreated — rebuild
-                // the handle and show immediately (no dwell delay for a rebuild).
-                this._caretHandle?.dispose();
-                this._caretHandle = null;
-                this._caretInput = target;
-                /* v8 ignore next -- inside the "same item, input changed"
-                   branch, `target` cannot be null: `!itemChanged` means
-                   `targetItemId === this._caretItemId`, and if `target` were
-                   null then `targetItemId` would be null too, forcing the
-                   `_caretItemId` we're comparing against to also be null —
-                   but then `_caretInput` was null too, so `inputChanged`
-                   would be false and we wouldn't be in this branch. */
-                if (target) {
-                    this._caretHandle = manager.createHandle(target, this._computeContent(target));
-                    this._caretHandle.show();
-                }
-            /* v8 ignore start -- reachable only when `forceShowIfSameTarget`
-               is true, which the render listener only sets when
-               `_refreshHoverHandles` observes a state change on the caret's
-               input WITHOUT the input being recreated — see the paired v8
-               ignore in `_refreshHoverHandles`. Defensive counterpart. */
-            } else if (target && this._caretHandle && options.forceShowIfSameTarget) {
-                this._caretHandle.setContent(this._computeContent(target));
-                this._caretHandle.show();
-            }
-            /* v8 ignore stop */
-            return;
-        }
-
-        this._caretHandle?.dispose();
-        this._caretHandle = null;
-        this._caretInput = target;
-        this._caretItemId = targetItemId;
-        if (target) {
-            this._caretHandle = manager.createHandle(target, this._computeContent(target));
-            this._caretHandle.showAfter(TOOLTIP_DWELL_MS);
         }
     }
 
@@ -434,38 +287,6 @@ export default class TodoListMultistateEditing extends Plugin {
             this.editor.t,
             renderShortcut(this.editor, STATE_CYCLE_SHORTCUT)
         );
-    }
-
-    /**
-     * The <input> DOM checkbox of the todo item the caret is currently inside, or
-     * `null` when the caret isn't inside a todo item. Walks up the model to find
-     * an ancestor block with `listType == "todo"`, then queries the editing DOM
-     * for the matching <li data-list-item-id="…">.
-     */
-    private _findCaretCheckbox(): HTMLInputElement | null {
-        const position = this.editor.model.document.selection.getFirstPosition();
-        let node: ModelElement | null = null;
-        let candidate = position?.parent ?? null;
-        while (candidate) {
-            if (candidate.is("element") && candidate.getAttribute("listType") === "todo") {
-                node = candidate as ModelElement;
-                break;
-            }
-            candidate = candidate.parent;
-        }
-        if (!node) {
-            return null;
-        }
-        const itemId = node.getAttribute("listItemId");
-        /* v8 ignore next 3 -- CKEditor's list plugin guarantees `listItemId`
-           is a non-empty string on every todo item; defensive fallback. */
-        if (typeof itemId !== "string" || !itemId) {
-            return null;
-        }
-        const domRoot = this.editor.editing.view.getDomRoot();
-        return domRoot?.querySelector<HTMLInputElement>(
-            `li[data-list-item-id="${CSS.escape(itemId)}"] .todo-list__label input[type="checkbox"]`
-        ) ?? null;
     }
 
 }


### PR DESCRIPTION
## Summary

- show the task-state content hint only when hovering a to-do checkbox
- remove the selection listener and caret-specific tooltip lifecycle
- keep the existing hover dwell, state-aware content refresh, and Content hints preference
- add regression coverage for caret navigation and hover behavior

Fixes #11030.

Related: #10574, #9881.

## Why

Moving the caret between to-do items previously disposed and recreated a Bootstrap tooltip for each item. In the desktop app this caused visible caret flicker and delayed caret movement. The tooltip is fixed in the bottom-left corner, so tying its lifecycle to each caret target provides no positioning benefit.

## Validation

- `pnpm --filter ckeditor5 test --run src/plugins/todo_list_multistate/todo_list_multistate_editing.spec.ts -t 'caret movement|hover-driven tooltip visibility|contentHintsEnabled config'` — 7 passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- manually verified the browser and Electron development apps

The complete plugin spec still has the same three pre-existing macOS keyboard-shortcut failures observed before this change; all other 46 tests pass.
