### PR TITLE
CardDAV address book server as a backend script (prototype)

### DIFF
--- a/apps/script-deployer/scripts/carddav.ts
+++ b/apps/script-deployer/scripts/carddav.ts
@@ -1,0 +1,989 @@
+/**
+ * @trilium-script
+ *
+ * id: carddav
+ * type: backend
+ * title: CardDAV Address Book Server
+ * customRequestHandler: carddav(/.*)?
+ */
+
+/*
+ * A CardDAV server implemented entirely as a Trilium backend script, exposing address book
+ * notes to CardDAV clients (DAVx⁵, iOS/macOS Contacts, Thunderbird) at /custom/carddav/.
+ *
+ * Data model — "one note per contact":
+ * - An address book is any note carrying #carddavAddressBook. One named "Contacts" is created
+ *   under the root on first use, as a `book` collection with table view and inheritable
+ *   promoted attribute definitions, so contacts edit nicely in the Trilium UI too.
+ * - A contact is a child note of an address book. vCard properties map to labels (#email,
+ *   #phone, #firstName, ...), FN maps to the note title and NOTE to the note content, so
+ *   contacts are searchable (`#email *=* "@acme.com"`) and cloneable like any other note.
+ *
+ * Authentication: HTTP Basic. The password is the value of #carddavPassword on this script
+ * note; the username is ignored. Requests are refused until that label is set.
+ *
+ * Protocol subset: OPTIONS, PROPFIND (depth 0/1), REPORT (addressbook-query and
+ * addressbook-multiget), GET, PUT, DELETE — the set DAVx⁵ and Apple clients need for
+ * two-way sync. No sync-collection REPORT (clients fall back to CTag polling) and no
+ * /.well-known/carddav (scripts cannot register routes outside /custom, so the client must
+ * be configured with the base URL directly).
+ */
+
+const BASE_PATH = "/custom/carddav";
+const DAV_CAPABILITIES = "1, 3, addressbook";
+const VCARD_CONTENT_TYPE = "text/vcard; charset=utf-8";
+const XML_CONTENT_TYPE = "application/xml; charset=utf-8";
+const ADDRESS_BOOK_LABEL = "carddavAddressBook";
+const PASSWORD_LABEL = "carddavPassword";
+
+/** vCard property name → contact note label, for single-valued properties. */
+const SINGLE_VALUE_LABELS: Record<string, string> = {
+    ORG: "organization",
+    TITLE: "jobTitle",
+    BDAY: "birthday",
+    URL: "website"
+};
+
+/** vCard property name → contact note label, for properties that repeat. */
+const MULTI_VALUE_LABELS: Record<string, string> = {
+    EMAIL: "email",
+    TEL: "phone"
+};
+
+/**
+ * Properties handled structurally (not via the two maps above). Anything outside this set
+ * and the maps is preserved verbatim in #vcardExtra so foreign clients' data survives a
+ * round trip — except PHOTO, whose inline base64 payload is too large for an attribute.
+ */
+const STRUCTURAL_PROPERTIES = new Set([
+    "BEGIN", "END", "VERSION", "PRODID", "REV", "UID", "FN", "N", "ADR", "NOTE", "CATEGORIES",
+    "PHOTO"
+]);
+
+interface VCardProperty {
+    name: string;
+    params: string[];
+    value: string;
+    rawLine: string;
+}
+
+type ScriptNote = NonNullable<ReturnType<typeof api.getNote>>;
+
+main();
+
+function main() {
+    const req = api.req;
+    const res = api.res;
+
+    if (!req || !res) {
+        throw new Error("carddav: not invoked as a custom request handler");
+    }
+
+    res.setHeader("DAV", DAV_CAPABILITIES);
+
+    try {
+        if (!checkAuthorization()) {
+            return;
+        }
+        dispatch();
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        api.log(`carddav: ${req.method} ${req.path} failed: ${message}`);
+        if (!res.headersSent) {
+            res.status(500).setHeader("Content-Type", "text/plain").send(message);
+        }
+    }
+}
+
+// ── Authentication ───────────────────────────────────────────────────────────
+
+function checkAuthorization(): boolean {
+    const req = api.req;
+    const res = api.res;
+    if (!req || !res) {
+        return false;
+    }
+
+    if (req.method === "OPTIONS") {
+        // Clients probe capabilities before authenticating.
+        return true;
+    }
+
+    const expected = api.currentNote.getLabelValue(PASSWORD_LABEL);
+    if (!expected) {
+        res.status(403).setHeader("Content-Type", "text/plain")
+            .send(`CardDAV is not configured: set #${PASSWORD_LABEL} on the script note.`);
+        return false;
+    }
+
+    const header = req.headers.authorization ?? "";
+    const [ scheme, encoded ] = header.split(" ");
+    if (scheme?.toLowerCase() === "basic" && encoded) {
+        const decoded = decodeBase64(encoded);
+        const colon = decoded.indexOf(":");
+        const password = colon === -1 ? decoded : decoded.slice(colon + 1);
+        if (constantTimeEquals(password, expected)) {
+            return true;
+        }
+    }
+
+    res.status(401)
+        .setHeader("WWW-Authenticate", 'Basic realm="Trilium CardDAV"')
+        .setHeader("Content-Type", "text/plain")
+        .send("Authentication required.");
+    return false;
+}
+
+/**
+ * Best-effort constant-time comparison. Scripts cannot require node:crypto (module
+ * blocklist) and cannot await crypto.subtle (backend scripts are synchronous), so
+ * timingSafeEqual is out of reach — this XOR fold is the scriptable approximation.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+    let diff = a.length === b.length ? 0 : 1;
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        diff |= (a.charCodeAt(i % Math.max(a.length, 1)) || 0)
+            ^ (b.charCodeAt(i % Math.max(b.length, 1)) || 0);
+    }
+    return diff === 0;
+}
+
+function decodeBase64(encoded: string): string {
+    // Scripts run in Node, where atob exists but Buffer decoding handles UTF-8 correctly.
+    // Buffer is a global, so no blocked module import is needed.
+    try {
+        return Buffer.from(encoded, "base64").toString("utf-8");
+    } catch {
+        return "";
+    }
+}
+
+// ── Routing ──────────────────────────────────────────────────────────────────
+
+function dispatch() {
+    const req = api.req;
+    const res = api.res;
+    if (!req || !res) {
+        return;
+    }
+
+    const method = req.method.toUpperCase();
+    const segments = req.path.slice(BASE_PATH.length).split("/").filter((s) => s.length > 0);
+
+    if (method === "OPTIONS") {
+        res.setHeader("Allow", "OPTIONS, PROPFIND, REPORT, GET, PUT, DELETE").status(200).send("");
+        return;
+    }
+
+    // /custom/carddav[/]              → service root
+    // /custom/carddav/principal/      → the (single) principal
+    // /custom/carddav/addressbooks/   → address book home set
+    // /custom/carddav/addressbooks/<bookNoteId>/            → one address book
+    // /custom/carddav/addressbooks/<bookNoteId>/<name>.vcf  → one contact
+    if (segments.length === 0) {
+        handleServiceRoot(method);
+    } else if (segments[0] === "principal" && segments.length === 1) {
+        handlePrincipal(method);
+    } else if (segments[0] === "addressbooks" && segments.length === 1) {
+        handleHomeSet(method);
+    } else if (segments[0] === "addressbooks" && segments.length === 2) {
+        handleAddressBook(method, segments[1]);
+    } else if (segments[0] === "addressbooks" && segments.length === 3) {
+        handleContact(method, segments[1], segments[2]);
+    } else {
+        res.status(404).setHeader("Content-Type", "text/plain").send("Unknown CardDAV path.");
+    }
+}
+
+function handleServiceRoot(method: string) {
+    const res = api.res;
+    if (!res) {
+        return;
+    }
+    if (method !== "PROPFIND") {
+        methodNotAllowed();
+        return;
+    }
+
+    const props = requestedProperties();
+    sendMultistatus([
+        propfindResponse(`${BASE_PATH}/`, props, {
+            "resourcetype": "<d:collection/>",
+            "current-user-principal": href(`${BASE_PATH}/principal/`),
+            "displayname": xmlEscape("Trilium CardDAV")
+        })
+    ]);
+}
+
+function handlePrincipal(method: string) {
+    if (method !== "PROPFIND") {
+        methodNotAllowed();
+        return;
+    }
+
+    const props = requestedProperties();
+    sendMultistatus([
+        propfindResponse(`${BASE_PATH}/principal/`, props, {
+            "resourcetype": "<d:collection/><d:principal/>",
+            "current-user-principal": href(`${BASE_PATH}/principal/`),
+            "principal-URL": href(`${BASE_PATH}/principal/`),
+            "displayname": xmlEscape("Trilium user"),
+            "addressbook-home-set": href(`${BASE_PATH}/addressbooks/`)
+        })
+    ]);
+}
+
+function handleHomeSet(method: string) {
+    if (method !== "PROPFIND") {
+        methodNotAllowed();
+        return;
+    }
+
+    const props = requestedProperties();
+    const responses = [
+        propfindResponse(`${BASE_PATH}/addressbooks/`, props, {
+            resourcetype: "<d:collection/>",
+            displayname: xmlEscape("Address books")
+        })
+    ];
+
+    if (depth() >= 1) {
+        for (const book of getAddressBooks()) {
+            responses.push(addressBookResponse(book, props));
+        }
+    }
+
+    sendMultistatus(responses);
+}
+
+function handleAddressBook(method: string, bookNoteId: string) {
+    const res = api.res;
+    if (!res) {
+        return;
+    }
+
+    const book = getAddressBooks().find((b) => b.noteId === bookNoteId);
+    if (!book) {
+        res.status(404).setHeader("Content-Type", "text/plain").send("No such address book.");
+        return;
+    }
+
+    if (method === "PROPFIND") {
+        const props = requestedProperties();
+        const responses = [ addressBookResponse(book, props) ];
+        if (depth() >= 1) {
+            for (const contact of book.getChildNotes()) {
+                responses.push(contactResponse(book, contact, props, false));
+            }
+        }
+        sendMultistatus(responses);
+    } else if (method === "REPORT") {
+        handleReport(book);
+    } else {
+        methodNotAllowed();
+    }
+}
+
+function handleReport(book: ScriptNote) {
+    const res = api.res;
+    const body = typeof api.req?.body === "string" ? api.req.body : "";
+    if (!res) {
+        return;
+    }
+
+    const parsed = body.trim() ? parseXml(body) : null;
+    const rootName = parsed ? Object.keys(parsed)[0] : "";
+    const root = parsed ? parsed[rootName] : null;
+    const wantsAddressData = xmlRequestsAddressData(root);
+
+    if (rootName === "addressbook-multiget") {
+        const hrefs: string[] = collectXmlText(root, "href");
+        const responses = hrefs.map((rawHref) => {
+            const base = contactBasename(rawHref);
+            const contact = base === null ? null : findContact(book, base);
+            if (!contact) {
+                return `<d:response>${href(normalizeHref(rawHref))}`
+                    + "<d:status>HTTP/1.1 404 Not Found</d:status></d:response>";
+            }
+            const props = [ "getetag", ...(wantsAddressData ? [ "address-data" ] : []) ];
+            return contactResponse(book, contact, props, wantsAddressData);
+        });
+        sendMultistatus(responses);
+    } else if (rootName === "addressbook-query") {
+        // Filters are not evaluated — the full collection is returned and the client narrows.
+        const props = [ "getetag", ...(wantsAddressData ? [ "address-data" ] : []) ];
+        const responses = book.getChildNotes().map((contact) =>
+            contactResponse(book, contact, props, wantsAddressData));
+        sendMultistatus(responses);
+    } else {
+        res.status(403).setHeader("Content-Type", XML_CONTENT_TYPE)
+            .send(`<?xml version="1.0" encoding="utf-8"?>`
+                + `<d:error xmlns:d="DAV:"><d:supported-report/></d:error>`);
+    }
+}
+
+function handleContact(method: string, bookNoteId: string, filename: string) {
+    const res = api.res;
+    if (!res) {
+        return;
+    }
+
+    const book = getAddressBooks().find((b) => b.noteId === bookNoteId);
+    const base = filename.endsWith(".vcf") ? filename.slice(0, -4) : filename;
+    if (!book || !base) {
+        res.status(404).setHeader("Content-Type", "text/plain").send("No such address book.");
+        return;
+    }
+
+    const contact = findContact(book, base);
+
+    if (method === "GET" || method === "HEAD") {
+        if (!contact) {
+            res.status(404).setHeader("Content-Type", "text/plain").send("No such contact.");
+            return;
+        }
+        res.status(200)
+            .setHeader("Content-Type", VCARD_CONTENT_TYPE)
+            .setHeader("ETag", contactEtag(contact))
+            .send(method === "HEAD" ? "" : serializeContact(contact));
+    } else if (method === "PUT") {
+        handlePut(book, contact, base);
+    } else if (method === "DELETE") {
+        if (!contact) {
+            res.status(404).setHeader("Content-Type", "text/plain").send("No such contact.");
+            return;
+        }
+        api.transactional(() => contact.deleteNote());
+        res.status(204).send("");
+    } else if (method === "PROPFIND") {
+        if (!contact) {
+            res.status(404).setHeader("Content-Type", "text/plain").send("No such contact.");
+            return;
+        }
+        sendMultistatus([ contactResponse(book, contact, requestedProperties(), false) ]);
+    } else {
+        methodNotAllowed();
+    }
+}
+
+function handlePut(book: ScriptNote, existing: ScriptNote | null, base: string) {
+    const req = api.req;
+    const res = api.res;
+    if (!req || !res) {
+        return;
+    }
+
+    const body = typeof req.body === "string" ? req.body : "";
+    if (!/BEGIN:VCARD/i.test(body)) {
+        res.status(400).setHeader("Content-Type", "text/plain")
+            .send("Request body is not a vCard.");
+        return;
+    }
+
+    const ifMatch = req.headers["if-match"];
+    const ifNoneMatch = req.headers["if-none-match"];
+    if (ifNoneMatch === "*" && existing) {
+        res.status(412).setHeader("Content-Type", "text/plain").send("Contact already exists.");
+        return;
+    }
+    const etagMismatch = !existing
+        || stripWeakPrefix(ifMatch ?? "") !== stripWeakPrefix(contactEtag(existing));
+    if (typeof ifMatch === "string" && etagMismatch) {
+        res.status(412).setHeader("Content-Type", "text/plain").send("ETag mismatch.");
+        return;
+    }
+
+    const properties = parseVCard(body);
+    let contact: ScriptNote | null = existing;
+
+    api.transactional(() => {
+        if (!contact) {
+            const created = api.createNewNote({
+                parentNoteId: book.noteId,
+                title: contactTitle(properties),
+                content: "",
+                type: "text"
+            });
+            contact = created.note as unknown as ScriptNote;
+            contact.setLabel("carddavHref", base);
+        }
+        applyVCard(contact, properties, base);
+    });
+
+    if (!contact) {
+        res.status(500).setHeader("Content-Type", "text/plain").send("Contact creation failed.");
+        return;
+    }
+
+    res.status(existing ? 204 : 201)
+        .setHeader("ETag", contactEtag(contact))
+        .send("");
+}
+
+function methodNotAllowed() {
+    api.res?.status(405)
+        .setHeader("Allow", "OPTIONS, PROPFIND, REPORT, GET, PUT, DELETE")
+        .setHeader("Content-Type", "text/plain")
+        .send("Method not supported on this resource.");
+}
+
+// ── Address book and contact lookup ──────────────────────────────────────────
+
+function getAddressBooks(): ScriptNote[] {
+    const books = api.getNotesWithLabel(ADDRESS_BOOK_LABEL);
+    if (books.length > 0) {
+        return books;
+    }
+    return [ createDefaultAddressBook() ];
+}
+
+/**
+ * First-use provisioning: a `book` collection with table view whose inheritable promoted
+ * attribute definitions mirror the vCard mapping, so contacts synced from a phone edit
+ * nicely in the Trilium UI (email/phone fields render mailto/tel action buttons).
+ */
+function createDefaultAddressBook(): ScriptNote {
+    return api.transactional(() => {
+        const { note } = api.createNewNote({
+            parentNoteId: "root",
+            title: "Contacts",
+            content: "",
+            type: "book"
+        });
+        const book = note as unknown as ScriptNote;
+        book.setLabel(ADDRESS_BOOK_LABEL);
+        book.setLabel("viewType", "table");
+        book.setLabel("hidePromotedAttributes");
+        const definitions: [string, string][] = [
+            [ "label:firstName", "promoted,alias=First name,single,text" ],
+            [ "label:lastName", "promoted,alias=Last name,single,text" ],
+            [ "label:email", "promoted,alias=Email,multi,email" ],
+            [ "label:phone", "promoted,alias=Phone,multi,phone" ],
+            [ "label:organization", "promoted,alias=Organization,single,text" ],
+            [ "label:jobTitle", "promoted,alias=Job title,single,text" ],
+            [ "label:birthday", "promoted,alias=Birthday,single,date" ],
+            [ "label:website", "promoted,alias=Website,single,url" ],
+            [ "label:address", "promoted,alias=Address,single,text" ],
+            [ "label:category", "promoted,alias=Groups,multi,text" ]
+        ];
+        for (const [ name, value ] of definitions) {
+            attachInheritableLabel(book, name, value);
+        }
+        api.log(`carddav: created default address book note '${book.noteId}'`);
+        return book;
+    });
+}
+
+/**
+ * setLabel() cannot create inheritable attributes, so definition labels go through the
+ * underlying entity API. The cast reaches past ScriptBNote, which does not expose
+ * addAttribute — one of the scripting gaps this prototype documents.
+ */
+function attachInheritableLabel(note: ScriptNote, name: string, value: string) {
+    const entity = note as unknown as {
+        addAttribute(type: string, name: string, value?: string, isInheritable?: boolean): unknown;
+    };
+    entity.addAttribute("label", name, value, true);
+}
+
+function findContact(book: ScriptNote, base: string): ScriptNote | null {
+    const direct = api.getNote(base) as unknown as ScriptNote | null;
+    if (direct && direct.getParentNotes().some((parent) => parent.noteId === book.noteId)) {
+        return direct;
+    }
+    for (const child of book.getChildNotes()) {
+        if (child.getLabelValue("carddavHref") === base
+            || child.getLabelValue("vcardUid") === base) {
+            return child;
+        }
+    }
+    return null;
+}
+
+function contactHref(book: ScriptNote, contact: ScriptNote): string {
+    const base = contact.getLabelValue("carddavHref") ?? contact.noteId;
+    return `${BASE_PATH}/addressbooks/${book.noteId}/${encodeURIComponent(base)}.vcf`;
+}
+
+// ── ETag / CTag ──────────────────────────────────────────────────────────────
+
+/**
+ * Changes whenever the note's content (blobId), metadata (utcDateModified) or any owned
+ * attribute changes — the three ways a contact can be edited from the Trilium side.
+ */
+function contactEtag(contact: ScriptNote): string {
+    let fingerprint = `${contact.noteId}|${contact.utcDateModified}|${contact.blobId}`;
+    for (const attribute of contact.getOwnedAttributes()) {
+        fingerprint += `|${attribute.name}=${attribute.value}@${attribute.utcDateModified}`;
+    }
+    return `"${fnv1a(fingerprint)}"`;
+}
+
+function addressBookCtag(book: ScriptNote): string {
+    let fingerprint = `${book.noteId}|${book.utcDateModified}`;
+    for (const contact of book.getChildNotes()) {
+        fingerprint += `|${contactEtag(contact)}`;
+    }
+    return fnv1a(fingerprint);
+}
+
+function fnv1a(input: string): string {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < input.length; i++) {
+        hash ^= input.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(16).padStart(8, "0");
+}
+
+function stripWeakPrefix(etag: string): string {
+    return etag.startsWith("W/") ? etag.slice(2) : etag;
+}
+
+// ── PROPFIND / REPORT plumbing ───────────────────────────────────────────────
+
+function depth(): number {
+    const raw = api.req?.headers["depth"];
+    if (raw === "0") {
+        return 0;
+    }
+    return 1; // "1", "infinity" and a missing header all behave as 1 here.
+}
+
+/** Property names requested in the PROPFIND body; a default set when absent or allprop. */
+function requestedProperties(): string[] {
+    const body = typeof api.req?.body === "string" ? api.req.body : "";
+    const fallback = [ "resourcetype", "displayname", "current-user-principal", "getetag",
+        "getctag" ];
+    if (!body.trim()) {
+        return fallback;
+    }
+    try {
+        const parsed = parseXml(body);
+        const prop = parsed?.propfind?.prop?.[0];
+        if (!prop || typeof prop !== "object") {
+            return fallback;
+        }
+        return Object.keys(prop);
+    } catch {
+        return fallback;
+    }
+}
+
+function propfindResponse(
+    path: string, requested: string[], available: Record<string, string>
+): string {
+    const found: string[] = [];
+    const missing: string[] = [];
+
+    for (const name of requested) {
+        if (name in available) {
+            found.push(`<${qualify(name)}>${available[name]}</${qualify(name)}>`);
+        } else {
+            missing.push(`<${qualify(name)}/>`);
+        }
+    }
+
+    let out = `<d:response>${href(path)}`;
+    if (found.length > 0) {
+        out += `<d:propstat><d:prop>${found.join("")}</d:prop>`
+            + "<d:status>HTTP/1.1 200 OK</d:status></d:propstat>";
+    }
+    if (missing.length > 0) {
+        out += `<d:propstat><d:prop>${missing.join("")}</d:prop>`
+            + "<d:status>HTTP/1.1 404 Not Found</d:status></d:propstat>";
+    }
+    return `${out}</d:response>`;
+}
+
+function addressBookResponse(book: ScriptNote, props: string[]): string {
+    return propfindResponse(`${BASE_PATH}/addressbooks/${book.noteId}/`, props, {
+        "resourcetype": "<d:collection/><card:addressbook/>",
+        "displayname": xmlEscape(book.title),
+        "getctag": addressBookCtag(book),
+        "supported-report-set":
+            "<d:supported-report><d:report><card:addressbook-query/></d:report>"
+            + "</d:supported-report>"
+            + "<d:supported-report><d:report><card:addressbook-multiget/></d:report>"
+            + "</d:supported-report>",
+        "supported-address-data":
+            '<card:address-data-type content-type="text/vcard" version="3.0"/>',
+        "current-user-privilege-set":
+            "<d:privilege><d:read/></d:privilege><d:privilege><d:write/></d:privilege>",
+        "addressbook-description": xmlEscape(book.title)
+    });
+}
+
+function contactResponse(
+    book: ScriptNote, contact: ScriptNote, props: string[], includeAddressData: boolean
+): string {
+    const available: Record<string, string> = {
+        resourcetype: "",
+        displayname: xmlEscape(contact.title),
+        getetag: xmlEscape(contactEtag(contact)),
+        getcontenttype: VCARD_CONTENT_TYPE
+    };
+    if (includeAddressData || props.includes("address-data")) {
+        available["address-data"] = xmlEscape(serializeContact(contact));
+    }
+    return propfindResponse(contactHref(book, contact), props, available);
+}
+
+function sendMultistatus(responses: string[]) {
+    const xml = `<?xml version="1.0" encoding="utf-8"?>` +
+        `<d:multistatus xmlns:d="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav"`
+        + ` xmlns:cs="http://calendarserver.org/ns/">` +
+        responses.join("") +
+        `</d:multistatus>`;
+    api.res?.status(207).setHeader("Content-Type", XML_CONTENT_TYPE).send(xml);
+}
+
+/** Namespace-qualifies a property name for response XML. */
+function qualify(name: string): string {
+    const carddav = new Set([
+        "addressbook-home-set", "address-data", "supported-address-data", "addressbook-description"
+    ]);
+    if (carddav.has(name)) {
+        return `card:${name}`;
+    }
+    if (name === "getctag") {
+        return "cs:getctag";
+    }
+    return `d:${name}`;
+}
+
+function href(path: string): string {
+    return `<d:href>${xmlEscape(path)}</d:href>`;
+}
+
+function xmlEscape(value: string): string {
+    return value
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;");
+}
+
+/** Extracts the contact basename from a client-supplied href (absolute URLs included). */
+function contactBasename(rawHref: string): string | null {
+    const path = normalizeHref(rawHref);
+    const match = path.match(/\/([^/]+)\.vcf$/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
+function normalizeHref(rawHref: string): string {
+    return rawHref.replace(/^https?:\/\/[^/]+/, "");
+}
+
+/** xml2js invokes its callback synchronously (async:false default), so this works untangled. */
+function parseXml(xml: string): Record<string, any> {
+    let output: Record<string, any> | null = null;
+    let failure: Error | null = null;
+    api.xml2js.parseString(
+        xml,
+        { tagNameProcessors: [ api.xml2js.processors.stripPrefix ] },
+        (err: Error | null, result: Record<string, any>) => {
+            failure = err;
+            output = result;
+        }
+    );
+    if (failure) {
+        throw failure;
+    }
+    if (!output) {
+        throw new Error("XML parser did not complete synchronously.");
+    }
+    return output;
+}
+
+function xmlRequestsAddressData(root: any): boolean {
+    const prop = root?.prop?.[0];
+    return Boolean(prop && typeof prop === "object" && "address-data" in prop);
+}
+
+/** Depth-first search for all text nodes of the given (namespace-stripped) element name. */
+function collectXmlText(node: any, name: string): string[] {
+    const out: string[] = [];
+    walk(node);
+    return out;
+
+    function walk(current: any) {
+        if (current === null || typeof current !== "object") {
+            return;
+        }
+        for (const [ key, value ] of Object.entries(current)) {
+            if (key === name && Array.isArray(value)) {
+                for (const entry of value) {
+                    if (typeof entry === "string") {
+                        out.push(entry);
+                    } else if (entry && typeof entry === "object" && typeof entry._ === "string") {
+                        out.push(entry._);
+                    }
+                }
+            } else if (Array.isArray(value)) {
+                value.forEach(walk);
+            }
+        }
+    }
+}
+
+// ── vCard parsing ────────────────────────────────────────────────────────────
+
+function parseVCard(text: string): VCardProperty[] {
+    const unfolded = text.replace(/\r?\n[ \t]/g, "");
+    const properties: VCardProperty[] = [];
+
+    for (const line of unfolded.split(/\r?\n/)) {
+        if (!line.trim()) {
+            continue;
+        }
+        const colon = findUnescaped(line, ":");
+        if (colon === -1) {
+            continue;
+        }
+        const nameAndParams = line.slice(0, colon);
+        const value = line.slice(colon + 1);
+        const parts = splitUnescaped(nameAndParams, ";");
+        // Group prefixes (item1.EMAIL) are stripped for mapping; the raw line keeps them.
+        const bareName = parts[0].replace(/^[^.]+\./, "").toUpperCase();
+        properties.push({ name: bareName, params: parts.slice(1), value, rawLine: line });
+    }
+
+    return properties;
+}
+
+function findUnescaped(text: string, char: string): number {
+    for (let i = 0; i < text.length; i++) {
+        if (text[i] === "\\") {
+            i++;
+        } else if (text[i] === char) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+function splitUnescaped(text: string, separator: string): string[] {
+    const parts: string[] = [];
+    let current = "";
+    for (let i = 0; i < text.length; i++) {
+        if (text[i] === "\\" && i + 1 < text.length) {
+            current += text[i] + text[i + 1];
+            i++;
+        } else if (text[i] === separator) {
+            parts.push(current);
+            current = "";
+        } else {
+            current += text[i];
+        }
+    }
+    parts.push(current);
+    return parts;
+}
+
+function unescapeValue(value: string): string {
+    return value.replace(/\\(.)/g, (_, ch: string) => (ch === "n" || ch === "N" ? "\n" : ch));
+}
+
+function escapeValue(value: string): string {
+    return value
+        .replaceAll("\\", "\\\\")
+        .replaceAll("\n", "\\n")
+        .replaceAll(",", "\\,")
+        .replaceAll(";", "\\;");
+}
+
+// ── vCard ⇄ note mapping ─────────────────────────────────────────────────────
+
+function contactTitle(properties: VCardProperty[]): string {
+    const fn = properties.find((p) => p.name === "FN");
+    if (fn && unescapeValue(fn.value).trim()) {
+        return unescapeValue(fn.value).trim();
+    }
+    const n = properties.find((p) => p.name === "N");
+    if (n) {
+        const [ last = "", first = "" ] = splitUnescaped(n.value, ";").map(unescapeValue);
+        const composed = `${first} ${last}`.trim();
+        if (composed) {
+            return composed;
+        }
+    }
+    return "Unnamed contact";
+}
+
+function applyVCard(contact: ScriptNote, properties: VCardProperty[], base: string) {
+    renameNote(contact, contactTitle(properties));
+
+    const managed = [
+        "firstName", "lastName", "address", "vcardUid", "vcardExtra",
+        ...Object.values(SINGLE_VALUE_LABELS),
+        ...Object.values(MULTI_VALUE_LABELS),
+        "category"
+    ];
+    for (const label of managed) {
+        for (const attribute of contact.getOwnedLabels(label)) {
+            contact.removeLabel(label, attribute.value);
+        }
+    }
+
+    const extras: string[] = [];
+
+    for (const property of properties) {
+        const single = SINGLE_VALUE_LABELS[property.name];
+        const multi = MULTI_VALUE_LABELS[property.name];
+
+        if (single) {
+            const value = unescapeValue(property.value).trim();
+            if (value) {
+                const cleaned = property.name === "ORG" ? value.replace(/;+$/, "") : value;
+                contact.setLabel(single, cleaned);
+            }
+        } else if (multi) {
+            const value = unescapeValue(property.value).trim();
+            if (value) {
+                addLabelValue(contact, multi, value);
+            }
+        } else if (property.name === "N") {
+            const [ last = "", first = "" ] = splitUnescaped(property.value, ";")
+                .map((v) => unescapeValue(v).trim());
+            if (first) {
+                contact.setLabel("firstName", first);
+            }
+            if (last) {
+                contact.setLabel("lastName", last);
+            }
+        } else if (property.name === "ADR") {
+            const joined = splitUnescaped(property.value, ";")
+                .map((v) => unescapeValue(v).trim())
+                .filter((v) => v.length > 0)
+                .join(", ");
+            if (joined) {
+                contact.setLabel("address", joined);
+            }
+        } else if (property.name === "CATEGORIES") {
+            for (const category of splitUnescaped(property.value, ",")) {
+                const value = unescapeValue(category).trim();
+                if (value) {
+                    addLabelValue(contact, "category", value);
+                }
+            }
+        } else if (property.name === "NOTE") {
+            const text = unescapeValue(property.value);
+            const html = text.split("\n").map((line) => `<p>${api.escapeHtml(line)}</p>`).join("");
+            contact.setContent(html);
+        } else if (property.name === "UID") {
+            contact.setLabel("vcardUid", unescapeValue(property.value).trim());
+        } else if (!STRUCTURAL_PROPERTIES.has(property.name)) {
+            extras.push(property.rawLine);
+        }
+    }
+
+    if (!contact.getLabelValue("vcardUid")) {
+        contact.setLabel("vcardUid", base);
+    }
+    if (extras.length > 0) {
+        contact.setLabel("vcardExtra", encodeURIComponent(extras.join("\n")));
+    }
+}
+
+/** setLabel() overwrites the first same-named label, so repeated values need the entity API. */
+function addLabelValue(note: ScriptNote, name: string, value: string) {
+    const entity = note as unknown as {
+        addAttribute(type: string, name: string, value?: string): unknown;
+    };
+    entity.addAttribute("label", name, value);
+}
+
+/** ScriptBNote exposes a writable title but no save(); another documented typing gap. */
+function renameNote(note: ScriptNote, title: string) {
+    if (note.title === title) {
+        return;
+    }
+    const entity = note as unknown as { title: string; save(): void };
+    entity.title = title;
+    entity.save();
+}
+
+function serializeContact(contact: ScriptNote): string {
+    const lines: string[] = [ "BEGIN:VCARD", "VERSION:3.0",
+        "PRODID:-//Trilium Notes//CardDAV script//EN" ];
+
+    lines.push(`UID:${escapeValue(contact.getLabelValue("vcardUid") ?? contact.noteId)}`);
+    lines.push(`FN:${escapeValue(contact.title)}`);
+
+    const first = contact.getLabelValue("firstName") ?? "";
+    const last = contact.getLabelValue("lastName") ?? "";
+    lines.push(`N:${escapeValue(last)};${escapeValue(first)};;;`);
+
+    for (const [ property, label ] of Object.entries(MULTI_VALUE_LABELS)) {
+        for (const value of contact.getLabelValues(label)) {
+            lines.push(`${property}:${escapeValue(value)}`);
+        }
+    }
+    for (const [ property, label ] of Object.entries(SINGLE_VALUE_LABELS)) {
+        const value = contact.getLabelValue(label);
+        if (value) {
+            lines.push(`${property}:${escapeValue(value)}`);
+        }
+    }
+
+    const address = contact.getLabelValue("address");
+    if (address) {
+        lines.push(`ADR:;;${escapeValue(address)};;;;`);
+    }
+
+    const categories = contact.getLabelValues("category");
+    if (categories.length > 0) {
+        lines.push(`CATEGORIES:${categories.map(escapeValue).join(",")}`);
+    }
+
+    const noteText = plainTextContent(contact);
+    if (noteText) {
+        lines.push(`NOTE:${escapeValue(noteText)}`);
+    }
+
+    const extras = contact.getLabelValue("vcardExtra");
+    if (extras) {
+        for (const raw of decodeURIComponent(extras).split("\n")) {
+            if (raw.trim()) {
+                lines.push(raw);
+            }
+        }
+    }
+
+    lines.push(`REV:${revisionTimestamp(contact)}`);
+    lines.push("END:VCARD");
+
+    return lines.map(foldLine).join("\r\n") + "\r\n";
+}
+
+function plainTextContent(contact: ScriptNote): string {
+    const content = contact.getContent();
+    if (typeof content !== "string" || !content.trim()) {
+        return "";
+    }
+    return api.unescapeHtml(
+        content
+            .replace(/<\/(p|div|li|h[1-6]|br)>/gi, "\n")
+            .replace(/<br\s*\/?>/gi, "\n")
+            .replace(/<[^>]*>/g, "")
+    ).replace(/\n{2,}/g, "\n").trim();
+}
+
+/** utcDateModified ("2026-08-17 20:14:55.123Z") → iCal basic format (20260817T201455Z). */
+function revisionTimestamp(contact: ScriptNote): string {
+    const digits = contact.utcDateModified.replace(/[^0-9]/g, "").slice(0, 14);
+    return `${digits.slice(0, 8)}T${digits.slice(8)}Z`;
+}
+
+/** RFC 6350 line folding at 75 octets (approximated as characters). */
+function foldLine(line: string): string {
+    if (line.length <= 75) {
+        return line;
+    }
+    const chunks: string[] = [ line.slice(0, 75) ];
+    for (let i = 75; i < line.length; i += 74) {
+        chunks.push(" " + line.slice(i, i + 74));
+    }
+    return chunks.join("\r\n");
+}

--- a/apps/script-deployer/scripts/probe.ts
+++ b/apps/script-deployer/scripts/probe.ts
@@ -1,0 +1,29 @@
+/**
+ * @trilium-script
+ *
+ * id: probe
+ * type: backend
+ * title: Custom handler probe
+ * customRequestHandler: probe/(.*)
+ */
+
+const req = api.req;
+const res = api.res;
+
+if (!req || !res) {
+    throw new Error("probe: no req/res — not invoked as a custom request handler");
+}
+
+res.status(200).json({
+    method: req.method,
+    path: req.path,
+    pathParams: api.pathParams,
+    contentType: req.headers["content-type"] ?? null,
+    depth: req.headers["depth"] ?? null,
+    authorization: req.headers["authorization"] ?? null,
+    bodyType: typeof req.body,
+    bodyIsBuffer: Buffer.isBuffer(req.body),
+    body: Buffer.isBuffer(req.body)
+        ? req.body.toString("utf-8").slice(0, 500)
+        : (typeof req.body === "string" ? req.body.slice(0, 500) : req.body ?? null)
+});

--- a/apps/script-deployer/src/deploy.ts
+++ b/apps/script-deployer/src/deploy.ts
@@ -149,7 +149,7 @@ export interface DeployResult {
 }
 
 /** Labels that map directly from front-matter keys to note attributes. */
-const PASSTHROUGH_LABELS = ["run", "executeButton", "executeDescription", "executeTitle"] as const;
+const PASSTHROUGH_LABELS = ["run", "executeButton", "executeDescription", "executeTitle", "customRequestHandler"] as const;
 
 function applyLabels(note: BeccaLike["notes"][string], meta: ScriptMeta) {
     note.setLabel("readOnly");

--- a/apps/script-deployer/src/dev.ts
+++ b/apps/script-deployer/src/dev.ts
@@ -23,6 +23,9 @@ process.env.TRILIUM_PORT = String(PORT);
 process.env.TRILIUM_RESOURCE_DIR = resolve(__dirname, "../../server/src");
 process.env.NODE_ENV = "development";
 process.env.TRILIUM_ENV = "dev";
+// Deployed scripts are the whole point of this instance, so backend scripting
+// must be on — without it every #customRequestHandler request answers 403.
+process.env.TRILIUM_SECURITY_BACKEND_SCRIPTING_ENABLED ??= "true";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 const SCRIPTS_DIR = resolve(__dirname, "../scripts");
@@ -186,15 +189,32 @@ function watchScripts() {
     console.log(`Watching ${SCRIPTS_DIR} for changes…`);
 }
 
+async function waitForServer() {
+    for (let attempt = 0; attempt < 240; attempt++) {
+        try {
+            await fetch(`http://localhost:${PORT}/`);
+            return;
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+    }
+    throw new Error(`Server did not come up on port ${PORT}.`);
+}
+
 async function main() {
     await ensureTranslations();
+
+    // Start the full server first — initializeCore() runs in main.js's startup
+    // path and owns one-time initialization (execution context, crypto/platform
+    // providers, database provider). ensureDatabase/ensureEtapiToken need cls,
+    // which only works after that, so they follow the server like the setup
+    // wizard does. main.js starts the server as an import side effect, so wait
+    // until the port answers.
+    await import("@triliumnext/server/src/main.js");
+    await waitForServer();
+
     await ensureDatabase();
     await ensureEtapiToken();
-
-    // Start the full HTTP server — this loads becca and makes the note
-    // tree available for subsequent setup steps.
-    const startTriliumServer = (await import("@triliumnext/server/src/www.js")).default;
-    await startTriliumServer();
 
     await ensureScriptsFolder();
     await deployScripts();

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -92,7 +92,11 @@ export default async function buildApp() {
         })
     );
 
-    app.use(express.text({ limit: "500mb" }));
+    // Also accept text/* and XML besides the text/plain default: custom request handlers
+    // (script notes with #customRequestHandler) receive external protocol payloads such as
+    // text/vcard and application/xml, and backend scripts are synchronous, so a body that no
+    // parser consumed is unreadable by the time the script runs (req.body stays undefined).
+    app.use(express.text({ limit: "500mb", type: ["text/*", "application/xml", "application/*+xml"] }));
     app.use(express.json({ limit: "500mb" }));
     app.use(express.raw({ limit: "500mb" }));
     app.use(express.urlencoded({ extended: false }));

--- a/docs/Developer Guide/Developer Guide/Interoperability/CardDAV prototype and scripting gaps.md
+++ b/docs/Developer Guide/Developer Guide/Interoperability/CardDAV prototype and scripting gaps.md
@@ -1,0 +1,115 @@
+# CardDAV prototype and scripting gaps
+
+`apps/script-deployer/scripts/carddav.ts` implements a CardDAV server as a Trilium backend
+script — a NextCloud-style address book that phones and desktop clients sync against, with
+**one note per contact**. It was deliberately built *entirely* inside the scripting system
+(a `#customRequestHandler` note, no dedicated server routes) to find out where the scripting
+system's limits are. This document records the design and every gap that surfaced.
+
+## What the prototype does
+
+- Serves the CardDAV subset real clients need at `/custom/carddav/`: `OPTIONS`, `PROPFIND`
+  (depth 0/1), `REPORT` (`addressbook-query`, `addressbook-multiget`), `GET`, `PUT` (with
+  `If-Match`/`If-None-Match` semantics), `DELETE`, plus principal/home-set discovery,
+  per-contact ETags and a collection CTag.
+- An address book is any note with `#carddavAddressBook`. On first use the script creates a
+  "Contacts" `book` collection (table view) with inheritable promoted attribute definitions,
+  so synced contacts edit nicely in the Trilium UI — `email`/`phone` promoted fields render
+  mailto/tel action buttons, and `#email *=* "@acme.com"` search works immediately.
+- A contact is a child note: `FN` ↔ note title, `NOTE` ↔ note content, and
+  `EMAIL`/`TEL`/`ORG`/`TITLE`/`BDAY`/`URL`/`ADR`/`CATEGORIES`/`N`/`UID` map to labels
+  (`#email`, `#phone`, `#organization`, `#jobTitle`, `#birthday`, `#website`, `#address`,
+  `#category`, `#firstName`/`#lastName`, `#vcardUid`). Unmapped vCard properties are
+  preserved in `#vcardExtra` so foreign clients' data survives a round trip (except `PHOTO`,
+  whose base64 payload does not belong in an attribute).
+- Authentication is HTTP Basic against the `#carddavPassword` label on the script note.
+
+### Using it
+
+1. Run `pnpm --filter @triliumnext/script-deployer dev` (or deploy the script note to a real
+   instance) with `[Security] backendScriptingEnabled=true`.
+2. Set `#carddavPassword=<password>` on the script note.
+3. Point DAVx⁵ / macOS Contacts / Thunderbird at `http://<host>/custom/carddav/` with any
+   username and that password. There is no `/.well-known/carddav`, so the base URL must be
+   entered explicitly.
+
+### Known behavioral limits
+
+- vCards are emitted as version 3.0; `TYPE` parameters on `EMAIL`/`TEL` are dropped.
+- `addressbook-query` filters are not evaluated (the full collection is returned; clients
+  filter locally). No `sync-collection` REPORT — clients fall back to CTag polling.
+- `PHOTO` is dropped, and a phone-side edit of the contact's note text replaces rich
+  Trilium content with plain paragraphs (`NOTE` is plain text by definition).
+
+## Scripting-system gaps found
+
+Each of these blocked the prototype or forced a workaround. Fixes marked ✔ landed with the
+prototype; the rest are candidate improvements.
+
+1. **Request bodies with non-default content types never reached scripts** ✔ fixed.
+   `apps/server/src/app.ts` mounted `express.text()` with its `text/plain` default, so a
+   `PROPFIND` body (`application/xml`) or vCard `PUT` (`text/vcard`) left `req.body`
+   `undefined` — and because backend scripts are synchronous (next item), a script cannot
+   read the unconsumed stream itself. The parser now accepts `text/*`, `application/xml`
+   and `application/*+xml`.
+
+2. **Backend scripts cannot be async.** `executeBundle` wraps scripts in a synchronous
+   function on purpose — the SQL transaction and CLS entity-change tracking would lose
+   their scope across `await` (`packages/trilium-core/src/services/script.ts`). This rules
+   out `fetch`, `crypto.subtle`, streaming request bodies, and any async-only library. A
+   scoped "async custom handler" (transaction per await-segment, or an explicit opt-out of
+   the transaction wrapper) would unlock a whole class of integrations.
+
+3. **No cryptography for scripts.** `node:crypto` is on the module blocklist,
+   `crypto.subtle` is unusable (async), and nothing hash- or HMAC-shaped is exposed on the
+   script API. Consequences here: ETags use a hand-rolled FNV-1a hash, and password
+   comparison is a best-effort constant-time loop instead of `timingSafeEqual`. Exposing a
+   small `api.crypto` (hash, hmac, timing-safe compare, randomBytes) would fix this class.
+
+4. **Scripts cannot validate ETAPI tokens.** The natural auth story for a protocol endpoint
+   ("Basic auth with an ETAPI token as password", as the MCP endpoint effectively does) is
+   impossible from a script: `etapi_tokens` is not exposed and the token hash cannot be
+   recomputed without crypto. Hence the plaintext `#carddavPassword` label.
+
+5. **All-or-nothing security toggle.** Running one custom handler requires
+   `backendScriptingEnabled=true`, which enables *every* backend script — the toggle is
+   documented as RCE-equivalent. There is no per-note or per-capability grant (e.g. "this
+   note may serve requests but not require modules").
+
+6. **No routes outside `/custom`.** A script cannot serve `/.well-known/carddav`, so
+   client auto-discovery cannot work; users must type the full base URL. A declarative
+   well-known → custom-handler redirect map would be enough.
+
+7. **`ScriptBNote` typings lag the runtime entity.** Missing from the typed surface, all
+   needed here and reached via casts: `save()` (rename a note), `addAttribute()` (create an
+   *inheritable* label, or a second label with the same name — `setLabel()` overwrites the
+   first value and cannot create inheritable ones, so multi-valued `#email` labels and
+   promoted-definition provisioning both need the entity API).
+
+8. **Module allowlist gaps.** `zlib` was neither allowed nor blocked, so the pre-existing
+   sample scripts (`auto-import-xopp`, `auto-import-rnote`) failed at `require` — ✔ now
+   allowed (pure computation, no OS access). There is also no vCard/iCal library available
+   to scripts, hence the hand-rolled parser; `xml2js` being allowed (and synchronous) is
+   what made the DAV XML side tractable.
+
+9. **script-deployer harness rot** ✔ fixed. The fresh-database path called `cls.init()`
+   before anything had initialized the core execution context (it now starts the server
+   first, like the setup wizard); front-matter labels other than `run`/`execute*` were not
+   deployable (`customRequestHandler` is now passed through); and the dev instance did not
+   enable backend scripting, so every deployed handler answered 403 (now enabled via
+   `TRILIUM_SECURITY_BACKEND_SCRIPTING_ENABLED=true`). Nothing CI-tests this harness
+   against a fresh database, which is how it rotted unnoticed.
+
+10. **Custom handlers run outside any SQL transaction.** Mutating handlers must remember
+    `api.transactional(...)` themselves; nothing documents this, and a forgotten wrapper
+    means entity changes land without transactional grouping. Either document it or wrap
+    handler execution the way API routes are wrapped.
+
+## Verified end-to-end
+
+Against the script-deployer dev instance, with curl driving the exact request shapes
+DAVx⁵ uses: discovery chain (root → principal → home set → address book), address book
+auto-provisioning, contact create/read/update/delete with correct `201`/`204`/`404`/`412`
+codes, ETag change on update, stale `If-Match` rejection, multiget with a missing href
+(per-href `404` inside the `207`), unknown-property round-trip via `#vcardExtra`, and the
+Trilium-side note carrying the expected title, labels and promoted definitions.

--- a/packages/trilium-core/src/services/script_context.ts
+++ b/packages/trilium-core/src/services/script_context.ts
@@ -25,6 +25,9 @@ const ALLOWED_MODULES = new Set([
     "escape-html",
     "sanitize-html",
     "lodash",
+    // Pure-computation Node built-in with no OS access; existing scripts use it
+    // to decompress note payloads (e.g. Xournal++ .xopp imports).
+    "zlib",
 ]);
 
 /**


### PR DESCRIPTION
## What this is

A NextCloud-style address book that CardDAV clients (DAVx⁵, iOS/macOS Contacts, Thunderbird) can sync against, implemented **entirely as a Trilium backend script** (`apps/script-deployer/scripts/carddav.ts`, a `#customRequestHandler` note) — deliberately, to probe the limits of the scripting system. The gaps that surfaced are recorded in the developer guide: *Interoperability / "CardDAV prototype and scripting gaps"*.

## Data model — one note per contact

- An address book is any note with `#carddavAddressBook`. On first use the script provisions a "Contacts" `book` collection (table view) with inheritable promoted attribute definitions.
- A contact is a child note: `FN` ↔ note title, `NOTE` ↔ note content, and `EMAIL`/`TEL`/`ORG`/`TITLE`/`BDAY`/`URL`/`ADR`/`CATEGORIES`/`N`/`UID` map to labels — so `#email *=* "@acme.com"` search works and promoted email/phone fields render mailto/tel buttons.
- Unmapped vCard properties round-trip via `#vcardExtra` (except `PHOTO`).

## Protocol subset

`OPTIONS`, `PROPFIND` (depth 0/1), `REPORT` (`addressbook-query`, `addressbook-multiget`), `GET`, `PUT` with `If-Match`/`If-None-Match`, `DELETE`; principal/home-set discovery, per-contact ETags, collection CTag; HTTP Basic auth against a `#carddavPassword` label on the script note. No `sync-collection` REPORT (clients fall back to CTag polling) and no `/.well-known/carddav` (scripts cannot register routes outside `/custom`), so clients need the explicit base URL `http://<host>/custom/carddav/`.

## Enablers fixed along the way

- **`apps/server/src/app.ts`**: `express.text()` now also accepts `text/*`, `application/xml`, `application/*+xml` — bodies of those types never reached (synchronous) custom handlers; `req.body` stayed `undefined`.
- **`packages/trilium-core/src/services/script_context.ts`**: allow `require("zlib")` — the existing sample scripts already import it and failed at runtime under the module allowlist.
- **script-deployer**: deploy `#customRequestHandler` from front matter; enable backend scripting in the dev instance; fix the fresh-database startup path (`cls` was used before `initializeCore()` ran — the server now starts first, like the setup wizard).
- `scripts/probe.ts`: minimal custom-handler echo script used to verify method routing and body parsing.

## Testing

- Verified end-to-end against the script-deployer dev instance with curl driving the request shapes DAVx⁵ uses: discovery chain, address-book auto-provisioning, contact create/read/update/delete (`201`/`204`/`404`/`412`), ETag change on update, stale `If-Match` rejection, multiget with a missing href, unknown-property round-trip, and the Trilium-side note carrying the expected title/labels/promoted definitions.
- `pnpm typecheck` clean; script-deployer (22), custom-route (6), script-context (server + standalone) and all 153 ETAPI specs pass; changed files pass the format config.

## Draft status / open questions

- Real-device DAVx⁵/iOS testing not yet done (curl-level flows only).
- A phone-side edit of a contact's note text replaces rich Trilium content with plain paragraphs (`NOTE` is plain text) — accept, or treat note content as Trilium-only?
- The plaintext `#carddavPassword` label is a stopgap; the gaps report proposes `api.crypto` / ETAPI-token validation for scripts as the proper fix, plus further harness improvements (route-table dispatch for custom handlers, script bundling/testability in script-deployer, opt-in async handlers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KM3Lo92WTx84W1S6pqSTb

---
_Generated by [Claude Code](https://claude.ai/code/session_019KM3Lo92WTx84W1S6pqSTb)_