### PR TITLE
fix(templates): apply template content to a note emptied in the editor

### DIFF
--- a/packages/trilium-core/src/services/content-emptiness.spec.ts
+++ b/packages/trilium-core/src/services/content-emptiness.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { isVisuallyEmptyTextContent } from "./content-emptiness.js";
+
+describe("isVisuallyEmptyTextContent", () => {
+    it("treats empty and whitespace-only content as empty", () => {
+        expect(isVisuallyEmptyTextContent("")).toBe(true);
+        expect(isVisuallyEmptyTextContent("   \n\t ")).toBe(true);
+    });
+
+    it("treats the editor's emptied-note skeletons as empty (#10908)", () => {
+        expect(isVisuallyEmptyTextContent("<p>&nbsp;</p>")).toBe(true);
+        expect(isVisuallyEmptyTextContent("<p><br></p>")).toBe(true);
+        expect(isVisuallyEmptyTextContent("<div><br></div>")).toBe(true);
+        expect(isVisuallyEmptyTextContent("<p>  </p>\n<p>&#160;</p>")).toBe(true);
+        expect(isVisuallyEmptyTextContent("<!-- comment only --><p><br></p>")).toBe(true);
+    });
+
+    it("keeps real content non-empty", () => {
+        expect(isVisuallyEmptyTextContent("<p>hello</p>")).toBe(false);
+        expect(isVisuallyEmptyTextContent("<p>&nbsp;</p><p>text</p>")).toBe(false);
+        // A list with an item label is content even though its tags strip away.
+        expect(isVisuallyEmptyTextContent("<ul><li>item</li></ul>")).toBe(false);
+        expect(isVisuallyEmptyTextContent("plain text")).toBe(false);
+    });
+});

