### PR TITLE
feat(website): offer every language Weblate reports as translated

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     paths:
       - "apps/client/src/translations/**"
+      - "apps/website/src/translations/**"
+      - "apps/website/src/locales.ts"
+      - "packages/commons/src/lib/i18n.ts"
+      - "scripts/translation/**"
       - ".github/workflows/i18n.yml"
 
 permissions:

--- a/apps/website/src/i18n.spec.ts
+++ b/apps/website/src/i18n.spec.ts
@@ -1,15 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { extractLocaleFromUrl, mapLocale, swapLocaleInUrl } from "./i18n";
+import { extractLocaleFromUrl, LOCALES, mapLocale, swapLocaleInUrl } from "./i18n";
 
 describe("mapLocale", () => {
     it("maps Chinese", () => {
         expect(mapLocale("zh-TW")).toStrictEqual("zh-Hant");
         expect(mapLocale("zh-CN")).toStrictEqual("zh-Hans");
+        expect(mapLocale("zh-Hant")).toStrictEqual("zh-Hant");
+        expect(mapLocale("zh-Hans")).toStrictEqual("zh-Hans");
     });
 
     it("maps languages without countries", () => {
         expect(mapLocale("ro-RO")).toStrictEqual("ro");
         expect(mapLocale("ro")).toStrictEqual("ro");
+    });
+
+    it("keeps the region of locales offered per region", () => {
+        expect(mapLocale("en-GB")).toStrictEqual("en-GB");
+        expect(mapLocale("pt-BR")).toStrictEqual("pt-BR");
+        expect(mapLocale("nb-NO")).toStrictEqual("nb-NO");
+    });
+
+    it("resolves a bare language to the only region offered for it", () => {
+        expect(mapLocale("nb")).toStrictEqual("nb-NO");
+        expect(mapLocale("pt")).toStrictEqual("pt-BR");
+    });
+
+    it("prefers the exact match over a region sharing the language", () => {
+        expect(mapLocale("en")).toStrictEqual("en");
+        expect(mapLocale("en-US")).toStrictEqual("en");
+        expect(mapLocale("de-AT")).toStrictEqual("de");
+    });
+
+    it("falls back to English for languages that are not offered", () => {
+        expect(mapLocale("sv")).toStrictEqual("en");
+        expect(mapLocale("hu-HU")).toStrictEqual("en");
+        expect(mapLocale("")).toStrictEqual("en");
+    });
+
+    it("only ever returns a locale the website offers", () => {
+        const ids = LOCALES.map(l => l.id);
+        const tags = [ "ro-RO", "zh-HK", "pt", "nb", "sv", "en-AU", "ug", "ar-EG" ];
+        for (const tag of tags) {
+            expect(ids).toContain(mapLocale(tag));
+        }
     });
 });
 

--- a/apps/website/src/i18n.ts
+++ b/apps/website/src/i18n.ts
@@ -1,16 +1,14 @@
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 
-interface Locale {
-    id: string;
-    name: string;
-    rtl?: boolean;
-}
+import { LOCALES } from "./locales";
+
+export { type Locale, LOCALES } from "./locales";
 
 i18next.use(initReactI18next);
 const localeFiles = import.meta.glob("./translations/*/translation.json", { eager: true });
 const resources: Record<string, Record<string, Record<string, string>>> = {};
-for (const [path, module] of Object.entries(localeFiles)) {
+for (const [ path, module ] of Object.entries(localeFiles)) {
     const id = path.split("/").at(-2);
     if (!id) continue;
 
@@ -31,32 +29,32 @@ export function initTranslations(lng: string) {
     });
 }
 
