### PR TITLE
fix(board): stop a deleted column resurrecting through the persisted mirror

### DIFF
--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -8,7 +8,12 @@ import server from "../../../services/server";
 import { buildNote } from "../../../test/easy-froca";
 import { BoardViewData } from ".";
 import BoardApi from "./api";
-import { BOARD_TEMPLATE_ID, getStatusDefinition } from "./columns";
+import {
+    BOARD_TEMPLATE_ID,
+    getStatusDefinition,
+    isRecentlyRemovedColumn,
+    unnoteColumnRemoved
+} from "./columns";
 
 vi.mock("../../../services/bulk_action", () => ({
     executeBulkActions: vi.fn(async () => {})
@@ -38,7 +43,7 @@ function createApi(
         () => {},
         getStatusDefinition(board, statusAttribute)
     );
-    return { api, saved };
+    return { api, saved, board };
 }
 
 describe("BoardApi column mutations", () => {
@@ -65,6 +70,35 @@ describe("BoardApi column mutations", () => {
             [ "To Do", "Shipped", "In Progress" ],
             [ "Shipped", "In Progress" ]
         ]);
+    });
+
+    it("clears the removal mark once the definition write settles, keeps it on failure", async () => {
+        const viewConfig: BoardViewData = { columns: [ { value: "Kept" }, { value: "Gone" } ] };
+        const { api, board } = createApi(viewConfig, [ "Kept", "Gone" ]);
+        let settle: ((ok: boolean) => void) | null = null;
+        vi.spyOn(api as never as { syncColumnsToDefinition: () => Promise<void> }, "syncColumnsToDefinition")
+            .mockImplementation(() => new Promise<void>((resolve, reject) => {
+                settle = (ok: boolean) => (ok ? resolve() : reject(new Error("write failed")));
+            }));
+
+        await api.removeColumn("Gone");
+        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(true);
+
+        // The definition write failing keeps the marker: the delete has not
+        // stuck, and the marker still wins the mirror ambiguity until its TTL.
+        settle?.(false);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(true);
+
+        await api.removeColumn("Gone");
+        settle?.(true);
+        await Promise.resolve();
+        await Promise.resolve();
+        // Settled successfully: any later appearance of the value is a
+        // recreation, so the marker must not veto it.
+        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(false);
+        unnoteColumnRemoved(board.noteId, "Gone");
     });
 
     it("does not save anything for a duplicate column", async () => {

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -8,12 +8,7 @@ import server from "../../../services/server";
 import { buildNote } from "../../../test/easy-froca";
 import { BoardViewData } from ".";
 import BoardApi from "./api";
-import {
-    BOARD_TEMPLATE_ID,
-    getStatusDefinition,
-    isRecentlyRemovedColumn,
-    unnoteColumnRemoved
-} from "./columns";
+import { BOARD_TEMPLATE_ID, getStatusDefinition } from "./columns";
 
 vi.mock("../../../services/bulk_action", () => ({
     executeBulkActions: vi.fn(async () => {})
@@ -70,35 +65,6 @@ describe("BoardApi column mutations", () => {
             [ "To Do", "Shipped", "In Progress" ],
             [ "Shipped", "In Progress" ]
         ]);
-    });
-
-    it("clears the removal mark once the definition write settles, keeps it on failure", async () => {
-        const viewConfig: BoardViewData = { columns: [ { value: "Kept" }, { value: "Gone" } ] };
-        const { api, board } = createApi(viewConfig, [ "Kept", "Gone" ]);
-        let settle: ((ok: boolean) => void) | null = null;
-        vi.spyOn(api as never as { syncColumnsToDefinition: () => Promise<void> }, "syncColumnsToDefinition")
-            .mockImplementation(() => new Promise<void>((resolve, reject) => {
-                settle = (ok: boolean) => (ok ? resolve() : reject(new Error("write failed")));
-            }));
-
-        await api.removeColumn("Gone");
-        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(true);
-
-        // The definition write failing keeps the marker: the delete has not
-        // stuck, and the marker still wins the mirror ambiguity until its TTL.
-        settle?.(false);
-        await Promise.resolve();
-        await Promise.resolve();
-        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(true);
-
-        await api.removeColumn("Gone");
-        settle?.(true);
-        await Promise.resolve();
-        await Promise.resolve();
-        // Settled successfully: any later appearance of the value is a
-        // recreation, so the marker must not veto it.
-        expect(isRecentlyRemovedColumn(board.noteId, "Gone")).toBe(false);
-        unnoteColumnRemoved(board.noteId, "Gone");
     });
 
     it("does not save anything for a duplicate column", async () => {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -92,7 +92,17 @@ export default class BoardApi {
         await executeBulkActions(noteIds, [ action ]);
         // Marked so the mirror filter knows this value is gone by intent, not by a race (#11100).
         noteColumnRemoved(this.parentNote.noteId, column);
-        this.storeColumns((this.viewConfig?.columns ?? []).filter(col => col.value !== column));
+        // Once the definition write settles, the marker has done its job: on
+        // success any later appearance of the value is a genuine recreation;
+        // on failure the marker stays (the delete did not stick) until its TTL
+        // expires, after which the column honestly reads back.
+        this.storeColumns((this.viewConfig?.columns ?? []).filter(col => col.value !== column)).then(
+            (definitionWriteLanded) => {
+                if (definitionWriteLanded) {
+                    unnoteColumnRemoved(this.parentNote.noteId, column);
+                }
+            }
+        );
     }
 
     async renameColumn(oldValue: string, newValue: string) {
@@ -144,17 +154,22 @@ export default class BoardApi {
      * re-renders off the identity of the config it was handed, so an in-place edit would be written
      * to disk but stay invisible until the view is re-entered.
      */
-    private storeColumns(columns: BoardColumnData[]) {
+    private storeColumns(columns: BoardColumnData[]): Promise<boolean> {
         this.viewConfig = { ...this.viewConfig, columns };
         this.saveConfig(this.viewConfig);
         // Not awaited — every caller is the tail of a user gesture the board has already rendered —
         // so the failure is caught here rather than left to reject unhandled. The columns are still
         // in the view config, so the board is not wrong, only out of step with the definition.
-        this.syncColumnsToDefinition(columns.map(({ value }) => value))
-            .catch((e) => {
+        // The promise resolves to whether the definition write landed, so a
+        // caller can react to the outcome without re-handling the rejection.
+        return this.syncColumnsToDefinition(columns.map(({ value }) => value)).then(
+            () => true,
+            (e) => {
                 console.error("Failed to store the board columns in the attribute definition:", e);
                 toast.showError(t("board_view.column-definition-save-error"));
-            });
+                return false;
+            }
+        );
     }
 
     /**

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -11,7 +11,13 @@ import note_create from "../../../services/note_create";
 import server from "../../../services/server";
 import toast from "../../../services/toast";
 import { BoardColumnData, BoardViewData } from ".";
-import { type BoardStatusDefinition, canStoreColumnsInDefinition, DEFAULT_GROUP_BY } from "./columns";
+import {
+    type BoardStatusDefinition,
+    canStoreColumnsInDefinition,
+    DEFAULT_GROUP_BY,
+    noteColumnRemoved,
+    unnoteColumnRemoved
+} from "./columns";
 import { ColumnMap } from "./data";
 
 export default class BoardApi {
@@ -71,6 +77,7 @@ export default class BoardApi {
 
         // Add the new column to persisted data if it doesn't exist
         if (columns.some(col => col.value === columnName)) return false;
+        unnoteColumnRemoved(this.parentNote.noteId, columnName);
         this.storeColumns([ ...columns, { value: columnName } ]);
         return true;
     }
@@ -83,6 +90,8 @@ export default class BoardApi {
             ? { name: "deleteRelation", relationName: this.statusAttribute }
             : { name: "deleteLabel", labelName: this.statusAttribute };
         await executeBulkActions(noteIds, [ action ]);
+        // Marked so the mirror filter knows this value is gone by intent, not by a race (#11100).
+        noteColumnRemoved(this.parentNote.noteId, column);
         this.storeColumns((this.viewConfig?.columns ?? []).filter(col => col.value !== column));
     }
 
@@ -95,6 +104,9 @@ export default class BoardApi {
             : { name: "updateLabelValue", labelName: this.statusAttribute, labelValue: newValue };
         await executeBulkActions(noteIds, [ action ]);
 
+        // The old value is gone by intent; the new one may be re-added later under this name.
+        noteColumnRemoved(this.parentNote.noteId, oldValue);
+        unnoteColumnRemoved(this.parentNote.noteId, newValue);
         // Rename the column in the persisted data.
         this.storeColumns((this.viewConfig?.columns ?? [])
             .map(col => col.value === oldValue ? { ...col, value: newValue } : col));

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -90,19 +90,13 @@ export default class BoardApi {
             ? { name: "deleteRelation", relationName: this.statusAttribute }
             : { name: "deleteLabel", labelName: this.statusAttribute };
         await executeBulkActions(noteIds, [ action ]);
-        // Marked so the mirror filter knows this value is gone by intent, not by a race (#11100).
+        // Marked so the mirror filter knows this value is gone by intent, not
+        // by a race (#11100). The marker clears only when a refresh observes
+        // the value in no source at all — see getBoardData — because a racy
+        // refresh can mirror the value back into board.json right up until
+        // the definition write's entity change lands.
         noteColumnRemoved(this.parentNote.noteId, column);
-        // Once the definition write settles, the marker has done its job: on
-        // success any later appearance of the value is a genuine recreation;
-        // on failure the marker stays (the delete did not stick) until its TTL
-        // expires, after which the column honestly reads back.
-        this.storeColumns((this.viewConfig?.columns ?? []).filter(col => col.value !== column)).then(
-            (definitionWriteLanded) => {
-                if (definitionWriteLanded) {
-                    unnoteColumnRemoved(this.parentNote.noteId, column);
-                }
-            }
-        );
+        this.storeColumns((this.viewConfig?.columns ?? []).filter(col => col.value !== column));
     }
 
     async renameColumn(oldValue: string, newValue: string) {
@@ -154,22 +148,21 @@ export default class BoardApi {
      * re-renders off the identity of the config it was handed, so an in-place edit would be written
      * to disk but stay invisible until the view is re-entered.
      */
-    private storeColumns(columns: BoardColumnData[]): Promise<boolean> {
+    private storeColumns(columns: BoardColumnData[]) {
         this.viewConfig = { ...this.viewConfig, columns };
         this.saveConfig(this.viewConfig);
         // Not awaited — every caller is the tail of a user gesture the board has already rendered —
         // so the failure is caught here rather than left to reject unhandled. The columns are still
         // in the view config, so the board is not wrong, only out of step with the definition.
-        // The promise resolves to whether the definition write landed, so a
-        // caller can react to the outcome without re-handling the rejection.
-        return this.syncColumnsToDefinition(columns.map(({ value }) => value)).then(
-            () => true,
-            (e) => {
+        // The removal marker outlives this write on purpose: a refresh that raced
+        // the write can still have mirrored the removed value back into
+        // board.json, and only the refresh that observes every source clean
+        // (see getBoardData) may clear the marker.
+        this.syncColumnsToDefinition(columns.map(({ value }) => value))
+            .catch((e) => {
                 console.error("Failed to store the board columns in the attribute definition:", e);
                 toast.showError(t("board_view.column-definition-save-error"));
-                return false;
-            }
-        );
+            });
     }
 
     /**

--- a/apps/client/src/widgets/collections/board/columns.spec.ts
+++ b/apps/client/src/widgets/collections/board/columns.spec.ts
@@ -30,6 +30,22 @@ describe("resolveBoardColumns", () => {
         expect(resolveBoardColumns([], [ "Todo" ], [ "Done" ])).toEqual([ "Todo", "Done" ]);
     });
 
+    it("does not let a mirror keep a column the definition and the notes have both dropped (#11100)", () => {
+        expect(resolveBoardColumns([ "Todo" ], [ "Todo", "Deleted" ], [], true))
+            .toEqual([ "Todo" ]);
+        expect(resolveBoardColumns([], [ "Todo", "Deleted" ], [], true)).toEqual([]);
+    });
+
+    it("keeps a mirrored column while the definition or the notes still name it", () => {
+        expect(resolveBoardColumns([ "Kept" ], [ "Kept" ], [], true)).toEqual([ "Kept" ]);
+        expect(resolveBoardColumns([], [ "Kept" ], [ "Kept" ], true)).toEqual([ "Kept" ]);
+    });
+
+    it("keeps an unmirrored persisted column even when nothing else names it", () => {
+        expect(resolveBoardColumns([ "Todo" ], [ "Todo", "Arranged" ], [], false))
+            .toEqual([ "Todo", "Arranged" ]);
+    });
+
     it("drops blanks and treats columns differing only in case as distinct", () => {
         expect(resolveBoardColumns([ "", "  " ], [ " Todo " ], [ "todo" ]))
             .toEqual([ "Todo", "todo" ]);

--- a/apps/client/src/widgets/collections/board/columns.spec.ts
+++ b/apps/client/src/widgets/collections/board/columns.spec.ts
@@ -146,4 +146,16 @@ describe("removed-column marking", () => {
         expect(isRecentlyRemovedColumn("another-board", "TCD")).toBe(false);
         unnoteColumnRemoved(BOARD, "TCD");
     });
+
+    it("expires the mark so a later recreation cannot be vetoed forever", () => {
+        const markedAt = 1_000_000;
+        noteColumnRemoved(BOARD, "TCD", markedAt);
+
+        // Inside the window the delete still wins the ambiguity.
+        expect(isRecentlyRemovedColumn(BOARD, "TCD", markedAt + 30_000)).toBe(true);
+        // Past it, a persisted-only value is read back as recreation.
+        expect(isRecentlyRemovedColumn(BOARD, "TCD", markedAt + 61_000)).toBe(false);
+        // And the expired entry is dropped, not just ignored.
+        expect(isRecentlyRemovedColumn(BOARD, "TCD", markedAt + 120_000)).toBe(false);
+    });
 });

--- a/apps/client/src/widgets/collections/board/columns.spec.ts
+++ b/apps/client/src/widgets/collections/board/columns.spec.ts
@@ -9,7 +9,10 @@ import {
     BOARD_TEMPLATE_ID,
     canStoreColumnsInDefinition,
     getStatusDefinition,
-    resolveBoardColumns
+    isRecentlyRemovedColumn,
+    noteColumnRemoved,
+    resolveBoardColumns,
+    unnoteColumnRemoved
 } from "./columns";
 
 describe("resolveBoardColumns", () => {
@@ -30,21 +33,6 @@ describe("resolveBoardColumns", () => {
         expect(resolveBoardColumns([], [ "Todo" ], [ "Done" ])).toEqual([ "Todo", "Done" ]);
     });
 
-    it("does not let a mirror keep a column the definition and the notes have both dropped (#11100)", () => {
-        expect(resolveBoardColumns([ "Todo" ], [ "Todo", "Deleted" ], [], true))
-            .toEqual([ "Todo" ]);
-        expect(resolveBoardColumns([], [ "Todo", "Deleted" ], [], true)).toEqual([]);
-    });
-
-    it("keeps a mirrored column while the definition or the notes still name it", () => {
-        expect(resolveBoardColumns([ "Kept" ], [ "Kept" ], [], true)).toEqual([ "Kept" ]);
-        expect(resolveBoardColumns([], [ "Kept" ], [ "Kept" ], true)).toEqual([ "Kept" ]);
-    });
-
-    it("keeps an unmirrored persisted column even when nothing else names it", () => {
-        expect(resolveBoardColumns([ "Todo" ], [ "Todo", "Arranged" ], [], false))
-            .toEqual([ "Todo", "Arranged" ]);
-    });
 
     it("drops blanks and treats columns differing only in case as distinct", () => {
         expect(resolveBoardColumns([ "", "  " ], [ " Todo " ], [ "todo" ]))
@@ -141,3 +129,21 @@ function buildBoard(
 
     return board;
 }
+
+describe("removed-column marking", () => {
+    const BOARD = "board-note-id";
+
+    it("marks a removed column until it is unmarked under the same name", () => {
+        noteColumnRemoved(BOARD, "TCD");
+        expect(isRecentlyRemovedColumn(BOARD, "TCD")).toBe(true);
+
+        unnoteColumnRemoved(BOARD, "TCD");
+        expect(isRecentlyRemovedColumn(BOARD, "TCD")).toBe(false);
+    });
+
+    it("scopes the mark to one board", () => {
+        noteColumnRemoved(BOARD, "TCD");
+        expect(isRecentlyRemovedColumn("another-board", "TCD")).toBe(false);
+        unnoteColumnRemoved(BOARD, "TCD");
+    });
+});

--- a/apps/client/src/widgets/collections/board/columns.ts
+++ b/apps/client/src/widgets/collections/board/columns.ts
@@ -103,12 +103,36 @@ export function canStoreColumnsInDefinition(statusDefinition: BoardStatusDefinit
 export function resolveBoardColumns(
     definitionOptions: string[],
     persistedColumns: string[],
-    discoveredValues: string[]
+    discoveredValues: string[],
+    /**
+     * Whether the persisted list is only a mirror of this resolution, written by the board that
+     * owns the definition. A mirror must not keep a column alive that the definition and the
+     * notes have both dropped: `removeColumn` writes the definition without the column, but the
+     * refresh that the config save triggers can read the definition before that write's entity
+     * change has arrived and write the column back into the mirror, from where it would never
+     * leave (#11100). Filtering the mirror against the other two sources makes the delete stick
+     * as soon as either settles, instead of never.
+     *
+     * Boards without a definition of their own keep the old behaviour: their persisted list is
+     * the arrangement itself, not a mirror of anything.
+     */
+    persistedColumnsAreMirror = false
 ): string[] {
     const columns: string[] = [];
     const seen = new Set<string>();
 
-    for (const candidate of [ ...definitionOptions, ...persistedColumns, ...discoveredValues ]) {
+    for (const value of [ ...definitionOptions, ...discoveredValues ]) {
+        const trimmed = value.trim();
+        if (trimmed) seen.add(trimmed);
+    }
+
+    const mirroredColumns = persistedColumnsAreMirror
+        ? persistedColumns.filter(column => seen.has(column.trim()))
+        : persistedColumns;
+
+    // Reset: the loop below seeds `seen` again so the definition's order leads the result.
+    seen.clear();
+    for (const candidate of [ ...definitionOptions, ...mirroredColumns, ...discoveredValues ]) {
         const value = candidate.trim();
         if (!value || seen.has(value)) continue;
         seen.add(value);

--- a/apps/client/src/widgets/collections/board/columns.ts
+++ b/apps/client/src/widgets/collections/board/columns.ts
@@ -103,36 +103,12 @@ export function canStoreColumnsInDefinition(statusDefinition: BoardStatusDefinit
 export function resolveBoardColumns(
     definitionOptions: string[],
     persistedColumns: string[],
-    discoveredValues: string[],
-    /**
-     * Whether the persisted list is only a mirror of this resolution, written by the board that
-     * owns the definition. A mirror must not keep a column alive that the definition and the
-     * notes have both dropped: `removeColumn` writes the definition without the column, but the
-     * refresh that the config save triggers can read the definition before that write's entity
-     * change has arrived and write the column back into the mirror, from where it would never
-     * leave (#11100). Filtering the mirror against the other two sources makes the delete stick
-     * as soon as either settles, instead of never.
-     *
-     * Boards without a definition of their own keep the old behaviour: their persisted list is
-     * the arrangement itself, not a mirror of anything.
-     */
-    persistedColumnsAreMirror = false
+    discoveredValues: string[]
 ): string[] {
     const columns: string[] = [];
     const seen = new Set<string>();
 
-    for (const value of [ ...definitionOptions, ...discoveredValues ]) {
-        const trimmed = value.trim();
-        if (trimmed) seen.add(trimmed);
-    }
-
-    const mirroredColumns = persistedColumnsAreMirror
-        ? persistedColumns.filter(column => seen.has(column.trim()))
-        : persistedColumns;
-
-    // Reset: the loop below seeds `seen` again so the definition's order leads the result.
-    seen.clear();
-    for (const candidate of [ ...definitionOptions, ...mirroredColumns, ...discoveredValues ]) {
+    for (const candidate of [ ...definitionOptions, ...persistedColumns, ...discoveredValues ]) {
         const value = candidate.trim();
         if (!value || seen.has(value)) continue;
         seen.add(value);
@@ -141,3 +117,30 @@ export function resolveBoardColumns(
 
     return columns;
 }
+
+/**
+ * Values this board's own column UI removed, so a refresh that races the
+ * definition write (#11100) can tell a resurrected deleted column from a
+ * brand-new one. In-memory per session: a removed value that is added again
+ * under the same name is unmarked, so the marker never outlives its intent.
+ */
+const removedColumnsByNote = new Map<string, Set<string>>();
+
+export function noteColumnRemoved(noteId: string, value: string): void {
+    let values = removedColumnsByNote.get(noteId);
+    if (!values) {
+        values = new Set();
+        removedColumnsByNote.set(noteId, values);
+    }
+    values.add(value);
+}
+
+export function unnoteColumnRemoved(noteId: string, value: string): void {
+    removedColumnsByNote.get(noteId)?.delete(value);
+}
+
+export function isRecentlyRemovedColumn(noteId: string, value: string): boolean {
+    return removedColumnsByNote.get(noteId)?.has(value) === true;
+}
+
+

--- a/apps/client/src/widgets/collections/board/columns.ts
+++ b/apps/client/src/widgets/collections/board/columns.ts
@@ -146,6 +146,11 @@ export function unnoteColumnRemoved(noteId: string, value: string): void {
     removedColumnsByNote.get(noteId)?.delete(value);
 }
 
+/** The board's currently-marked removed values, for convergence checks. */
+export function recentlyRemovedColumnsFor(noteId: string): string[] {
+    return [ ...(removedColumnsByNote.get(noteId)?.keys() ?? []) ];
+}
+
 export function isRecentlyRemovedColumn(
     noteId: string,
     value: string,

--- a/apps/client/src/widgets/collections/board/columns.ts
+++ b/apps/client/src/widgets/collections/board/columns.ts
@@ -119,28 +119,48 @@ export function resolveBoardColumns(
 }
 
 /**
- * Values this board's own column UI removed, so a refresh that races the
- * definition write (#11100) can tell a resurrected deleted column from a
- * brand-new one. In-memory per session: a removed value that is added again
- * under the same name is unmarked, so the marker never outlives its intent.
+ * How long a removal mark can veto a persisted column. The delete race it
+ * exists for (#11100) resolves in seconds — the definition write's entity
+ * change arrives, or its failure has surfaced — so anything still vetoed
+ * after this window is far more likely a deliberate recreation from another
+ * surface (a synced client, the attribute panel) than the tail of a race.
  */
-const removedColumnsByNote = new Map<string, Set<string>>();
+const REMOVED_COLUMN_MARK_TTL_MS = 60_000;
 
-export function noteColumnRemoved(noteId: string, value: string): void {
+const removedColumnsByNote = new Map<string, Map<string, number>>();
+
+export function noteColumnRemoved(
+    noteId: string,
+    value: string,
+    now: number = Date.now()
+): void {
     let values = removedColumnsByNote.get(noteId);
     if (!values) {
-        values = new Set();
+        values = new Map();
         removedColumnsByNote.set(noteId, values);
     }
-    values.add(value);
+    values.set(value, now);
 }
 
 export function unnoteColumnRemoved(noteId: string, value: string): void {
     removedColumnsByNote.get(noteId)?.delete(value);
 }
 
-export function isRecentlyRemovedColumn(noteId: string, value: string): boolean {
-    return removedColumnsByNote.get(noteId)?.has(value) === true;
+export function isRecentlyRemovedColumn(
+    noteId: string,
+    value: string,
+    now: number = Date.now()
+): boolean {
+    const markedAt = removedColumnsByNote.get(noteId)?.get(value);
+    if (markedAt === undefined) {
+        return false;
+    }
+    if (now - markedAt > REMOVED_COLUMN_MARK_TTL_MS) {
+        // Expired: drop it so the map cannot grow unbounded across a session.
+        unnoteColumnRemoved(noteId, value);
+        return false;
+    }
+    return true;
 }
 
 

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -77,6 +77,27 @@ describe("Board data", () => {
         expect(unmirrored.columns).toEqual([ "Kept", "Arranged" ]);
     });
 
+    it("clears the removal mark once a note carries the value again", async () => {
+        const parentNote = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "mirror-board-note-3", title: "Back again", "#status": "Kept" }
+            ]
+        });
+        // The column was deleted in this session; another surface has since put
+        // a note back into that status, and the persisted mirror still names it.
+        noteColumnRemoved(parentNote.noteId, "Kept");
+
+        const afterRecreation = await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" } ] },
+            false, [], true
+        );
+        expect(afterRecreation.columns).toEqual([ "Kept" ]);
+    });
+
     it("keeps a brand-new empty column that is in no source yet (#11100 review)", async () => {
         const parentNote = buildNote({
             title: "Board",

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import FBranch from "../../../entities/fbranch";
 import froca from "../../../services/froca";
 import { buildNote } from "../../../test/easy-froca";
+import { noteColumnRemoved } from "./columns";
 import { getBoardData } from "./data";
 
 describe("Board data", () => {
@@ -31,7 +32,7 @@ describe("Board data", () => {
         expect(noteIds.length).toBe(3);
     });
 
-    it("drops a deleted column resurrected through the mirror when the board owns its definition (#11100)", async () => {
+    it("drops a column the board removed when it resurrects through the mirror", async () => {
         const parentNote = buildNote({
             title: "Board",
             "#collection": "",
@@ -40,15 +41,58 @@ describe("Board data", () => {
                 { id: "mirror-board-note", title: "Only note", "#status": "Kept" }
             ]
         });
+        // What removeColumn leaves behind when its definition write is still in flight: the
+        // notes have dropped the value, the stale definition options will resurrect it, and the
+        // persisted mirror still carries it.
+        noteColumnRemoved(parentNote.noteId, "Deleted");
 
-        // The persisted attachment still lists the deleted column — the refresh raced the
-        // definition write and wrote it back — while the definition and the notes have dropped it.
-        const mirror = await getBoardData(parentNote, "status", { columns: [ { value: "Kept" }, { value: "Deleted" } ] }, false, [ "Kept" ], true);
-        expect(mirror.columns).toEqual([ "Kept" ]);
-        expect(mirror.newPersistedData?.columns).toEqual([ { value: "Kept" } ]);
+        const mirror = await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" }, { value: "Deleted" } ] },
+            false, [ "Kept", "Deleted" ], true
+        );
+        // The stale definition still names it, so the resolved list does too (transiently),
+        // but the persisted input leg was filtered — the write-back below is what the stale
+        // definition produced, and it is the last time Deleted can appear anywhere.
+        expect(mirror.columns).toEqual([ "Kept", "Deleted" ]);
+        expect(mirror.newPersistedData?.columns).toEqual(
+            [ { value: "Kept" }, { value: "Deleted" } ]
+        );
 
-        // A board that does not own its definition keeps the attachment-borne column.
-        const unmirrored = await getBoardData(parentNote, "status", { columns: [ { value: "Kept" }, { value: "Arranged" } ] }, false, [ "Kept" ], false);
+        // Once the definition write lands, nothing names the removed column anymore.
+        const settled = await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" } ] },
+            false, [ "Kept" ], true
+        );
+        expect(settled.columns).toEqual([ "Kept" ] as string[]);
+
+        // A board that does not own its definition keeps attachment-borne columns: its
+        // persisted list is the arrangement itself, not a mirror, and nothing is marked.
+        const unmirrored = await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" }, { value: "Arranged" } ] },
+            false, [ "Kept" ], false
+        );
         expect(unmirrored.columns).toEqual([ "Kept", "Arranged" ]);
+    });
+
+    it("keeps a brand-new empty column that is in no source yet (#11100 review)", async () => {
+        const parentNote = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "mirror-board-note-2", title: "Only note", "#status": "Kept" }
+            ]
+        });
+        // addNewColumn saved the config; the definition write has not landed, no note
+        // carries the value. The mirror filter must not eat it.
+        const added = await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" }, { value: "New Column" } ] },
+            false, [ "Kept" ], true
+        );
+        expect(added.columns).toEqual([ "Kept", "New Column" ]);
     });
 });

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -30,4 +30,25 @@ describe("Board data", () => {
         const noteIds = [...data.byColumn.values()].flat().map(item => item.note.noteId);
         expect(noteIds.length).toBe(3);
     });
+
+    it("drops a deleted column resurrected through the mirror when the board owns its definition (#11100)", async () => {
+        const parentNote = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "mirror-board-note", title: "Only note", "#status": "Kept" }
+            ]
+        });
+
+        // The persisted attachment still lists the deleted column — the refresh raced the
+        // definition write and wrote it back — while the definition and the notes have dropped it.
+        const mirror = await getBoardData(parentNote, "status", { columns: [ { value: "Kept" }, { value: "Deleted" } ] }, false, [ "Kept" ], true);
+        expect(mirror.columns).toEqual([ "Kept" ]);
+        expect(mirror.newPersistedData?.columns).toEqual([ { value: "Kept" } ]);
+
+        // A board that does not own its definition keeps the attachment-borne column.
+        const unmirrored = await getBoardData(parentNote, "status", { columns: [ { value: "Kept" }, { value: "Arranged" } ] }, false, [ "Kept" ], false);
+        expect(unmirrored.columns).toEqual([ "Kept", "Arranged" ]);
+    });
 });

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import FBranch from "../../../entities/fbranch";
 import froca from "../../../services/froca";
 import { buildNote } from "../../../test/easy-froca";
-import { noteColumnRemoved } from "./columns";
+import { isRecentlyRemovedColumn, noteColumnRemoved } from "./columns";
 import { getBoardData } from "./data";
 
 describe("Board data", () => {
@@ -96,6 +96,45 @@ describe("Board data", () => {
             false, [], true
         );
         expect(afterRecreation.columns).toEqual([ "Kept" ]);
+    });
+
+    it("clears the removal mark only once every source has converged away", async () => {
+        const parentNote = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "mirror-board-note-4", title: "Kept", "#status": "Kept" }
+            ]
+        });
+        noteColumnRemoved(parentNote.noteId, "Gone");
+
+        // A refresh still reading the STALE definition (it names the value) keeps
+        // the marker even though the raw mirror is clean, or a write-back via the
+        // definition leg could resurrect the column.
+        await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" } ] },
+            false, [ "Kept", "Gone" ], true
+        );
+        expect(isRecentlyRemovedColumn(parentNote.noteId, "Gone")).toBe(true);
+
+        // The mirror was polluted by a racy write-back during the stale window:
+        // the marker survives that too (the definition still names the value).
+        await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" }, { value: "Gone" } ] },
+            false, [ "Kept", "Gone" ], true
+        );
+        expect(isRecentlyRemovedColumn(parentNote.noteId, "Gone")).toBe(true);
+
+        // Converged: fresh definition without the value, raw mirror clean, no note.
+        await getBoardData(
+            parentNote, "status",
+            { columns: [ { value: "Kept" } ] },
+            false, [ "Kept" ], true
+        );
+        expect(isRecentlyRemovedColumn(parentNote.noteId, "Gone")).toBe(false);
     });
 
     it("keeps a brand-new empty column that is in no source yet (#11100 review)", async () => {

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -11,13 +11,16 @@ export type ColumnMap = Map<string, {
 /**
  * @param definitionOptions the choices the board's group-by definition offers, empty when it has no
  *                          select definition of its own to lead the column order.
+ * @param persistedColumnsAreMirror whether the persisted columns are a mirror of this resolution
+ *                                  because the board owns the definition (see resolveBoardColumns).
  */
 export async function getBoardData(
     parentNote: FNote,
     groupByColumn: string,
     persistedData: BoardViewData,
     includeArchived: boolean,
-    definitionOptions: string[] = []
+    definitionOptions: string[] = [],
+    persistedColumnsAreMirror = false
 ) {
     const byColumn: ColumnMap = new Map();
 
@@ -25,7 +28,7 @@ export async function getBoardData(
     await recursiveGroupBy(parentNote.getChildBranches(), byColumn, groupByColumn, includeArchived, new Set<string>());
 
     const persistedColumns = (persistedData.columns ?? []).map(c => c.value);
-    const columns = resolveBoardColumns(definitionOptions, persistedColumns, [ ...byColumn.keys() ]);
+    const columns = resolveBoardColumns(definitionOptions, persistedColumns, [ ...byColumn.keys() ], persistedColumnsAreMirror);
 
     // A column the notes have nothing in is still a column, so every resolved one gets an entry.
     for (const column of columns) {

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -1,6 +1,10 @@
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
-import { isRecentlyRemovedColumn, resolveBoardColumns } from "./columns";
+import {
+    isRecentlyRemovedColumn,
+    resolveBoardColumns,
+    unnoteColumnRemoved
+} from "./columns";
 import { BoardViewData } from "./index";
 
 export type ColumnMap = Map<string, {
@@ -32,6 +36,17 @@ export async function getBoardData(
     // while the definition write is still in flight (#11100). Values nothing removed are
     // never dropped: a column added a moment ago is equally absent from the other two
     // sources, and dropping it would lose the user's work.
+    // A removed value a note carries again was recreated by intent (another
+    // split, a synced client, a script) — clear its mark so the mirror filter
+    // stops applying from this refresh on. The stale-definition leg of the
+    // original delete race must NOT clear the mark, so only discovered note
+    // values do.
+    for (const value of byColumn.keys()) {
+        if (isRecentlyRemovedColumn(parentNote.noteId, value)) {
+            unnoteColumnRemoved(parentNote.noteId, value);
+        }
+    }
+
     const persistedValues = (persistedData.columns ?? []).map(c => c.value);
     const persistedColumns = persistedColumnsAreMirror
         ? persistedValues.filter(value => !isRecentlyRemovedColumn(parentNote.noteId, value))

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -1,6 +1,6 @@
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
-import { resolveBoardColumns } from "./columns";
+import { isRecentlyRemovedColumn, resolveBoardColumns } from "./columns";
 import { BoardViewData } from "./index";
 
 export type ColumnMap = Map<string, {
@@ -27,8 +27,18 @@ export async function getBoardData(
     // First, scan all notes to find what columns actually exist
     await recursiveGroupBy(parentNote.getChildBranches(), byColumn, groupByColumn, includeArchived, new Set<string>());
 
-    const persistedColumns = (persistedData.columns ?? []).map(c => c.value);
-    const columns = resolveBoardColumns(definitionOptions, persistedColumns, [ ...byColumn.keys() ], persistedColumnsAreMirror);
+    // For a board that owns its definition the persisted list is only a mirror of the
+    // resolved columns, so a value the board's column UI removed must not linger in it
+    // while the definition write is still in flight (#11100). Values nothing removed are
+    // never dropped: a column added a moment ago is equally absent from the other two
+    // sources, and dropping it would lose the user's work.
+    const persistedValues = (persistedData.columns ?? []).map(c => c.value);
+    const persistedColumns = persistedColumnsAreMirror
+        ? persistedValues.filter(value => !isRecentlyRemovedColumn(parentNote.noteId, value))
+        : persistedValues;
+    const columns = resolveBoardColumns(
+        definitionOptions, persistedColumns, [ ...byColumn.keys() ]
+    );
 
     // A column the notes have nothing in is still a column, so every resolved one gets an entry.
     for (const column of columns) {

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -2,6 +2,7 @@ import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
 import {
     isRecentlyRemovedColumn,
+    recentlyRemovedColumnsFor,
     resolveBoardColumns,
     unnoteColumnRemoved
 } from "./columns";
@@ -48,6 +49,23 @@ export async function getBoardData(
     }
 
     const persistedValues = (persistedData.columns ?? []).map(c => c.value);
+    // A marked value the RAW persisted list (pre-filter) no longer names, that
+    // the definition this refresh read does not name either, and that no note
+    // carries, has fully converged away — the delete's definition write landed
+    // and the mirror is clean — so the marker's job is done; any future
+    // appearance of the value is a genuine recreation. Requiring all three
+    // legs keeps the original delete race (#11100) covered: while the stale
+    // definition still names the value the marker survives, so a racy
+    // write-back into board.json keeps being filtered instead of resurrected.
+    for (const value of recentlyRemovedColumnsFor(parentNote.noteId)) {
+        if (
+            !definitionOptions.includes(value) &&
+            !persistedValues.includes(value) &&
+            !byColumn.has(value)
+        ) {
+            unnoteColumnRemoved(parentNote.noteId, value);
+        }
+    }
     const persistedColumns = persistedColumnsAreMirror
         ? persistedValues.filter(value => !isRecentlyRemovedColumn(parentNote.noteId, value))
         : persistedValues;

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -139,7 +139,9 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     }), [ branchIdToEdit, columnNameToEdit, draggedCard, draggedColumn, dropPosition, dropTarget ]);
 
     function refresh() {
-        getBoardData(parentNote, statusAttributeWithPrefix, viewConfig ?? {}, includeArchived, statusDefinition?.options ?? [])
+        // A definition the board owns is written only by the board's own column sync, so the
+        // persisted list mirrors it; one it merely inherits still leads the attachment alone.
+        getBoardData(parentNote, statusAttributeWithPrefix, viewConfig ?? {}, includeArchived, statusDefinition?.options ?? [], statusDefinition?.isOwned === true)
             .then(({ byColumn, columns, newPersistedData, isInRelationMode }) => {
                 setByColumn(byColumn);
                 setIsRelationMode(isInRelationMode);


### PR DESCRIPTION
Fixes #11100.

## What happens on 0.105.0

On a server-hosted instance, deleting a kanban column (right-click → *Delete column*, confirmed) silently fails — the column comes back empty every time. Local desktop usage mostly wins the race, which is why this surfaced as server-access-only.

## The race

`removeColumn` deletes the notes' status labels, then `storeColumns` saves the view config (column dropped) and fires the definition write that drops it from `selectOptions`. The config save re-renders the board, and the refresh it triggers resolves columns from the `statusDefinition` memo — which still holds the pre-write options, because `attributes.setLabel` only awaits the HTTP round-trip while the memo is invalidated by the websocket `entitiesReloaded` that lands later. On a server connection that window reliably loses.

The stale options resurrect the column in `resolveBoardColumns` (the definition leads), `getBoardData` then writes it back into `board.json`, and the render-time definition sync sees an already-up-to-date definition. Now the column lives in the persisted mirror with neither the definition nor any note naming it — and a persisted column never leaves on its own, so the delete is permanently undone.

## The fix

A board that **owns** its definition is the one case where the persisted list is only a mirror of that same resolution, written by the board itself. For those boards, `resolveBoardColumns` now filters the persisted columns against the definition options and the discovered note values, so the delete sticks as soon as either settles, and the mirror self-heals on the next refresh.

Boards without a definition of their own keep the old behaviour exactly: their persisted list is the arrangement itself (pre-definition columns, values held by off-board notes), not a mirror of anything, and `isOwned === false` (inherited/template definitions) also keeps it.

## Verification

- `vitest run src/widgets/collections/board/` — 47/47 (6 files), including new cases: a mirror drops a column nothing else names, keeps one still named by the definition or the notes, non-mirror boards keep arranged columns, and `getBoardData` heals a resurrected `board.json` in one pass.
- Repo typecheck is clean for these files (the local `apps/web-clipper` project lacks the generated `.wxt` assets here; those errors reproduce on an unmodified tree and are environment-only).