### PR TITLE
fix(api): fail /api/search on a parse error instead of returning everything

### DIFF
--- a/packages/trilium-core/src/routes/api/search.spec.ts
+++ b/packages/trilium-core/src/routes/api/search.spec.ts
@@ -44,6 +44,28 @@ describe("Search API (core)", () => {
         expect(Array.isArray(res.body.newTemplateNoteIds)).toBe(true);
     });
 
+
+    it("400s with the parser error instead of silently returning every note (#11116)", async () => {
+        // `note.ancestor` is an unrecognized property: the parse layer records
+        // the error and degrades to a match-everything scan. The API must fail
+        // the query rather than answer HTTP 200 with the whole tree.
+        const res = await api.get(
+            `/api/search/${encodeURIComponent("#tcprop8 AND not(note.ancestor.title = tcbox)")}`
+        );
+        expect(res.status).toBe(400);
+        expect(res.body).toMatchObject({
+            message: expect.stringContaining("Unrecognized note property")
+        });
+    });
+
+    it("still returns results for a valid property expression", async () => {
+        const res = await api.get<string[]>(
+            `/api/search/${encodeURIComponent("#template")}`
+        );
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body)).toBe(true);
+    });
+
     it("400s when searching from a note that is not a search note", async () => {
         const res = await api.get("/api/search-note/root");
         expect(res.status).toBe(400);

--- a/packages/trilium-core/src/routes/api/search.ts
+++ b/packages/trilium-core/src/routes/api/search.ts
@@ -112,7 +112,17 @@ function search(req: Request<{ searchString: string }>) {
         ignoreHoistedNote: true
     });
 
-    return searchService.findResultsWithQuery(searchString, searchContext).map((sr) => sr.noteId);
+    const results = searchService.findResultsWithQuery(searchString, searchContext);
+
+    // The parse layer records the problem and degrades the expression to a
+    // match-everything scan, so a dropped error answers HTTP 200 with the whole
+    // tree (root and _hidden included). Fail the query instead — quick-search
+    // already surfaces this same error to its caller.
+    if (searchContext.hasError()) {
+        throw new ValidationError(searchContext.getError()!);
+    }
+
+    return results.map((sr) => sr.noteId);
 }
 
 function getRelatedNotes(req: Request) {


### PR DESCRIPTION
## Summary

**What**

`GET /api/search/:searchString` now fails with a `400 ValidationError` carrying the parser's message when the search context recorded an error, instead of returning the degraded match-everything result with HTTP 200.

**Why**

#11116 — the search parser already detects the problem (`Unrecognized note property "ancestor" …` via `SearchContext.addError`) and already has the right message; the plain search handler simply never read it. Because a failed property expression degrades to a match-everything scan, the caller got the **entire tree** — root and `_hidden` included — with HTTP 200, which looks like a successful broad query. The sibling `quick-search` handler in the same file surfaces the identical error to its caller; only `/api/search` dropped it.

**Testing** (`packages/trilium-core/src/routes/api/search.spec.ts`, run via the apps/server suite that includes core specs — 13/13):

- New: the reporter's exact query (`#tcprop8 AND not(note.ancestor.title = tcbox)`) now answers 400 with a message containing "Unrecognized note property" — verified to fail on the pre-fix handler (200 + full tree).
- New: a valid property expression (`#template`) still returns its result array unchanged.

Fixes #11116