### PR TITLE
fix(ckeditor5): stop content-hint flicker on cross-element transitions

### DIFF
--- a/packages/ckeditor5/src/content_hint_manager.spec.ts
+++ b/packages/ckeditor5/src/content_hint_manager.spec.ts
@@ -88,6 +88,51 @@ describe("ContentHintManager", () => {
             expect(livePopupText()).toBe("A tip");
         });
 
+        it("reuses the live popup across an element switch with unchanged content when the popup is CSS-pinned", () => {
+            const pinned = new ContentHintManager({popupPositionIsFixed: true});
+            const handleA = pinned.createHandle(a, "same tip");
+            const handleB = pinned.createHandle(b, "same tip");
+            handleA.show();
+            const popup = livePopup();
+            expect(popup).not.toBeNull();
+
+            handleB.show();
+            // The same DOM node survives the switch — no dispose/create/fade.
+            expect(livePopup()).toBe(popup);
+            expect(livePopupText()).toBe("same tip");
+
+            handleB.hide();
+            expect(livePopup()).toBe(popup);
+            expect(livePopupText()).toBe("same tip");
+            pinned.destroy();
+        });
+
+        it("still rebuilds the popup across an element switch when content differs", () => {
+            const pinned = new ContentHintManager({popupPositionIsFixed: true});
+            const handleA = pinned.createHandle(a, "tip one");
+            const handleB = pinned.createHandle(b, "tip two");
+            handleA.show();
+            const popup = livePopup();
+
+            handleB.show();
+            expect(livePopup()).not.toBe(popup);
+            expect(livePopupText()).toBe("tip two");
+            pinned.destroy();
+        });
+
+        it("still rebuilds across an element switch when the popup is anchored", () => {
+            const handleA = manager.createHandle(a, "same tip");
+            const handleB = manager.createHandle(b, "same tip");
+            handleA.show();
+            const popup = livePopup();
+
+            handleB.show();
+            // Unpinned managers keep Bootstrap's own placement, so the popup
+            // must follow the new anchor even when the text is unchanged.
+            expect(livePopup()).not.toBe(popup);
+            manager.destroy();
+        });
+
         it("show() on a handle already in the stack moves it to the top", () => {
             const first = manager.createHandle(a, "A");
             const second = manager.createHandle(b, "B");

--- a/packages/ckeditor5/src/content_hint_manager.ts
+++ b/packages/ckeditor5/src/content_hint_manager.ts
@@ -118,6 +118,15 @@ export interface ContentHintManagerOptions {
      * `null` / `undefined` disables auto-hide.
      */
     autoHideAfterMs?: number;
+    /**
+     * Set when the hint popup is CSS-pinned (fixed position, same corner for
+     * every hint), so the Bootstrap anchor element is visually irrelevant.
+     * A top-of-stack transition between elements then reuses the live popup
+     * instead of disposing and recreating it whenever the content is
+     * unchanged — the dispose/create/fade cycle renders the exact same
+     * pixels, so it is pure flicker (the desktop caret hop in #11030).
+     */
+    popupPositionIsFixed?: boolean;
 }
 
 interface StackEntry {
@@ -173,7 +182,10 @@ export class ContentHintManager {
      */
     private _destroyed = false;
 
+    private readonly _popupPositionIsFixed: boolean;
+
     constructor(options: ContentHintManagerOptions = {}) {
+        this._popupPositionIsFixed = options.popupPositionIsFixed === true;
         this._baseOptions = options.tooltipOptions ?? {};
         this._autoHideAfterMs = options.autoHideAfterMs ?? null;
     }
@@ -333,8 +345,28 @@ export class ContentHintManager {
             return;
         }
 
-        // Element changed (or nothing on top). Dispose the outgoing popup;
-        // create + show a fresh one for the new element.
+        // Element changed (or nothing on top). With a CSS-pinned popup and
+        // identical content, the rebuild below would render the exact same
+        // pixels through a dispose/create/fade cycle — pure flicker. Reuse the
+        // live popup and just retarget the bookkeeping (#11030). The outgoing
+        // element must still be connected, or Bootstrap teardown of a detached
+        // anchor could leave a stray popup we no longer control.
+        if (
+            this._popupPositionIsFixed &&
+            this._currentTooltip &&
+            top &&
+            top.content === this._currentContent &&
+            this._currentElement?.isConnected
+        ) {
+            this._currentElement = targetElement;
+            if (wasFading) {
+                this._currentTooltip.show();
+            }
+            this._resetAutoHide();
+            return;
+        }
+
+        // Dispose the outgoing popup; create + show a fresh one for the new element.
         if (this._currentTooltip) {
             this._currentTooltip.dispose();
             this._currentTooltip = null;

--- a/packages/ckeditor5/src/plugins/collapsible/collapsible_editing.ts
+++ b/packages/ckeditor5/src/plugins/collapsible/collapsible_editing.ts
@@ -1247,7 +1247,8 @@ export default class CollapsibleEditing extends Plugin {
                 sanitize: false,
                 customClass: "text-editor-content-tooltip"
             },
-            autoHideAfterMs: HINT_AUTO_HIDE_MS
+            autoHideAfterMs: HINT_AUTO_HIDE_MS,
+            popupPositionIsFixed: true
         });
         this.summaryHintManager = manager;
 

--- a/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.ts
+++ b/packages/ckeditor5/src/plugins/todo_list_multistate/todo_list_multistate_editing.ts
@@ -98,7 +98,8 @@ export default class TodoListMultistateEditing extends Plugin {
                 // keep the hint alive — hover crossing, caret movement, state
                 // change — pushes to the manager, so the timer resets and the
                 // popup stays. When events stop, it fades on its own.
-                autoHideAfterMs: 2000
+                autoHideAfterMs: 2000,
+                popupPositionIsFixed: true
             });
         }
 


### PR DESCRIPTION
Fixes #11030 (the flicker and caret lag; see scope note below).

## What was wrong

The content-hint popup is CSS-pinned to the bottom-left corner (`.text-editor-content-tooltip { position: fixed; inset: auto auto 1rem 1rem }`), so its Bootstrap anchor element is visually irrelevant. Yet a top-of-stack transition between elements always **disposed the live tooltip and created + faded in a fresh one**. When the caret moves between to-do items, the hint text is identical every time — so the cycle rendered the exact same pixels through a dispose/create/fade: the visible flicker and the caret lag in the desktop app, exactly as reported.

## The fix

`ContentHintManager` gains a `popupPositionIsFixed` option. When set, a cross-element transition **with unchanged content reuses the live popup**: only the bookkeeping retargets, and the auto-hide timer resets. The outgoing anchor must still be connected, so Bootstrap teardown always stays in control. Different content, unpinned managers, and detached anchors keep the full rebuild. Both fixed-corner consumers (to-do multistate, collapsible summary hints) opt in; the collapsible **drag-handle** manager keeps Bootstrap's own anchored placement and deliberately does not.

## Scope note

The report also asks for hover-only hints (no caret-driven hint at all). That part is a design change to the deliberate dwell behaviour ("a stationary caret pops the checkbox tooltip") introduced with the multistate work, so I've left it out — this PR fixes the defect (flicker/lag) without changing when hints appear.

## Testing

`content_hint_manager.spec.ts` — 32/32 under jsdom (this package's browser-mode runner can't start here; the manager spec needs no CKEditor toolbar, so jsdom exercises real Bootstrap tooltips against the DOM), with three new cases: a pinned manager reuses the same popup DOM node across an element switch with unchanged content; it still rebuilds when content differs; an unpinned manager still rebuilds on element switch (anchored placement must follow the new anchor). The plugin suites' jsdom failures are pre-existing environment gaps (no `ResizeObserver`) — identical 52 with and without this change; CI's browser mode is their gate.