### PR TITLE
fix(text editor): anchor reference-link insertion at the mention pick position

### DIFF
--- a/packages/ckeditor5/src/plugins/referencelink.spec.ts
+++ b/packages/ckeditor5/src/plugins/referencelink.spec.ts
@@ -1,4 +1,4 @@
-import { _getViewData as getViewData, _setModelData as setModelData, ClassicEditor, Essentials, LinkEditing, Paragraph } from "ckeditor5";
+import { _getModelData as getModelData, _getViewData as getViewData, _setModelData as setModelData, ClassicEditor, Essentials, LinkEditing, Paragraph } from "ckeditor5";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestEditor } from "../../test/editor-kit.js";
@@ -59,6 +59,88 @@ describe("ReferenceLink", () => {
 
         expect(getReferenceLinkTitle).not.toHaveBeenCalled();
         expect(findReference(editor)).toBeUndefined();
+    });
+
+    describe("anchored insertion during the title fetch (#10663)", () => {
+        let resolveTitle: () => void = () => {};
+
+        beforeEach(() => {
+            getReferenceLinkTitle.mockImplementation(
+                () =>
+                    new Promise<void>((resolve) => {
+                        resolveTitle = resolve;
+                    })
+            );
+        });
+
+        it("inserts at the position captured at execute time even when typing continues during the fetch", async () => {
+            setModelData(editor.model, "<paragraph>foo[]</paragraph>");
+
+            editor.execute("referenceLink", { href: "#root/noteAbc" });
+
+            // Simulate the user continuing to type while the title fetch is still pending.
+            editor.execute("insertText", { text: " BBB" });
+
+            resolveTitle();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            const data = getModelData(editor.model, { withoutSelection: true });
+            expect(data).toBe('<paragraph>foo<reference href="#root/noteAbc"></reference> BBB</paragraph>');
+
+            // The caret must stay where typing left it, not get yanked back onto the reference.
+            const selection = editor.model.document.selection;
+            const reference = findReference(editor);
+            expect(reference).toBeDefined();
+            if (!reference) {
+                return;
+            }
+            const afterReference = editor.model.createPositionAfter(reference);
+            expect(selection.getFirstPosition()?.isEqual(afterReference)).toBe(false);
+        });
+
+        it("puts the caret after the link when the selection has not moved during the fetch", async () => {
+            setModelData(editor.model, "<paragraph>foo[]</paragraph>");
+
+            editor.execute("referenceLink", { href: "#root/noteAbc" });
+
+            resolveTitle();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            const reference = findReference(editor);
+            expect(reference).toBeDefined();
+            if (!reference) {
+                return;
+            }
+
+            const selection = editor.model.document.selection;
+            expect(selection.isCollapsed).toBe(true);
+            const afterReference = editor.model.createPositionAfter(reference);
+            expect(selection.getFirstPosition()?.isEqual(afterReference)).toBe(true);
+        });
+
+        it("does not insert when the picked context was deleted during the fetch", async () => {
+            setModelData(editor.model, "<paragraph>foo[]</paragraph>");
+
+            editor.execute("referenceLink", { href: "#root/noteAbc" });
+
+            const root = editor.model.document.getRoot();
+            expect(root).toBeDefined();
+            if (root) {
+                editor.model.change((writer) => {
+                    for (const child of Array.from(root.getChildren())) {
+                        writer.remove(child);
+                    }
+                });
+            }
+
+            resolveTitle();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(findReference(editor)).toBeUndefined();
+        });
     });
 
     it("is enabled where text is allowed and disabled where it is not", () => {

--- a/packages/ckeditor5/src/plugins/referencelink.ts
+++ b/packages/ckeditor5/src/plugins/referencelink.ts
@@ -1,4 +1,4 @@
-import { Command, ModelElement, LinkEditing, Plugin, toWidget, viewToModelPositionOutsideModelElement, Widget } from "ckeditor5";
+import { Command, ModelElement, ModelLivePosition, LinkEditing, Plugin, toWidget, viewToModelPositionOutsideModelElement, Widget } from "ckeditor5";
 
 export default class ReferenceLink extends Plugin {
 	static get requires() {
@@ -15,17 +15,41 @@ class ReferenceLinkCommand extends Command {
 
 		const editor = this.editor;
 
+		const selectionPosition = editor.model.document.selection.getFirstPosition();
+		if (!selectionPosition) {
+			return;
+		}
+
+		// Fetching the title can be a network round trip (froca cache miss), and the
+		// user keeps typing while we wait. Anchor the insertion at the position
+		// captured here rather than wherever the caret ends up at resolve time (#10663).
+		const insertionPosition = ModelLivePosition.fromPosition(selectionPosition, 'toPrevious');
+
 		// make sure the referenced note is in cache before adding the reference element
 		glob.getReferenceLinkTitle(href).then(() => {
+			if (insertionPosition.root.rootName === '$graveyard') {
+				// The context the user picked in was deleted while the title loaded.
+				return;
+			}
+
+			const currentSelection = editor.model.document.selection;
+			const selectionUntouched = currentSelection.isCollapsed
+				&& (currentSelection.getFirstPosition()?.isEqual(insertionPosition) ?? false);
+
 			editor.model.change(writer => {
 				const placeholder = writer.createElement('reference', {href});
 
 				// ... and insert it into the document.
-				editor.model.insertContent(placeholder);
+				editor.model.insertContent(placeholder, insertionPosition);
 
-				// Put the selection on the inserted element.
-				writer.setSelection(placeholder, 'after');
+				// Put the selection on the inserted element, but only if the user hasn't
+				// moved on while we were waiting for the title.
+				if (selectionUntouched) {
+					writer.setSelection(placeholder, 'after');
+				}
 			});
+		}).finally(() => {
+			insertionPosition.detach();
 		});
 	}
 


### PR DESCRIPTION
## Why

Fixes #10663. Picking an `@`-mention and continuing to type could interleave or duplicate the text around the inserted note link, reported on Android but not Android-specific.

`ReferenceLinkCommand.execute` is async: the mention command synchronously deletes the typed `@query`, then the command awaits `getReferenceLinkTitle(href)` - a real network round trip when the target note is not in the froca cache - and called `insertContent(placeholder)` with no position. The link therefore landed at wherever the caret was when the fetch resolved. Reproduced deterministically on desktop (main 964e23ec56, web client, 2000 ms injected latency, froca-cold target): typing `AAA @Themes`, picking the note, and immediately typing ` BBB CCC DDD` settled as `AAA  BBB CCC DDD[Themes-link]` - the link after the typed text - and in one variant the link never visibly materialized because the insertion context was gone. On a slow Android link the same gap, amplified by IME composition, is the plausible route to the reported duplicated text. Details in the triage comment on the issue.

## What

In `ReferenceLinkCommand.execute`:

- capture a `ModelLivePosition` (stickiness `toPrevious`) from the document selection before starting the title fetch, so text typed during the fetch lands after the anchor and the link keeps the spot where the mention was picked;
- insert the reference at that anchored position instead of the live caret;
- skip the insertion when the anchor has been transformed into the graveyard (the paragraph the user picked in was deleted while the title loaded);
- move the caret onto the link (`setSelection(placeholder, "after")`, the previous behavior) only when the selection has not moved during the fetch - a user who kept typing keeps their caret;
- detach the live position on both resolve and reject.

Every current caller executes this command with a collapsed selection: the mention pick deletes the query first, and the Add link dialog only offers the reference-link type when nothing is selected (`add_link.tsx` defaults a selection to hyper-link and hides the radio group). The anchored insertion preserves that contract; behavior with a hypothetical future non-collapsed caller is to insert before the selected text rather than replace it, which is the conservative choice.

With the fix, the same throttled protocol settles as `AAA [Themes-link] BBB CCC DDD`, verified end to end on a dev server.

## Validation

- Three new tests in `referencelink.spec.ts` under "anchored insertion during the title fetch (#10663)": link inserted at the captured position while typing continues (with the caret left where typing put it), caret still placed after the link in the no-typing flow, and no insertion when the picked context was deleted mid-fetch.
- `pnpm --filter ckeditor5 test referencelink`: 12/12 passed. `pnpm --filter ckeditor5 test mention_customization`: 6/6 passed. `pnpm typecheck`: no errors.
- Live throttled repro before/after on a dev server as described above.

## Scope

Only `packages/ckeditor5/src/plugins/referencelink.ts` and its spec. The Android-device confirmation of the original duplication symptom is still outstanding; this fixes the confirmed underlying race.
