### PR TITLE
fix(search): load db-backed note properties for pure '#' queries and count revisions

### DIFF
--- a/packages/trilium-core/src/services/search/services/search.ts
+++ b/packages/trilium-core/src/services/search/services/search.ts
@@ -227,9 +227,12 @@ function loadNeededInfoFromDatabase() {
         noteBlobs[noteId][blobId] = length;
 
         if (isNoteRevision) {
-            const noteRevision = becca.notes[noteId];
-            if (noteRevision && noteRevision.revisionCount) {
-                noteRevision.revisionCount++;
+            const note = becca.notes[noteId];
+            // Why the existence-only guard: `revisionCount` was reset to 0 a few lines above, so
+            // the old truthiness check made this increment dead code and every comparison against
+            // `note.revisionCount` matched only zero (#11131).
+            if (note) {
+                note.revisionCount = (note.revisionCount ?? 0) + 1;
             }
         }
     }
@@ -429,7 +432,15 @@ function findResultsWithQuery(query: string, searchContext: SearchContext): Sear
     const isPureExpressionQuery = query.trim().startsWith('#');
 
     if (isPureExpressionQuery) {
-        // For pure expression queries, use standard search without progressive phases
+        // For pure expression queries, use standard search without progressive phases.
+        // This path must not skip the database load: `#label note.contentSize >= 0` asks for a
+        // db-backed property just like any other query, and the values are memoized on the becca
+        // notes, so skipping the load made the answer depend on what was searched earlier in the
+        // process (#11131).
+        if (searchContext.dbLoadNeeded) {
+            loadNeededInfoFromDatabase();
+        }
+
         return performSearch(expression, searchContext, searchContext.enableFuzzyMatching);
     }
 

--- a/packages/trilium-core/src/services/search/services/search_db_properties.spec.ts
+++ b/packages/trilium-core/src/services/search/services/search_db_properties.spec.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { getContext } from "../../context.js";
 import noteService from "../../notes.js";
 import sql_init from "../../sql_init.js";
+import { getSql } from "../../sql/index.js";
 import searchService from "./search.js";
 
 /**
@@ -30,9 +31,57 @@ describe("search on database-backed note properties", () => {
                 title: "DbPropsProbe",
                 type: "text",
                 mime: "text/html",
-                content: `<p>${"x".repeat(BODY_LENGTH)}</p>`
+                content: `<p>${"x".repeat(BODY_LENGTH)}</p>`,
+                attributes: [{ type: "label", name: "tcDbProbe", isInheritable: false, position: 0 }]
             })
         );
+    });
+
+    /**
+     * The loader memoizes its results onto the becca notes, so a test that ran any other
+     * db-backed query first would mask exactly the cold-process failure these tests assert.
+     */
+    function resetMemoizedNoteProperties() {
+        const probe = searchService.searchNotes("note.title *=* DbPropsProbe")[0];
+        probe.contentSize = undefined;
+        probe.contentAndAttachmentsSize = undefined;
+        probe.contentAndAttachmentsAndRevisionsSize = undefined;
+        probe.revisionCount = undefined;
+    }
+
+    it("loads the database-backed properties for a pure '#' query", () => {
+        resetMemoizedNoteProperties();
+
+        // Regression (#11131): queries starting with '#' take the pure-expression shortcut,
+        // which used to skip loadNeededInfoFromDatabase() entirely — the comparison then ran
+        // against undefined, and the same query answered differently depending on what had
+        // been searched earlier in the process.
+        expect(searchService.searchNotes("#tcDbProbe note.contentSize >= 0")).toHaveLength(1);
+        expect(searchService.searchNotes(`#tcDbProbe note.contentSize > ${BODY_LENGTH}`)).toHaveLength(1);
+        expect(searchService.searchNotes(`#tcDbProbe note.contentSize > ${BODY_LENGTH * 10}`)).toHaveLength(0);
+    });
+
+    it("counts revisions instead of always reporting zero", () => {
+        const probe = searchService.searchNotes("note.title *=* DbPropsProbe")[0];
+        const utcNow = "2026-01-01T00:00:00.000Z";
+        const dateNow = "2026-01-01 00:00:00";
+
+        getSql().execute(
+            `INSERT INTO blobs (blobId, content, dateModified, utcDateModified) VALUES (?, ?, ?, ?)`,
+            ["tcRevBlob1", "y".repeat(200), dateNow, utcNow]
+        );
+        getSql().execute(
+            `INSERT INTO revisions (revisionId, noteId, title, blobId, utcDateLastEdited, utcDateCreated, utcDateModified, dateLastEdited, dateCreated)
+             VALUES (?, ?, 'DbPropsProbe', ?, ?, ?, ?, ?, ?)`,
+            ["tcRev1", probe.noteId, "tcRevBlob1", utcNow, utcNow, utcNow, dateNow, dateNow]
+        );
+
+        resetMemoizedNoteProperties();
+
+        // Regression (#11131): the increment was guarded by the truthiness of a counter that had
+        // just been reset to zero, so revisionCount stayed 0 on every path.
+        expect(searchService.searchNotes("note.title *=* DbPropsProbe AND note.revisionCount >= 1")).toHaveLength(1);
+        expect(searchService.searchNotes("note.title *=* DbPropsProbe AND note.revisionCount = 0")).toHaveLength(0);
     });
 
     it("filters on contentSize instead of silently matching nothing", () => {

--- a/packages/trilium-core/src/services/search/services/search_db_properties.spec.ts
+++ b/packages/trilium-core/src/services/search/services/search_db_properties.spec.ts
@@ -3,7 +3,6 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { getContext } from "../../context.js";
 import noteService from "../../notes.js";
 import sql_init from "../../sql_init.js";
-import { getSql } from "../../sql/index.js";
 import searchService from "./search.js";
 
 /**
@@ -63,18 +62,7 @@ describe("search on database-backed note properties", () => {
 
     it("counts revisions instead of always reporting zero", () => {
         const probe = searchService.searchNotes("note.title *=* DbPropsProbe")[0];
-        const utcNow = "2026-01-01T00:00:00.000Z";
-        const dateNow = "2026-01-01 00:00:00";
-
-        getSql().execute(
-            `INSERT INTO blobs (blobId, content, dateModified, utcDateModified) VALUES (?, ?, ?, ?)`,
-            ["tcRevBlob1", "y".repeat(200), dateNow, utcNow]
-        );
-        getSql().execute(
-            `INSERT INTO revisions (revisionId, noteId, title, blobId, utcDateLastEdited, utcDateCreated, utcDateModified, dateLastEdited, dateCreated)
-             VALUES (?, ?, 'DbPropsProbe', ?, ?, ?, ?, ?, ?)`,
-            ["tcRev1", probe.noteId, "tcRevBlob1", utcNow, utcNow, utcNow, dateNow, dateNow]
-        );
+        getContext().init(() => probe.saveRevision());
 
         resetMemoizedNoteProperties();
 


### PR DESCRIPTION
## What

Two fixes in the database-backed note-property search path:

1. **Pure `#` queries now load the size/revision columns.** `findResultsWithQuery` routes queries that start with `#` straight to `performSearch` (skipping progressive search). That shortcut also skipped `loadNeededInfoFromDatabase()` — the only caller lives in `findResultsWithExpression` — even though `PropertyComparisonExp` had already set `dbLoadNeeded` during parsing. The comparison then ran against `undefined`.
2. **`note.revisionCount` actually counts now.** The increment in the loader was guarded by `if (note.revisionCount)` on a counter that had been reset to `0` a few lines above, so the branch was dead and every comparison against `revisionCount` only ever matched zero.

## Why (issue #11131)

Because the loader memoizes its results onto the in-memory becca notes and nothing clears them, the answer depended on what had been searched earlier in the process: on a cold server `#tcprop9 note.contentSize >= 0` returned `[]` (comparing `undefined`), while the reordered `note.contentSize > 0 AND #tcprop9` loaded the columns, answered correctly — and permanently repaired the first query for the rest of the process. A restart killed it again. `>= 0` can never be false for a real value, so the `[]` answer was silently wrong, not an empty match.

## How

```ts
if (isPureExpressionQuery) {
    if (searchContext.dbLoadNeeded) {
        loadNeededInfoFromDatabase();
    }
    return performSearch(expression, searchContext, searchContext.enableFuzzyMatching);
}
```

and

```ts
if (note) {
    note.revisionCount = (note.revisionCount ?? 0) + 1;
}
```

## Testing

Extended `search_db_properties.spec.ts` (the file that already owns this area with a real database):

- `loads the database-backed properties for a pure '#' query` — resets the memoized fields first (a prior db-backed query in the same process would otherwise mask the cold-state failure), then asserts `#tcDbProbe note.contentSize >= 0` finds the note, `> BODY_LENGTH` still finds it, and `> BODY_LENGTH * 10` excludes it, so the value is genuinely compared.
- `counts revisions instead of always reporting zero` — inserts a revision + blob row, then asserts `note.revisionCount >= 1` matches and `note.revisionCount = 0` does not.
- Diff-verified: with only the `search.ts` change stashed, exactly these two new tests fail; with it applied the full search suite passes (31 files, 356 tests).

Fixes #11131
