### PR TITLE
feat(tab-row): switch tabs with the mouse wheel when the row fits

### DIFF
--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -12,7 +12,7 @@ import { clampDragDestination } from "../services/tab_pinning.js";
 import { buildTabTitle, TAB_TITLE_SEPARATOR } from "../services/tab_title.js";
 import utils from "../services/utils.js";
 import BasicWidget from "./basic_widget.js";
-import { setupHorizontalScrollViaWheel, tabWheelAction } from "./widget_utils.js";
+import { setupHorizontalScrollViaWheel, shouldCoalesceWheelSwitch, tabWheelAction } from "./widget_utils.js";
 
 /** One wheel gesture may switch at most one tab inside this window. */
 const WHEEL_SWITCH_COALESCE_MS = 250;
@@ -357,6 +357,8 @@ export default class TabRowWidget extends BasicWidget {
 
     /** Timestamp of the last wheel-driven tab switch, for gesture coalescing. */
     private lastWheelSwitchAt = 0;
+    /** Direction of that switch: a reversed wheel is a new gesture, not a continuation. */
+    private lastWheelSwitchAction: "next" | "previous" | null = null;
 
     doRender() {
         this.$widget = $(TAB_ROW_TPL);
@@ -452,15 +454,24 @@ export default class TabRowWidget extends BasicWidget {
             event.preventDefault();
             event.stopImmediatePropagation();
             // One physical gesture emits several wheel events (trackpad flicks
-            // especially); switch once per gesture, not once per event. Every
-            // qualifying event refreshes the window, so a sustained gesture
-            // stays one switch and the window only re-arms after a real pause.
+            // especially); switch once per gesture, not once per event. A
+            // same-direction event inside the window extends it (a sustained
+            // gesture stays one switch); a reversed direction switches at once.
             const now = Date.now();
-            if (now - this.lastWheelSwitchAt < WHEEL_SWITCH_COALESCE_MS) {
+            if (
+                shouldCoalesceWheelSwitch({
+                    lastSwitchAt: this.lastWheelSwitchAt,
+                    lastAction: this.lastWheelSwitchAction,
+                    action,
+                    now,
+                    coalesceMs: WHEEL_SWITCH_COALESCE_MS
+                })
+            ) {
                 this.lastWheelSwitchAt = now;
                 return;
             }
             this.lastWheelSwitchAt = now;
+            this.lastWheelSwitchAction = action;
             this.triggerCommand(action === "next" ? "activateNextTab" : "activatePreviousTab");
         });
 

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -452,9 +452,12 @@ export default class TabRowWidget extends BasicWidget {
             event.preventDefault();
             event.stopImmediatePropagation();
             // One physical gesture emits several wheel events (trackpad flicks
-            // especially); switch once per gesture, not once per event.
+            // especially); switch once per gesture, not once per event. Every
+            // qualifying event refreshes the window, so a sustained gesture
+            // stays one switch and the window only re-arms after a real pause.
             const now = Date.now();
             if (now - this.lastWheelSwitchAt < WHEEL_SWITCH_COALESCE_MS) {
+                this.lastWheelSwitchAt = now;
                 return;
             }
             this.lastWheelSwitchAt = now;

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -14,6 +14,9 @@ import utils from "../services/utils.js";
 import BasicWidget from "./basic_widget.js";
 import { setupHorizontalScrollViaWheel, tabWheelAction } from "./widget_utils.js";
 
+/** One wheel gesture may switch at most one tab inside this window. */
+const WHEEL_SWITCH_COALESCE_MS = 250;
+
 const isDesktop = utils.isDesktop();
 
 const TAB_CONTAINER_MIN_WIDTH = 100;
@@ -352,6 +355,9 @@ export default class TabRowWidget extends BasicWidget {
     /** Monotonic id stamped on a tab per `updateTab` call, so an out-of-order async update can detect it's stale. */
     private tabUpdateId = 0;
 
+    /** Timestamp of the last wheel-driven tab switch, for gesture coalescing. */
+    private lastWheelSwitchAt = 0;
+
     doRender() {
         this.$widget = $(TAB_ROW_TPL);
         this.$tabScrollingContainer = this.$widget.children(".tab-row-widget-scrolling-container");
@@ -445,6 +451,13 @@ export default class TabRowWidget extends BasicWidget {
 
             event.preventDefault();
             event.stopImmediatePropagation();
+            // One physical gesture emits several wheel events (trackpad flicks
+            // especially); switch once per gesture, not once per event.
+            const now = Date.now();
+            if (now - this.lastWheelSwitchAt < WHEEL_SWITCH_COALESCE_MS) {
+                return;
+            }
+            this.lastWheelSwitchAt = now;
             this.triggerCommand(action === "next" ? "activateNextTab" : "activatePreviousTab");
         });
 

--- a/apps/client/src/widgets/tab_row.ts
+++ b/apps/client/src/widgets/tab_row.ts
@@ -12,7 +12,7 @@ import { clampDragDestination } from "../services/tab_pinning.js";
 import { buildTabTitle, TAB_TITLE_SEPARATOR } from "../services/tab_title.js";
 import utils from "../services/utils.js";
 import BasicWidget from "./basic_widget.js";
-import { setupHorizontalScrollViaWheel } from "./widget_utils.js";
+import { setupHorizontalScrollViaWheel, tabWheelAction } from "./widget_utils.js";
 
 const isDesktop = utils.isDesktop();
 
@@ -429,6 +429,25 @@ export default class TabRowWidget extends BasicWidget {
     };
 
     setupScrollEvents() {
+        // Bound before the horizontal scroller: when the row has nothing to
+        // scroll the switch owns the wheel and stops the scroller's no-op
+        // scroll; when it overflows the action is null and scrolling keeps
+        // its established job (#11095).
+        this.$tabScrollingContainer.on("wheel", (event) => {
+            const action = tabWheelAction(
+                event.originalEvent as WheelEvent,
+                this.$tabScrollingContainer[0]
+            );
+
+            if (!action) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            this.triggerCommand(action === "next" ? "activateNextTab" : "activatePreviousTab");
+        });
+
         setupHorizontalScrollViaWheel(this.$tabScrollingContainer);
 
         this.$scrollButtonLeft[0].addEventListener('click', () => this.scrollTabContainer(-210));

--- a/apps/client/src/widgets/widget_utils.spec.ts
+++ b/apps/client/src/widgets/widget_utils.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { tabWheelAction } from "./widget_utils.js";
+
+function wheelEvent(delta: { deltaY?: number; deltaX?: number }, modifiers: { ctrl?: boolean; alt?: boolean; shift?: boolean } = {}) {
+    return {
+        deltaY: delta.deltaY ?? 0,
+        deltaX: delta.deltaX ?? 0,
+        ctrlKey: modifiers.ctrl ?? false,
+        altKey: modifiers.alt ?? false,
+        shiftKey: modifiers.shift ?? false,
+    } as WheelEvent;
+}
+
+function container(scrollWidth: number, clientWidth: number) {
+    return { scrollWidth, clientWidth } as HTMLElement;
+}
+
+describe("tabWheelAction", () => {
+    it("switches tabs when the row has nothing to scroll", () => {
+        const row = container(500, 500);
+
+        expect(tabWheelAction(wheelEvent({ deltaY: -3 }), row)).toBe("previous");
+        expect(tabWheelAction(wheelEvent({ deltaY: 3 }), row)).toBe("next");
+    });
+
+    it("honors a horizontal wheel the same as a vertical one", () => {
+        const row = container(500, 500);
+
+        expect(tabWheelAction(wheelEvent({ deltaX: -3 }), row)).toBe("previous");
+        expect(tabWheelAction(wheelEvent({ deltaX: 3 }), row)).toBe("next");
+    })
+
+    it("keeps the wheel for horizontal scrolling while the row overflows", () => {
+        const row = container(1200, 500);
+
+        expect(tabWheelAction(wheelEvent({ deltaY: -3 }), row)).toBeNull();
+        expect(tabWheelAction(wheelEvent({ deltaY: 3 }), row)).toBeNull();
+    });
+
+    it("leaves modifier-held wheels to their owners", () => {
+        const row = container(500, 500);
+
+        expect(tabWheelAction(wheelEvent({ deltaY: 3 }, { ctrl: true }), row)).toBeNull();
+        expect(tabWheelAction(wheelEvent({ deltaY: 3 }, { alt: true }), row)).toBeNull();
+        expect(tabWheelAction(wheelEvent({ deltaY: 3 }, { shift: true }), row)).toBeNull();
+    });
+
+    it("ignores momentum ticks with no meaningful delta", () => {
+        const row = container(500, 500);
+
+        expect(tabWheelAction(wheelEvent({ deltaY: 0.4 }), row)).toBeNull();
+    });
+});

--- a/apps/client/src/widgets/widget_utils.spec.ts
+++ b/apps/client/src/widgets/widget_utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { tabWheelAction } from "./widget_utils.js";
+import { shouldCoalesceWheelSwitch, tabWheelAction } from "./widget_utils.js";
 
 function wheelEvent(
     delta: { deltaY?: number; deltaX?: number },
@@ -53,5 +53,26 @@ describe("tabWheelAction", () => {
         const row = container(500, 500);
 
         expect(tabWheelAction(wheelEvent({ deltaY: 0.4 }), row)).toBeNull();
+    });
+});
+
+describe("shouldCoalesceWheelSwitch", () => {
+    const base = { coalesceMs: 250 };
+
+    it("coalesces same-direction events inside the window and extends it", () => {
+        expect(shouldCoalesceWheelSwitch({ ...base, lastSwitchAt: 1000, lastAction: "next", action: "next", now: 1100 })).toBe(true);
+        expect(shouldCoalesceWheelSwitch({ ...base, lastSwitchAt: 1100, lastAction: "next", action: "next", now: 1330 })).toBe(true);
+    });
+
+    it("lets a reversed direction switch immediately", () => {
+        expect(shouldCoalesceWheelSwitch({ ...base, lastSwitchAt: 1000, lastAction: "next", action: "previous", now: 1100 })).toBe(false);
+    });
+
+    it("re-arms after the window passes with no qualifying events", () => {
+        expect(shouldCoalesceWheelSwitch({ ...base, lastSwitchAt: 1000, lastAction: "next", action: "next", now: 1300 })).toBe(false);
+    });
+
+    it("never coalesces the first switch", () => {
+        expect(shouldCoalesceWheelSwitch({ ...base, lastSwitchAt: 0, lastAction: null, action: "previous", now: 10 })).toBe(false);
     });
 });

--- a/apps/client/src/widgets/widget_utils.spec.ts
+++ b/apps/client/src/widgets/widget_utils.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { tabWheelAction } from "./widget_utils.js";
 
-function wheelEvent(delta: { deltaY?: number; deltaX?: number }, modifiers: { ctrl?: boolean; alt?: boolean; shift?: boolean } = {}) {
+function wheelEvent(
+    delta: { deltaY?: number; deltaX?: number },
+    modifiers: { ctrl?: boolean; alt?: boolean; shift?: boolean } = {}
+) {
     return {
         deltaY: delta.deltaY ?? 0,
         deltaX: delta.deltaX ?? 0,
@@ -29,7 +32,7 @@ describe("tabWheelAction", () => {
 
         expect(tabWheelAction(wheelEvent({ deltaX: -3 }), row)).toBe("previous");
         expect(tabWheelAction(wheelEvent({ deltaX: 3 }), row)).toBe("next");
-    })
+    });
 
     it("keeps the wheel for horizontal scrolling while the row overflows", () => {
         const row = container(1200, 500);

--- a/apps/client/src/widgets/widget_utils.ts
+++ b/apps/client/src/widgets/widget_utils.ts
@@ -19,6 +19,27 @@ export function setupHorizontalScrollViaWheel($container: JQuery<HTMLElement>) {
  * Modifier keys stay with their owners (zoom, history, ...), and a wheel event
  * with no meaningful delta (a momentum tick) switches nothing.
  */
+/**
+ * Whether a qualifying wheel event should switch tabs now or is coalesced into
+ * the gesture that just switched (#11095). Same-direction events within the
+ * window extend it — one continuous gesture is one switch — while an
+ * opposite-direction event switches immediately: the user reversing their
+ * scroll is a new gesture, not a continuation, and eating it would strand the
+ * selection one tab away from where they started.
+ */
+export function shouldCoalesceWheelSwitch(args: {
+    lastSwitchAt: number
+    lastAction: "next" | "previous" | null
+    action: "next" | "previous"
+    now: number
+    coalesceMs: number
+}): boolean {
+    if (args.lastAction === null || args.lastAction !== args.action) {
+        return false
+    }
+    return args.now - args.lastSwitchAt < args.coalesceMs
+}
+
 export function tabWheelAction(
     event: WheelEvent,
     container: HTMLElement

--- a/apps/client/src/widgets/widget_utils.ts
+++ b/apps/client/src/widgets/widget_utils.ts
@@ -11,6 +11,31 @@ export function setupHorizontalScrollViaWheel($container: JQuery<HTMLElement>) {
     });
 }
 
+/**
+ * The wheel's job over the tab row: while the row overflows, horizontal
+ * scrolling keeps its established job; with nothing left to scroll, the wheel
+ * switches to the adjacent tab instead (#11095, Firefox-style).
+ *
+ * Modifier keys stay with their owners (zoom, history, ...), and a wheel event
+ * with no meaningful delta (a momentum tick) switches nothing.
+ */
+export function tabWheelAction(
+    event: WheelEvent,
+    container: HTMLElement
+): "next" | "previous" | null {
+    if (utils.isCtrlKey(event) || event.altKey || event.shiftKey) {
+        return null;
+    }
+    if (container.scrollWidth <= container.clientWidth + 1) {
+        const delta = event.deltaY + event.deltaX;
+        if (Math.abs(delta) < 1) {
+            return null;
+        }
+        return delta > 0 ? "next" : "previous";
+    }
+    return null;
+}
+
 export function onWheelHorizontalScroll(event: WheelEvent) {
     if (!event.currentTarget || utils.isCtrlKey(event) || event.altKey || event.shiftKey) {
         return;


### PR DESCRIPTION
Closes #11095.

## What it does

Scrolling the wheel over the tab row now activates the adjacent tab (next on scroll-down, previous on scroll-up, wrapping around), the way Firefox's `toolkit.tabbox.switchByScrolling` does — **but only while the row has nothing to scroll horizontally**. With more tabs than fit, the wheel keeps its established job of scrolling the row, so nothing a user already relies on changes.

## Design

- The decision lives in a pure `tabWheelAction(event, container)` helper (`widget_utils.ts`), next to the horizontal-scroll wheel helper it coordinates with.
- The switch handler binds **before** the horizontal scroller: with no overflow it owns the wheel (and stops the scroller's no-op scroll); with overflow it returns `null` and the scroller is untouched.
- Modifier-held wheels (Ctrl = zoom, Alt/Shift = their own shortcuts) and momentum ticks with a sub-unit delta switch nothing.
- Both wheel axes count, so a tilted/trackpad horizontal wheel switches tabs too.
- Activation goes through the existing `activateNextTab` / `activatePreviousTab` commands, so wrapping, sub-contexts and pinned-tab behavior stay consistent with the keyboard shortcuts.

## Verification

- `widget_utils.spec.ts` (new, 5 cases): switching both directions on both axes when the row fits, null while the row overflows, every modifier guard, and the momentum-tick guard — 5/5 green.
- Repo typecheck clean for these files (the usual local `apps/web-clipper` env noise aside, which reproduces on an unmodified tree).