--- a/packages/trilium-core/src/services/content-emptiness.ts
+++ b/packages/trilium-core/src/services/content-emptiness.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether a note's string content carries no user-visible text.
+ *
+ * A text note "emptied" in the editor does not store an empty string: the
+ * editor serializes its empty paragraph, so the blob holds something like
+ * `<p>&nbsp;</p>` or `<p><br></p>`. Checks that compare raw content against
+ * "" therefore treat an emptied note as having content (#10908).
+ */
+
+const BLOCK_SCAFFOLDING_TAG_RE = /<\/?(?:p|div|span|br|h[1-6]|ul|ol|li)(?:\s[^>]*)?\/?>/gi
+
+/** Empty-string forms the editor and HTML sources produce for a blank line. */
+const HTML_BLANK_ENTITIES_RE = /(?:&nbsp;|&#160;|&#xa0;)/gi
+
+/** Also treats a bare `data-`-only attribute payload as whitespace-grade noise. */
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g
+
+export function isVisuallyEmptyTextContent(content: string): boolean {
+    const stripped = content
+        .replace(HTML_COMMENT_RE, "")
+        .replace(BLOCK_SCAFFOLDING_TAG_RE, "")
+        .replace(HTML_BLANK_ENTITIES_RE, " ")
+    return stripped.trim().length === 0
+}

--- a/packages/trilium-core/src/services/handlers.spec.ts
+++ b/packages/trilium-core/src/services/handlers.spec.ts
@@ -134,6 +134,31 @@ describe("handlers", () => {
             expect(setContent).toHaveBeenCalledWith("TEMPLATE BODY");
             expect(duplicateSubtree).toHaveBeenCalledWith("tmpl", "n");
         });
+
+        it("copies template content into a note emptied in the editor (skeleton content, #10908)", () => {
+            buildNote({ id: "tmpl2", type: "text", mime: "text/html", content: "TEMPLATE BODY" });
+            // An emptied CKEditor note stores its empty paragraph, not "".
+            const note = buildNote({ id: "n2", type: "text", mime: "text/html", content: "<p>&nbsp;</p>" });
+            const setContent = vi.spyOn(note, "setContent").mockImplementation(() => {});
+            vi.spyOn(note, "save").mockReturnValue(note);
+            const rel = addAttribute("n2", "relation", "template", "tmpl2");
+
+            eventService.emit(eventService.ENTITY_CREATED, { entityName: "attributes", entity: rel });
+
+            expect(setContent).toHaveBeenCalledWith("TEMPLATE BODY");
+        });
+
+        it("still refuses to overwrite a note with real content", () => {
+            buildNote({ id: "tmpl3", type: "text", mime: "text/html", content: "TEMPLATE BODY" });
+            const note = buildNote({ id: "n3", type: "text", mime: "text/html", content: "<p>my draft</p>" });
+            const setContent = vi.spyOn(note, "setContent").mockImplementation(() => {});
+            vi.spyOn(note, "save").mockReturnValue(note);
+            const rel = addAttribute("n3", "relation", "template", "tmpl3");
+
+            eventService.emit(eventService.ENTITY_CREATED, { entityName: "attributes", entity: rel });
+
+            expect(setContent).not.toHaveBeenCalled();
+        });
     });
 
     describe("ENTITY_DELETED", () => {

--- a/packages/trilium-core/src/services/handlers.ts
+++ b/packages/trilium-core/src/services/handlers.ts
@@ -10,6 +10,7 @@ import oneTimeTimer from "./one_time_timer.js";
 import type BNote from "../becca/entities/bnote.js";
 import type AbstractBeccaEntity from "../becca/entities/abstract_becca_entity.js";
 import { DefinitionObject } from "@triliumnext/commons";
+import { isVisuallyEmptyTextContent } from "./content-emptiness.js"
 
 type Handler = (definition: DefinitionObject, note: BNote, targetNote: BNote) => void;
 
@@ -105,8 +106,10 @@ eventService.subscribe(eventService.ENTITY_CREATED, ({ entityName, entity }) => 
             if (
                 note.hasStringContent() &&
                 typeof content === "string" &&
-                // if the note has already content we're not going to overwrite it with template's one
-                (!content || content.trim().length === 0) &&
+                // if the note has already content we're not going to overwrite it with template's one.
+                // Emptied-in-editor notes store the empty paragraph skeleton (<p>&nbsp;</p>), so
+                // a raw ""/whitespace check would refuse the template on a visually empty note (#10908).
+                (!content || isVisuallyEmptyTextContent(content)) &&
                 templateNote.hasStringContent()
             ) {
                 const templateNoteContent = templateNote.getContent();


### PR DESCRIPTION
## Summary

**What**

The template-relation handler's "don't overwrite existing content" gate now uses a shared `isVisuallyEmptyTextContent` helper: content consisting solely of block scaffolding — empty `<p>`/`<div>`/`<br>` skeletons, `&nbsp;`/`&#160;` entities, and HTML comments — counts as empty. Notes with any real text still refuse the overwrite, exactly as before.

**Why**

#10908 — switching templates on a note whose body the user emptied did nothing, silently. The handler compares the stored blob against `''`/whitespace, but a note emptied in the editor stores the serialized empty paragraph (`<p>&nbsp;</p>` or `<p><br></p>`), so the check read it as content: no template content copied, no `type`/`mime` adoption (both live inside the same guard), and no feedback. The reporter's linked #10907 hit the same gate. The check is the culprit the community bot pointed at; this makes it see what the user sees.

**Scope**: the emptied-note case now just works — the primary complaint. The overwrite-refusal for genuinely non-empty notes (and its silent nature) is unchanged behavior; a confirmation affordance for that half would be a separate product decision.

**Testing** (via the apps/server suite that runs core specs):

- New `content-emptiness.spec.ts` (3 cases): empty/whitespace; the editor skeletons from the report (`<p>&nbsp;</p>`, `<p><br></p>`, `<div><br></div>`, entity-only, comment-only); real content stays non-empty (text, mixed, list with labels, plain text).
- `handlers.spec.ts` +2 (20 total): template content now copies into a skeleton-content note — **verified to fail on the pre-fix handler** (no copy) — and still refuses a note with a real draft. Suite 20/20.

Fixes #10908