### PR TITLE
fix(desktop): resolve a working Linux autostart Exec for unbundled Electron

### DIFF
--- a/apps/desktop/src/services/auto_launch.spec.ts
+++ b/apps/desktop/src/services/auto_launch.spec.ts
@@ -14,6 +14,8 @@ const state = vi.hoisted(() => ({
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
     rmSync: vi.fn(),
+    readdirSync: vi.fn(),
+    readFileSync: vi.fn(),
     log: { info: vi.fn(), error: vi.fn() }
 }));
 
@@ -37,7 +39,11 @@ vi.mock("fs", () => ({
     default: {
         mkdirSync: (...a: unknown[]) => state.mkdirSync(...a),
         writeFileSync: (...a: unknown[]) => state.writeFileSync(...a),
-        rmSync: (...a: unknown[]) => state.rmSync(...a)
+        rmSync: (...a: unknown[]) => state.rmSync(...a),
+        // Detection must survive these being unimplemented (undefined return):
+        // a missing applications directory is the normal case, not an error.
+        readdirSync: (...a: unknown[]) => state.readdirSync(...a),
+        readFileSync: (...a: unknown[]) => state.readFileSync(...a)
     }
 }));
 
@@ -73,7 +79,9 @@ function setExecPath(p: string) {
 }
 
 beforeEach(() => {
-    vi.clearAllMocks();
+    // reset (not clear): the detection tests install per-test fs implementations
+    // that must not leak into the execPath-fallback tests after them.
+    vi.resetAllMocks();
     state.launchOnStartup = false;
     state.hideOnAutoStart = false;
     state.setLoginItemThrows = false;
@@ -81,6 +89,9 @@ beforeEach(() => {
     state.ipcOn.clear();
     delete process.env.APPIMAGE;
     delete process.env.XDG_CONFIG_HOME;
+    delete process.env.TRILIUM_LAUNCH_EXEC;
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.XDG_DATA_DIRS;
 });
 
 afterEach(() => {
@@ -88,6 +99,9 @@ afterEach(() => {
     setExecPath(ORIGINAL_EXECPATH);
     delete process.env.APPIMAGE;
     delete process.env.XDG_CONFIG_HOME;
+    delete process.env.TRILIUM_LAUNCH_EXEC;
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.XDG_DATA_DIRS;
 });
 
 describe("auto_launch", () => {
@@ -164,6 +178,72 @@ describe("auto_launch", () => {
 
         const [, content] = state.writeFileSync.mock.calls[0] as [string, string];
         expect(content).toContain('Exec="/home/user/Apps/Trilium.AppImage"');
+    });
+
+    it("honours $TRILIUM_LAUNCH_EXEC as an unbundled-Electron packager override", () => {
+        setPlatform("linux");
+        // A system-Electron install: execPath is the bare electron binary that
+        // cannot relaunch the app on its own (#10918).
+        setExecPath("/usr/lib/electron42/electron");
+        process.env.TRILIUM_LAUNCH_EXEC = "/usr/bin/triliumnext";
+        state.launchOnStartup = true;
+
+        applyLaunchOnStartup();
+
+        const [, content] = state.writeFileSync.mock.calls[0] as [string, string];
+        expect(content).toContain('Exec="/usr/bin/triliumnext"');
+    });
+
+    it("reuses the installed launcher's Exec when execPath is a bare system Electron", () => {
+        setPlatform("linux");
+        setExecPath("/usr/lib/electron42/electron");
+        process.env.XDG_DATA_DIRS = "/usr/share";
+        // path.join keeps these comparable on every host OS.
+        const sysApps = path.join("/usr/share", "applications");
+        state.readdirSync.mockImplementation((dir: string) =>
+            dir === sysApps ? ["gimp.desktop", "triliumnext.desktop", "vim.desktop"] : undefined
+        );
+        state.readFileSync.mockImplementation((file: string) =>
+            file === path.join(sysApps, "triliumnext.desktop")
+                ? [
+                      "[Desktop Entry]",
+                      "Type=Application",
+                      "Name=Trilium Next Notes",
+                      "Exec=/usr/bin/triliumnext %U",
+                      "Icon=triliumnext"
+                  ].join("\n")
+                : undefined
+        );
+        state.launchOnStartup = true;
+
+        applyLaunchOnStartup();
+
+        const [, content] = state.writeFileSync.mock.calls[0] as [string, string];
+        // The wrapper is reused verbatim (its env setup must not be bypassed)
+        // and the %U field code — a file-manager launch placeholder — is gone.
+        expect(content).toContain("Exec=/usr/bin/triliumnext\n");
+    });
+
+    it("prefers a user-local launcher over the system package's", () => {
+        setPlatform("linux");
+        setExecPath("/usr/lib/electron42/electron");
+        process.env.XDG_DATA_DIRS = "/usr/share";
+        const userApps = path.join("/home/user/.local", "share", "applications");
+        const sysApps = path.join("/usr/share", "applications");
+        state.readdirSync.mockImplementation((dir: string) =>
+            dir === userApps || dir === sysApps ? ["triliumnext.desktop"] : undefined
+        );
+        state.readFileSync.mockImplementation((file: string) =>
+            file === path.join(userApps, "triliumnext.desktop")
+                ? "[Desktop Entry]\nExec=/home/user/bin/trilium-custom\n"
+                : "[Desktop Entry]\nExec=/usr/bin/triliumnext\n"
+        );
+        state.launchOnStartup = true;
+
+        applyLaunchOnStartup();
+
+        const [, content] = state.writeFileSync.mock.calls[0] as [string, string];
+        expect(content).toContain("Exec=/home/user/bin/trilium-custom\n");
     });
 
     it("honours $XDG_CONFIG_HOME for the Linux autostart directory", () => {

--- a/apps/desktop/src/services/auto_launch.ts
+++ b/apps/desktop/src/services/auto_launch.ts
@@ -82,10 +82,8 @@ function getLinuxAutostartDir() {
 }
 
 function buildLinuxDesktopEntry(hidden: boolean) {
-    // When packaged as an AppImage, APPIMAGE points at the bundle to relaunch;
-    // otherwise fall back to the running executable.
-    const exec = process.env.APPIMAGE ?? process.execPath;
-    const execLine = hidden ? `Exec="${exec}" ${START_HIDDEN_FLAG}` : `Exec="${exec}"`;
+    const exec = resolveLinuxAutostartExec();
+    const execLine = hidden ? `Exec=${exec} ${START_HIDDEN_FLAG}` : `Exec=${exec}`;
     return [
         "[Desktop Entry]",
         "Type=Application",
@@ -95,4 +93,118 @@ function buildLinuxDesktopEntry(hidden: boolean) {
         "X-GNOME-Autostart-enabled=true",
         ""
     ].join("\n");
+}
+
+/**
+ * The command the OS should run to relaunch this app on Linux.
+ *
+ * `process.execPath` is only the right answer when the running process *is* the
+ * whole app — an AppImage bundle or a bundled-Electron build. On a "system
+ * Electron + wrapper script" install (e.g. the Arch `triliumnext-bin` package)
+ * it is the bare `electron` binary with no app attached, so autostart launches
+ * generic Electron, which prints its usage and exits (#10918).
+ *
+ * Resolution order:
+ *  1. `$APPIMAGE` — AppImage builds relaunch the bundle itself.
+ *  2. `$TRILIUM_LAUNCH_EXEC` — explicit contract for unbundled-Electron
+ *     packagers whose wrapper (env setup, `app.asar` path) must not be bypassed.
+ *  3. The app's installed `.desktop` launcher — distro packages already ship a
+ *     correct `Exec=` (the wrapper); reusing it repairs existing installs with
+ *     no packager changes.
+ *  4. `process.execPath` — bundled builds where the executable is the app.
+ */
+function resolveLinuxAutostartExec(): string {
+    if (process.env.APPIMAGE) {
+        return quoteDesktopExecValue(process.env.APPIMAGE);
+    }
+    if (process.env.TRILIUM_LAUNCH_EXEC?.trim()) {
+        return quoteDesktopExecValue(process.env.TRILIUM_LAUNCH_EXEC.trim());
+    }
+    const installed = findInstalledLinuxDesktopExec();
+    if (installed) {
+        return installed;
+    }
+    return quoteDesktopExecValue(process.execPath);
+}
+
+function quoteDesktopExecValue(value: string): string {
+    return `"${value}"`;
+}
+
+/**
+ * Locate a trilium application launcher among the installed `.desktop` files
+ * and return its `Exec=` line, stripped of freedesktop field codes (`%f`, `%U`,
+ * …), which the autostart entry has no use for. Scans user-local applications
+ * first so a user override beats the system package's entry. Best-effort: any
+ * error or missing directory just yields null and the caller falls back.
+ */
+function findInstalledLinuxDesktopExec(): string | null {
+    try {
+        for (const dir of linuxApplicationsDirs()) {
+            let listed: unknown;
+            try {
+                listed = fs.readdirSync(dir);
+            } catch {
+                continue;
+            }
+            if (!Array.isArray(listed)) {
+                continue;
+            }
+            const candidates = (listed as string[])
+                .filter((name) => name.toLowerCase().includes("trilium") && name.endsWith(".desktop"))
+                .sort();
+            for (const name of candidates) {
+                const exec = readDesktopExec(path.join(dir, name));
+                if (exec) {
+                    return exec;
+                }
+            }
+        }
+    } catch {
+        // Detection is a convenience layer; never block autostart on it.
+    }
+    return null;
+}
+
+function linuxApplicationsDirs(): string[] {
+    const dirs: string[] = [];
+    const dataHome = process.env.XDG_DATA_HOME?.trim() || path.join(os.homedir(), ".local", "share");
+    dirs.push(path.join(dataHome, "applications"));
+    const dataDirs = process.env.XDG_DATA_DIRS?.trim() || "/usr/local/share:/usr/share";
+    for (const entry of dataDirs.split(":")) {
+        if (entry.trim()) {
+            dirs.push(path.join(entry.trim(), "applications"));
+        }
+    }
+    return dirs;
+}
+
+function readDesktopExec(file: string): string | null {
+    let contents: string;
+    try {
+        contents = fs.readFileSync(file, "utf8");
+    } catch {
+        return null;
+    }
+    let inDesktopEntry = false;
+    for (const line of contents.split("\n")) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            inDesktopEntry = trimmed === "[Desktop Entry]";
+            continue;
+        }
+        if (!inDesktopEntry || !trimmed.startsWith("Exec=")) {
+            continue;
+        }
+        // Field codes (%f, %F, %u, %U, …) are launch-context placeholders the
+        // spec defines for file-manager launches; autostart has none to offer.
+        const exec = trimmed
+            .slice("Exec=".length)
+            .split(/\s+/)
+            .filter((token) => !token.startsWith("%"))
+            .join(" ")
+            .trim();
+        return exec || null;
+    }
+    return null;
 }


### PR DESCRIPTION
## Summary
**What**

The Linux autostart `.desktop` entry's `Exec=` line is now resolved from four layered sources instead of `APPIMAGE ?? process.execPath`:

1. `$APPIMAGE` — AppImage builds relaunch the bundle (unchanged).
2. `$TRILIUM_LAUNCH_EXEC` — the explicit packager override proposed in the issue, for unbundled-Electron wrappers that must not be bypassed.
3. The app's **installed launcher** — the trilium `.desktop` file shipped by the distro package; its `Exec=` (the wrapper script) is reused verbatim with freedesktop field codes (`%f`, `%U`, …) stripped. User-local applications dirs are scanned before system ones so a user override wins.
4. `process.execPath` — bundled-Electron builds where the executable *is* the app (previous behaviour).

**Why**

#10918 — on a "system Electron + wrapper script" install (Arch `triliumnext-bin` and similar), `process.execPath` is the bare `electron42` binary with no app attached, so the autostart entry launches generic Electron, which prints its usage and exits — Trilium never starts. Because `applyLaunchOnStartup()` rewrites the entry on every launch (by design, to repair drift), hand-fixing the file doesn't stick either.

Layer 3 is what repairs existing installs with no packager changes: the wrapper exists precisely because it sets up `LD_LIBRARY_PATH`/`app.asar`, and the distro's own launcher already points at it. Layer 2 adds the explicit contract from the issue for packagers who want determinism rather than detection.

**Testing**

`apps/desktop/src/services/auto_launch.spec.ts`, 16/16 (12 existing + 4 new):

- `honours $TRILIUM_LAUNCH_EXEC as an unbundled-Electron packager override` — bare system-electron `execPath` + the env var → `Exec="/usr/bin/triliumnext"`.
- `reuses the installed launcher's Exec when execPath is a bare system Electron` — finds `triliumnext.desktop` among unrelated entries, reuses `Exec=/usr/bin/triliumnext`, and strips the `%U` field code.
- `prefers a user-local launcher over the system package's` — `~/.local/share/applications` beats `/usr/share/applications`.
- Existing `execPath`-fallback tests still pass: detection is best-effort and falls through on missing dirs / parse failures, so it can never break autostart application.

`tsc --noEmit` on `apps/desktop` is clean.

Fixes #10918