### PR TITLE
fix(print): carry the note's title into the exported PDF metadata

### DIFF
--- a/apps/client/src/print.spec.tsx
+++ b/apps/client/src/print.spec.tsx
@@ -24,7 +24,14 @@ vi.mock("./widgets/collections/NoteList", () => ({
     }
 }));
 
-import { App, applyPrintDocumentTitle, Error404, loadCustomCss, main, SingleNoteRenderer } from "./print";
+import {
+    App,
+    applyPrintDocumentTitle,
+    Error404,
+    loadCustomCss,
+    main,
+    SingleNoteRenderer
+} from "./print";
 import froca from "./services/froca";
 import { buildNote } from "./test/easy-froca";
 

--- a/apps/client/src/print.spec.tsx
+++ b/apps/client/src/print.spec.tsx
@@ -24,14 +24,7 @@ vi.mock("./widgets/collections/NoteList", () => ({
     }
 }));
 
-import {
-    App,
-    applyPrintDocumentTitle,
-    Error404,
-    loadCustomCss,
-    main,
-    SingleNoteRenderer
-} from "./print";
+import { App, Error404, loadCustomCss, main, SingleNoteRenderer } from "./print";
 import froca from "./services/froca";
 import { buildNote } from "./test/easy-froca";
 
@@ -240,8 +233,6 @@ describe("main", () => {
         expect(document.head.querySelector('link[href="api/fonts"]')).toBeTruthy();
         const titles = [...document.body.querySelectorAll("h1")].map((el) => el.textContent);
         expect(titles).toContain("Main Note");
-        // Regression (#11140): the exported PDF's metadata title follows the note, not the
-        // app shell default the print window inherits.
         expect(document.title).toBe("Main Note");
     });
 
@@ -255,23 +246,5 @@ describe("main", () => {
 
         expect(countPageStyles()).toBe(before);
         expect(document.body.querySelectorAll("h1").length).toBeGreaterThan(0);
-    });
-});
-
-describe("applyPrintDocumentTitle", () => {
-    const originalTitle = document.title;
-
-    afterEach(() => {
-        document.title = originalTitle;
-    });
-
-    it("keeps the inherited title when no note loaded", () => {
-        document.title = "Trilium Notes";
-
-        applyPrintDocumentTitle(null);
-        applyPrintDocumentTitle(undefined);
-        applyPrintDocumentTitle({ title: "" });
-
-        expect(document.title).toBe("Trilium Notes");
     });
 });

--- a/apps/client/src/print.spec.tsx
+++ b/apps/client/src/print.spec.tsx
@@ -24,7 +24,7 @@ vi.mock("./widgets/collections/NoteList", () => ({
     }
 }));
 
-import { App, Error404, loadCustomCss, main, SingleNoteRenderer } from "./print";
+import { App, applyPrintDocumentTitle, Error404, loadCustomCss, main, SingleNoteRenderer } from "./print";
 import froca from "./services/froca";
 import { buildNote } from "./test/easy-froca";
 
