### PR TITLE
fix(saved search): run the saved search from "Search now" instead of creating a new empty one

### DIFF
--- a/apps/client/src/widgets/search_result.spec.tsx
+++ b/apps/client/src/widgets/search_result.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from "preact";
 import { act } from "preact/test-utils";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // The widget follows the note the tab shows; the tests hand it one directly.
 const shownNote = vi.hoisted(() => ({ current: null as import("../entities/fnote").default | null }));
@@ -51,6 +51,8 @@ describe("SearchResult", () => {
         froca.loadSearchNote = loadSearchNote as unknown as typeof froca.loadSearchNote;
     });
 
+    let mounted: HTMLDivElement | null = null;
+
     function mount() {
         const host = document.createElement("div");
         document.body.appendChild(host);
@@ -60,8 +62,17 @@ describe("SearchResult", () => {
             </ParentComponent.Provider>,
             host
         ));
+        mounted = host;
         return host;
     }
+
+    afterEach(() => {
+        if (mounted) {
+            render(null, mounted);
+            mounted.remove();
+            mounted = null;
+        }
+    });
 
     it("runs the saved search itself instead of navigating to a new empty one", async () => {
         // Regression (#11130): the "Search now" button used to trigger the global `searchNotes`
@@ -73,10 +84,10 @@ describe("SearchResult", () => {
 
         const button = container.querySelector("button");
         expect(button).toBeTruthy();
-        expect(button!.dataset.triggerCommand).toBeUndefined();
+        expect(button?.dataset.triggerCommand).toBeUndefined();
 
         await act(async () => {
-            button!.click();
+            button?.click();
         });
 
         expect(loadSearchNote).toHaveBeenCalledWith(savedSearch.noteId);

--- a/apps/client/src/widgets/search_result.spec.tsx
+++ b/apps/client/src/widgets/search_result.spec.tsx
@@ -1,0 +1,96 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The widget follows the note the tab shows; the tests hand it one directly.
+const shownNote = vi.hoisted(() => ({ current: null as import("../entities/fnote").default | null }));
+vi.mock("./react/hooks", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./react/hooks")>()),
+    useNoteContext: () => ({
+        note: shownNote.current,
+        notePath: shownNote.current ? `root/${shownNote.current.noteId}` : "root",
+        ntxId: "ntx1"
+    })
+}));
+
+// The rendered result list is a world of its own; the contract under test is the wiring around it.
+vi.mock("./collections/NoteList", () => ({
+    SearchNoteList: () => null
+}));
+
+import type Component from "../components/component";
+import type FNote from "../entities/fnote";
+import froca from "../services/froca";
+import { buildNote } from "../test/easy-froca";
+import SearchResult from "./search_result";
+import { ParentComponent } from "./react/react_utils";
+
+describe("SearchResult", () => {
+    let container: HTMLDivElement;
+    const handlers = new Map<string, (data: unknown) => void>();
+    const triggerEvent = vi.fn((name: string, data: unknown) => {
+        // Route the event back through the registered handler, the way a real parent would.
+        handlers.get(name)?.(data);
+    });
+    const parent = {
+        componentId: "cid",
+        registerHandler: (name: string, callback: (data: unknown) => void) => handlers.set(name, callback),
+        removeHandler: () => {},
+        triggerEvent
+    } as unknown as Component;
+
+    const loadSearchNote = vi.fn(async (noteId: string) => {
+        // Mirror what the real loader does to the note it loads.
+        (froca.notes[noteId] as FNote | undefined ?? shownNote.current)!.searchResultsLoaded = true;
+    });
+
+    beforeEach(() => {
+        handlers.clear();
+        triggerEvent.mockClear();
+        loadSearchNote.mockClear();
+        froca.loadSearchNote = loadSearchNote as unknown as typeof froca.loadSearchNote;
+    });
+
+    function mount() {
+        const host = document.createElement("div");
+        document.body.appendChild(host);
+        act(() => render(
+            <ParentComponent.Provider value={parent}>
+                <SearchResult />
+            </ParentComponent.Provider>,
+            host
+        ));
+        return host;
+    }
+
+    it("runs the saved search itself instead of navigating to a new empty one", async () => {
+        // Regression (#11130): the "Search now" button used to trigger the global `searchNotes`
+        // command, which creates a brand-new search note with an empty string and navigates to
+        // it — the one affordance on this screen abandoned the search it was supposed to run.
+        const savedSearch = buildNote({ title: "My search", type: "search", "#searchString": "#tcfindme" });
+        shownNote.current = savedSearch;
+        container = mount();
+
+        const button = container.querySelector("button");
+        expect(button).toBeTruthy();
+        expect(button!.dataset.triggerCommand).toBeUndefined();
+
+        await act(async () => {
+            button!.click();
+        });
+
+        expect(loadSearchNote).toHaveBeenCalledWith(savedSearch.noteId);
+        expect(triggerEvent).toHaveBeenCalledWith("searchRefreshed", { ntxId: "ntx1" });
+
+        // The event routed back through the parent flipped the widget out of the empty state.
+        expect(container.querySelector("button")).toBeNull();
+    });
+
+    it("keeps the empty state for a non-search note", () => {
+        shownNote.current = buildNote({ title: "Plain text" });
+        container = mount();
+
+        expect(container.querySelector("button")).toBeNull();
+        expect(loadSearchNote).not.toHaveBeenCalled();
+    });
+});

--- a/apps/client/src/widgets/search_result.tsx
+++ b/apps/client/src/widgets/search_result.tsx
@@ -1,13 +1,17 @@
 import "./search_result.css";
 
 import clsx from "clsx";
-import { useEffect, useState } from "preact/hooks";
+import { useContext, useEffect, useState } from "preact/hooks";
 
+import froca from "../services/froca";
 import { t } from "../services/i18n";
+import toast from "../services/toast";
+import { getErrorMessage } from "../services/utils";
 import { SearchNoteList } from "./collections/NoteList";
 import Button from "./react/Button";
-import { useNoteContext,  useTriliumEvent } from "./react/hooks";
+import { useNoteContext, useTriliumEvent } from "./react/hooks";
 import NoItems from "./react/NoItems";
+import { ParentComponent } from "./react/react_utils";
 
 enum SearchResultState {
     NO_RESULTS,
@@ -19,6 +23,7 @@ export default function SearchResult() {
     const { note, notePath, ntxId } = useNoteContext();
     const [ state, setState ] = useState<SearchResultState>();
     const [ highlightedTokens, setHighlightedTokens ] = useState<string[]>();
+    const parentComponent = useContext(ParentComponent);
 
     function refresh() {
         if (note?.type !== "search") {
@@ -31,6 +36,25 @@ export default function SearchResult() {
             setState(SearchResultState.GOT_RESULTS);
             setHighlightedTokens(note.highlightedTokens);
         }
+    }
+
+    // Why a dedicated handler instead of the global `searchNotes` command: that command creates
+    // a brand-new (empty) search note and navigates to it, so the one affordance on the
+    // "not executed" screen abandoned the saved search it was supposed to run (#11130).
+    async function executeThisSearch() {
+        const noteId = note?.noteId;
+        if (!noteId) {
+            return;
+        }
+
+        try {
+            await froca.loadSearchNote(noteId);
+        } catch (e: unknown) {
+            toast.showError(getErrorMessage(e));
+            return;
+        }
+
+        parentComponent?.triggerEvent("searchRefreshed", { ntxId });
     }
 
     useEffect(() => refresh(), [ note ]);
@@ -49,7 +73,7 @@ export default function SearchResult() {
         <div className={clsx("search-result-widget", state === undefined && "hidden-ext")}>
             {state === SearchResultState.NOT_EXECUTED && (
                 <NoItems icon="bx bx-file-find" text={t("search_result.search_not_executed")}>
-                    <Button text={t("search_result.search_now")} triggerCommand="searchNotes" />
+                    <Button text={t("search_result.search_now")} onClick={() => executeThisSearch()} />
                 </NoItems>
             )}
 


### PR DESCRIPTION
## What

The `Search now` button on a saved search's "Search has not been executed yet." screen now executes **that saved search** (`froca.loadSearchNote(note.noteId)` + the tab-scoped `searchRefreshed` event, exactly what the Search definition ribbon's refresh does). Previously it triggered the global `searchNotes` command.

## Why (issue #11130)

`searchNotes` is the "new search" command: it creates a brand-new search note with an empty `searchString` and navigates to it. Pressing the only control the widget offers therefore navigated away from the saved search (note id changed, search string emptied) and rendered an empty query — the full instance — as its results. The API confirmed the abandonment: `GET /api/search-note/<saved>` answered the 2 real hits while the note on screen afterwards answered 20 notes. A first-time user following the one affordance ended up looking at a full-instance listing that looked like an answer.

## How

```tsx
async function executeThisSearch() {
    const noteId = note?.noteId;
    if (!noteId) return;
    try {
        await froca.loadSearchNote(noteId);
    } catch (e) {
        toast.showError(getErrorMessage(e));
        return;
    }
    parentComponent?.triggerEvent("searchRefreshed", { ntxId });
}
```

wired via `onClick` instead of `triggerCommand="searchNotes"`.

## Testing

New `apps/client/src/widgets/search_result.spec.tsx` (preact `act` harness following `PromotedAttributes.spec.tsx`):

- mounts the widget on a saved search (`type: "search"`, `#searchString`), asserts the button no longer carries `data-trigger-command`, clicks it, and asserts `froca.loadSearchNote` was called with **this** note's id and `searchRefreshed` was triggered with the tab's `ntxId` — and that the event routed back through the parent flips the widget out of the empty state.
- guards the non-search case (no button, no load).
- Diff-verified: with only the `search_result.tsx` change stashed, the main test fails (old wiring never calls `loadSearchNote`); with it applied it passes, alone and within the full `src/widgets/` suite. (The suite has a handful of pre-existing concurrency-flaky failures on pristine `main` — verified by running it on a clean tree — none related to this change.)

Fixes #11130
