### PR TITLE
fix(search): keep commas inside quoted operands

### DIFF
--- a/packages/trilium-core/src/services/search/services/lex.spec.ts
+++ b/packages/trilium-core/src/services/search/services/lex.spec.ts
@@ -20,6 +20,13 @@ describe("Lexer fulltext", () => {
         expect(lex("'i can use \" or ` or #~=*' without problem").fulltextTokens.map((t) => t.token)).toEqual(['i can use " or ` or #~=*', "without", "problem"]);
     });
 
+    it("commas are noise in fulltext but kept inside quotes", () => {
+        expect(lex("europe, austria").fulltextTokens.map((t) => t.token)).toEqual(["europe", "austria"]);
+
+        // Quoted values must survive verbatim — e.g. the Geo Map manual's #geolocation="48.8583,2.2945".
+        expect(lex("'48.8583,2.2945'").fulltextTokens.map((t) => t.token)).toEqual(["48.8583,2.2945"]);
+    });
+
     it("I can use backslash to escape quotes", () => {
         expect(lex('hello \\"world\\"').fulltextTokens.map((t) => t.token)).toEqual(["hello", '"world"']);
 
@@ -104,6 +111,20 @@ describe("Lexer expression", () => {
             { token: "*=*", inQuotes: false, startIndex: 6, endIndex: 8 },
             { token: "text", inQuotes: true, startIndex: 10, endIndex: 13 }
         ]);
+    });
+
+    it("keeps commas inside a quoted operand", () => {
+        // The Geo Map manual stores coordinates as #geolocation="48.8583,2.2945"; the lexer used
+        // to strip the comma even inside quotes, making the stored value unreachable (#11132).
+        expect(lex('#geolocation="48.8583,2.2945"').expressionTokens.map((t) => t.token)).toEqual(
+            ["#geolocation", "=", "48.8583,2.2945"]
+        );
+        expect(lex("#geolocation='48.8583,2.2945'").expressionTokens.map((t) => t.token)).toEqual(
+            ["#geolocation", "=", "48.8583,2.2945"]
+        );
+
+        const quoted = lex('#geolocation="48.8583,2.2945"').expressionTokens[2];
+        expect(quoted.inQuotes).toBe(true);
     });
 
     it("simple label operator with param without quotes", () => {

--- a/packages/trilium-core/src/services/search/services/lex.ts
+++ b/packages/trilium-core/src/services/search/services/lex.ts
@@ -122,7 +122,9 @@ function lex(str: string) {
             }
         }
 
-        if (chr === ",") {
+        // Commas are stripped as fulltext noise, but not inside quotes — a quoted operand
+        // (e.g. #geolocation="48.8583,2.2945") must keep the exact value the user stored.
+        if (chr === "," && !quotes) {
             continue;
         }
 

--- a/packages/trilium-core/src/services/search/services/search.spec.ts
+++ b/packages/trilium-core/src/services/search/services/search.spec.ts
@@ -112,6 +112,26 @@ describe("Search", () => {
         expect(findNoteByTitle(searchResults, "Austria")).toBeTruthy();
     });
 
+    it("label comparison with a comma in a quoted value", () => {
+        rootNote.child(note("Eiffel Tower").label("geolocation", "48.8583,2.2945")).child(note("Charles Bridge").label("geolocation", "50.0865,14.4114"));
+
+        const searchContext = new SearchContext();
+
+        // The Geo Map manual documents exactly this form; the lexer used to strip the comma
+        // inside the quotes, so the stored value could never be matched (#11132).
+        let searchResults = searchService.findResultsWithQuery('#geolocation="48.8583,2.2945"', searchContext);
+        expect(searchResults.length).toEqual(1);
+        expect(findNoteByTitle(searchResults, "Eiffel Tower")).toBeTruthy();
+
+        searchResults = searchService.findResultsWithQuery("#geolocation='50.0865,14.4114'", searchContext);
+        expect(searchResults.length).toEqual(1);
+        expect(findNoteByTitle(searchResults, "Charles Bridge")).toBeTruthy();
+
+        // A quoted value that matches no stored value still returns nothing.
+        searchResults = searchService.findResultsWithQuery('#geolocation="48.8583"', searchContext);
+        expect(searchResults.length).toEqual(0);
+    });
+
     it("label comparison with full syntax", () => {
         rootNote.child(note("Europe").child(note("Austria").label("capital", "Vienna")).child(note("Czech Republic").label("capital", "Prague")));
 


### PR DESCRIPTION
## What

The search lexer no longer strips commas inside quoted strings. `#geolocation="48.8583,2.2945"` now lexes to the operand `48.8583,2.2945` and matches the stored attribute value, in double and single quotes. Comma stripping outside quotes (fulltext noise like `europe, austria`) is unchanged.

## Why (issue #11132)

`lex.ts` dropped every comma unconditionally:

```ts
if (chr === ",") {
    continue;
}
```

The quote-handling branch above it only manages the quote state, so a quoted operand fell straight through the strip. The Geo Map manual documents storing coordinates exactly as `#geolocation="48.8583,2.2945"` (lat and long separated by a comma, value wrapped in quotes), which made that documented value — and any comma-containing label value — unreachable by equality search: the lexed operand became `48.85832.2945`, a string nobody ever stored, and the API answered `200 []` instead of an error.

Downstream code was already ready: `resolveConstantOperand` returns an `inQuotes` operand verbatim, so the lexer was the only place the value was mangled.

## How

One-line condition plus a comment:

```ts
if (chr === "," && !quotes) {
    continue;
}
```

## Testing

- `lex.spec.ts` — new cases: quoted fulltext keeps the comma (`'48.8583,2.2945'` → one token), and `#geolocation="48.8583,2.2945"` / single-quoted form produce `["#geolocation", "=", "48.8583,2.2945"]` with `inQuotes: true`.
- `search.spec.ts` — end-to-end: two notes with comma-valued `#geolocation` labels, each found by its exact quoted value in both quote styles; a non-matching quoted value still returns nothing.
- Diff-verified: with only the `lex.ts` change stashed, the three new tests fail exactly as reported (operand loses its comma); with it applied, the full search suite passes — 31 files, 357 tests.

Fixes #11132
