### PR TITLE
fix(client/tooltips): put away a delegated tooltip whose trigger left the DOM

### DIFF
--- a/apps/client/src/widgets/react/IconPicker.tsx
+++ b/apps/client/src/widgets/react/IconPicker.tsx
@@ -1,7 +1,7 @@
 import "./IconPicker.css";
 
 import { IconRegistry } from "@triliumnext/commons";
-import { Dropdown as BootstrapDropdown } from "bootstrap";
+import { Dropdown as BootstrapDropdown, Tooltip } from "bootstrap";
 import clsx from "clsx";
 import { CSSProperties } from "preact";
 import { createPortal } from "preact/compat";
@@ -21,6 +21,15 @@ import Modal from "./Modal";
 
 /** The room one icon takes in the grid, which also decides how many fit across a given width. */
 export const ICON_SIZE = isMobile() ? 56 : 48;
+
+// One tooltip on the grid, delegated to the icon tiles. A module constant so the grid re-rendering
+// on every keystroke in the search does not tear the tooltip down and build it again each time.
+const ICON_TOOLTIP_CONFIG: Partial<Tooltip.Options> = {
+    selector: "span",
+    customClass: "pre-wrap-text",
+    animation: false,
+    title() { return this.getAttribute("title") || ""; },
+};
 
 interface IconPickerProps {
     /** Receives the class of the icon picked, e.g. `bx bx-star`. */
@@ -47,12 +56,7 @@ export default function IconPicker({ onSelect, onReset, resetText, columnCount }
     const iconListRef = useRef<HTMLDivElement>(null);
     const [ search, setSearch ] = useState<string>();
     const [ filterByPrefix, setFilterByPrefix ] = useState<string | null>(null);
-    useStaticTooltip(iconListRef, {
-        selector: "span",
-        customClass: "pre-wrap-text",
-        animation: false,
-        title() { return this.getAttribute("title") || ""; },
-    });
+    useStaticTooltip(iconListRef, ICON_TOOLTIP_CONFIG);
 
     const allIcons = useAllIcons();
     const filteredIcons = useFilteredIcons(allIcons, search, filterByPrefix);

--- a/apps/client/src/widgets/react/hooks.spec.tsx
+++ b/apps/client/src/widgets/react/hooks.spec.tsx
@@ -224,6 +224,89 @@ describe("useStaticTooltip", () => {
 
         expect(document.querySelector(".tooltip"), "gone once the observer sees the removal").toBeNull();
     });
+
+    it("stops tracking a delegated tooltip that was put away normally, and leaves its instance alone", async () => {
+        await act(async () => render(<DelegatedTooltipHarness generation={1} />, container));
+
+        const span = container.querySelector("span");
+        expect(span).not.toBeNull();
+
+        let instance: Tooltip | undefined;
+        act(() => {
+            if (span) {
+                instance = Tooltip.getOrCreateInstance(span, {
+                    animation: false,
+                    title() {
+                        return this.getAttribute("title") || "";
+                    }
+                });
+                instance.show();
+            }
+        });
+        expect(document.querySelector(".tooltip"), "shown").not.toBeNull();
+
+        // An ordinary mouseleave-driven hide fires `hidden.bs.tooltip`, which must untrack the
+        // span — otherwise the observer below would dispose an instance Bootstrap still owns.
+        act(() => instance?.hide());
+        expect(document.querySelector(".tooltip"), "hidden the normal way").toBeNull();
+
+        await act(async () => render(<DelegatedTooltipHarness generation={2} />, container));
+        await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+
+        expect(span && Tooltip.getInstance(span), "instance untouched by the observer").not.toBeNull();
+    });
+
+    it("leaves a shown delegated tooltip standing when the mutation removed something else", async () => {
+        await act(async () => render(<DelegatedTooltipHarness generation={1} />, container));
+
+        const span = container.querySelector("span");
+        expect(span).not.toBeNull();
+        act(() => {
+            if (span) {
+                Tooltip.getOrCreateInstance(span, {
+                    animation: false,
+                    title() {
+                        return this.getAttribute("title") || "";
+                    }
+                }).show();
+            }
+        });
+        expect(document.querySelector(".tooltip"), "shown").not.toBeNull();
+
+        // Add and remove an unrelated sibling — the observer fires, but the hovered span is
+        // still connected, so its tooltip must stay up.
+        await act(async () => {
+            const bystander = document.createElement("i");
+            span?.parentElement?.appendChild(bystander);
+            bystander.remove();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        expect(document.querySelector(".tooltip"), "still shown after an unrelated mutation").not.toBeNull();
+    });
+
+    it("removes the popup by its aria-describedby link when the instance is already gone", async () => {
+        await act(async () => render(<DelegatedTooltipHarness generation={1} />, container));
+
+        const span = container.querySelector("span");
+        expect(span).not.toBeNull();
+
+        // Simulate a popup whose Tooltip instance has already been torn down on its own: no
+        // instance on the span, just the shown-state markers Bootstrap leaves while a popup is up.
+        const strayPopup = document.createElement("div");
+        strayPopup.id = "stray-popup-10680";
+        strayPopup.className = "tooltip";
+        document.body.appendChild(strayPopup);
+        act(() => {
+            span?.setAttribute("aria-describedby", strayPopup.id);
+            span?.dispatchEvent(new Event("inserted.bs.tooltip", { bubbles: true }));
+        });
+
+        await act(async () => render(<DelegatedTooltipHarness generation={2} />, container));
+        await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+
+        expect(document.getElementById(strayPopup.id), "stray popup swept by its id").toBeNull();
+    });
 });
 
 describe("useTooltip", () => {

--- a/apps/client/src/widgets/react/hooks.spec.tsx
+++ b/apps/client/src/widgets/react/hooks.spec.tsx
@@ -171,10 +171,11 @@ describe("useStaticTooltip", () => {
         expect(document.querySelector(".tooltip"), "gone with the press").toBeNull();
     });
 
-    // Module-level (not recreated per render) on purpose: the icon picker's own container effect
-    // never re-runs when its virtualized grid re-keys a cell, so the MutationObserver #10680's fix
-    // installs has to survive across that re-render on its own — a config recreated inline, like
-    // TooltipHarness above, would re-run the effect and mask exactly what this test checks.
+    // Module-level (not recreated per render) on purpose, as the icon picker's `ICON_TOOLTIP_CONFIG`
+    // is: the container effect never re-runs when the virtualized grid re-keys a cell, so the
+    // MutationObserver #10680's fix installs has to survive across that re-render on its own — a
+    // config recreated inline, like TooltipHarness above, would re-run the effect and mask exactly
+    // what this test checks.
     const DELEGATED_CONFIG = {
         selector: "span",
         animation: false,
@@ -226,10 +227,14 @@ describe("useStaticTooltip", () => {
     });
 
     it("stops tracking a delegated tooltip that was put away normally, and leaves its instance alone", async () => {
+        const observe = vi.spyOn(MutationObserver.prototype, "observe");
+        const disconnect = vi.spyOn(MutationObserver.prototype, "disconnect");
         await act(async () => render(<DelegatedTooltipHarness generation={1} />, container));
 
         const span = container.querySelector("span");
         expect(span).not.toBeNull();
+        // The container is watched only while a popup is up, not from the moment it mounts.
+        expect(observe, "not observing before anything is shown").not.toHaveBeenCalled();
 
         let instance: Tooltip | undefined;
         act(() => {
@@ -244,11 +249,16 @@ describe("useStaticTooltip", () => {
             }
         });
         expect(document.querySelector(".tooltip"), "shown").not.toBeNull();
+        expect(observe, "observing once a popup is shown").toHaveBeenCalledTimes(1);
 
         // An ordinary mouseleave-driven hide fires `hidden.bs.tooltip`, which must untrack the
         // span — otherwise the observer below would dispose an instance Bootstrap still owns.
+        disconnect.mockClear();
         act(() => instance?.hide());
         expect(document.querySelector(".tooltip"), "hidden the normal way").toBeNull();
+        expect(disconnect, "observer let go once nothing is shown").toHaveBeenCalled();
+        observe.mockRestore();
+        disconnect.mockRestore();
 
         await act(async () => render(<DelegatedTooltipHarness generation={2} />, container));
         await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });

--- a/apps/client/src/widgets/react/hooks.spec.tsx
+++ b/apps/client/src/widgets/react/hooks.spec.tsx
@@ -170,6 +170,60 @@ describe("useStaticTooltip", () => {
         await act(async () => { trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
         expect(document.querySelector(".tooltip"), "gone with the press").toBeNull();
     });
+
+    // Module-level (not recreated per render) on purpose: the icon picker's own container effect
+    // never re-runs when its virtualized grid re-keys a cell, so the MutationObserver #10680's fix
+    // installs has to survive across that re-render on its own — a config recreated inline, like
+    // TooltipHarness above, would re-run the effect and mask exactly what this test checks.
+    const DELEGATED_CONFIG = {
+        selector: "span",
+        animation: false,
+        title() {
+            return this.getAttribute("title") || "";
+        }
+    } satisfies Partial<Tooltip.Options>;
+
+    function DelegatedTooltipHarness({ generation }: { generation: number }) {
+        const ref = useRef<HTMLDivElement>(null);
+        useStaticTooltip(ref, DELEGATED_CONFIG);
+        return (
+            <div ref={ref}>
+                <span key={generation} title="smile" />
+            </div>
+        );
+    }
+
+    it("removes an orphaned popup when a delegated tooltip's hovered child is removed without a mouseleave (#10680)", async () => {
+        await act(async () => render(<DelegatedTooltipHarness generation={1} />, container));
+
+        const span = container.querySelector("span");
+        expect(span).not.toBeNull();
+
+        // A synthetic mouseenter does not reliably reach Bootstrap's own delegated listener under
+        // happy-dom, so the per-span instance is created directly instead — the fix only depends on
+        // showing it firing `inserted.bs.tooltip` on the span, which then bubbles to the container
+        // exactly as it would from Bootstrap's own delegated hover handling.
+        act(() => {
+            if (span) {
+                Tooltip.getOrCreateInstance(span, {
+                    animation: false,
+                    title() {
+                        return this.getAttribute("title") || "";
+                    }
+                }).show();
+            }
+        });
+        expect(document.querySelector(".tooltip"), "shown before the remount").not.toBeNull();
+
+        // Replace the hovered span with a fresh one — a keyed remount, like the icon picker's grid
+        // re-keying its cells on every keystroke in its search box — without ever firing mouseleave.
+        await act(async () => render(<DelegatedTooltipHarness generation={2} />, container));
+
+        // The MutationObserver callback runs as a microtask; give it a turn to fire.
+        await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+
+        expect(document.querySelector(".tooltip"), "gone once the observer sees the removal").toBeNull();
+    });
 });
 
 describe("useTooltip", () => {

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -1182,28 +1182,14 @@ export function useStaticTooltip(elRef: RefObject<Element>, config?: Partial<Too
         // own mouseleave. If that child leaves the DOM while its popup is still shown — the note
         // icon picker's virtualized grid re-keys its cells on every keystroke in the search box,
         // and does the same on scroll — no mouseleave ever fires, so the instance never hides and
-        // its popup is orphaned in `document.body` until reload (#10680). Track which delegate
-        // elements currently have a popup shown, via the container-level events Bootstrap's own
-        // component events bubble to.
+        // its popup is orphaned in `document.body` until reload (#10680). While a delegate has its
+        // popup up, watch the container for removals and put the popup away the moment its trigger
+        // is gone — the hook's own cleanup cannot be relied on, since a grid re-render driven by the
+        // grid's own state never re-runs this effect. The observer is connected only for as long
+        // as a popup is shown, so it costs nothing while the grid is merely typed into or scrolled.
         let disposeDelegateTracking = () => {};
         if (config?.selector) {
             const shownDelegates = new Set<Element>();
-            const onDelegateShown = (event: Event) => {
-                if (event.target instanceof Element && event.target !== element) {
-                    shownDelegates.add(event.target);
-                }
-            };
-            const onDelegateHidden = (event: Event) => {
-                if (event.target instanceof Element) {
-                    shownDelegates.delete(event.target);
-                }
-            };
-            element.addEventListener("inserted.bs.tooltip", onDelegateShown);
-            element.addEventListener("hidden.bs.tooltip", onDelegateHidden);
-
-            // A MutationObserver catches the removal the moment it happens, rather than
-            // depending on this hook's own cleanup running again — which a grid re-render
-            // triggered by its own state, not by `elRef`/`config` changing, never causes.
             const delegateObserver = new MutationObserver(() => {
                 for (const target of shownDelegates) {
                     if (target.isConnected) continue;
@@ -1220,8 +1206,23 @@ export function useStaticTooltip(elRef: RefObject<Element>, config?: Partial<Too
                     }
                     shownDelegates.delete(target);
                 }
+                if (!shownDelegates.size) delegateObserver.disconnect();
             });
-            delegateObserver.observe(element, { childList: true, subtree: true });
+            // Bootstrap's component events bubble from the delegate up to the container.
+            const onDelegateShown = (event: Event) => {
+                if (!(event.target instanceof Element) || event.target === element) return;
+                if (!shownDelegates.size) {
+                    delegateObserver.observe(element, { childList: true, subtree: true });
+                }
+                shownDelegates.add(event.target);
+            };
+            const onDelegateHidden = (event: Event) => {
+                if (!(event.target instanceof Element)) return;
+                shownDelegates.delete(event.target);
+                if (!shownDelegates.size) delegateObserver.disconnect();
+            };
+            element.addEventListener("inserted.bs.tooltip", onDelegateShown);
+            element.addEventListener("hidden.bs.tooltip", onDelegateHidden);
 
             disposeDelegateTracking = () => {
                 delegateObserver.disconnect();

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -1177,7 +1177,61 @@ export function useStaticTooltip(elRef: RefObject<Element>, config?: Partial<Too
         };
         element.addEventListener("click", dismissOnPress);
 
+        // For delegated (`selector:`) configs, a hovered child gets its own per-target Tooltip
+        // instance (see the sweep at the end of the cleanup below) that only ever hides on its
+        // own mouseleave. If that child leaves the DOM while its popup is still shown — the note
+        // icon picker's virtualized grid re-keys its cells on every keystroke in the search box,
+        // and does the same on scroll — no mouseleave ever fires, so the instance never hides and
+        // its popup is orphaned in `document.body` until reload (#10680). Track which delegate
+        // elements currently have a popup shown, via the container-level events Bootstrap's own
+        // component events bubble to.
+        let disposeDelegateTracking = () => {};
+        if (config?.selector) {
+            const shownDelegates = new Set<Element>();
+            const onDelegateShown = (event: Event) => {
+                if (event.target instanceof Element && event.target !== element) {
+                    shownDelegates.add(event.target);
+                }
+            };
+            const onDelegateHidden = (event: Event) => {
+                if (event.target instanceof Element) {
+                    shownDelegates.delete(event.target);
+                }
+            };
+            element.addEventListener("inserted.bs.tooltip", onDelegateShown);
+            element.addEventListener("hidden.bs.tooltip", onDelegateHidden);
+
+            // A MutationObserver catches the removal the moment it happens, rather than
+            // depending on this hook's own cleanup running again — which a grid re-render
+            // triggered by its own state, not by `elRef`/`config` changing, never causes.
+            const delegateObserver = new MutationObserver(() => {
+                for (const target of shownDelegates) {
+                    if (target.isConnected) continue;
+                    const instance = Tooltip.getInstance(target);
+                    if (instance) {
+                        // Reuses the bootstrap#37474 guard the patched dispose() above installs.
+                        instance.dispose();
+                    } else {
+                        // Belt-and-braces: the instance may already be gone on its own.
+                        const popupId = target.getAttribute("aria-describedby");
+                        if (popupId) {
+                            document.getElementById(popupId)?.remove();
+                        }
+                    }
+                    shownDelegates.delete(target);
+                }
+            });
+            delegateObserver.observe(element, { childList: true, subtree: true });
+
+            disposeDelegateTracking = () => {
+                delegateObserver.disconnect();
+                element.removeEventListener("inserted.bs.tooltip", onDelegateShown);
+                element.removeEventListener("hidden.bs.tooltip", onDelegateHidden);
+            };
+        }
+
         return () => {
+            disposeDelegateTracking();
             element.removeEventListener("click", dismissOnPress);
             tooltips.delete(tooltip);
             // Dispose even when the trigger element is already detached (e.g. a keyed remount


### PR DESCRIPTION
## Why

Fixes #10680. Since 0.104.0, hovering a tile in the note icon picker and then typing in its search box (or scrolling the grid) leaves the tile's tooltip stuck on screen until the app is restarted.

A delegated (`selector:`) `useStaticTooltip` config spawns a per-child Bootstrap Tooltip instance that only hides on that child's own `mouseleave`. Typing in the picker search re-renders the react-window grid and replaces the hovered span (keyed by icon id), so no `mouseleave` ever fires; the per-span instance never hides and its popup is orphaned as a direct child of `document.body`. The scoped `[aria-describedby]` cleanup sweep cannot see a trigger that already left the container, and the grid re-render never re-runs the hook's effect at all. The leak predates 0.104.0, but until 95b244e0c6 replaced the blanket `.tooltip` sweep (which had its own collateral damage) it was invisibly wiped whenever the picker closed - which is why the report starts at 0.104.0.

Reproduced live on main (964e23ec56) before the fix and verified gone after it: hover a tile, type in the search box, the popup previously survived closing the picker and everything short of a reload.

## What

In `useStaticTooltip`, for delegated configs only:

- track which delegate triggers currently show a popup via the bubbled `inserted.bs.tooltip` / `hidden.bs.tooltip` container events;
- watch the container with a `MutationObserver` (`childList` + `subtree`); a tracked trigger found disconnected has its instance disposed - `dispose()` also removes a currently-shown popup, the same property the earlier #10567 fix relies on, and the existing twbs/bootstrap#37474 dispose patch guards the pending-callback crash - with a fallback removal by `aria-describedby` id;
- disconnect the observer and listeners in the effect cleanup; the existing scoped sweep is untouched (it still covers container-unmount-while-child-attached, which the observer does not).

Fixing at the hook covers every delegated user (icon picker, MIME type list, ...) including the hover-then-scroll variant, rather than patching the icon picker alone.

## Validation

- New regression test "removes an orphaned popup when a delegated tooltip's hovered child is removed without a mouseleave (#10680)" in `hooks.spec.tsx`, driving the keyed-remount scenario with a render-stable delegated config (an inline config would re-run the effect and exercise the old sweep instead). Verified the test fails without the `hooks.tsx` change.
- `pnpm --filter client test hooks.spec`: 22/22 passed.
- `pnpm typecheck`: no errors.
- Live end-to-end check on a dev server: the repro sequence above no longer leaves a popup behind.

## Scope

Only `apps/client/src/widgets/react/hooks.tsx` and its spec. No behavior change for non-delegated tooltips.