@@ -225,6 +225,7 @@ describe("main", () => {
     it("injects @page margins (browser) plus the font link and renders the app", async () => {
         buildNote({ id: "main-note", title: "Main Note", type: "text" });
         window.location.hash = "main-note";
+        document.title = "Trilium Notes";
 
         await main();
 
@@ -232,6 +233,9 @@ describe("main", () => {
         expect(document.head.querySelector('link[href="api/fonts"]')).toBeTruthy();
         const titles = [...document.body.querySelectorAll("h1")].map((el) => el.textContent);
         expect(titles).toContain("Main Note");
+        // Regression (#11140): the exported PDF's metadata title follows the note, not the
+        // app shell default the print window inherits.
+        expect(document.title).toBe("Main Note");
     });
 
     it("skips @page injection under Electron", async () => {
@@ -244,5 +248,23 @@ describe("main", () => {
 
         expect(countPageStyles()).toBe(before);
         expect(document.body.querySelectorAll("h1").length).toBeGreaterThan(0);
+    });
+});
+
+describe("applyPrintDocumentTitle", () => {
+    const originalTitle = document.title;
+
+    afterEach(() => {
+        document.title = originalTitle;
+    });
+
+    it("keeps the inherited title when no note loaded", () => {
+        document.title = "Trilium Notes";
+
+        applyPrintDocumentTitle(null);
+        applyPrintDocumentTitle(undefined);
+        applyPrintDocumentTitle({ title: "" });
+
+        expect(document.title).toBe("Trilium Notes");
     });
 });

--- a/apps/client/src/print.tsx
+++ b/apps/client/src/print.tsx
@@ -49,9 +49,22 @@ export async function main() {
 
     const note = await froca.getNote(noteId);
 
+    applyPrintDocumentTitle(note);
+
     const bodyWrapper = document.createElement("div");
     render(<App note={note} noteId={noteId} />, bodyWrapper);
     document.body.appendChild(bodyWrapper);
+}
+
+/**
+ * Why (#11140): `printToPDF()` and the browser print dialog take the exported document's
+ * metadata title from `document.title`; the print window inherits the app shell's
+ * "Trilium Notes" default, so every export announced itself as that instead of the note.
+ */
+export function applyPrintDocumentTitle(note: { title: string } | null | undefined): void {
+    if (note?.title) {
+        document.title = note.title;
+    }
 }
 
 export function App({ note, noteId }: { note: FNote | null | undefined, noteId: string }) {

--- a/apps/client/src/print.tsx
+++ b/apps/client/src/print.tsx
@@ -49,22 +49,14 @@ export async function main() {
 
     const note = await froca.getNote(noteId);
 
-    applyPrintDocumentTitle(note);
+    // printToPDF() and the browser print dialog name the document after document.title.
+    if (note?.title) {
+        document.title = note.title;
+    }
 
     const bodyWrapper = document.createElement("div");
     render(<App note={note} noteId={noteId} />, bodyWrapper);
     document.body.appendChild(bodyWrapper);
-}
-
-/**
- * Why (#11140): `printToPDF()` and the browser print dialog take the exported document's
- * metadata title from `document.title`; the print window inherits the app shell's
- * "Trilium Notes" default, so every export announced itself as that instead of the note.
- */
-export function applyPrintDocumentTitle(note: { title: string } | null | undefined): void {
-    if (note?.title) {
-        document.title = note.title;
-    }
 }
 
 export function App({ note, noteId }: { note: FNote | null | undefined, noteId: string }) {


### PR DESCRIPTION
## What

The print entry now applies the loaded note's title to `document.title` before rendering, so the exported PDF's metadata title follows the note instead of the app shell default.

## Why (issue #11140)

The print window loads the shared `index.html` (`<title>Trilium Notes</title>`) and `print.tsx` never touched `document.title`. Electron's `printToPDF()` derives the PDF document title from the page title, so every export announced itself as "Trilium Notes" — the issue's screenshot, and the exact case its second suggested behavior ("have it automatically follow the title of the note itself") covers. The same setting also fixes the browser print path, where `document.title` drives the print dialog's document name.

## How

```ts
const note = await froca.getNote(noteId);

applyPrintDocumentTitle(note);
```

with the helper exported as

```ts
export function applyPrintDocumentTitle(note: { title: string } | null | undefined): void {
    if (note?.title) {
        document.title = note.title;
    }
}
```

— a no-op when the note did not load (the Error404 path keeps the default title), no new setting surface needed.

## Testing

Extended the existing `print.spec.tsx` harness:

- the `main()` end-to-end test now resets `document.title` to the app default first and asserts it equals the note's title after `main()` resolves;
- a new `applyPrintDocumentTitle` block pins the no-op guards (null / undefined / empty title keep the inherited title).
- Diff-verified: with only `print.tsx` stashed, both assertions fail (title stays "Trilium Notes"); with it applied the file passes 12/12.

Fixes #11140