-export const LOCALES: Locale[] = [
-    { id: "en", name: "English" },
-    { id: "ro", name: "Română" },
-    { id: "zh-Hans", name: "简体中文" },
-    { id: "zh-Hant", name: "繁體中文" },
-    { id: "fr", name: "Français" },
-    { id: "it", name: "Italiano" },
-    { id: "ja", name: "日本語" },
-    { id: "pl", name: "Polski" },
-    { id: "es", name: "Español" },
-    { id: "ar", name: "اَلْعَرَبِيَّةُ", rtl: true },
-].toSorted((a, b) => a.name.localeCompare(b.name));
-
+/**
+ * Resolves a language tag, either a URL segment or `navigator.language`, to a locale
+ * from {@link LOCALES}, falling back to `en` for languages the website does not offer.
+ */
 export function mapLocale(locale: string) {
-    if (!locale) return 'en';
+    if (!locale) return "en";
     const lower = locale.toLowerCase();
 
-    if (lower.startsWith('zh')) {
-        if (lower.includes('tw') || lower.includes('hk') || lower.includes('mo') || lower.includes('hant')) {
-            return 'zh-Hant';
-        }
-        return 'zh-Hans';
+    // Chinese is offered by script, which browsers report only through the region.
+    if (lower.startsWith("zh")) {
+        const traditional = [ "tw", "hk", "mo", "hant" ].some(marker => lower.includes(marker));
+        return traditional ? "zh-Hant" : "zh-Hans";
     }
 
-    // Default for everything else
-    return locale.split('-')[0]; // e.g. "en-US" -> "en"
+    const exact = LOCALES.find(l => l.id.toLowerCase() === lower);
+    if (exact) return exact.id;
+
+    // "de-AT" falls back to "de". The region-less entry wins over a regional one sharing
+    // the language, so "en-US" reaches "en" rather than whichever of "en"/"en-GB" sorts first.
+    const language = lower.split("-")[0];
+    const regionless = LOCALES.find(l => l.id.toLowerCase() === language);
+    if (regionless) return regionless.id;
+
+    // A bare "nb" reaches "nb-NO", the only region offered for it.
+    const sameLanguage = LOCALES.find(l => l.id.toLowerCase().split("-")[0] === language);
+    return sameLanguage?.id ?? "en";
 }
 
 export function swapLocaleInUrl(url: string, newLocale: string) {
@@ -76,7 +74,7 @@ export function swapLocaleInUrl(url: string, newLocale: string) {
 }
 
 export function extractLocaleFromUrl(url: string) {
-    const localeId = url.split('/')[1];
+    const localeId = url.split("/")[1];
     const correspondingLocale = LOCALES.find(l => l.id === localeId);
     if (!correspondingLocale) return undefined;
     return localeId;

--- a/apps/website/src/locales.ts
+++ b/apps/website/src/locales.ts
@@ -1,0 +1,39 @@
+export interface Locale {
+    id: string;
+    name: string;
+    rtl?: boolean;
+}
+
+/**
+ * The languages offered by the language selector, in their own script.
+ *
+ * `scripts/translation/check-translation-coverage.ts` fails the build when Weblate
+ * reports a language above the coverage threshold that is missing here. A locale
+ * carrying a region (`pt-BR`, `nb-NO`) also needs `mapLocale()` to resolve it, which
+ * it does by matching this list.
+ */
+export const LOCALES: Locale[] = [
+    { id: "ar", name: "اَلْعَرَبِيَّةُ", rtl: true },
+    { id: "cs", name: "Čeština" },
+    { id: "de", name: "Deutsch" },
+    { id: "el", name: "Ελληνικά" },
+    { id: "en", name: "English (United States)" },
+    { id: "en-GB", name: "English (United Kingdom)" },
+    { id: "es", name: "Español" },
+    { id: "fr", name: "Français" },
+    { id: "ga", name: "Gaeilge" },
+    { id: "hi", name: "हिन्दी" },
+    { id: "id", name: "Bahasa Indonesia" },
+    { id: "it", name: "Italiano" },
+    { id: "ja", name: "日本語" },
+    { id: "ko", name: "한국어" },
+    { id: "nb-NO", name: "Norsk bokmål" },
+    { id: "pl", name: "Polski" },
+    { id: "pt-BR", name: "Português (Brasil)" },
+    { id: "ro", name: "Română" },
+    { id: "ru", name: "Русский" },
+    { id: "ug", name: "ئۇيغۇرچە", rtl: true },
+    { id: "uk", name: "Українська" },
+    { id: "zh-Hans", name: "简体中文" },
+    { id: "zh-Hant", name: "繁體中文" }
+].toSorted((a, b) => a.name.localeCompare(b.name));

--- a/docs/Developer Guide/Developer Guide/Concepts/Internationalisation  Translations/Adding a new locale.md
+++ b/docs/Developer Guide/Developer Guide/Concepts/Internationalisation  Translations/Adding a new locale.md
@@ -12,3 +12,16 @@ To do so:
 7.  Locale mappings for PDF.js might need adjustment. To do so, in `packages/pdfjs-viewer/scripts/build.ts` there is `LOCALE_MAPPINGS`. No entry is needed when the locale's `electronLocale` already names a directory under `packages/pdfjs-viewer/viewer/locale`.
 
 Steps 1 to 6 are keyed by `DISPLAYABLE_LOCALE_IDS`, so `pnpm typecheck` reports each one still missing after step 1.
+
+## The website
+
+The website tracks its own Weblate component and its own list, so a locale added to the application above is not offered on [triliumnotes.org](https://triliumnotes.org) until it is added there too.
+
+1.  In `apps/website`, look for `locales.ts` and add an entry to `LOCALES`, using the language's own name and setting `rtl` where it applies. The id must match the folder under `apps/website/src/translations`, which Weblate creates.
+2.  A locale carrying a region, such as `pt-BR`, is resolved by `mapLocale()` in `i18n.ts` by matching `LOCALES`, so it needs no further mapping. Chinese is the exception: it is selected by script, which browsers report only through the region, and `mapLocale()` special-cases it.
+
+## The coverage gate
+
+`scripts/translation/check-translation-coverage.ts` fails CI once Weblate reports a language above 50% that is missing from either list. It runs on the `weblate:*` branches, so the pull request that brings the translations in is where it fires.
+
+The gate only catches a language that is translated but not offered. It does not notice one that is offered and has since fallen behind, and it does not check that the locale renders — only that the id is listed.

--- a/scripts/translation/check-translation-coverage.ts
+++ b/scripts/translation/check-translation-coverage.ts
@@ -1,19 +1,58 @@
-import { LOCALES } from "../../packages/commons/src/lib/i18n";
-import { getLanguageStats } from "./utils";
+import { LOCALES as WEBSITE_LOCALES } from "../../apps/website/src/locales";
+import { LOCALES as APP_LOCALES } from "../../packages/commons/src/lib/i18n";
+import { getLanguageStats, type WeblateProject } from "./utils";
+
+/**
+ * Coverage above which a language must be offered, rather than sitting
+ * translated but unreachable.
+ */
+const MINIMUM_COVERAGE_PERCENT = 50;
+
+interface GatedProject {
+    project: WeblateProject;
+    /** Names the list a maintainer has to add the locale to, quoted in the failure. */
+    listDescription: string;
+    localeIds: string[];
+}
+
+const GATED_PROJECTS: GatedProject[] = [
+    {
+        project: "client",
+        listDescription: "LOCALES in packages/commons/src/lib/i18n.ts",
+        localeIds: APP_LOCALES.map(l => l.id)
+    },
+    {
+        project: "website",
+        listDescription: "LOCALES in apps/website/src/locales.ts",
+        localeIds: WEBSITE_LOCALES.map(l => l.id)
+    }
+];
 
 async function main() {
-    const project = "client";
-    const languageStats = await getLanguageStats(project);
-    const localesWithCoverage = languageStats.results
-        .filter(language => language.translated_percent > 50)
+    const failures: string[] = [];
 
-    for (const localeData of localesWithCoverage) {
-        const { language_code: localeId, translated_percent: percentage, language } = localeData;
-        const locale = LOCALES.find(l => l.id === localeId);
-        if (!locale) {
-            console.error(`❌ Language ${language.name} (${localeId}) has a coverage of ${percentage}% in '${project}', but it is not supported by the application.`);
-            process.exit(1);
+    for (const { project, listDescription, localeIds } of GATED_PROJECTS) {
+        const languageStats = await getLanguageStats(project);
+        for (const localeData of languageStats.results) {
+            const localeId = localeData.language_code;
+            const percentage = localeData.translated_percent;
+            if (percentage <= MINIMUM_COVERAGE_PERCENT || localeIds.includes(localeId)) {
+                continue;
+            }
+
+            failures.push(
+                `❌ ${localeData.language.name} (${localeId}) is ${percentage}% translated `
+                + `in '${project}', but is missing from ${listDescription}.`);
         }
+    }
+
+    if (failures.length > 0) {
+        for (const failure of failures.toSorted((a, b) => a.localeCompare(b))) {
+            console.error(failure);
+        }
+        console.error(`\n${failures.length} language(s) above `
+            + `${MINIMUM_COVERAGE_PERCENT}% are translated but not offered.`);
+        process.exit(1);
     }
 
     console.log("✅ Translation coverage check passed.");

--- a/scripts/translation/utils.spec.ts
+++ b/scripts/translation/utils.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { CACHE_MAX_AGE_MS, isCacheFresh } from "./utils";
+
+describe("isCacheFresh", () => {
+    const now = new Date("2026-08-20T12:00:00Z").getTime();
+
+    it("accepts a cache younger than the maximum age", () => {
+        expect(isCacheFresh(now, now)).toBe(true);
+        expect(isCacheFresh(now - 1000, now)).toBe(true);
+        expect(isCacheFresh(now - CACHE_MAX_AGE_MS + 1, now)).toBe(true);
+    });
+
+    it("rejects a cache at or past the maximum age", () => {
+        expect(isCacheFresh(now - CACHE_MAX_AGE_MS, now)).toBe(false);
+        expect(isCacheFresh(now - 7 * CACHE_MAX_AGE_MS, now)).toBe(false);
+    });
+
+    it("rejects a cache stamped in the future", () => {
+        expect(isCacheFresh(now + 1, now)).toBe(false);
+        expect(isCacheFresh(now + CACHE_MAX_AGE_MS, now)).toBe(false);
+    });
+});

--- a/scripts/translation/utils.spec.ts
+++ b/scripts/translation/utils.spec.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { CACHE_MAX_AGE_MS, isCacheFresh } from "./utils";
+import { CACHE_MAX_AGE_MS, fetchAllPages, isCacheFresh } from "./utils";
 
 describe("isCacheFresh", () => {
     const now = new Date("2026-08-20T12:00:00Z").getTime();
@@ -19,5 +19,45 @@ describe("isCacheFresh", () => {
     it("rejects a cache stamped in the future", () => {
         expect(isCacheFresh(now + 1, now)).toBe(false);
         expect(isCacheFresh(now + CACHE_MAX_AGE_MS, now)).toBe(false);
+    });
+});
+
+describe("fetchAllPages", () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    /** Answers each URL with a canned page, and records the order they were requested in. */
+    function stubPages(pages: Record<string, unknown>) {
+        const requested: string[] = [];
+        vi.stubGlobal("fetch", async (url: string) => {
+            requested.push(url);
+            const page = pages[url];
+            if (!page) return { ok: false, status: 404, statusText: "Not Found" };
+            return { ok: true, json: async () => page };
+        });
+        return requested;
+    }
+
+    it("follows every page and merges the results in order", async () => {
+        const requested = stubPages({
+            "/first": { count: 3, next: "/second", results: [ "a", "b" ] },
+            "/second": { count: 3, next: null, results: [ "c" ] }
+        });
+
+        const merged = await fetchAllPages("/first");
+        expect(merged).toStrictEqual({ count: 3, results: [ "a", "b", "c" ] });
+        expect(requested).toStrictEqual([ "/first", "/second" ]);
+    });
+
+    it("counts what it read rather than trusting the reported total", async () => {
+        stubPages({ "/only": { count: 99, next: null, results: [ "a" ] } });
+
+        expect(await fetchAllPages("/only")).toStrictEqual({ count: 1, results: [ "a" ] });
+    });
+
+    it("names the failing URL instead of failing to parse the body", async () => {
+        stubPages({ "/first": { count: 2, next: "/gone", results: [ "a" ] } });
+
+        await expect(fetchAllPages("/first"))
+            .rejects.toThrow("Weblate answered 404 Not Found for /gone.");
     });
 });

--- a/scripts/translation/utils.ts
+++ b/scripts/translation/utils.ts
@@ -3,10 +3,13 @@ import { join } from "path";
 
 const scriptDir = __dirname;
 
+/** The Weblate components under https://hosted.weblate.org/projects/trilium/ that are gated. */
+export type WeblateProject = "readme" | "client" | "website";
+
 /** How long a `.language-stats-*.json` cache file is reused before Weblate is queried again. */
 export const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
-export async function getLanguageStats(project: "readme" | "client") {
+export async function getLanguageStats(project: WeblateProject) {
     const cacheFile = join(scriptDir, `.language-stats-${project}.json`);
 
     // Try to read from the cache.

--- a/scripts/translation/utils.ts
+++ b/scripts/translation/utils.ts
@@ -27,13 +27,39 @@ export async function getLanguageStats(project: WeblateProject) {
 
     // Make the request
     console.log("Reading language stats from Weblate API.");
-    const request = await fetch(`https://hosted.weblate.org/api/components/trilium/${project}/translations/`);
-    const stats = JSON.parse(await request.text());
+    const stats = await fetchAllPages(
+        `https://hosted.weblate.org/api/components/trilium/${project}/translations/`);
 
     // Update the cache
     await writeFile(cacheFile, JSON.stringify(stats, null, 4));
 
     return stats;
+}
+
+/**
+ * Reads every page of a paginated Weblate endpoint into a single `results` array.
+ *
+ * The API serves 50 entries per page. Each component is already at 40 languages, so a
+ * caller reading only the first response would start losing languages once translators
+ * pick up ten more, and the coverage gate would pass by never seeing them.
+ */
+export async function fetchAllPages(firstPageUrl: string) {
+    const results: unknown[] = [];
+    let url: string | null = firstPageUrl;
+
+    while (url) {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(
+                `Weblate answered ${response.status} ${response.statusText} for ${url}.`);
+        }
+
+        const page = await response.json();
+        results.push(...page.results);
+        url = page.next;
+    }
+
+    return { count: results.length, results };
 }
 
 /**

--- a/scripts/translation/utils.ts
+++ b/scripts/translation/utils.ts
@@ -3,15 +3,16 @@ import { join } from "path";
 
 const scriptDir = __dirname;
 
+/** How long a `.language-stats-*.json` cache file is reused before Weblate is queried again. */
+export const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 export async function getLanguageStats(project: "readme" | "client") {
     const cacheFile = join(scriptDir, `.language-stats-${project}.json`);
 
     // Try to read from the cache.
     try {
         const cacheStats = await stat(cacheFile);
-        const now = new Date();
-        const oneDay = 24 * 60 * 60 * 1000; // milliseconds
-        if (cacheStats.mtimeMs < now.getTime() + oneDay) {
+        if (isCacheFresh(cacheStats.mtimeMs, Date.now())) {
             console.log("Reading language stats from cache.");
             return JSON.parse(await readFile(cacheFile, "utf-8"));
         }
@@ -30,4 +31,15 @@ export async function getLanguageStats(project: "readme" | "client") {
     await writeFile(cacheFile, JSON.stringify(stats, null, 4));
 
     return stats;
+}
+
+/**
+ * Determines whether a cache file written at `mtimeMs` can still be used at `nowMs`.
+ *
+ * A file stamped in the future is treated as stale, so a bad clock or a copied timestamp
+ * cannot pin the cache to a snapshot that never expires.
+ */
+export function isCacheFresh(mtimeMs: number, nowMs: number) {
+    const age = nowMs - mtimeMs;
+    return age >= 0 && age < CACHE_MAX_AGE_MS;
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -15,7 +15,8 @@
   "include": [
     "**/*.ts",
     "**/*.mts",
-    "../packages/commons/src/lib/i18n.ts"
+    "../packages/commons/src/lib/i18n.ts",
+    "../apps/website/src/locales.ts"
   ],
   "exclude": [
     "dist"

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     test: {
         name: "scripts",
         environment: "node",
-        include: [ "*.spec.ts" ]
+        include: [ "**/*.spec.ts" ]
     }
 });


### PR DESCRIPTION
Closes #11103

The website's language picker read from a hand-maintained `LOCALES` array that nothing checked, so it had drifted from the `website` Weblate component. Thirteen languages above the 50% bar the client already uses were bundled but unreachable — German, Indonesian, Korean and Irish among them at **100%** — while Romanian at 54.9% was offered.

## Changes

**Offer the missing languages.** `LOCALES` goes from 10 entries to 23, reusing the endonyms already curated in `packages/commons/src/lib/i18n.ts` where they exist (`el`, `nb-NO`, `ug` are new).

**Fix `mapLocale()` for locales carrying a region.** It ended in `locale.split('-')[0]`, so `en-GB`, `pt-BR` and `nb-NO` would have collapsed to `en`, a 5.1% `pt`, and a nonexistent `nb` — added to the list, they would have rendered as English rather than failing visibly. It now resolves against `LOCALES`: exact match, then the region-less entry for the language, then any region sharing it, then `en`.

Two behaviour changes fall out. A bare `nb` or `pt` reaches `nb-NO` / `pt-BR` instead of English, and a language the site does not offer (`sv`) returns `en` rather than a locale with no entry in the picker. The region-less step is load-bearing: `LOCALES` is sorted by display name, so without it `en-US` resolves to `en-GB`.

**Gate the drift.** `check-translation-coverage.ts` now checks the `website` component alongside `client`, so the next language to cross 50% fails CI instead of sitting unreachable. It reports every missing locale rather than exiting on the first, and names the file to add it to.

**Expire the stats cache** (first commit). The freshness check compared the cache mtime against a point one day in the *future*, always true for a file on disk, so `.language-stats-<project>.json` was reused forever once written — both this gate and `manage-readme.ts` were reading whatever snapshot was fetched first. CI was unaffected (the caches are gitignored), but local runs were.

## Notes for review

- `LOCALES` moves to `apps/website/src/locales.ts` because the gate runs under `tsx`, which cannot evaluate the `import.meta.glob` at the top of `i18n.ts`. `i18n.ts` re-exports it, so no call site changes.
- **`en` is renamed** to "English (United States)", matching `packages/commons`, since "English" next to "English (United Kingdom)" names nothing in particular. This is the one user-visible string change beyond the new languages.
- The gate is one-directional by design: it catches a language translated but not offered, not one offered that has since fallen behind, and it checks that an id is listed rather than that the locale renders. Documented as such.

## Pre-existing, not addressed here

RTL locales prerender without `dir`: `ar/index.html` is `<html lang="ar">`. `dir` is set in a `useLayoutEffect`, which does not run during prerender, and `prerender()`'s `head` only returns `lang` — so RTL pages paint LTR until hydration. Adding `ug` doubles the exposure, but the fix needs its own look at what preact-iso's `head` accepts.

## Verification

- Gate run live against Weblate: passes. Mutation-tested by removing `de` and `ko` — reports both, exits 1.
- `pnpm --filter website test` — 15 passing (was 11). The new `mapLocale` cases caught the `en-US` → `en-GB` ordering bug during development.
- `pnpm scripts:test` — 14 passing. The `scripts` project globbed `*.spec.ts`, matching only its own root, so nothing under `scripts/translation/` would ever have run; widened to `**/*.spec.ts`.
- `pnpm typecheck` — clean. `scripts/tsconfig.json` lists cross-project files explicitly, so `locales.ts` needed adding the same way commons' `i18n.ts` already was.
- `pnpm --filter website build` — prerenders all 23 locales; spot-checked `/de/`, `/ko/`, `/nb-NO/` for real translated content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
