### PR TITLE
fix(llm-chat): treat a done-less SSE body end as an interruption

### DIFF
--- a/apps/client/src/services/llm_chat.spec.ts
+++ b/apps/client/src/services/llm_chat.spec.ts
@@ -245,6 +245,34 @@ describe("streamChatCompletion", () => {
         ]);
     });
 
+
+    it("reports an interruption when the body ends without a terminal chunk (#10883)", async () => {
+        // A proxy can close an SSE body cleanly: end-of-stream without the
+        // server's done chunk is a dropped response, not a completion.
+        const chunks = [`data: ${JSON.stringify({ type: "text", content: "partial" })}
+`];
+        vi.stubGlobal("fetch", vi.fn(async () => makeStreamResponse(chunks)));
+
+        const cb = makeCallbacks();
+        await streamChatCompletion(messages, config, cb);
+        expect(cb.onChunk).toHaveBeenCalledWith("partial");
+        expect(cb.onDone).not.toHaveBeenCalled();
+        expect(cb.onError).toHaveBeenCalledWith(
+            "LLM stream ended without completing — the connection closed before the response finished (network or proxy interruption)."
+        );
+    });
+
+    it("does not stack the missing-terminal error on top of a stream error chunk", async () => {
+        const chunks = [`data: ${JSON.stringify({ type: "error", error: "model failed" })}
+`];
+        vi.stubGlobal("fetch", vi.fn(async () => makeStreamResponse(chunks)));
+
+        const cb = makeCallbacks();
+        await streamChatCompletion(messages, config, cb);
+        expect(cb.onError).toHaveBeenCalledTimes(1);
+        expect(cb.onError).toHaveBeenCalledWith("model failed", undefined);
+    });
+
     it("skips optional callbacks that are not provided", async () => {
         const events = [
             { type: "thinking", content: "TH" },
@@ -253,7 +281,8 @@ describe("streamChatCompletion", () => {
             { type: "tool_use", toolCallId: "c1", toolName: "search", toolInput: { q: "x" } },
             { type: "tool_result", toolCallId: "c1", toolName: "search", result: "res" },
             { type: "citation", citation: { id: "cit1" } },
-            { type: "usage", usage: { totalTokens: 1 } }
+            { type: "usage", usage: { totalTokens: 1 } },
+            { type: "done" }
         ];
         const chunks = events.map((e) => `data: ${JSON.stringify(e)}\n`);
         vi.stubGlobal("fetch", vi.fn(async () => makeStreamResponse(chunks)));

--- a/apps/client/src/services/llm_chat.ts
+++ b/apps/client/src/services/llm_chat.ts
@@ -129,6 +129,13 @@ async function streamChatOverSse(
 
     const decoder = new TextDecoder();
     let buffer = "";
+    // Why (#10883): a proxy or flaky VPN can close the SSE body *cleanly*, which
+    // reads as end-of-stream here even though the server never sent its terminal
+    // chunk. Treating a bare body end as completion returns the chat to idle with
+    // no error anywhere — output silently dropped. Only an explicit done/error
+    // chunk completes the stream; anything else is an interruption.
+    let terminalChunk: "done" | "error" | null = null;
+    let aborted = false;
 
     try {
         while (true) {
@@ -142,7 +149,10 @@ async function streamChatOverSse(
             for (const line of lines) {
                 if (line.startsWith("data: ")) {
                     try {
-                        await handleChunk(JSON.parse(line.slice(6)), callbacks);
+                        const terminal = await handleChunk(JSON.parse(line.slice(6)), callbacks);
+                        if (terminal) {
+                            terminalChunk = terminal;
+                        }
                     } catch (e) {
                         console.error("Failed to parse SSE data line:", line, e);
                     }
@@ -151,11 +161,20 @@ async function streamChatOverSse(
         }
     } catch (e) {
         if (e instanceof DOMException && e.name === "AbortError") {
+            aborted = true;
             throw e;
         }
         const message = e instanceof Error ? e.message : String(e);
         callbacks.onError(`LLM stream interrupted: ${message}`);
+        // An interruption error was already reported; don't stack the
+        // missing-terminal message on top of it.
+        terminalChunk = "error";
     } finally {
+        if (!aborted && terminalChunk === null) {
+            callbacks.onError(
+                "LLM stream ended without completing — the connection closed before the response finished (network or proxy interruption)."
+            );
+        }
         reader.releaseLock();
     }
 }
@@ -244,7 +263,8 @@ function rejectWhenAborted(signal?: AbortSignal): Promise<never> {
  * Dispatch one chunk to the callbacks. Shared by both transports, so a chunk means
  * the same thing however it arrived.
  */
-async function handleChunk(chunk: LlmStreamChunk, callbacks: StreamCallbacks): Promise<void> {
+/** Returns the stream's terminal chunk type when this chunk ends it, else null. */
+async function handleChunk(chunk: LlmStreamChunk, callbacks: StreamCallbacks): Promise<"done" | "error" | null> {
     switch (chunk.type) {
         case "text":
             callbacks.onChunk(chunk.content);
@@ -283,9 +303,10 @@ async function handleChunk(chunk: LlmStreamChunk, callbacks: StreamCallbacks): P
             break;
         case "error":
             callbacks.onError(chunk.error, chunk.errorDetails);
-            break;
+            return "error";
         case "done":
             callbacks.onDone();
-            break;
+            return "done";
     }
+    return null;
 }


### PR DESCRIPTION
## Summary

**What**

The LLM-chat SSE consumer now tracks whether an explicit `done` or `error` chunk arrived. When the response body ends **without** a terminal chunk, the client reports "LLM stream ended without completing — the connection closed before the response finished (network or proxy interruption)" through the normal error path instead of treating end-of-body as a normal completion.

User aborts still rethrow untouched, and a mid-read failure keeps its specific `LLM stream interrupted: …` message without the missing-terminal message stacking on top of it.

**Why**

#10883 — under poor network conditions (the reporter drives Claude through a TUN-mode proxy), the model's output is sometimes dropped: the chat returns to the "Type a message…" idle state with the prompt intact, no output, and no backend errors logged. A proxy that terminates an SSE connection **cleanly** produces exactly this signature: the browser's `reader.read()` reports `done`, which is byte-for-byte indistinguishable from the server finishing — unless you require the server's own terminal chunk. The server always sends `done` (or a terminal `error`) via `streamToChunks`, so a body end with neither means the response was cut.

**Testing** (`apps/client/src/services/llm_chat.spec.ts`, 25/25):

- New: a body ending after a text chunk with no terminal reports the interruption error (message received but `onDone` never fired) — **verified to fail on the pre-fix consumer** (returns silently).
- New: an `error` chunk as the terminal counts — exactly one `onError`, no stacked missing-terminal message.
- Updated: the optional-callbacks fixture now includes the `done` chunk the server always sends (its omission was an unrealistic fixture shape my change correctly rejects).
- Existing abort/read-failure semantics pinned by the unchanged neighboring tests.

Fixes #10883