### PR TITLE
feat(geomap): search the map, and look up places through Nominatim

### DIFF
--- a/apps/client/src/test/setup.ts
+++ b/apps/client/src/test/setup.ts
@@ -35,7 +35,10 @@ function mockWebsocket() {
         // consumers also import these as named exports (e.g. useNoteIds); leaving them out makes
         // the subscription effect throw, which silently skips every later effect of the component
         subscribeToMessages,
-        unsubscribeToMessage
+        unsubscribeToMessage,
+        // Code that reports a failure this way is usually in a catch block, so an undefined export
+        // here throws over the error being handled and loses whatever the component did about it.
+        logError(_message: string) {}
     };
 }
 

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2962,7 +2962,10 @@
     "search-failed": "Couldn't search for places",
     "results-nearby": "Nearby",
     "results-far": "Far away",
-    "add-place-as-marker": "Add as marker"
+    "add-place-as-marker": "Add as marker",
+    "previous-result": "Previous result",
+    "next-result": "Next result",
+    "result-position": "Result {{index}} of {{total}}, click to return to it"
   },
   "embedded_note": {
     "open-note": "Open note",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2959,7 +2959,10 @@
     "search-online": "Search online for \"{{- query}}\"",
     "searching-online": "Searching online…",
     "no-places-found": "No places found",
-    "search-failed": "Couldn't search for places"
+    "search-failed": "Couldn't search for places",
+    "results-nearby": "Nearby",
+    "results-far": "Far away",
+    "add-place-as-marker": "Add as marker"
   },
   "embedded_note": {
     "open-note": "Open note",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2953,7 +2953,9 @@
     "exit-3d": "Lay the map flat again",
     "close-details": "Close",
     "marker-color": "Marker color",
-    "copy-coordinates": "Copy coordinates"
+    "copy-coordinates": "Copy coordinates",
+    "search": "Search",
+    "search-placeholder": "Search for a place"
   },
   "embedded_note": {
     "open-note": "Open note",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2955,7 +2955,11 @@
     "marker-color": "Marker color",
     "copy-coordinates": "Copy coordinates",
     "search": "Search",
-    "search-placeholder": "Search for a place"
+    "search-placeholder": "Search for a place",
+    "search-online": "Search online for \"{{- query}}\"",
+    "searching-online": "Searching online…",
+    "no-places-found": "No places found",
+    "search-failed": "Couldn't search for places"
   },
   "embedded_note": {
     "open-note": "Open note",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2965,7 +2965,8 @@
     "add-place-as-marker": "Add as marker",
     "previous-result": "Previous result",
     "next-result": "Next result",
-    "result-position": "Result {{index}} of {{total}}, click to return to it"
+    "result-position": "Result {{index}} of {{total}}, click to return to it",
+    "results-on-map": "On this map"
   },
   "embedded_note": {
     "open-note": "Open note",

--- a/apps/client/src/utils/formatters.ts
+++ b/apps/client/src/utils/formatters.ts
@@ -1,6 +1,6 @@
 import { getLocaleById, t } from "../services/i18n";
-import type { MeasurementSystem } from "./units";
 import options from "../services/options";
+import type { MeasurementSystem } from "./units";
 
 type DateTimeStyle = "full" | "long" | "medium" | "short" | "none" | undefined;
 

--- a/apps/client/src/utils/formatters.ts
+++ b/apps/client/src/utils/formatters.ts
@@ -1,4 +1,5 @@
 import { getLocaleById, t } from "../services/i18n";
+import type { MeasurementSystem } from "./units";
 import options from "../services/options";
 
 type DateTimeStyle = "full" | "long" | "medium" | "short" | "none" | undefined;
@@ -221,7 +222,7 @@ export function isContentRightToLeft(noteLanguage: string | null | undefined): b
  * carrying no region is maximized first, which is what makes Trilium's plain `en` -- listed as
  * "English (United States)" -- resolve to `US`; `en-GB` is a separate entry and resolves to `GB`.
  */
-export function getMeasurementSystem(): "metric" | "imperial" {
+export function getMeasurementSystem(): MeasurementSystem {
     // An explicitly chosen formatting locale wins. Failing that the browser's locale is preferred
     // over what getFormattingLocale() would settle on (the UI language), because the UI language
     // says nothing about where the user is -- an English UI is common well outside the US.

--- a/apps/client/src/utils/units.spec.ts
+++ b/apps/client/src/utils/units.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * How a measurement is read out, in either of the systems Trilium states distances in.
+ *
+ * The unit strings resolve to nothing under test — i18next is never initialized — so what is checked
+ * is which unit was reached for and what was handed to it: the number, and how far it was rounded.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { formatDistance, formatElevation, formatSpeed } from "./units";
+
+vi.mock("../services/i18n", () => ({
+    t: (key: string, vars?: Record<string, unknown>) => `${key}|${Object.values(vars ?? {}).join()}`
+}));
+
+describe("formatDistance", () => {
+    it("reads in metres up close and kilometres beyond, where distances are stated in metric", () => {
+        expect(formatDistance(0, "metric")).toBe("gpx_preview.unit_m|0");
+        expect(formatDistance(850.4, "metric")).toBe("gpx_preview.unit_m|850");
+        // The last metre before it turns over, and the first kilometre after.
+        expect(formatDistance(999, "metric")).toBe("gpx_preview.unit_m|999");
+        expect(formatDistance(1000, "metric")).toBe("gpx_preview.unit_km|1");
+    });
+
+    it("reads in miles throughout, where that is how distances are stated", () => {
+        // Under a mile is still stated in miles: nobody gives a distance in feet.
+        expect(formatDistance(804.672, "imperial")).toBe("gpx_preview.unit_mi|0.5");
+        expect(formatDistance(1609.344, "imperial")).toBe("gpx_preview.unit_mi|1");
+    });
+
+    it("keeps fewer decimals the larger the number, a distance being read at what it is worth", () => {
+        expect(formatDistance(1234, "metric")).toBe("gpx_preview.unit_km|1.23");
+        expect(formatDistance(12_340, "metric")).toBe("gpx_preview.unit_km|12.3");
+        expect(formatDistance(1_234_000, "metric")).toBe("gpx_preview.unit_km|1,234");
+    });
+});
+
+describe("formatElevation", () => {
+    it("reads in metres or in feet, whole either way — a hill is not measured to the centimetre", () => {
+        expect(formatElevation(1234.6, "metric")).toBe("gpx_preview.unit_m|1,235");
+        expect(formatElevation(1000, "imperial")).toBe("gpx_preview.unit_ft|3,281");
+    });
+});
+
+describe("formatSpeed", () => {
+    it("reads in kilometres or miles an hour, from the kilometres an hour it is given", () => {
+        expect(formatSpeed(12.34, "metric")).toBe("gpx_preview.unit_kmh|12.3");
+        expect(formatSpeed(160.9344, "imperial")).toBe("gpx_preview.unit_mph|100");
+    });
+});

--- a/apps/client/src/utils/units.ts
+++ b/apps/client/src/utils/units.ts
@@ -1,0 +1,44 @@
+import { t } from "../services/i18n";
+
+/** Whether distances are stated in miles or in kilometres (see `getMeasurementSystem`). */
+export type MeasurementSystem = "metric" | "imperial";
+
+const METERS_PER_MILE = 1609.344;
+const FEET_PER_METER = 3.28084;
+
+/**
+ * A distance as it is read: metres up close and kilometres beyond, or miles throughout where that is
+ * how distances are stated.
+ *
+ * The unit strings are keyed under `gpx_preview`, which is where they were first written. They name
+ * nothing in particular — "{{value}} km" — and a renamed key drops what 38 locales have made of it.
+ */
+export function formatDistance(meters: number, system: MeasurementSystem): string {
+    if (system === "imperial") {
+        return t("gpx_preview.unit_mi", { value: round(meters / METERS_PER_MILE) });
+    }
+    if (meters < 1000) {
+        return t("gpx_preview.unit_m", { value: Math.round(meters).toLocaleString() });
+    }
+    return t("gpx_preview.unit_km", { value: round(meters / 1000) });
+}
+
+export function formatElevation(meters: number, system: MeasurementSystem): string {
+    if (system === "imperial") {
+        return t("gpx_preview.unit_ft", { value: Math.round(meters * FEET_PER_METER).toLocaleString() });
+    }
+    return t("gpx_preview.unit_m", { value: Math.round(meters).toLocaleString() });
+}
+
+export function formatSpeed(kmh: number, system: MeasurementSystem): string {
+    if (system === "imperial") {
+        return t("gpx_preview.unit_mph", { value: round(kmh * 1000 / METERS_PER_MILE) });
+    }
+    return t("gpx_preview.unit_kmh", { value: round(kmh) });
+}
+
+/** Fewer decimals the larger the number, so a measurement reads at the precision it is worth. */
+function round(value: number): string {
+    const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+    return value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: decimals });
+}

--- a/apps/client/src/widgets/collections/geomap/DetailPane.css
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.css
@@ -81,6 +81,7 @@
  * own until it is aimed at.
  */
 .geo-map-container .geo-detail-pane .geo-detail-pane-location,
+.geo-map-container .geo-place-panel .geo-detail-pane-location,
 .modal.geo-detail-sheet .geo-detail-pane-location {
     display: flex;
     align-items: center;

--- a/apps/client/src/widgets/collections/geomap/DetailPane.css
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.css
@@ -10,17 +10,13 @@
 }
 
 .geo-map-container .geo-detail-pane {
-    /* Room at the foot for the bar of buttons, which stands in this same corner: wherever that bar
-       has been pushed up to (a home bar in fullscreen, say — see the insets in index.css), its own
-       height, and as much air again. Standing clear of it rather than moving it aside — the mind
-       map's panel reckons its foot the same way. */
-    --detail-pane-foot: calc(var(--geo-map-inset-bottom) + var(--geo-map-toolbar-height) + var(--geo-map-inset));
-
     position: absolute;
     /* A fixed height rather than one sized to its contents, which would be a different pane for
-       every marker. What it holds scrolls within it (see OverlayPanel.css). */
+       every marker. What it holds scrolls within it (see OverlayPanel.css). It stands clear of the
+       bar of buttons in this same corner rather than moving it aside — the mind map's panel reckons
+       its foot the same way. */
     top: var(--geo-map-inset-top);
-    bottom: var(--detail-pane-foot);
+    bottom: var(--geo-map-foot);
     inset-inline-end: var(--geo-map-inset-end);
     width: var(--geo-detail-pane-width);
     /* An embedded map may be narrower than the pane would like to be — and in fullscreen the sides

--- a/apps/client/src/widgets/collections/geomap/DetailPane.tsx
+++ b/apps/client/src/widgets/collections/geomap/DetailPane.tsx
@@ -632,7 +632,7 @@ function MarkerLocation({ note }: { note: FNote }) {
  * pane does: the hook binds on mount and does not look again, and there is a render before the
  * location has been read in which there is no button to bind to.
  */
-function LocationButton({ coordinates }: { coordinates: [number, number] }) {
+export function LocationButton({ coordinates }: { coordinates: [number, number] }) {
     const buttonRef = useRef<HTMLButtonElement>(null);
 
     // The app's own tooltip rather than the browser's, as the buttons under it wear (see

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.spec.tsx
@@ -10,7 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MapStyleLoaded, ParentMap } from "./map";
 import { LABEL_PAINT, MARKER_SHADOW_PADDING, markerImageId } from "./Markers";
-import PlaceMarker, { PLACE_LAYER, PLACE_MARKER_COLOR, PLACE_MARKER_ICON, PLACE_SOURCE } from "./PlaceMarker";
+import PlaceMarker, { OUTLINE_FILL_LAYER, OUTLINE_LINE_LAYER, OUTLINE_SOURCE, PLACE_LAYER, PLACE_MARKER_COLOR, PLACE_MARKER_ICON, PLACE_SOURCE } from "./PlaceMarker";
 
 // The pin is rasterized by loading an SVG into an Image, and happy-dom never fires that load — so
 // the layer, which waits for the pin, would never be added. Only the rasterizing is stood in for;
@@ -22,11 +22,23 @@ vi.mock("./Markers", async (importOriginal) => ({
 
 const TOKYO: [number, number] = [ 139.6503, 35.6762 ];
 
+/** The ground a place covers, as a geocoder reports the boundary of a country or a county. */
+const OUTLINE: GeoJSON.Geometry = {
+    type: "Polygon",
+    coordinates: [ [ [ 139.5, 35.5 ], [ 139.9, 35.5 ], [ 139.9, 35.8 ], [ 139.5, 35.8 ], [ 139.5, 35.5 ] ] ]
+};
+
 interface FakeLayer {
     id: string;
     source?: string;
     layout?: Record<string, unknown>;
     paint?: Record<string, unknown>;
+}
+
+/** A layer as it was added: what it was, and which layer it was asked to go under. */
+interface AddedLayer {
+    layer: FakeLayer;
+    beforeId?: string;
 }
 
 /** A map that records what the component adds to it and takes away again. */
@@ -35,15 +47,21 @@ function fakeMap() {
     const sources = new Map<string, unknown>();
     const images = new Set<string>();
     const removals: string[] = [];
+    const added: AddedLayer[] = [];
 
     return {
         removals,
+        /** Where a layer was asked to be placed, which is what settles what is drawn over what. */
+        addedBefore: (id: string) => added.find((entry) => entry.layer.id === id)?.beforeId,
         layer: (id: string) => layers.get(id),
         source: (id: string) => sources.get(id),
         hasImage: (id: string) => images.has(id),
         addImage: (id: string) => { images.add(id); },
         addSource: (id: string, source: unknown) => { sources.set(id, source); },
-        addLayer: (layer: FakeLayer) => { layers.set(layer.id, layer); },
+        addLayer: (layer: FakeLayer, beforeId?: string) => {
+            layers.set(layer.id, layer);
+            added.push({ layer, beforeId });
+        },
         getSource: (id: string) => sources.get(id),
         getLayer: (id: string) => layers.get(id),
         removeSource: (id: string) => { removals.push(`source:${id}`); sources.delete(id); },
@@ -56,24 +74,34 @@ function fakeMap() {
 const containers: HTMLElement[] = [];
 
 /** Puts the pin on a map whose style is ready, and settles the pin image the layer waits for. */
-async function renderMarker(map: ReturnType<typeof fakeMap>, { name = "Tokyo", isDarkTheme = false } = {}) {
+async function renderMarker(map: ReturnType<typeof fakeMap>, props: {
+    name?: string; isDarkTheme?: boolean; outline?: GeoJSON.Geometry;
+} = {}) {
     const container = document.createElement("div");
     document.body.appendChild(container);
     containers.push(container);
 
-    await act(async () => {
-        render(
-            <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
-                <MapStyleLoaded.Provider value={true}>
-                    <PlaceMarker center={TOKYO} name={name} isDarkTheme={isDarkTheme} />
-                </MapStyleLoaded.Provider>
-            </ParentMap.Provider>,
-            container
-        );
-    });
-    await settle();
+    async function draw({ name = "Tokyo", isDarkTheme = false, outline }: typeof props) {
+        await act(async () => {
+            render(
+                <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
+                    <MapStyleLoaded.Provider value={true}>
+                        <PlaceMarker center={TOKYO} name={name} isDarkTheme={isDarkTheme} outline={outline} />
+                    </MapStyleLoaded.Provider>
+                </ParentMap.Provider>,
+                container
+            );
+        });
+        await settle();
+    }
 
-    return { unmount: async () => { await act(async () => { render(null, container); }); } };
+    await draw(props);
+
+    return {
+        /** The same pin drawn again with something changed — a boundary having arrived, say. */
+        rerender: (changed: typeof props) => draw({ ...props, ...changed }),
+        unmount: async () => { await act(async () => { render(null, container); }); }
+    };
 }
 
 /** Lets the awaited pin image arrive, which is what the layer is held back for. */
@@ -129,6 +157,31 @@ describe("geo map PlaceMarker", () => {
         expect(dark.layer(PLACE_LAYER)?.paint).toMatchObject(LABEL_PAINT.dark);
     });
 
+    it("draws the ground a place covers under its pin, where it covers any", async () => {
+        const map = fakeMap();
+
+        // The boundary is fetched once a place has been picked, so it arrives after the pin is up.
+        const { rerender } = await renderMarker(map);
+        await rerender({ outline: OUTLINE });
+
+        expect(map.source(OUTLINE_SOURCE)).toMatchObject({ type: "geojson", data: { geometry: OUTLINE } });
+        // A tint the map still shows through, ringed by the same colour the pin is drawn in.
+        expect(map.layer(OUTLINE_FILL_LAYER)?.paint).toMatchObject({ "fill-color": PLACE_MARKER_COLOR });
+        expect(map.layer(OUTLINE_LINE_LAYER)?.paint).toMatchObject({ "line-color": PLACE_MARKER_COLOR });
+        // Under the pin, which would otherwise be buried by its own boundary.
+        expect(map.addedBefore(OUTLINE_FILL_LAYER)).toBe(PLACE_LAYER);
+        expect(map.addedBefore(OUTLINE_LINE_LAYER)).toBe(PLACE_LAYER);
+    });
+
+    it("draws no boundary for a place that stands at a point", async () => {
+        const map = fakeMap();
+
+        await renderMarker(map);
+
+        expect(map.layer(OUTLINE_FILL_LAYER)).toBeUndefined();
+        expect(map.source(OUTLINE_SOURCE)).toBeUndefined();
+    });
+
     it("takes the layer and its source away with it, the layer first", async () => {
         const map = fakeMap();
         const { unmount } = await renderMarker(map);
@@ -138,5 +191,17 @@ describe("geo map PlaceMarker", () => {
 
         // A source still drawn from cannot be removed, so the layer goes first.
         expect(map.removals).toEqual([ `layer:${PLACE_LAYER}`, `source:${PLACE_SOURCE}` ]);
+    });
+
+    it("takes the boundary away with it too", async () => {
+        const map = fakeMap();
+        const { unmount } = await renderMarker(map, { outline: OUTLINE });
+
+        await unmount();
+
+        expect(map.removals).toEqual([
+            `layer:${PLACE_LAYER}`, `source:${PLACE_SOURCE}`,
+            `layer:${OUTLINE_FILL_LAYER}`, `layer:${OUTLINE_LINE_LAYER}`, `source:${OUTLINE_SOURCE}`
+        ]);
     });
 });

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.spec.tsx
@@ -1,0 +1,142 @@
+/**
+ * The pin standing on a place taken from the search: that it is drawn as a marker of the map rather
+ * than as something laid over it, labelled with the place's name and following the style from light
+ * to dark, and that it leaves nothing behind when it goes.
+ */
+import type { Map as MapLibreGLMap } from "maplibre-gl";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MapStyleLoaded, ParentMap } from "./map";
+import { LABEL_PAINT, MARKER_SHADOW_PADDING, markerImageId } from "./Markers";
+import PlaceMarker, { PLACE_LAYER, PLACE_MARKER_COLOR, PLACE_MARKER_ICON, PLACE_SOURCE } from "./PlaceMarker";
+
+// The pin is rasterized by loading an SVG into an Image, and happy-dom never fires that load — so
+// the layer, which waits for the pin, would never be added. Only the rasterizing is stood in for;
+// the layout and paint the assertions read are the real ones.
+vi.mock("./Markers", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./Markers")>()),
+    buildMarkerImage: vi.fn(async () => new Image())
+}));
+
+const TOKYO: [number, number] = [ 139.6503, 35.6762 ];
+
+interface FakeLayer {
+    id: string;
+    source?: string;
+    layout?: Record<string, unknown>;
+    paint?: Record<string, unknown>;
+}
+
+/** A map that records what the component adds to it and takes away again. */
+function fakeMap() {
+    const layers = new Map<string, FakeLayer>();
+    const sources = new Map<string, unknown>();
+    const images = new Set<string>();
+    const removals: string[] = [];
+
+    return {
+        removals,
+        layer: (id: string) => layers.get(id),
+        source: (id: string) => sources.get(id),
+        hasImage: (id: string) => images.has(id),
+        addImage: (id: string) => { images.add(id); },
+        addSource: (id: string, source: unknown) => { sources.set(id, source); },
+        addLayer: (layer: FakeLayer) => { layers.set(layer.id, layer); },
+        getSource: (id: string) => sources.get(id),
+        getLayer: (id: string) => layers.get(id),
+        removeSource: (id: string) => { removals.push(`source:${id}`); sources.delete(id); },
+        removeLayer: (id: string) => { removals.push(`layer:${id}`); layers.delete(id); },
+        on: () => {},
+        off: () => {}
+    };
+}
+
+const containers: HTMLElement[] = [];
+
+/** Puts the pin on a map whose style is ready, and settles the pin image the layer waits for. */
+async function renderMarker(map: ReturnType<typeof fakeMap>, { name = "Tokyo", isDarkTheme = false } = {}) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    await act(async () => {
+        render(
+            <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
+                <MapStyleLoaded.Provider value={true}>
+                    <PlaceMarker center={TOKYO} name={name} isDarkTheme={isDarkTheme} />
+                </MapStyleLoaded.Provider>
+            </ParentMap.Provider>,
+            container
+        );
+    });
+    await settle();
+
+    return { unmount: async () => { await act(async () => { render(null, container); }); } };
+}
+
+/** Lets the awaited pin image arrive, which is what the layer is held back for. */
+async function settle() {
+    await act(async () => { await Promise.resolve(); });
+}
+
+afterEach(() => {
+    for (const container of containers) {
+        render(null, container);
+        container.remove();
+    }
+    containers.length = 0;
+});
+
+describe("geo map PlaceMarker", () => {
+    it("stands the place on its own layer, pinned and named where the geocoder put it", async () => {
+        const map = fakeMap();
+
+        await renderMarker(map);
+
+        expect(map.source(PLACE_SOURCE)).toMatchObject({
+            type: "geojson",
+            data: {
+                geometry: { type: "Point", coordinates: TOKYO },
+                properties: { name: "Tokyo" }
+            }
+        });
+
+        const layer = map.layer(PLACE_LAYER);
+        expect(layer?.source).toBe(PLACE_SOURCE);
+        expect(layer?.layout).toMatchObject({
+            "icon-image": markerImageId(PLACE_MARKER_COLOR, PLACE_MARKER_ICON),
+            // The tip stands on the coordinate rather than the bottom edge of the image, as the note
+            // pins do.
+            "icon-anchor": "bottom",
+            "icon-offset": [ 0, MARKER_SHADOW_PADDING ],
+            // The one thing on the map the user has just asked to see does not give way to a label
+            // that was already there.
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true,
+            "text-field": [ "get", "name" ]
+        });
+    });
+
+    it("labels the place the way the map labels its own markers, on a light style and a dark one", async () => {
+        const light = fakeMap();
+        await renderMarker(light);
+        expect(light.layer(PLACE_LAYER)?.paint).toMatchObject(LABEL_PAINT.light);
+
+        const dark = fakeMap();
+        await renderMarker(dark, { isDarkTheme: true });
+        expect(dark.layer(PLACE_LAYER)?.paint).toMatchObject(LABEL_PAINT.dark);
+    });
+
+    it("takes the layer and its source away with it, the layer first", async () => {
+        const map = fakeMap();
+        const { unmount } = await renderMarker(map);
+        expect(map.layer(PLACE_LAYER)).toBeTruthy();
+
+        await unmount();
+
+        // A source still drawn from cannot be removed, so the layer goes first.
+        expect(map.removals).toEqual([ `layer:${PLACE_LAYER}`, `source:${PLACE_SOURCE}` ]);
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
@@ -6,7 +6,7 @@ import { buildMarkerImage, LABEL_LAYOUT, LABEL_PAINT, MARKER_SHADOW_PADDING, mar
 /** The colour the pin is drawn in, so a searched place is not read as one of the map's own notes. */
 export const PLACE_MARKER_COLOR = "#E8833A";
 
-/** The icon that pin wears, naming where it came from. */
+/** The icon inside that pin, naming where it came from. */
 export const PLACE_MARKER_ICON = "bx bx-search";
 
 export const PLACE_SOURCE = "searched-place";

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
@@ -1,0 +1,128 @@
+import { useContext, useEffect } from "preact/hooks";
+
+import { MapStyleLoaded, ParentMap } from "./map";
+import { buildMarkerImage, LABEL_LAYOUT, LABEL_PAINT, MARKER_SHADOW_PADDING, markerImageId } from "./Markers";
+
+/** The colour the pin is drawn in, so a searched place is not read as one of the map's own notes. */
+export const PLACE_MARKER_COLOR = "#E8833A";
+
+/** The icon that pin wears, naming where it came from. */
+export const PLACE_MARKER_ICON = "bx bx-search";
+
+export const PLACE_SOURCE = "searched-place";
+export const PLACE_LAYER = "searched-place-layer";
+
+interface PlaceMarkerProps {
+    /** Where the place stands, as `[lng, lat]`. */
+    center: [number, number];
+    /** What the pin is labelled with: the place's own name rather than its full address. */
+    name: string;
+    /** Whether the map's style is a dark one, which decides how the label is drawn (see Markers). */
+    isDarkTheme: boolean;
+}
+
+/**
+ * The pin standing on a place taken from the geocoder.
+ *
+ * A symbol layer of its own rather than a feature among the notes': that layer is built from the
+ * notes and reloaded with them, and a searched place is neither. It goes through the same pin
+ * rasterizer and the same label layout and paint the note markers use (see Markers), so it is drawn
+ * as a marker of the map rather than as something laid over it — the name included, which follows
+ * the style from light to dark as every other label on the map does.
+ */
+export default function PlaceMarker({ center, name, isDarkTheme }: PlaceMarkerProps) {
+    const parentMap = useContext(ParentMap);
+    const styleLoaded = useContext(MapStyleLoaded);
+
+    useEffect(() => {
+        if (!parentMap) return;
+        // Aliased so the narrowing above carries into the nested function below.
+        const map = parentMap;
+        const imageId = markerImageId(PLACE_MARKER_COLOR, PLACE_MARKER_ICON);
+        let cancelled = false;
+        let image: HTMLImageElement | null = null;
+
+        function addLayer() {
+            const pin = image;
+            if (cancelled || !pin) return;
+
+            try {
+                if (map.getLayer(PLACE_LAYER)) return;
+
+                if (!map.hasImage(imageId)) {
+                    map.addImage(imageId, pin, { pixelRatio: window.devicePixelRatio || 1 });
+                }
+
+                map.addSource(PLACE_SOURCE, {
+                    type: "geojson",
+                    data: {
+                        type: "Feature",
+                        geometry: { type: "Point", coordinates: center },
+                        properties: { name }
+                    }
+                });
+
+                map.addLayer({
+                    id: PLACE_LAYER,
+                    type: "symbol",
+                    source: PLACE_SOURCE,
+                    layout: {
+                        "icon-image": imageId,
+                        "icon-size": 1,
+                        "icon-anchor": "bottom",
+                        // The image carries padding for its shadow, pushed back down by exactly that
+                        // much so the tip stands on the coordinate — as the note pins are.
+                        "icon-offset": [ 0, MARKER_SHADOW_PADDING ],
+                        ...LABEL_LAYOUT,
+                        // Neither the pin nor its name gives way to a crowded map: this is the one
+                        // thing on it the user has just asked to be shown, and it stands only until
+                        // they have done with it.
+                        "icon-allow-overlap": true,
+                        "text-allow-overlap": true
+                    },
+                    paint: {
+                        ...LABEL_PAINT[isDarkTheme ? "dark" : "light"],
+                        "text-halo-width": 2,
+                        "text-halo-blur": 1
+                    }
+                });
+            } catch (e) {
+                // Only worth a word if the style was ready and it still would not take the pin.
+                if (styleLoaded) {
+                    console.warn("Geo map: could not pin the searched place —", e);
+                }
+            }
+        }
+
+        buildMarkerImage(PLACE_MARKER_COLOR, PLACE_MARKER_ICON).then((built) => {
+            if (cancelled) return;
+            image = built;
+            if (styleLoaded) {
+                addLayer();
+            }
+        });
+
+        if (styleLoaded) {
+            addLayer();
+        }
+        map.on("style.load", addLayer);
+
+        return () => {
+            cancelled = true;
+            map.off("style.load", addLayer);
+            try {
+                // The layer before the source it draws from: one still in use cannot be removed.
+                if (map.getLayer(PLACE_LAYER)) {
+                    map.removeLayer(PLACE_LAYER);
+                }
+                if (map.getSource(PLACE_SOURCE)) {
+                    map.removeSource(PLACE_SOURCE);
+                }
+            } catch {
+                // The map may already have been removed.
+            }
+        };
+    }, [ parentMap, styleLoaded, center, name, isDarkTheme ]);
+
+    return null;
+}

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
@@ -6,7 +6,7 @@ import { buildMarkerImage, LABEL_LAYOUT, LABEL_PAINT, MARKER_SHADOW_PADDING, mar
 /** The colour the pin is drawn in, so a searched place is not read as one of the map's own notes. */
 export const PLACE_MARKER_COLOR = "#E8833A";
 
-/** The icon inside that pin, naming where it came from. */
+/** The icon inside that pin, for a place whose kind the geocoder does not say. */
 export const PLACE_MARKER_ICON = "bx bx-search";
 
 export const PLACE_SOURCE = "searched-place";
@@ -26,6 +26,8 @@ interface PlaceMarkerProps {
     name: string;
     /** Whether the map's style is a dark one, which decides how the label is drawn (see Markers). */
     isDarkTheme: boolean;
+    /** A boxicons class saying what kind of place it is, drawn inside the pin (see osm_icons). */
+    icon?: string;
     /** The ground the place covers, for one that is an area rather than a point. */
     outline?: GeoJSON.Geometry;
 }
@@ -42,7 +44,7 @@ interface PlaceMarkerProps {
  * A place that covers ground rather than standing at a point — a country, a county — also has that
  * ground drawn under the pin, in the pin's own colour so the two read as one answer.
  */
-export default function PlaceMarker({ center, name, isDarkTheme, outline }: PlaceMarkerProps) {
+export default function PlaceMarker({ center, name, isDarkTheme, icon, outline }: PlaceMarkerProps) {
     const parentMap = useContext(ParentMap);
     const styleLoaded = useContext(MapStyleLoaded);
 
@@ -50,7 +52,8 @@ export default function PlaceMarker({ center, name, isDarkTheme, outline }: Plac
         if (!parentMap) return;
         // Aliased so the narrowing above carries into the nested function below.
         const map = parentMap;
-        const imageId = markerImageId(PLACE_MARKER_COLOR, PLACE_MARKER_ICON);
+        const iconClass = icon ?? PLACE_MARKER_ICON;
+        const imageId = markerImageId(PLACE_MARKER_COLOR, iconClass);
         let cancelled = false;
         let image: HTMLImageElement | null = null;
 
@@ -106,7 +109,7 @@ export default function PlaceMarker({ center, name, isDarkTheme, outline }: Plac
             }
         }
 
-        buildMarkerImage(PLACE_MARKER_COLOR, PLACE_MARKER_ICON).then((built) => {
+        buildMarkerImage(PLACE_MARKER_COLOR, iconClass).then((built) => {
             if (cancelled) return;
             image = built;
             if (styleLoaded) {
@@ -134,7 +137,7 @@ export default function PlaceMarker({ center, name, isDarkTheme, outline }: Plac
                 // The map may already have been removed.
             }
         };
-    }, [ parentMap, styleLoaded, center, name, isDarkTheme ]);
+    }, [ parentMap, styleLoaded, center, name, isDarkTheme, icon ]);
 
     useEffect(() => {
         if (!parentMap || !outline) return;

--- a/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlaceMarker.tsx
@@ -12,6 +12,13 @@ export const PLACE_MARKER_ICON = "bx bx-search";
 export const PLACE_SOURCE = "searched-place";
 export const PLACE_LAYER = "searched-place-layer";
 
+export const OUTLINE_SOURCE = "searched-place-outline";
+export const OUTLINE_FILL_LAYER = "searched-place-outline-fill";
+export const OUTLINE_LINE_LAYER = "searched-place-outline-line";
+
+/** How much of the map shows through the boundary's fill, which is a tint rather than a covering. */
+const OUTLINE_FILL_OPACITY = 0.12;
+
 interface PlaceMarkerProps {
     /** Where the place stands, as `[lng, lat]`. */
     center: [number, number];
@@ -19,6 +26,8 @@ interface PlaceMarkerProps {
     name: string;
     /** Whether the map's style is a dark one, which decides how the label is drawn (see Markers). */
     isDarkTheme: boolean;
+    /** The ground the place covers, for one that is an area rather than a point. */
+    outline?: GeoJSON.Geometry;
 }
 
 /**
@@ -29,8 +38,11 @@ interface PlaceMarkerProps {
  * rasterizer and the same label layout and paint the note markers use (see Markers), so it is drawn
  * as a marker of the map rather than as something laid over it — the name included, which follows
  * the style from light to dark as every other label on the map does.
+ *
+ * A place that covers ground rather than standing at a point — a country, a county — also has that
+ * ground drawn under the pin, in the pin's own colour so the two read as one answer.
  */
-export default function PlaceMarker({ center, name, isDarkTheme }: PlaceMarkerProps) {
+export default function PlaceMarker({ center, name, isDarkTheme, outline }: PlaceMarkerProps) {
     const parentMap = useContext(ParentMap);
     const styleLoaded = useContext(MapStyleLoaded);
 
@@ -123,6 +135,74 @@ export default function PlaceMarker({ center, name, isDarkTheme }: PlaceMarkerPr
             }
         };
     }, [ parentMap, styleLoaded, center, name, isDarkTheme ]);
+
+    useEffect(() => {
+        if (!parentMap || !outline) return;
+        // Aliased so the narrowing above carries into the nested function below.
+        const map = parentMap;
+        const geometry = outline;
+
+        function addOutline() {
+            try {
+                if (map.getLayer(OUTLINE_FILL_LAYER)) return;
+
+                map.addSource(OUTLINE_SOURCE, {
+                    type: "geojson",
+                    data: { type: "Feature", geometry, properties: {} }
+                });
+
+                // Under the pin, which would otherwise be buried by the boundary drawn around it.
+                // The pin's layer is only there once its image has been rasterized, so where it is
+                // not yet, the boundary goes on top and the pin is added above it in its turn.
+                const beforeId = map.getLayer(PLACE_LAYER) ? PLACE_LAYER : undefined;
+
+                map.addLayer({
+                    id: OUTLINE_FILL_LAYER,
+                    type: "fill",
+                    source: OUTLINE_SOURCE,
+                    paint: {
+                        "fill-color": PLACE_MARKER_COLOR,
+                        "fill-opacity": OUTLINE_FILL_OPACITY
+                    }
+                }, beforeId);
+
+                map.addLayer({
+                    id: OUTLINE_LINE_LAYER,
+                    type: "line",
+                    source: OUTLINE_SOURCE,
+                    paint: {
+                        "line-color": PLACE_MARKER_COLOR,
+                        "line-width": 2
+                    }
+                }, beforeId);
+            } catch (e) {
+                if (styleLoaded) {
+                    console.warn("Geo map: could not draw the searched place's boundary —", e);
+                }
+            }
+        }
+
+        if (styleLoaded) {
+            addOutline();
+        }
+        map.on("style.load", addOutline);
+
+        return () => {
+            map.off("style.load", addOutline);
+            try {
+                for (const layer of [ OUTLINE_FILL_LAYER, OUTLINE_LINE_LAYER ]) {
+                    if (map.getLayer(layer)) {
+                        map.removeLayer(layer);
+                    }
+                }
+                if (map.getSource(OUTLINE_SOURCE)) {
+                    map.removeSource(OUTLINE_SOURCE);
+                }
+            } catch {
+                // The map may already have been removed.
+            }
+        };
+    }, [ parentMap, styleLoaded, outline ]);
 
     return null;
 }

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.css
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.css
@@ -1,0 +1,28 @@
+/* The corner the detail pane stands in, and the width it is given, the two never standing at once.
+   Sized to what it holds, though: it is a card rather than a pane the height of the map. */
+.geo-map-container .geo-place-panel {
+    position: absolute;
+    top: var(--geo-map-inset-top);
+    inset-inline-end: var(--geo-map-inset-end);
+    width: var(--geo-detail-pane-width);
+    max-width: calc(100% - var(--geo-map-inset-start) - var(--geo-map-inset-end));
+    /* Clear of MapLibre's own control corners, which sit at 2 (see MapToolbar.css). */
+    z-index: 3;
+}
+
+.geo-map-container .geo-place-panel .geo-place-panel-body {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px 12px;
+}
+
+.geo-map-container .geo-place-panel .geo-place-panel-address {
+    font-size: 0.9em;
+    opacity: 0.8;
+}
+
+.geo-map-container .geo-place-panel .geo-place-panel-add {
+    align-self: stretch;
+}

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.css
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.css
@@ -10,6 +10,17 @@
     z-index: 3;
 }
 
+/* On a phone the panel is as wide as the map, so at the head it would cover the search bar and the
+   result navigator standing under it (see index.css). It stands at the foot instead, which leaves
+   those reachable: results can be stepped through with a place open. */
+body.mobile .geo-map-container .geo-place-panel {
+    top: auto;
+    bottom: var(--geo-map-foot);
+    /* Half the map at most, so a long address cannot grow the card back over the bar; what does not
+       fit scrolls within it (see OverlayPanel.css). */
+    max-height: 50%;
+}
+
 .geo-map-container .geo-place-panel .geo-place-panel-body {
     display: flex;
     flex-direction: column;

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.spec.tsx
@@ -61,6 +61,23 @@ describe("geo map PlacePanel", () => {
         expect(onClose).toHaveBeenCalledOnce();
     });
 
+    it("takes the keyboard as it appears, so keeping the place is the next press", () => {
+        const { container } = renderPanel();
+
+        expect(document.activeElement).toBe(container.querySelector(".geo-place-panel-add"));
+    });
+
+    it("sends itself away on Escape, the focus it took having to have a way out", () => {
+        const { container, onClose } = renderPanel();
+
+        act(() => {
+            container.querySelector(".tn-overlay-panel")
+                ?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        });
+
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
     it("offers no marker on a map that may not be edited, the place still being worth reading", () => {
         const { container } = renderPanel({ isReadOnly: true });
 

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.spec.tsx
@@ -1,0 +1,70 @@
+/**
+ * The panel standing over a place taken from the search: what it says about the place, and the two
+ * things that can be done with one — kept as a marker of the map, or sent away.
+ */
+import { act } from "preact/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderInto } from "../../../test/render";
+import type { GeoSearchResult } from "./geocoding";
+import PlacePanel from "./PlacePanel";
+
+// The real module besides `t`, which is left to stand for the text it would return: something in the
+// tree below awaits `translationsInitializedPromise`, and a mock without it fails after the test has
+// passed.
+vi.mock("../../../services/i18n", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/i18n")>()),
+    t: (key: string) => key
+}));
+
+const JUMBO: GeoSearchResult = {
+    id: "N5",
+    name: "Jumbo",
+    label: "Jumbo, Str. Șos. Alba Iulia 70, Sibiu, Romania",
+    lat: 45.796,
+    lng: 24.147
+};
+
+function renderPanel({ isReadOnly = false } = {}) {
+    const onAddMarker = vi.fn();
+    const onClose = vi.fn();
+    let container: HTMLElement | undefined;
+
+    act(() => {
+        container = renderInto(
+            <PlacePanel place={JUMBO} isReadOnly={isReadOnly} onAddMarker={onAddMarker} onClose={onClose} />
+        );
+    });
+    if (!container) throw new Error("the panel was not rendered");
+
+    return { container, onAddMarker, onClose };
+}
+
+describe("geo map PlacePanel", () => {
+    it("names the place and gives the address under it, with the coordinates to copy", () => {
+        const { container } = renderPanel();
+
+        expect(container.querySelector(".tn-overlay-panel-title-text")?.textContent).toBe("Jumbo");
+        // The whole of it, the heading carrying only the name.
+        expect(container.querySelector(".geo-place-panel-address")?.textContent)
+            .toBe("Jumbo, Str. Șos. Alba Iulia 70, Sibiu, Romania");
+        expect(container.querySelector(".geo-detail-pane-location")?.textContent).toContain("45.796");
+    });
+
+    it("keeps the place as a marker when asked, and sends itself away when told", () => {
+        const { container, onAddMarker, onClose } = renderPanel();
+
+        act(() => { container.querySelector<HTMLButtonElement>(".geo-place-panel-add")?.click(); });
+        expect(onAddMarker).toHaveBeenCalledOnce();
+
+        act(() => { container.querySelector<HTMLButtonElement>(".tn-overlay-panel-close")?.click(); });
+        expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("offers no marker on a map that may not be edited, the place still being worth reading", () => {
+        const { container } = renderPanel({ isReadOnly: true });
+
+        expect(container.querySelector(".geo-place-panel-add")).toBeNull();
+        expect(container.querySelector(".geo-place-panel-address")).not.toBeNull();
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
@@ -30,7 +30,7 @@ export default function PlacePanel({ place, isReadOnly, onAddMarker, onClose }: 
     return (
         <OverlayPanel
             className="geo-place-panel"
-            header={<OverlayPanelTitle icon={PLACE_MARKER_ICON} text={place.name} />}
+            header={<OverlayPanelTitle icon={place.icon ?? PLACE_MARKER_ICON} text={place.name} />}
             close={{ text: t("geo-map.close-details"), onClick: onClose }}
         >
             <OverlayPanelBody className="geo-place-panel-body">

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
@@ -1,0 +1,56 @@
+import "./PlacePanel.css";
+
+import { t } from "../../../services/i18n";
+import Button from "../../react/Button";
+import OverlayPanel, { OverlayPanelBody, OverlayPanelTitle } from "../../react/OverlayPanel";
+import { LocationButton } from "./DetailPane";
+import type { GeoSearchResult } from "./geocoding";
+import { PLACE_MARKER_ICON } from "./PlaceMarker";
+
+interface PlacePanelProps {
+    place: GeoSearchResult;
+    /** The map may not be edited, so the place can be looked at but not kept. */
+    isReadOnly: boolean;
+    /** Makes a note of the place, which is what turns the temporary pin into a marker of the map. */
+    onAddMarker(): void;
+    /** Sends the panel away, and the pin with it. */
+    onClose(): void;
+}
+
+/**
+ * What can be done with a place taken from the search: kept as a marker of the map, or read and
+ * dismissed.
+ *
+ * It stands where the detail pane stands, and the two are one selection between them — picking a
+ * place closes the pane and selecting a note closes this (see index.tsx). A panel rather than a popup
+ * over the pin: a popup would crowd the address that tells two places of the same name apart, and
+ * MapLibre's popups already belong to the markers' previews (see Tooltips).
+ */
+export default function PlacePanel({ place, isReadOnly, onAddMarker, onClose }: PlacePanelProps) {
+    return (
+        <OverlayPanel
+            className="geo-place-panel"
+            header={<OverlayPanelTitle icon={PLACE_MARKER_ICON} text={place.name} />}
+            close={{ text: t("geo-map.close-details"), onClick: onClose }}
+        >
+            <OverlayPanelBody className="geo-place-panel-body">
+                {/* The whole of what the geocoder calls the place, the heading above carrying only
+                    its name. */}
+                <div className="geo-place-panel-address">{place.label}</div>
+
+                {/* The pane's own, so a place and a marker offer their coordinates alike. */}
+                <LocationButton coordinates={[ place.lng, place.lat ]} />
+
+                {!isReadOnly && (
+                    <Button
+                        className="geo-place-panel-add"
+                        kind="primary"
+                        icon="bx bx-pin"
+                        text={t("geo-map.add-place-as-marker")}
+                        onClick={onAddMarker}
+                    />
+                )}
+            </OverlayPanelBody>
+        </OverlayPanel>
+    );
+}

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
@@ -36,8 +36,6 @@ export default function PlacePanel({ place, isReadOnly, onAddMarker, onClose }: 
     const panelRef = useRef<HTMLDivElement>(null);
     const addRef = useRef<HTMLButtonElement>(null);
 
-    // Nothing to move to on a map that may not be edited, where the panel is only to be read: the
-    // field keeps the focus, which is where the reader left it.
     useEffect(() => { addRef.current?.focus(); }, [ place ]);
 
     useEffect(() => {

--- a/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
+++ b/apps/client/src/widgets/collections/geomap/PlacePanel.tsx
@@ -1,5 +1,7 @@
 import "./PlacePanel.css";
 
+import { useEffect, useRef } from "preact/hooks";
+
 import { t } from "../../../services/i18n";
 import Button from "../../react/Button";
 import OverlayPanel, { OverlayPanelBody, OverlayPanelTitle } from "../../react/OverlayPanel";
@@ -25,11 +27,37 @@ interface PlacePanelProps {
  * place closes the pane and selecting a note closes this (see index.tsx). A panel rather than a popup
  * over the pin: a popup would crowd the address that tells two places of the same name apart, and
  * MapLibre's popups already belong to the markers' previews (see Tooltips).
+ *
+ * The keyboard follows the panel as it appears, so that searching, taking a place and keeping it are
+ * three presses of Enter and the search bar stops reading as the thing in hand. Escape sends the
+ * panel away again, the way out being what makes taking the focus fair.
  */
 export default function PlacePanel({ place, isReadOnly, onAddMarker, onClose }: PlacePanelProps) {
+    const panelRef = useRef<HTMLDivElement>(null);
+    const addRef = useRef<HTMLButtonElement>(null);
+
+    // Nothing to move to on a map that may not be edited, where the panel is only to be read: the
+    // field keeps the focus, which is where the reader left it.
+    useEffect(() => { addRef.current?.focus(); }, [ place ]);
+
+    useEffect(() => {
+        const panel = panelRef.current;
+        if (!panel) return;
+
+        const dismiss = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                onClose();
+            }
+        };
+
+        panel.addEventListener("keydown", dismiss);
+        return () => panel.removeEventListener("keydown", dismiss);
+    }, [ onClose ]);
+
     return (
         <OverlayPanel
             className="geo-place-panel"
+            containerRef={panelRef}
             header={<OverlayPanelTitle icon={place.icon ?? PLACE_MARKER_ICON} text={place.name} />}
             close={{ text: t("geo-map.close-details"), onClick: onClose }}
         >
@@ -44,6 +72,7 @@ export default function PlacePanel({ place, isReadOnly, onAddMarker, onClose }: 
                 {!isReadOnly && (
                     <Button
                         className="geo-place-panel-add"
+                        buttonRef={addRef}
                         kind="primary"
                         icon="bx bx-pin"
                         text={t("geo-map.add-place-as-marker")}

--- a/apps/client/src/widgets/collections/geomap/ResultNavigator.css
+++ b/apps/client/src/widgets/collections/geomap/ResultNavigator.css
@@ -1,8 +1,8 @@
-/* Under the search bar, in the same corner: the room the bar keeps from the top, the bar's own
-   height, and as much air again. */
+/* Under the search bar, in the same corner: where that bar stands, its own height, and as much air
+   again — read from the bar's own top, which on mobile is below the attribution (see index.css). */
 .geo-map-container .geo-result-navigator {
     --overlay-group-inset-top: calc(
-        var(--geo-map-inset-top) + var(--geo-map-toolbar-height) + var(--geo-map-inset));
+        var(--geo-map-search-top) + var(--geo-map-toolbar-height) + var(--geo-map-inset));
 }
 
 /* The count is read rather than pressed for its own sake, so it keeps a readout's room rather than

--- a/apps/client/src/widgets/collections/geomap/ResultNavigator.css
+++ b/apps/client/src/widgets/collections/geomap/ResultNavigator.css
@@ -1,0 +1,14 @@
+/* Under the search bar, in the same corner: the room the bar keeps from the top, the bar's own
+   height, and as much air again. */
+.geo-map-container .geo-result-navigator {
+    --overlay-group-inset-top: calc(
+        var(--geo-map-inset-top) + var(--geo-map-toolbar-height) + var(--geo-map-inset));
+}
+
+/* The count is read rather than pressed for its own sake, so it keeps a readout's room rather than
+   an icon button's width. */
+.geo-map-container .geo-result-navigator .geo-result-position {
+    min-width: 0;
+    padding-inline: 10px;
+    font-variant-numeric: tabular-nums;
+}

--- a/apps/client/src/widgets/collections/geomap/ResultNavigator.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/ResultNavigator.spec.tsx
@@ -1,0 +1,91 @@
+/**
+ * Stepping through what a search turned up: which of them the map is pointed at, how the ends are
+ * held, and where a step leaves the reader.
+ */
+import type { Map as MapLibreGLMap } from "maplibre-gl";
+import { act } from "preact/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderInto } from "../../../test/render";
+import { ParentMap } from "./map";
+import type { SearchResult } from "./results";
+import ResultNavigator from "./ResultNavigator";
+
+vi.mock("../../../services/i18n", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/i18n")>()),
+    t: (key: string) => key
+}));
+
+const RESULTS: SearchResult[] = [
+    { kind: "note", noteId: "note1", center: [ 24.15, 45.79 ] },
+    { kind: "place", place: { id: "N5", name: "Jumbo", label: "Jumbo, Sibiu", lat: 45.8, lng: 24.2, bounds: [ [ 24.1, 45.7 ], [ 24.3, 45.9 ] ] } },
+    { kind: "place", place: { id: "N6", name: "Jumbo", label: "Jumbo, Ohio", lat: 40.4, lng: -82.9 } }
+];
+
+function fakeMap() {
+    return { flyTo: vi.fn(), fitBounds: vi.fn() };
+}
+
+function renderNavigator(index: number, results = RESULTS) {
+    const map = fakeMap();
+    const onStep = vi.fn();
+    let container: HTMLElement | undefined;
+
+    act(() => {
+        container = renderInto(
+            <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
+                <ResultNavigator results={results} index={index} onStep={onStep} />
+            </ParentMap.Provider>
+        );
+    });
+    if (!container) throw new Error("the navigator was not rendered");
+
+    const buttons = [ ...container.querySelectorAll<HTMLButtonElement>("button") ];
+    return { map, onStep, buttons, container };
+}
+
+describe("geo map ResultNavigator", () => {
+    it("says where the reader stands among the results, counting from one", () => {
+        const { buttons } = renderNavigator(1);
+
+        expect(buttons[1].textContent).toBe("2 / 3");
+    });
+
+    it("steps to the next result and points the map at it", () => {
+        const { buttons, onStep, map } = renderNavigator(0);
+
+        act(() => { buttons[2].click(); });
+
+        expect(onStep).toHaveBeenCalledWith(1);
+        // The place covers ground the geocoder reported, so it is framed rather than flown to.
+        expect(map.fitBounds).toHaveBeenCalledOnce();
+    });
+
+    it("steps back to a note, which marks a spot and is flown to", () => {
+        const { buttons, onStep, map } = renderNavigator(1);
+
+        act(() => { buttons[0].click(); });
+
+        expect(onStep).toHaveBeenCalledWith(0);
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ 24.15, 45.79 ], zoom: expect.any(Number) });
+    });
+
+    it("holds the ends rather than wrapping round them", () => {
+        expect(renderNavigator(0).buttons[0].disabled).toBe(true);
+        expect(renderNavigator(2).buttons[2].disabled).toBe(true);
+        expect(renderNavigator(1).buttons.some((button) => button.disabled)).toBe(false);
+    });
+
+    it("points the map back at where it stands when the count itself is pressed", () => {
+        const { buttons, onStep, map } = renderNavigator(2);
+
+        act(() => { buttons[1].click(); });
+
+        expect(onStep).toHaveBeenCalledWith(2);
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ -82.9, 40.4 ], zoom: expect.any(Number) });
+    });
+
+    it("stands aside where there is nothing to step between", () => {
+        expect(renderNavigator(0, RESULTS.slice(0, 1)).container.querySelector("button")).toBeNull();
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/ResultNavigator.tsx
+++ b/apps/client/src/widgets/collections/geomap/ResultNavigator.tsx
@@ -1,0 +1,65 @@
+import "./ResultNavigator.css";
+
+import { useContext } from "preact/hooks";
+
+import { t } from "../../../services/i18n";
+import OverlayControlGroup, { OverlayControlButton } from "../../react/OverlayControlGroup";
+import { ParentMap } from "./map";
+import { frameResult, type SearchResult } from "./results";
+
+interface ResultNavigatorProps {
+    /** What the search turned up, in the order the list offered it. */
+    results: SearchResult[];
+    /** Which of them the map is standing on. */
+    index: number;
+    /** Stands the map on another of them; the map is pointed at it here. */
+    onStep(index: number): void;
+}
+
+/**
+ * Steps through what a search turned up, one result at a time.
+ *
+ * Taking a result closes the list, so comparing several of them meant asking for the list again for
+ * each — this walks them in the order they were offered, nearest first.
+ *
+ * A group of its own under the search bar rather than buttons in it: the bar has no room for three
+ * more, and one of the results may be a note of the map's own, which opens the detail pane instead of
+ * the place panel — buttons living on either panel would go as soon as the other was reached.
+ */
+export default function ResultNavigator({ results, index, onStep }: ResultNavigatorProps) {
+    const map = useContext(ParentMap);
+
+    // Nothing to step between, and nothing worth saying about where one stands among one.
+    if (!map || results.length < 2) return null;
+
+    const step = (to: number) => {
+        onStep(to);
+        frameResult(map, results[to]);
+    };
+
+    return (
+        <OverlayControlGroup className="geo-result-navigator" placement="top-start" overCanvas>
+            <OverlayControlButton
+                title={t("geo-map.previous-result")}
+                icon="bx-chevron-left"
+                disabled={index <= 0}
+                onClick={() => step(index - 1)}
+            />
+            {/* The count is a readout rather than a choice, so pressing it does the one thing that
+                needs no choosing: points the map back at what it is standing on, after the reader
+                has panned away from it. */}
+            <OverlayControlButton
+                text={`${index + 1} / ${results.length}`}
+                className="geo-result-position"
+                aria-label={t("geo-map.result-position", { index: index + 1, total: results.length })}
+                onClick={() => step(index)}
+            />
+            <OverlayControlButton
+                title={t("geo-map.next-result")}
+                icon="bx-chevron-right"
+                disabled={index >= results.length - 1}
+                onClick={() => step(index + 1)}
+            />
+        </OverlayControlGroup>
+    );
+}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -50,6 +50,24 @@ body.mobile .geo-map-container .geo-search-toolbar {
     opacity: 0.6;
 }
 
+/*
+ * Sized to the field beside it rather than to a toolbar's own buttons, so the bar keeps its height.
+ *
+ * It holds its place in the bar with nothing to clear rather than leaving it, which would take the
+ * bar's width with it — hidden rather than gone, so it is out of reach of the pointer and the tab
+ * key as well as out of sight.
+ */
+.geo-map-container .geo-search-toolbar .geo-search-clear {
+    --icon-button-size: 24px;
+    width: 24px;
+    height: 24px;
+    visibility: hidden;
+}
+
+.geo-map-container .geo-search-toolbar .geo-search-clear.shown {
+    visibility: visible;
+}
+
 /* The dropdown is portalled to the body, so these are not scoped under .geo-map-container. */
 .form-autocomplete-dropdown .geo-search-entry {
     display: flex;

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -101,6 +101,12 @@ body.mobile .geo-map-container .geo-search-toolbar {
     opacity: 0.85;
 }
 
+/* A heading names the rows under it and reads as the dropdown's own furniture rather than as one of
+   the entries, so it keeps none of the room a row's mark and distance are given. */
+.form-autocomplete-dropdown .geo-search-heading {
+    display: block;
+}
+
 /* A report is not a choice, so it neither highlights nor takes a pointer. */
 .form-autocomplete-dropdown .form-autocomplete-item:has(.geo-search-entry-info) {
     cursor: default;

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -67,6 +67,19 @@ body.mobile .geo-map-container .geo-search-toolbar {
     display: flex;
     flex-direction: column;
     min-width: 0;
+    /* Takes the room the mark and the distance leave, so the distance keeps the trailing edge. */
+    flex: 1;
+}
+
+/* How far off the place is, against the trailing edge where a row's rightmost column belongs — read
+   after what the row offers rather than before it. */
+.form-autocomplete-dropdown .geo-search-entry-distance {
+    flex-shrink: 0;
+    align-self: center;
+    padding-inline-start: 8px;
+    font-size: 0.85em;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.6;
 }
 
 .form-autocomplete-dropdown .geo-search-entry-address {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -66,33 +66,3 @@ body.mobile .geo-map-container .geo-search-toolbar {
     background: none;
     color: inherit;
 }
-
-/*
- * The pin standing on a place taken from the geocoder. MapLibre places the element and writes its
- * transform, so the drop is animated on the image inside it.
- */
-.geo-map-container .geo-place-marker {
-    /* A click at the place belongs to the map, which is what arms placement and opens the context
-       menu (see index.tsx). */
-    pointer-events: none;
-}
-
-.geo-map-container .geo-place-marker img {
-    display: block;
-    /* The canvas drawMarkerImage draws, in CSS pixels: the pin plus the room left around it for its
-       shadow. Must agree with MARKER_WIDTH, MARKER_HEIGHT and MARKER_SHADOW_PADDING (Markers.tsx). */
-    width: 37px;
-    height: 53px;
-    animation: geo-place-marker-drop 200ms ease-out;
-}
-
-@keyframes geo-place-marker-drop {
-    from {
-        transform: translateY(-10px);
-        opacity: 0;
-    }
-    to {
-        transform: none;
-        opacity: 1;
-    }
-}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -1,7 +1,7 @@
 /* Top leading corner of the map, using the insets and z-index every overlay here uses (see
    index.css). */
 .geo-map-container .geo-search-toolbar {
-    top: var(--geo-map-inset-top);
+    top: var(--geo-map-search-top);
     inset-inline-start: var(--geo-map-inset-start);
     z-index: 3;
     gap: 6px;
@@ -12,11 +12,6 @@
     background: var(--geo-map-panel-background);
     color: var(--geo-map-panel-text-color);
     border-color: var(--geo-map-panel-border-color);
-}
-
-/* On mobile the attribution takes the top leading corner (see map.tsx), so start below it. */
-body.mobile .geo-map-container .geo-search-toolbar {
-    top: calc(var(--geo-map-inset-top) * 2 + var(--geo-map-toolbar-height));
 }
 
 /* The bar is the field, icon and all, so it takes the focus outline an input group takes (see the

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -39,11 +39,12 @@ body.mobile .geo-map-container .geo-search-toolbar {
     opacity: 0.6;
 }
 
-/* Every row reads as icon + label, whether it offers a marker, a place, the geocoder or a report on
-   it. Scoped to the portalled dropdown, which is a body child rather than part of the map. */
+/* Every row reads as icon + what it says, whether it offers a marker, a place, the geocoder or a
+   report on it. Scoped to the portalled dropdown, which is a body child rather than part of the map. */
 .form-autocomplete-dropdown .geo-search-entry {
     display: flex;
-    align-items: center;
+    /* The mark sits on the first line rather than in the middle of a row that runs to two. */
+    align-items: flex-start;
     gap: 6px;
     overflow: hidden;
 }
@@ -51,6 +52,33 @@ body.mobile .geo-map-container .geo-search-toolbar {
 .form-autocomplete-dropdown .geo-search-entry .tn-icon {
     flex-shrink: 0;
     opacity: 0.7;
+    /* Set against the line beside it, the mark being drawn taller than the text it stands with. */
+    line-height: 1.4;
+}
+
+/* A place says what it is called and then where it is, so the row is given the height of both and
+   the address wraps instead of ending in an ellipsis a word in. */
+.form-autocomplete-dropdown .form-autocomplete-item:has(.geo-search-entry) {
+    white-space: normal;
+    padding-block: 6px;
+}
+
+.form-autocomplete-dropdown .geo-search-entry-lines {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.form-autocomplete-dropdown .geo-search-entry-address {
+    font-size: 0.85em;
+    opacity: 0.7;
+    /* Two lines of address and no more: past that the list is a page, and what is cut is the part of
+       an address that names a postcode or a country. */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 /* The geocoder row and its reports are set apart from the places they produce. */

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -66,3 +66,33 @@ body.mobile .geo-map-container .geo-search-toolbar {
     background: none;
     color: inherit;
 }
+
+/*
+ * The pin standing on a place taken from the geocoder. MapLibre places the element and writes its
+ * transform, so the drop is animated on the image inside it.
+ */
+.geo-map-container .geo-place-marker {
+    /* A click at the place belongs to the map, which is what arms placement and opens the context
+       menu (see index.tsx). */
+    pointer-events: none;
+}
+
+.geo-map-container .geo-place-marker img {
+    display: block;
+    /* The canvas drawMarkerImage draws, in CSS pixels: the pin plus the room left around it for its
+       shadow. Must agree with MARKER_WIDTH, MARKER_HEIGHT and MARKER_SHADOW_PADDING (Markers.tsx). */
+    width: 37px;
+    height: 53px;
+    animation: geo-place-marker-drop 200ms ease-out;
+}
+
+@keyframes geo-place-marker-drop {
+    from {
+        transform: translateY(-10px);
+        opacity: 0;
+    }
+    to {
+        transform: none;
+        opacity: 1;
+    }
+}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -38,3 +38,31 @@ body.mobile .geo-map-container .geo-search-toolbar {
     color: inherit;
     opacity: 0.6;
 }
+
+/* Every row reads as icon + label, whether it offers a marker, a place, the geocoder or a report on
+   it. Scoped to the portalled dropdown, which is a body child rather than part of the map. */
+.form-autocomplete-dropdown .geo-search-entry {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    overflow: hidden;
+}
+
+.form-autocomplete-dropdown .geo-search-entry .tn-icon {
+    flex-shrink: 0;
+    opacity: 0.7;
+}
+
+/* The geocoder row and its reports are set apart from the places they produce. */
+.form-autocomplete-dropdown .geo-search-entry-geocode,
+.form-autocomplete-dropdown .geo-search-entry-info {
+    font-style: italic;
+    opacity: 0.85;
+}
+
+/* A report is not a choice, so it neither highlights nor takes a pointer. */
+.form-autocomplete-dropdown .form-autocomplete-item:has(.geo-search-entry-info) {
+    cursor: default;
+    background: none;
+    color: inherit;
+}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -19,11 +19,18 @@ body.mobile .geo-map-container .geo-search-toolbar {
     top: calc(var(--geo-map-inset-top) * 2 + var(--geo-map-toolbar-height));
 }
 
+/* The bar is the field, icon and all, so it takes the focus outline an input group takes (see the
+   input group in theme-next/forms.css). Only Next names the colour. */
+.geo-map-container .geo-search-toolbar:focus-within {
+    outline: 3px solid var(--input-focus-outline-color, var(--main-border-color));
+    outline-offset: 0;
+}
+
 .geo-map-container .geo-search-toolbar .geo-search-icon {
     opacity: 0.7;
 }
 
-/* The toolbar already frames the field, so drop the input's own border. */
+/* The toolbar already frames the field, so drop the input's own border and focus outline. */
 .geo-map-container .geo-search-toolbar .geo-search-input {
     width: 15rem;
     max-width: 40vw;
@@ -32,6 +39,10 @@ body.mobile .geo-map-container .geo-search-toolbar {
     background: transparent;
     border: none;
     box-shadow: none;
+}
+
+.geo-map-container .geo-search-toolbar .geo-search-input:focus {
+    outline: none;
 }
 
 .geo-map-container .geo-search-toolbar .geo-search-input::placeholder {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -1,0 +1,40 @@
+/* Top leading corner of the map, using the insets and z-index every overlay here uses (see
+   index.css). */
+.geo-map-container .geo-search-toolbar {
+    top: var(--geo-map-inset-top);
+    inset-inline-start: var(--geo-map-inset-start);
+    z-index: 3;
+    gap: 6px;
+    padding-inline: 8px;
+
+    /* The surface the control groups use, rather than the menu background OverlayToolbar defaults
+       to, which stays light over a dark map. */
+    background: var(--geo-map-panel-background);
+    color: var(--geo-map-panel-text-color);
+    border-color: var(--geo-map-panel-border-color);
+}
+
+/* On mobile the attribution takes the top leading corner (see map.tsx), so start below it. */
+body.mobile .geo-map-container .geo-search-toolbar {
+    top: calc(var(--geo-map-inset-top) * 2 + var(--geo-map-toolbar-height));
+}
+
+.geo-map-container .geo-search-toolbar .geo-search-icon {
+    opacity: 0.7;
+}
+
+/* The toolbar already frames the field, so drop the input's own border. */
+.geo-map-container .geo-search-toolbar .geo-search-input {
+    width: 15rem;
+    max-width: 40vw;
+    padding: 0;
+    color: inherit;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+}
+
+.geo-map-container .geo-search-toolbar .geo-search-input::placeholder {
+    color: inherit;
+    opacity: 0.6;
+}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.css
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.css
@@ -50,11 +50,10 @@ body.mobile .geo-map-container .geo-search-toolbar {
     opacity: 0.6;
 }
 
-/* Every row reads as icon + what it says, whether it offers a marker, a place, the geocoder or a
-   report on it. Scoped to the portalled dropdown, which is a body child rather than part of the map. */
+/* The dropdown is portalled to the body, so these are not scoped under .geo-map-container. */
 .form-autocomplete-dropdown .geo-search-entry {
     display: flex;
-    /* The mark sits on the first line rather than in the middle of a row that runs to two. */
+    /* The icon sits on the first line of a row that runs to two. */
     align-items: flex-start;
     gap: 6px;
     overflow: hidden;
@@ -63,12 +62,10 @@ body.mobile .geo-map-container .geo-search-toolbar {
 .form-autocomplete-dropdown .geo-search-entry .tn-icon {
     flex-shrink: 0;
     opacity: 0.7;
-    /* Set against the line beside it, the mark being drawn taller than the text it stands with. */
     line-height: 1.4;
 }
 
-/* A place says what it is called and then where it is, so the row is given the height of both and
-   the address wraps instead of ending in an ellipsis a word in. */
+/* Overrides the single-line ellipsis in FormAutocomplete.css, so an address can wrap. */
 .form-autocomplete-dropdown .form-autocomplete-item:has(.geo-search-entry) {
     white-space: normal;
     padding-block: 6px;
@@ -78,12 +75,9 @@ body.mobile .geo-map-container .geo-search-toolbar {
     display: flex;
     flex-direction: column;
     min-width: 0;
-    /* Takes the room the mark and the distance leave, so the distance keeps the trailing edge. */
     flex: 1;
 }
 
-/* How far off the place is, against the trailing edge where a row's rightmost column belongs — read
-   after what the row offers rather than before it. */
 .form-autocomplete-dropdown .geo-search-entry-distance {
     flex-shrink: 0;
     align-self: center;
@@ -96,8 +90,7 @@ body.mobile .geo-map-container .geo-search-toolbar {
 .form-autocomplete-dropdown .geo-search-entry-address {
     font-size: 0.85em;
     opacity: 0.7;
-    /* Two lines of address and no more: past that the list is a page, and what is cut is the part of
-       an address that names a postcode or a country. */
+    /* Two lines at most: a Nominatim address can run to five. */
     display: -webkit-box;
     -webkit-line-clamp: 2;
     line-clamp: 2;
@@ -110,12 +103,6 @@ body.mobile .geo-map-container .geo-search-toolbar {
 .form-autocomplete-dropdown .geo-search-entry-info {
     font-style: italic;
     opacity: 0.85;
-}
-
-/* A heading names the rows under it and reads as the dropdown's own furniture rather than as one of
-   the entries, so it keeps none of the room a row's mark and distance are given. */
-.form-autocomplete-dropdown .geo-search-heading {
-    display: block;
 }
 
 /* A report is not a choice, so it neither highlights nor takes a pointer. */

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -14,40 +14,11 @@ import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchRes
 import { ParentMap } from "./map";
 import SearchBox from "./SearchBox";
 
-// Hoisted, because map.tsx imports maplibre-gl as this file is loaded — a class declared below would
-// still be in its temporal dead zone when the factory runs.
-const { FakeMarker } = vi.hoisted(() => {
-    /** Stands in for MapLibre's own marker, which wants a real map to attach itself to. */
-    class FakeMarker {
-        static standing: FakeMarker[] = [];
-        lngLat?: [number, number];
-
-        constructor(readonly options: { element: HTMLElement; anchor?: string; offset?: [number, number] }) {}
-
-        setLngLat(lngLat: [number, number]) {
-            this.lngLat = lngLat;
-            return this;
-        }
-
-        addTo(_map: unknown) {
-            FakeMarker.standing.push(this);
-            return this;
-        }
-
-        remove() {
-            FakeMarker.standing = FakeMarker.standing.filter((marker) => marker !== this);
-            return this;
-        }
-    }
-
-    return { FakeMarker };
-});
-
-vi.mock("maplibre-gl", () => ({ Marker: FakeMarker }));
-
-// The pin's image is drawn from an icon the glyph service resolves against the real stylesheet.
-vi.mock("../../../services/icon_glyphs", () => ({
-    renderIconImage: vi.fn(async () => "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")
+/** The pin is drawn on the map by its own component, which has a spec of its own; here it only has to
+ *  stand in the right place, so it is rendered as something the DOM can be asked about. */
+vi.mock("./PlaceMarker", () => ({
+    default: ({ center, name }: { center: [number, number]; name: string }) =>
+        <div className="place-marker" data-center={center.join(",")} data-name={name} />
 }));
 
 // i18next is not initialized under test, so t() returns "". The key stands in for the text, with any
@@ -56,7 +27,7 @@ vi.mock("../../../services/i18n", () => ({
     t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}(${Object.values(vars).join(",")})` : key)
 }));
 
-const TOKYO: GeoSearchResult = { id: "1", label: "Tokyo, Japan", lat: 35.6762, lng: 139.6503 };
+const TOKYO: GeoSearchResult = { id: "1", label: "Tokyo, Japan", name: "Tokyo", lat: 35.6762, lng: 139.6503 };
 
 /** Stands in for the geocoder, which would otherwise reach for the network. */
 function mockGeocoder(results: GeoSearchResult[]) {
@@ -84,7 +55,7 @@ function renderSearchBox(map: ReturnType<typeof fakeMap> | null, notes: FNote[] 
     act(() => {
         container = renderInto(
             <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
-                <SearchBox notes={notes} />
+                <SearchBox notes={notes} isDarkTheme={false} />
             </ParentMap.Provider>
         );
     });
@@ -130,10 +101,7 @@ async function pick(index: number) {
     await settle();
 }
 
-beforeEach(() => {
-    vi.useFakeTimers();
-    FakeMarker.standing = [];
-});
+beforeEach(() => vi.useFakeTimers());
 afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -224,7 +192,7 @@ describe("geo map SearchBox", () => {
     });
 
     it("offers the geocoder again once the query moves on from what it answered", async () => {
-        mockGeocoder([ { id: "2", label: "Berlin, Germany", lat: 52.52, lng: 13.405 } ]);
+        mockGeocoder([ { id: "2", label: "Berlin, Germany", name: "Berlin", lat: 52.52, lng: 13.405 } ]);
         const container = renderSearchBox(fakeMap(), []);
 
         await type(container, "berlin");
@@ -235,7 +203,7 @@ describe("geo map SearchBox", () => {
         expect(labels()).toEqual([ "geo-map.search-online(berlin de)" ]);
     });
 
-    it("pins a searched place where it stands, since the map has nothing there of its own", async () => {
+    it("pins a searched place where it stands, named as the geocoder names it", async () => {
         mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), mapNotes());
 
@@ -243,15 +211,15 @@ describe("geo map SearchBox", () => {
         await pick(1);
         await pick(1);
 
-        expect(FakeMarker.standing).toHaveLength(1);
-        expect(FakeMarker.standing[0].lngLat).toEqual([ TOKYO.lng, TOKYO.lat ]);
-        // The tip of the pin stands on the place rather than the bottom edge of its image.
-        expect(FakeMarker.standing[0].options.anchor).toBe("bottom");
+        const pin = () => container.querySelector<HTMLElement>(".place-marker");
+        expect(pin()?.dataset.center).toBe(`${TOKYO.lng},${TOKYO.lat}`);
+        // The place's own name rather than the full label the list reads.
+        expect(pin()?.dataset.name).toBe("Tokyo");
 
         // A note of the map's own is already pinned, so taking one takes the searched pin away.
         await type(container, "tokyo trip");
         await pick(0);
-        expect(FakeMarker.standing).toHaveLength(0);
+        expect(pin()).toBeNull();
     });
 
     it("takes the pin off the map once the field is emptied", async () => {
@@ -261,11 +229,11 @@ describe("geo map SearchBox", () => {
         await type(container, "tokyo");
         await pick(0);
         await pick(0);
-        expect(FakeMarker.standing).toHaveLength(1);
+        expect(container.querySelector(".place-marker")).not.toBeNull();
 
         await type(container, "");
 
-        expect(FakeMarker.standing).toHaveLength(0);
+        expect(container.querySelector(".place-marker")).toBeNull();
     });
 
     it("renders nothing when the map failed to initialize", () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -421,6 +421,34 @@ describe("geo map SearchBox", () => {
         expect(labels()).toEqual([ "Tokyo" ]);
     });
 
+    it("offers to clear the field only once there is something in it to clear", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+        const clearButton = () => container.querySelector<HTMLButtonElement>(".geo-search-clear");
+        const isShown = () => clearButton()?.classList.contains("shown");
+
+        // Standing in the bar either way, so the field beside it does not move as it comes and goes.
+        expect(clearButton()).not.toBeNull();
+        expect(isShown()).toBe(false);
+
+        await type(container, "tokyo");
+        expect(isShown()).toBe(true);
+
+        await pickNamed("geo-map.search-online(tokyo)");
+        await pickNamed("Tokyo");
+        expect(picked).toEqual([ TOKYO ]);
+
+        await act(async () => { clearButton()?.click(); });
+        await settle();
+
+        expect(field(container).value).toBe("");
+        expect(isShown()).toBe(false);
+        // Clearing the field is what takes the place off the map, panel and pin alike.
+        expect(picked).toEqual([ TOKYO, null ]);
+        // Rarely the end of searching, so the field is where the reader was left.
+        expect(document.activeElement).toBe(field(container));
+    });
+
     it("reports moving on from a place once the field is emptied", async () => {
         mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), []);

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -17,8 +17,8 @@ import SearchBox from "./SearchBox";
 /** The pin is drawn on the map by its own component, which has a spec of its own; here it only has to
  *  stand in the right place, so it is rendered as something the DOM can be asked about. */
 vi.mock("./PlaceMarker", () => ({
-    default: ({ center, name }: { center: [number, number]; name: string }) =>
-        <div className="place-marker" data-center={center.join(",")} data-name={name} />
+    default: ({ center, name, outline }: { center: [number, number]; name: string; outline?: GeoJSON.Geometry }) =>
+        <div className="place-marker" data-center={center.join(",")} data-name={name} data-outline={outline?.type} />
 }));
 
 // i18next is not initialized under test, so t() returns "". The key stands in for the text, with any
@@ -246,6 +246,40 @@ describe("geo map SearchBox", () => {
         await type(container, "tokyo trip");
         await pick(0);
         expect(pin()).toBeNull();
+    });
+
+    it("asks for a place's boundary only once that place has been picked", async () => {
+        const outline = vi.fn(async () => ({ type: "Polygon", coordinates: [] } as GeoJSON.Geometry));
+        mockGeocoder([ { ...TOKYO, outline } ]);
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "tokyo");
+        // The row that runs the geocoder, which offers the place but does not settle on it.
+        await pick(0);
+        expect(outline).not.toHaveBeenCalled();
+
+        await pick(0);
+
+        expect(outline).toHaveBeenCalledOnce();
+        expect(container.querySelector<HTMLElement>(".place-marker")?.dataset.outline).toBe("Polygon");
+    });
+
+    it("drops a boundary that arrives after the place it belongs to has been replaced", async () => {
+        let deliver: ((outline: GeoJSON.Geometry) => void) | undefined;
+        const outline = vi.fn(() => new Promise<GeoJSON.Geometry>((resolve) => { deliver = resolve; }));
+        mockGeocoder([ { ...TOKYO, outline } ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        await type(container, "tokyo");
+        await pick(1);
+        await pick(1);
+
+        // A note of the map's own is settled on while the boundary is still being fetched.
+        await type(container, "tokyo trip");
+        await pick(0);
+        await act(async () => { deliver?.({ type: "Polygon", coordinates: [] }); });
+
+        expect(container.querySelector(".place-marker")).toBeNull();
     });
 
     it("takes the pin off the map once the field is emptied", async () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -126,6 +126,14 @@ function labels() {
         ?? entry.textContent);
 }
 
+/** Presses a key in the field, as the reader reaching for the keyboard rather than the pointer. */
+async function press(container: HTMLElement, key: string) {
+    await act(async () => {
+        field(container).dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+    });
+    await settle();
+}
+
 /** Picks a row and lets whatever it started settle. */
 async function pick(index: number) {
     await act(async () => { entries()[index].click(); });
@@ -352,6 +360,37 @@ describe("geo map SearchBox", () => {
 
         // The place the geocoder found is measured the same way.
         expect(distances()[1]).toMatch(/^gpx_preview\.unit_km/);
+    });
+
+    it("stands the first row ready, so Enter takes it without arrowing down to it", async () => {
+        mockGeocoder([ TOKYO ]);
+        const map = fakeMap();
+        const container = renderSearchBox(map, mapNotes());
+
+        await type(container, "tokyo");
+        expect(entries()[0].className).toContain("active");
+
+        // The map's own note stands first, so Enter goes there rather than to the geocoder.
+        await press(container, "Enter");
+
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.7, 35.6 ], zoom: expect.any(Number) });
+        expect(field(container).value).toBe("Tokyo trip");
+    });
+
+    it("runs the geocoder on Enter where the map has nothing of its own, and takes the first place on the next", async () => {
+        const search = mockGeocoder([ TOKYO ]);
+        const map = fakeMap();
+        const container = renderSearchBox(map, []);
+
+        // Nothing of the map's own matches, so the row that stands ready is the geocoder's.
+        await type(container, "tokyo");
+        await press(container, "Enter");
+        expect(search).toHaveBeenCalledOnce();
+
+        await press(container, "Enter");
+
+        expect(map.fitBounds).toHaveBeenCalledWith(TOKYO.bounds, expect.anything());
+        expect(field(container).value).toBe("Tokyo, Japan");
     });
 
     it("takes the pin off the map once the field is emptied", async () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -27,7 +27,13 @@ vi.mock("../../../services/i18n", () => ({
     t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}(${Object.values(vars).join(",")})` : key)
 }));
 
-const TOKYO: GeoSearchResult = { id: "1", label: "Tokyo, Japan", name: "Tokyo", lat: 35.6762, lng: 139.6503 };
+const TOKYO: GeoSearchResult = {
+    id: "1", label: "Tokyo, Japan", name: "Tokyo", lat: 35.6762, lng: 139.6503,
+    bounds: [ [ 139.5, 35.5 ], [ 139.9, 35.8 ] ]
+};
+
+/** A result the geocoder gave no extent for, which is what the fallback zoom is left for. */
+const UNBOUNDED: GeoSearchResult = { id: "9", label: "Somewhere", name: "Somewhere", lat: 10, lng: 20 };
 
 /** Stands in for the geocoder, which would otherwise reach for the network. */
 function mockGeocoder(results: GeoSearchResult[]) {
@@ -35,9 +41,9 @@ function mockGeocoder(results: GeoSearchResult[]) {
         .mockResolvedValue(results);
 }
 
-/** A map that can be flown somewhere, which is all the bar uses. */
+/** A map that can be flown somewhere or framed on something, which is all the bar uses. */
 function fakeMap() {
-    return { flyTo: vi.fn() };
+    return { flyTo: vi.fn(), fitBounds: vi.fn() };
 }
 
 /** Two notes on the map and one that is only in its subtree, having no location to be drawn at. */
@@ -158,18 +164,38 @@ describe("geo map SearchBox", () => {
         expect(entries()).toHaveLength(0);
     });
 
-    it("flies to a geocoded place, further out than to a marker", async () => {
+    it("frames a place on the ground it covers, so a street is not shown as its city", async () => {
         mockGeocoder([ TOKYO ]);
+        const map = fakeMap();
+        const container = renderSearchBox(map, []);
+
+        await type(container, "tokyo");
+        await pick(0);
+        await pick(0);
+
+        expect(map.fitBounds).toHaveBeenCalledWith(TOKYO.bounds, {
+            padding: expect.any(Number),
+            // A house covers a few metres, which framed on its own would fill the screen with a roof.
+            maxZoom: expect.any(Number)
+        });
+        expect(map.flyTo).not.toHaveBeenCalled();
+        expect(field(container).value).toBe("Tokyo, Japan");
+    });
+
+    it("falls back to a zoom for a place the geocoder gave no extent for", async () => {
+        mockGeocoder([ UNBOUNDED ]);
         const map = fakeMap();
         const container = renderSearchBox(map, mapNotes());
 
-        await type(container, "tokyo");
-        await pick(1);
-        await pick(1);
+        await type(container, "somewhere");
+        await pick(0);
+        await pick(0);
 
-        expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.6503, 35.6762 ], zoom: expect.any(Number) });
-        expect(field(container).value).toBe("Tokyo, Japan");
+        expect(map.fitBounds).not.toHaveBeenCalled();
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ UNBOUNDED.lng, UNBOUNDED.lat ], zoom: expect.any(Number) });
 
+        // A note marks a spot rather than an area, so it is shown closer in than a place of unknown
+        // size.
         const [ { zoom: placeZoom } ] = map.flyTo.mock.calls[0];
         await type(container, "tokyo trip");
         await pick(0);

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -113,17 +113,28 @@ async function type(container: HTMLElement, text: string) {
     await settle();
 }
 
-/** The dropdown is portalled to the body, so look for it there rather than in the container. */
-function entries() {
-    return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown .form-autocomplete-item") ];
+/**
+ * Every row of the list, headings included. The dropdown is portalled to the body, so it is looked
+ * for there rather than in the container.
+ */
+function rows() {
+    return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown li") ];
 }
 
-/** What each row is called: the first line of a place, and the whole of any other row. */
+/** The rows that can be taken, which is every row but the headings. */
+function entries() {
+    return rows().filter((row) => row.classList.contains("form-autocomplete-item"));
+}
+
+/** What a row is called: the first line of a place, and the whole of any other row. */
+function nameOf(row: HTMLElement) {
+    return row.querySelector(".geo-search-entry-name")?.textContent
+        ?? row.querySelector(".geo-search-entry-lines")?.textContent
+        ?? row.textContent;
+}
+
 function labels() {
-    return entries().map((entry) =>
-        entry.querySelector(".geo-search-entry-name")?.textContent
-        ?? entry.querySelector(".geo-search-entry-lines")?.textContent
-        ?? entry.textContent);
+    return rows().map(nameOf);
 }
 
 /** Presses a key in the field, as the reader reaching for the keyboard rather than the pointer. */
@@ -131,6 +142,16 @@ async function press(container: HTMLElement, key: string) {
     await act(async () => {
         field(container).dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
     });
+    await settle();
+}
+
+/** Picks the row that reads as the given name, the list standing in distance order rather than a
+ *  settled one. */
+async function pickNamed(name: string) {
+    const row = rows().find((candidate) => nameOf(candidate) === name);
+    if (!row) throw new Error(`the list offers no "${name}": ${labels().join(", ")}`);
+
+    await act(async () => { row.click(); });
     await settle();
 }
 
@@ -184,8 +205,8 @@ describe("geo map SearchBox", () => {
             // answered with the one at hand.
             viewport: [ [ VIEWPORT.west, VIEWPORT.south ], [ VIEWPORT.east, VIEWPORT.north ] ]
         });
-        // The row is replaced by what it found, the markers still standing above it.
-        expect(labels()).toEqual([ "Tokyo trip", "Tokyo" ]);
+        // The row is replaced by what it found, standing among the map's own notes.
+        expect([ ...labels() ].sort()).toEqual([ "Tokyo", "Tokyo trip" ]);
     });
 
     it("flies to a marker, and closes the list rather than leaving it open over the map", async () => {
@@ -271,8 +292,8 @@ describe("geo map SearchBox", () => {
         const container = renderSearchBox(fakeMap(), mapNotes());
 
         await type(container, "tokyo");
-        await pick(1);
-        await pick(1);
+        await pickNamed("geo-map.search-online(tokyo)");
+        await pickNamed("Tokyo");
 
         const pin = () => container.querySelector<HTMLElement>(".place-marker");
         expect(pin()?.dataset.center).toBe(`${TOKYO.lng},${TOKYO.lat}`);
@@ -391,6 +412,43 @@ describe("geo map SearchBox", () => {
 
         expect(map.fitBounds).toHaveBeenCalledWith(TOKYO.bounds, expect.anything());
         expect(field(container).value).toBe("Tokyo, Japan");
+    });
+
+    it("puts what is at hand under one heading and what is far off under another, nearest first", async () => {
+        // Half of Corfu away, a good way up the coast, and another country entirely.
+        mockGeocoder([
+            { id: "near", label: "Jumbo, Corfu", name: "Jumbo", lat: CENTRE.lat + 0.09, lng: CENTRE.lng },
+            { id: "far", label: "Jumbo, Ohio", name: "Jumbo", lat: 40.4, lng: -82.9 }
+        ]);
+        const container = renderSearchBox(fakeMap(), [
+            buildNote({ title: "Jumbo receipt", "#geolocation": `${CENTRE.lat + 0.04},${CENTRE.lng}` })
+        ]);
+
+        await type(container, "jumbo");
+        await pickNamed("geo-map.search-online(jumbo)");
+
+        expect(labels()).toEqual([
+            "geo-map.results-nearby",
+            // The note is nearer than the shop, and the shop nearer than the one across the ocean.
+            "Jumbo receipt",
+            "Jumbo",
+            "geo-map.results-far",
+            "Jumbo"
+        ]);
+        // A heading names the rows below it rather than offering anything, so it is not among the
+        // rows that can be taken.
+        expect(entries().map(nameOf)).toEqual([ "Jumbo receipt", "Jumbo", "Jumbo" ]);
+    });
+
+    it("leaves the headings off where every result is on one side of the line", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "tokyo");
+        await pickNamed("geo-map.search-online(tokyo)");
+
+        // Nothing at hand to tell it apart from: one name over one run of rows says nothing.
+        expect(labels()).toEqual([ "Tokyo" ]);
     });
 
     it("takes the pin off the map once the field is emptied", async () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -21,6 +21,11 @@ vi.mock("./PlaceMarker", () => ({
         <div className="place-marker" data-center={center.join(",")} data-name={name} data-outline={outline?.type} />
 }));
 
+vi.mock("../../../utils/formatters", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../utils/formatters")>()),
+    getMeasurementSystem: () => "metric"
+}));
+
 // i18next is not initialized under test, so t() returns "". The key stands in for the text, with any
 // interpolated values after it, which is enough to tell the rows apart.
 vi.mock("../../../services/i18n", () => ({
@@ -44,11 +49,15 @@ function mockGeocoder(results: GeoSearchResult[]) {
 /** Where a fake map is looking, which is what a search is told to prefer. */
 const VIEWPORT = { west: 19.8, south: 39.5, east: 20.1, north: 39.8 };
 
+/** The middle of that view, which is what a row's distance is measured from. */
+const CENTRE = { lng: 19.95, lat: 39.65 };
+
 /** A map that can be flown somewhere or framed on something, and that says what it is showing. */
 function fakeMap() {
     return {
         flyTo: vi.fn(),
         fitBounds: vi.fn(),
+        getCenter: () => ({ toArray: () => [ CENTRE.lng, CENTRE.lat ] as [number, number] }),
         getBounds: () => ({
             getWest: () => VIEWPORT.west,
             getSouth: () => VIEWPORT.south,
@@ -112,7 +121,9 @@ function entries() {
 /** What each row is called: the first line of a place, and the whole of any other row. */
 function labels() {
     return entries().map((entry) =>
-        entry.querySelector(".geo-search-entry-name")?.textContent ?? entry.textContent);
+        entry.querySelector(".geo-search-entry-name")?.textContent
+        ?? entry.querySelector(".geo-search-entry-lines")?.textContent
+        ?? entry.textContent);
 }
 
 /** Picks a row and lets whatever it started settle. */
@@ -319,6 +330,28 @@ describe("geo map SearchBox", () => {
             [ "Tokyo", "Ōta, Japan" ],
             [ "Scramble", "Shibuya Crossing" ]
         ]);
+    });
+
+    it("says how far off each place stands, and says nothing of the rows that are nowhere", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        await type(container, "tokyo");
+
+        const distances = () => entries().map((entry) =>
+            entry.querySelector(".geo-search-entry-distance")?.textContent ?? null);
+
+        // The note is on the other side of the world from the view, which is in Corfu.
+        const [ tokyoTrip, geocoderRow ] = distances();
+        expect(tokyoTrip).toMatch(/^gpx_preview\.unit_km/);
+        expect(Number(tokyoTrip?.replace(/\D/g, ""))).toBeGreaterThan(9000);
+        // The row that runs the geocoder names no place, so it stands nowhere.
+        expect(geocoderRow).toBeNull();
+
+        await pick(1);
+
+        // The place the geocoder found is measured the same way.
+        expect(distances()[1]).toMatch(/^gpx_preview\.unit_km/);
     });
 
     it("takes the pin off the map once the field is emptied", async () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -77,12 +77,16 @@ function mapNotes(): FNote[] {
     ];
 }
 
+/** What the bar has reported picking, the map being what stands a place on itself (see index.tsx). */
+let picked: (GeoSearchResult | null)[] = [];
+
 function renderSearchBox(map: ReturnType<typeof fakeMap> | null, notes: FNote[] = []) {
+    picked = [];
     let container: HTMLElement | undefined;
     act(() => {
         container = renderInto(
             <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
-                <SearchBox notes={notes} isDarkTheme={false} />
+                <SearchBox notes={notes} onPickPlace={(place) => picked.push(place)} />
             </ParentMap.Provider>
         );
     });
@@ -218,7 +222,8 @@ describe("geo map SearchBox", () => {
         await pick(0);
 
         expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.7, 35.6 ], zoom: expect.any(Number) });
-        expect(field(container).value).toBe("Tokyo trip");
+        // The field keeps what was typed, so the next search starts from it.
+        expect(field(container).value).toBe("tokyo trip");
         expect(entries()).toHaveLength(0);
     });
 
@@ -237,7 +242,8 @@ describe("geo map SearchBox", () => {
             maxZoom: expect.any(Number)
         });
         expect(map.flyTo).not.toHaveBeenCalled();
-        expect(field(container).value).toBe("Tokyo, Japan");
+        // Not the place's whole label, which is an address the field has no room for.
+        expect(field(container).value).toBe("tokyo");
     });
 
     it("falls back to a zoom for a place the geocoder gave no extent for", async () => {
@@ -287,7 +293,7 @@ describe("geo map SearchBox", () => {
         expect(labels()).toEqual([ "geo-map.search-online(berlin de)" ]);
     });
 
-    it("pins a searched place where it stands, named as the geocoder names it", async () => {
+    it("reports the place picked, whole, and reports moving on from it", async () => {
         mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), mapNotes());
 
@@ -295,49 +301,13 @@ describe("geo map SearchBox", () => {
         await pickNamed("geo-map.search-online(tokyo)");
         await pickNamed("Tokyo");
 
-        const pin = () => container.querySelector<HTMLElement>(".place-marker");
-        expect(pin()?.dataset.center).toBe(`${TOKYO.lng},${TOKYO.lat}`);
-        // The place's own name rather than the full label the list reads.
-        expect(pin()?.dataset.name).toBe("Tokyo");
+        // Once, and whole — so what stands it on the map has its boundary and its bounds to hand.
+        expect(picked).toEqual([ TOKYO ]);
 
-        // A note of the map's own is already pinned, so taking one takes the searched pin away.
+        // A note of the map's own has a marker already, so taking one moves on from the place.
         await type(container, "tokyo trip");
         await pick(0);
-        expect(pin()).toBeNull();
-    });
-
-    it("asks for a place's boundary only once that place has been picked", async () => {
-        const outline = vi.fn(async () => ({ type: "Polygon", coordinates: [] } as GeoJSON.Geometry));
-        mockGeocoder([ { ...TOKYO, outline } ]);
-        const container = renderSearchBox(fakeMap(), []);
-
-        await type(container, "tokyo");
-        // The row that runs the geocoder, which offers the place but does not settle on it.
-        await pick(0);
-        expect(outline).not.toHaveBeenCalled();
-
-        await pick(0);
-
-        expect(outline).toHaveBeenCalledOnce();
-        expect(container.querySelector<HTMLElement>(".place-marker")?.dataset.outline).toBe("Polygon");
-    });
-
-    it("drops a boundary that arrives after the place it belongs to has been replaced", async () => {
-        let deliver: ((outline: GeoJSON.Geometry) => void) | undefined;
-        const outline = vi.fn(() => new Promise<GeoJSON.Geometry>((resolve) => { deliver = resolve; }));
-        mockGeocoder([ { ...TOKYO, outline } ]);
-        const container = renderSearchBox(fakeMap(), mapNotes());
-
-        await type(container, "tokyo");
-        await pick(1);
-        await pick(1);
-
-        // A note of the map's own is settled on while the boundary is still being fetched.
-        await type(container, "tokyo trip");
-        await pick(0);
-        await act(async () => { deliver?.({ type: "Polygon", coordinates: [] }); });
-
-        expect(container.querySelector(".place-marker")).toBeNull();
+        expect(picked).toEqual([ TOKYO, null ]);
     });
 
     it("gives a place two lines: what it is called, and the address that places it", async () => {
@@ -395,7 +365,7 @@ describe("geo map SearchBox", () => {
         await press(container, "Enter");
 
         expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.7, 35.6 ], zoom: expect.any(Number) });
-        expect(field(container).value).toBe("Tokyo trip");
+        expect(field(container).value).toBe("tokyo");
     });
 
     it("runs the geocoder on Enter where the map has nothing of its own, and takes the first place on the next", async () => {
@@ -411,7 +381,7 @@ describe("geo map SearchBox", () => {
         await press(container, "Enter");
 
         expect(map.fitBounds).toHaveBeenCalledWith(TOKYO.bounds, expect.anything());
-        expect(field(container).value).toBe("Tokyo, Japan");
+        expect(field(container).value).toBe("tokyo");
     });
 
     it("puts what is at hand under one heading and what is far off under another, nearest first", async () => {
@@ -451,18 +421,18 @@ describe("geo map SearchBox", () => {
         expect(labels()).toEqual([ "Tokyo" ]);
     });
 
-    it("takes the pin off the map once the field is emptied", async () => {
+    it("reports moving on from a place once the field is emptied", async () => {
         mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), []);
 
         await type(container, "tokyo");
-        await pick(0);
-        await pick(0);
-        expect(container.querySelector(".place-marker")).not.toBeNull();
+        await pickNamed("geo-map.search-online(tokyo)");
+        await pickNamed("Tokyo");
+        expect(picked).toEqual([ TOKYO ]);
 
         await type(container, "");
 
-        expect(container.querySelector(".place-marker")).toBeNull();
+        expect(picked).toEqual([ TOKYO, null ]);
     });
 
     it("renders nothing when the map failed to initialize", () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -217,8 +217,12 @@ describe("geo map SearchBox", () => {
             // answered with the one at hand.
             viewport: [ [ VIEWPORT.west, VIEWPORT.south ], [ VIEWPORT.east, VIEWPORT.north ] ]
         });
-        // The row is replaced by what it found, standing among the map's own notes.
-        expect([ ...labels() ].sort()).toEqual([ "Tokyo", "Tokyo trip" ]);
+        // The row is replaced by what it found, under a heading of its own: a place the geocoder
+        // turned up is a different answer from a note already standing on the map.
+        expect(labels()).toEqual([
+            "geo-map.results-on-map", "Tokyo trip",
+            "geo-map.results-far", "Tokyo"
+        ]);
     });
 
     it("flies to a marker, and closes the list rather than leaving it open over the map", async () => {
@@ -395,7 +399,7 @@ describe("geo map SearchBox", () => {
         expect(field(container).value).toBe("tokyo");
     });
 
-    it("puts what is at hand under one heading and what is far off under another, nearest first", async () => {
+    it("puts the map's own notes, what is at hand and what is far off each under their own heading", async () => {
         // Half of Corfu away, a good way up the coast, and another country entirely.
         mockGeocoder([
             { id: "near", label: "Jumbo, Corfu", name: "Jumbo", lat: CENTRE.lat + 0.09, lng: CENTRE.lng },
@@ -409,12 +413,10 @@ describe("geo map SearchBox", () => {
         await pickNamed("geo-map.search-online(jumbo)");
 
         expect(labels()).toEqual([
-            "geo-map.results-nearby",
-            // The note is nearer than the shop, and the shop nearer than the one across the ocean.
-            "Jumbo receipt",
-            "Jumbo",
-            "geo-map.results-far",
-            "Jumbo"
+            // The map's own first, whatever the distances say.
+            "geo-map.results-on-map", "Jumbo receipt",
+            "geo-map.results-nearby", "Jumbo",
+            "geo-map.results-far", "Jumbo"
         ]);
         // A heading names the rows below it rather than offering anything, so it is not among the
         // rows that can be taken.

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -12,6 +12,7 @@ import { buildNote } from "../../../test/easy-froca";
 import { renderInto } from "../../../test/render";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
+import type { SearchResult } from "./results";
 import SearchBox from "./SearchBox";
 
 /** The pin is drawn on the map by its own component, which has a spec of its own; here it only has to
@@ -77,8 +78,15 @@ function mapNotes(): FNote[] {
     ];
 }
 
-/** What the bar has reported picking, the map being what stands a place on itself (see index.tsx). */
-let picked: (GeoSearchResult | null)[] = [];
+/** What the bar has reported picking, the map being what stands a result on itself (see index.tsx). */
+let picked: ({ results: SearchResult[]; index: number } | null)[] = [];
+
+/** The place of the last result reported, or none where the bar reported moving on from the search. */
+function pickedPlace() {
+    const last = picked.at(-1);
+    const result = last && last.results[last.index];
+    return result?.kind === "place" ? result.place : null;
+}
 
 function renderSearchBox(map: ReturnType<typeof fakeMap> | null, notes: FNote[] = []) {
     picked = [];
@@ -86,7 +94,7 @@ function renderSearchBox(map: ReturnType<typeof fakeMap> | null, notes: FNote[] 
     act(() => {
         container = renderInto(
             <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
-                <SearchBox notes={notes} onPickPlace={(place) => picked.push(place)} />
+                <SearchBox notes={notes} onPickResult={(result) => picked.push(result)} />
             </ParentMap.Provider>
         );
     });
@@ -301,13 +309,16 @@ describe("geo map SearchBox", () => {
         await pickNamed("geo-map.search-online(tokyo)");
         await pickNamed("Tokyo");
 
-        // Once, and whole — so what stands it on the map has its boundary and its bounds to hand.
-        expect(picked).toEqual([ TOKYO ]);
+        // Whole, so what stands it on the map has its boundary and its bounds to hand.
+        expect(pickedPlace()).toBe(TOKYO);
+        // And with everything the list offered, so the rest can be stepped through after it.
+        expect(picked.at(-1)?.results).toHaveLength(2);
 
-        // A note of the map's own has a marker already, so taking one moves on from the place.
+        // A note of the map's own is one of the results too, and taking it stands the map there.
         await type(container, "tokyo trip");
         await pick(0);
-        expect(picked).toEqual([ TOKYO, null ]);
+        expect(picked.at(-1)?.results[picked.at(-1)?.index ?? -1])
+            .toEqual({ kind: "note", noteId: expect.any(String), center: [ 139.7, 35.6 ] });
     });
 
     it("gives a place two lines: what it is called, and the address that places it", async () => {
@@ -489,15 +500,15 @@ describe("geo map SearchBox", () => {
 
         await pickNamed("geo-map.search-online(tokyo)");
         await pickNamed("Tokyo");
-        expect(picked).toEqual([ TOKYO ]);
+        expect(pickedPlace()).toBe(TOKYO);
 
         await act(async () => { clearButton()?.click(); });
         await settle();
 
         expect(field(container).value).toBe("");
         expect(isShown()).toBe(false);
-        // Clearing the field is what takes the place off the map, panel and pin alike.
-        expect(picked).toEqual([ TOKYO, null ]);
+        // Clearing the field is what takes the search off the map, panel and pin alike.
+        expect(picked.at(-1)).toBeNull();
         // Rarely the end of searching, so the field is where the reader was left.
         expect(document.activeElement).toBe(field(container));
     });
@@ -509,11 +520,11 @@ describe("geo map SearchBox", () => {
         await type(container, "tokyo");
         await pickNamed("geo-map.search-online(tokyo)");
         await pickNamed("Tokyo");
-        expect(picked).toEqual([ TOKYO ]);
+        expect(pickedPlace()).toBe(TOKYO);
 
         await type(container, "");
 
-        expect(picked).toEqual([ TOKYO, null ]);
+        expect(picked.at(-1)).toBeNull();
     });
 
     it("renders nothing when the map failed to initialize", () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -1,0 +1,90 @@
+/**
+ * The geo map search bar: which results a query produces, and what picking one does to the map.
+ * Results come from the dummy provider, so these cover the bar rather than any one geocoder.
+ */
+import type { Map as MapLibreGLMap } from "maplibre-gl";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderInto } from "../../../test/render";
+import { ParentMap } from "./map";
+import SearchBox from "./SearchBox";
+
+/** A map that can be flown somewhere, which is all the bar uses. */
+function fakeMap() {
+    return { flyTo: vi.fn() };
+}
+
+function renderSearchBox(map: ReturnType<typeof fakeMap> | null) {
+    let container: HTMLElement | undefined;
+    act(() => {
+        container = renderInto(
+            <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
+                <SearchBox />
+            </ParentMap.Provider>
+        );
+    });
+    if (!container) throw new Error("the search bar was not rendered");
+    return container;
+}
+
+function field(container: HTMLElement) {
+    const input = container.querySelector<HTMLInputElement>("input.geo-search-input");
+    if (!input) throw new Error("the search bar has no field");
+    return input;
+}
+
+/** Types into the field and runs out the debounced lookup. */
+async function type(container: HTMLElement, text: string) {
+    const input = field(container);
+    // Two acts: the field has to re-render as open before the effect that schedules the lookup runs,
+    // so advancing the timers in the same act would find nothing scheduled.
+    await act(async () => {
+        input.value = text;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+}
+
+/** The dropdown is portalled to the body, so look for it there rather than in the container. */
+function entries() {
+    return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown .form-autocomplete-item") ];
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("geo map SearchBox", () => {
+    it("lists the places a query matches, and nothing for a query below the minimum length", async () => {
+        const container = renderSearchBox(fakeMap());
+
+        await type(container, "l");
+        expect(entries()).toHaveLength(0);
+
+        await type(container, "london");
+        // Two places of the same name, distinguished by the rest of the label.
+        expect(entries().map((entry) => entry.textContent)).toEqual([
+            "London, England, United Kingdom",
+            "London, Ontario, Canada"
+        ]);
+
+        await type(container, "nowhere at all");
+        expect(entries()).toHaveLength(0);
+    });
+
+    it("flies the map to the place picked and puts its name in the field", async () => {
+        const map = fakeMap();
+        const container = renderSearchBox(map);
+
+        await type(container, "tokyo");
+        await act(async () => { entries()[0].click(); });
+
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.6503, 35.6762 ], zoom: expect.any(Number) });
+        expect(field(container).value).toBe("Tokyo, Japan");
+        expect(entries()).toHaveLength(0);
+    });
+
+    it("renders nothing when the map failed to initialize", () => {
+        expect(renderSearchBox(null).querySelector(".geo-search-toolbar")).toBeNull();
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -1,26 +1,46 @@
 /**
- * The geo map search bar: which results a query produces, and what picking one does to the map.
- * Results come from the dummy provider, so these cover the bar rather than any one geocoder.
+ * The geo map search bar: what a query lists, when the geocoder is allowed to run, and what picking
+ * a row does to the map. The geocoder is the dummy provider, so these cover the bar rather than any
+ * one geocoder.
  */
 import type { Map as MapLibreGLMap } from "maplibre-gl";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type FNote from "../../../entities/fnote";
+import { buildNote } from "../../../test/easy-froca";
 import { renderInto } from "../../../test/render";
+import { GEOCODING_PROVIDERS } from "./geocoding";
 import { ParentMap } from "./map";
 import SearchBox from "./SearchBox";
+
+// i18next is not initialized under test, so t() returns "". The key stands in for the text, with any
+// interpolated values after it, which is enough to tell the rows apart.
+vi.mock("../../../services/i18n", () => ({
+    t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}(${Object.values(vars).join(",")})` : key)
+}));
 
 /** A map that can be flown somewhere, which is all the bar uses. */
 function fakeMap() {
     return { flyTo: vi.fn() };
 }
 
-function renderSearchBox(map: ReturnType<typeof fakeMap> | null) {
+/** Two notes on the map and one that is only in its subtree, having no location to be drawn at. */
+function mapNotes(): FNote[] {
+    return [
+        buildNote({ title: "London hotel", "#geolocation": "51.5,-0.12" }),
+        buildNote({ title: "London office", "#geolocation": "51.6,-0.1" }),
+        buildNote({ title: "London packing list" }),
+        buildNote({ title: "Tokyo trip", "#geolocation": "35.6,139.7" })
+    ];
+}
+
+function renderSearchBox(map: ReturnType<typeof fakeMap> | null, notes: FNote[] = []) {
     let container: HTMLElement | undefined;
     act(() => {
         container = renderInto(
             <ParentMap.Provider value={map as unknown as MapLibreGLMap}>
-                <SearchBox />
+                <SearchBox notes={notes} />
             </ParentMap.Provider>
         );
     });
@@ -34,6 +54,11 @@ function field(container: HTMLElement) {
     return input;
 }
 
+/** Lets the debounced lookup and anything it started run to completion. */
+async function settle() {
+    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+}
+
 /** Types into the field and runs out the debounced lookup. */
 async function type(container: HTMLElement, text: string) {
     const input = field(container);
@@ -43,7 +68,7 @@ async function type(container: HTMLElement, text: string) {
         input.value = text;
         input.dispatchEvent(new Event("input", { bubbles: true }));
     });
-    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+    await settle();
 }
 
 /** The dropdown is portalled to the body, so look for it there rather than in the container. */
@@ -51,37 +76,111 @@ function entries() {
     return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown .form-autocomplete-item") ];
 }
 
+function labels() {
+    return entries().map((entry) => entry.textContent);
+}
+
+/** Picks a row and lets whatever it started settle. */
+async function pick(index: number) {
+    await act(async () => { entries()[index].click(); });
+    await settle();
+}
+
 beforeEach(() => vi.useFakeTimers());
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
 
 describe("geo map SearchBox", () => {
-    it("lists the places a query matches, and nothing for a query below the minimum length", async () => {
-        const container = renderSearchBox(fakeMap());
-
-        await type(container, "l");
-        expect(entries()).toHaveLength(0);
+    it("lists the map's own markers by title, skipping notes with nowhere to fly to", async () => {
+        const container = renderSearchBox(fakeMap(), mapNotes());
 
         await type(container, "london");
-        // Two places of the same name, distinguished by the rest of the label.
-        expect(entries().map((entry) => entry.textContent)).toEqual([
-            "London, England, United Kingdom",
-            "London, Ontario, Canada"
-        ]);
 
-        await type(container, "nowhere at all");
+        // "London packing list" has no location, so it has no marker to offer.
+        expect(labels()).toEqual([
+            "London hotel",
+            "London office",
+            "geo-map.search-online(london)"
+        ]);
+    });
+
+    it("offers nothing for a query below the minimum length", async () => {
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        await type(container, "l");
+
         expect(entries()).toHaveLength(0);
     });
 
-    it("flies the map to the place picked and puts its name in the field", async () => {
-        const map = fakeMap();
-        const container = renderSearchBox(map);
+    it("does not reach the geocoder until its row is picked", async () => {
+        const search = vi.spyOn(GEOCODING_PROVIDERS.dummy, "search");
+        const container = renderSearchBox(fakeMap(), mapNotes());
 
         await type(container, "tokyo");
-        await act(async () => { entries()[0].click(); });
+        expect(search).not.toHaveBeenCalled();
+        expect(labels()).toEqual([ "Tokyo trip", "geo-map.search-online(tokyo)" ]);
+
+        await pick(1);
+
+        expect(search).toHaveBeenCalledWith("tokyo");
+        // The row is replaced by what it found, the markers still standing above it.
+        expect(labels()).toEqual([ "Tokyo trip", "Tokyo, Japan" ]);
+    });
+
+    it("flies to a marker, and closes the list rather than leaving it open over the map", async () => {
+        const map = fakeMap();
+        const container = renderSearchBox(map, mapNotes());
+
+        await type(container, "tokyo trip");
+        await pick(0);
+
+        expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.7, 35.6 ], zoom: expect.any(Number) });
+        expect(field(container).value).toBe("Tokyo trip");
+        expect(entries()).toHaveLength(0);
+    });
+
+    it("flies to a geocoded place, further out than to a marker", async () => {
+        const map = fakeMap();
+        const container = renderSearchBox(map, mapNotes());
+
+        await type(container, "tokyo");
+        await pick(1);
+        await pick(1);
 
         expect(map.flyTo).toHaveBeenCalledWith({ center: [ 139.6503, 35.6762 ], zoom: expect.any(Number) });
         expect(field(container).value).toBe("Tokyo, Japan");
-        expect(entries()).toHaveLength(0);
+
+        const [ { zoom: placeZoom } ] = map.flyTo.mock.calls[0];
+        await type(container, "tokyo trip");
+        await pick(0);
+        const [ { zoom: markerZoom } ] = map.flyTo.mock.calls[1];
+        expect(markerZoom).toBeGreaterThan(placeZoom);
+    });
+
+    it("says so when the geocoder finds nothing, and when it cannot be reached", async () => {
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "atlantis");
+        await pick(0);
+        expect(labels()).toEqual([ "geo-map.no-places-found" ]);
+
+        vi.spyOn(GEOCODING_PROVIDERS.dummy, "search").mockRejectedValue(new Error("rate limited"));
+        await type(container, "berlin");
+        await pick(0);
+        expect(labels()).toEqual([ "geo-map.search-failed" ]);
+    });
+
+    it("offers the geocoder again once the query moves on from what it answered", async () => {
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "berlin");
+        await pick(0);
+        expect(labels()).toEqual([ "Berlin, Germany" ]);
+
+        await type(container, "berlin de");
+        expect(labels()).toEqual([ "geo-map.search-online(berlin de)" ]);
     });
 
     it("renders nothing when the map failed to initialize", () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -325,6 +325,26 @@ describe("geo map SearchBox", () => {
             .toEqual({ kind: "note", noteId: expect.any(String), center: [ 139.7, 35.6 ] });
     });
 
+    it("names the geocoder on the rows it answers for, before the asking and during it", async () => {
+        const provider = GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME];
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), []);
+
+        const detailOf = (name: string) => rows()
+            .find((row) => nameOf(row) === name)
+            ?.querySelector(".geo-search-entry-address")?.textContent;
+
+        await type(container, "tokyo");
+        // What is about to leave the map, said where it is read rather than in a setting somewhere.
+        expect(detailOf("geo-map.search-online(tokyo)")).toBe(provider.name);
+        expect(provider.name).toContain("Nominatim");
+
+        await pickNamed("geo-map.search-online(tokyo)");
+
+        // And where the places it turned up came from.
+        expect(detailOf("Tokyo")).toBe("Japan");
+    });
+
     it("gives a place two lines: what it is called, and the address that places it", async () => {
         mockGeocoder([
             { ...TOKYO, label: "Tokyo, Ōta, Japan" },

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -14,6 +14,42 @@ import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchRes
 import { ParentMap } from "./map";
 import SearchBox from "./SearchBox";
 
+// Hoisted, because map.tsx imports maplibre-gl as this file is loaded — a class declared below would
+// still be in its temporal dead zone when the factory runs.
+const { FakeMarker } = vi.hoisted(() => {
+    /** Stands in for MapLibre's own marker, which wants a real map to attach itself to. */
+    class FakeMarker {
+        static standing: FakeMarker[] = [];
+        lngLat?: [number, number];
+
+        constructor(readonly options: { element: HTMLElement; anchor?: string; offset?: [number, number] }) {}
+
+        setLngLat(lngLat: [number, number]) {
+            this.lngLat = lngLat;
+            return this;
+        }
+
+        addTo(_map: unknown) {
+            FakeMarker.standing.push(this);
+            return this;
+        }
+
+        remove() {
+            FakeMarker.standing = FakeMarker.standing.filter((marker) => marker !== this);
+            return this;
+        }
+    }
+
+    return { FakeMarker };
+});
+
+vi.mock("maplibre-gl", () => ({ Marker: FakeMarker }));
+
+// The pin's image is drawn from an icon the glyph service resolves against the real stylesheet.
+vi.mock("../../../services/icon_glyphs", () => ({
+    renderIconImage: vi.fn(async () => "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")
+}));
+
 // i18next is not initialized under test, so t() returns "". The key stands in for the text, with any
 // interpolated values after it, which is enough to tell the rows apart.
 vi.mock("../../../services/i18n", () => ({
@@ -94,7 +130,10 @@ async function pick(index: number) {
     await settle();
 }
 
-beforeEach(() => vi.useFakeTimers());
+beforeEach(() => {
+    vi.useFakeTimers();
+    FakeMarker.standing = [];
+});
 afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -194,6 +233,39 @@ describe("geo map SearchBox", () => {
 
         await type(container, "berlin de");
         expect(labels()).toEqual([ "geo-map.search-online(berlin de)" ]);
+    });
+
+    it("pins a searched place where it stands, since the map has nothing there of its own", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        await type(container, "tokyo");
+        await pick(1);
+        await pick(1);
+
+        expect(FakeMarker.standing).toHaveLength(1);
+        expect(FakeMarker.standing[0].lngLat).toEqual([ TOKYO.lng, TOKYO.lat ]);
+        // The tip of the pin stands on the place rather than the bottom edge of its image.
+        expect(FakeMarker.standing[0].options.anchor).toBe("bottom");
+
+        // A note of the map's own is already pinned, so taking one takes the searched pin away.
+        await type(container, "tokyo trip");
+        await pick(0);
+        expect(FakeMarker.standing).toHaveLength(0);
+    });
+
+    it("takes the pin off the map once the field is emptied", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "tokyo");
+        await pick(0);
+        await pick(0);
+        expect(FakeMarker.standing).toHaveLength(1);
+
+        await type(container, "");
+
+        expect(FakeMarker.standing).toHaveLength(0);
     });
 
     it("renders nothing when the map failed to initialize", () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -421,6 +421,59 @@ describe("geo map SearchBox", () => {
         expect(labels()).toEqual([ "Tokyo" ]);
     });
 
+    it("puts the rows back on Enter once one of them has been taken", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        const offered = [ "Tokyo trip", "geo-map.search-online(tokyo)" ];
+
+        await type(container, "tokyo");
+        expect(labels()).toEqual(offered);
+
+        // The first row is taken, and the list stands down rather than staying open on it.
+        await press(container, "Enter");
+        expect(entries()).toHaveLength(0);
+
+        // The query was right, so looking at what it offers again should not mean retyping it.
+        await press(container, "Enter");
+        expect(labels()).toEqual(offered);
+    });
+
+    it("puts the rows back on Enter after Escape has sent them away", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+
+        await type(container, "tokyo");
+        await press(container, "Escape");
+        expect(entries()).toHaveLength(0);
+
+        await press(container, "Enter");
+
+        expect(labels()).toEqual([ "Tokyo trip", "geo-map.search-online(tokyo)" ]);
+    });
+
+    it("puts the rows back when the field is come back to, without a key being pressed", async () => {
+        mockGeocoder([ TOKYO ]);
+        const container = renderSearchBox(fakeMap(), mapNotes());
+        const offered = [ "Tokyo trip", "geo-map.search-online(tokyo)" ];
+
+        await act(async () => { field(container).focus(); });
+        await type(container, "tokyo");
+        expect(labels()).toEqual(offered);
+
+        // Clicking away from the field, as a press on the map does, takes the list with it.
+        await act(async () => { field(container).blur(); });
+        await settle();
+        expect(entries()).toHaveLength(0);
+
+        // Coming back to the field is asking for what it was offering; Enter is not reaching it
+        // while the map has the focus, so it cannot be what brings the list back.
+        await act(async () => { field(container).focus(); });
+        await settle();
+
+        expect(labels()).toEqual(offered);
+    });
+
     it("offers to clear the field only once there is something in it to clear", async () => {
         mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), mapNotes());

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type FNote from "../../../entities/fnote";
 import { buildNote } from "../../../test/easy-froca";
 import { renderInto } from "../../../test/render";
-import { GEOCODING_PROVIDERS } from "./geocoding";
+import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
 import SearchBox from "./SearchBox";
 
@@ -19,6 +19,14 @@ import SearchBox from "./SearchBox";
 vi.mock("../../../services/i18n", () => ({
     t: (key: string, vars?: Record<string, unknown>) => (vars ? `${key}(${Object.values(vars).join(",")})` : key)
 }));
+
+const TOKYO: GeoSearchResult = { id: "1", label: "Tokyo, Japan", lat: 35.6762, lng: 139.6503 };
+
+/** Stands in for the geocoder, which would otherwise reach for the network. */
+function mockGeocoder(results: GeoSearchResult[]) {
+    return vi.spyOn(GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME], "search")
+        .mockResolvedValue(results);
+}
 
 /** A map that can be flown somewhere, which is all the bar uses. */
 function fakeMap() {
@@ -94,6 +102,7 @@ afterEach(() => {
 
 describe("geo map SearchBox", () => {
     it("lists the map's own markers by title, skipping notes with nowhere to fly to", async () => {
+        mockGeocoder([]);
         const container = renderSearchBox(fakeMap(), mapNotes());
 
         await type(container, "london");
@@ -115,7 +124,7 @@ describe("geo map SearchBox", () => {
     });
 
     it("does not reach the geocoder until its row is picked", async () => {
-        const search = vi.spyOn(GEOCODING_PROVIDERS.dummy, "search");
+        const search = mockGeocoder([ TOKYO ]);
         const container = renderSearchBox(fakeMap(), mapNotes());
 
         await type(container, "tokyo");
@@ -130,6 +139,7 @@ describe("geo map SearchBox", () => {
     });
 
     it("flies to a marker, and closes the list rather than leaving it open over the map", async () => {
+        mockGeocoder([]);
         const map = fakeMap();
         const container = renderSearchBox(map, mapNotes());
 
@@ -142,6 +152,7 @@ describe("geo map SearchBox", () => {
     });
 
     it("flies to a geocoded place, further out than to a marker", async () => {
+        mockGeocoder([ TOKYO ]);
         const map = fakeMap();
         const container = renderSearchBox(map, mapNotes());
 
@@ -160,19 +171,21 @@ describe("geo map SearchBox", () => {
     });
 
     it("says so when the geocoder finds nothing, and when it cannot be reached", async () => {
+        mockGeocoder([]);
         const container = renderSearchBox(fakeMap(), []);
 
         await type(container, "atlantis");
         await pick(0);
         expect(labels()).toEqual([ "geo-map.no-places-found" ]);
 
-        vi.spyOn(GEOCODING_PROVIDERS.dummy, "search").mockRejectedValue(new Error("rate limited"));
+        mockGeocoder([]).mockRejectedValue(new Error("rate limited"));
         await type(container, "berlin");
         await pick(0);
         expect(labels()).toEqual([ "geo-map.search-failed" ]);
     });
 
     it("offers the geocoder again once the query moves on from what it answered", async () => {
+        mockGeocoder([ { id: "2", label: "Berlin, Germany", lat: 52.52, lng: 13.405 } ]);
         const container = renderSearchBox(fakeMap(), []);
 
         await type(container, "berlin");

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -41,9 +41,21 @@ function mockGeocoder(results: GeoSearchResult[]) {
         .mockResolvedValue(results);
 }
 
-/** A map that can be flown somewhere or framed on something, which is all the bar uses. */
+/** Where a fake map is looking, which is what a search is told to prefer. */
+const VIEWPORT = { west: 19.8, south: 39.5, east: 20.1, north: 39.8 };
+
+/** A map that can be flown somewhere or framed on something, and that says what it is showing. */
 function fakeMap() {
-    return { flyTo: vi.fn(), fitBounds: vi.fn() };
+    return {
+        flyTo: vi.fn(),
+        fitBounds: vi.fn(),
+        getBounds: () => ({
+            getWest: () => VIEWPORT.west,
+            getSouth: () => VIEWPORT.south,
+            getEast: () => VIEWPORT.east,
+            getNorth: () => VIEWPORT.north
+        })
+    };
 }
 
 /** Two notes on the map and one that is only in its subtree, having no location to be drawn at. */
@@ -148,7 +160,11 @@ describe("geo map SearchBox", () => {
 
         await pick(1);
 
-        expect(search).toHaveBeenCalledWith("tokyo");
+        expect(search).toHaveBeenCalledWith("tokyo", {
+            // The geocoder is told where the map is looking, so a name shared by two places is
+            // answered with the one at hand.
+            viewport: [ [ VIEWPORT.west, VIEWPORT.south ], [ VIEWPORT.east, VIEWPORT.north ] ]
+        });
         // The row is replaced by what it found, the markers still standing above it.
         expect(labels()).toEqual([ "Tokyo trip", "Tokyo" ]);
     });

--- a/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.spec.tsx
@@ -97,8 +97,10 @@ function entries() {
     return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown .form-autocomplete-item") ];
 }
 
+/** What each row is called: the first line of a place, and the whole of any other row. */
 function labels() {
-    return entries().map((entry) => entry.textContent);
+    return entries().map((entry) =>
+        entry.querySelector(".geo-search-entry-name")?.textContent ?? entry.textContent);
 }
 
 /** Picks a row and lets whatever it started settle. */
@@ -148,7 +150,7 @@ describe("geo map SearchBox", () => {
 
         expect(search).toHaveBeenCalledWith("tokyo");
         // The row is replaced by what it found, the markers still standing above it.
-        expect(labels()).toEqual([ "Tokyo trip", "Tokyo, Japan" ]);
+        expect(labels()).toEqual([ "Tokyo trip", "Tokyo" ]);
     });
 
     it("flies to a marker, and closes the list rather than leaving it open over the map", async () => {
@@ -223,7 +225,7 @@ describe("geo map SearchBox", () => {
 
         await type(container, "berlin");
         await pick(0);
-        expect(labels()).toEqual([ "Berlin, Germany" ]);
+        expect(labels()).toEqual([ "Berlin" ]);
 
         await type(container, "berlin de");
         expect(labels()).toEqual([ "geo-map.search-online(berlin de)" ]);
@@ -280,6 +282,27 @@ describe("geo map SearchBox", () => {
         await act(async () => { deliver?.({ type: "Polygon", coordinates: [] }); });
 
         expect(container.querySelector(".place-marker")).toBeNull();
+    });
+
+    it("gives a place two lines: what it is called, and the address that places it", async () => {
+        mockGeocoder([
+            { ...TOKYO, label: "Tokyo, Ōta, Japan" },
+            // A label that does not begin with the name has nothing to repeat, so it is left whole.
+            { id: "3", label: "Shibuya Crossing", name: "Scramble", lat: 35.6, lng: 139.7 }
+        ]);
+        const container = renderSearchBox(fakeMap(), []);
+
+        await type(container, "tokyo");
+        await pick(0);
+
+        const lines = entries().map((entry) => [
+            entry.querySelector(".geo-search-entry-name")?.textContent,
+            entry.querySelector(".geo-search-entry-address")?.textContent
+        ]);
+        expect(lines).toEqual([
+            [ "Tokyo", "Ōta, Japan" ],
+            [ "Scramble", "Shibuya Crossing" ]
+        ]);
     });
 
     it("takes the pin off the map once the field is emptied", async () => {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -18,6 +18,7 @@ import { DEFAULT_GEOCODING_PROVIDER_NAME, DEFAULT_PLACE_ICON, type GeoBounds, GE
 import { ParentMap } from "./map";
 import { describePlace } from "./place_address";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
+import { frameResult, type SearchResult } from "./results";
 
 /** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
@@ -57,11 +58,11 @@ interface SearchBoxProps {
     /** The notes on the map, searched by title. */
     notes: FNote[];
     /**
-     * Reports the place picked from the list, or none where the reader has moved on from it — a note
-     * of the map's own taken instead, or the field emptied. What is done with it is the map's (see
-     * `pickPlace` in index.tsx).
+     * Reports what the list offered and which of it was taken, so the map can stand on that one and
+     * step through the rest (see `showResult` in index.tsx). None where the reader has moved on from
+     * the search altogether, the field having been emptied.
      */
-    onPickPlace(place: GeoSearchResult | null): void;
+    onPickResult(picked: { results: SearchResult[]; index: number } | null): void;
 }
 
 /**
@@ -76,7 +77,7 @@ type SearchEntry = {
     /** How far the place is from the middle of the map, in metres. */
     distance?: number;
 } & (
-    | { kind: "marker"; center: [number, number] }
+    | { kind: "marker"; center: [number, number]; noteId: string }
     /** A place from the geocoder, carried whole for whoever the pick is reported to. */
     | { kind: "place"; center: [number, number]; result: GeoSearchResult }
     /** Names the run of rows below it; not a choice (see `isHeading` on FormAutocomplete). */
@@ -115,7 +116,7 @@ interface GeocodeRun {
  * geocoder row can replace itself with results, so closing it after a marker or place is taken is
  * this component's job — see `dismissed`.
  */
-export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
+export default function SearchBox({ notes, onPickResult }: SearchBoxProps) {
     const map = useContext(ParentMap);
     const [ query, setQuery ] = useState("");
     const [ geocodeRun, setGeocodeRun ] = useState<GeocodeRun>();
@@ -149,11 +150,11 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
     const changeQuery = useCallback((newQuery: string) => {
         setDismissed(false);
         setQuery(newQuery);
-        // Emptying the field is how the pin is taken back off the map.
+        // Emptying the field is how the search is taken back off the map, pin and all.
         if (!newQuery.trim()) {
-            onPickPlace(null);
+            onPickResult(null);
         }
-    }, [ onPickPlace ]);
+    }, [ onPickResult ]);
 
     const runGeocoder = useCallback(async (searchQuery: string) => {
         const runId = ++latestRun.current;
@@ -206,19 +207,15 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
             runGeocoder(entry.query);
         } else if (entry.kind === "marker" || entry.kind === "place") {
             setDismissed(true);
-            // A note of the map's own has a marker already; only a place needs one put down for it.
-            onPickPlace(entry.kind === "place" ? entry.result : null);
 
-            const bounds = entry.kind === "place" ? entry.result.bounds : undefined;
-            if (bounds) {
-                // Framed by what the place covers rather than flown to at a level guessed for every
-                // place alike: one zoom that suits a city shows a street as the city around it.
-                map.fitBounds(bounds, { padding: PLACE_PADDING, maxZoom: PLACE_MAX_ZOOM });
-            } else {
-                map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
-            }
+            // The whole of what was offered, so the map can step through the rest of it once the
+            // list has stood down (see ResultNavigator).
+            const results = walkableResults(entriesByKey.current);
+            const index = results.findIndex((result) => keyOf(result) === entry.key);
+            onPickResult({ results, index });
+            frameResult(map, results[index]);
         }
-    }, [ map, runGeocoder, onPickPlace ]);
+    }, [ map, runGeocoder, onPickResult ]);
 
     const isHeading = useCallback(
         (key: string) => entriesByKey.current.get(key)?.kind === "heading", []);
@@ -293,6 +290,29 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
 }
 
 /**
+ * The rows that stand somewhere on the map, in the order they were offered — the headings and the
+ * geocoder's own rows being neither results nor anywhere.
+ */
+function walkableResults(entries: Map<string, SearchEntry>): SearchResult[] {
+    const results: SearchResult[] = [];
+
+    for (const entry of entries.values()) {
+        if (entry.kind === "marker") {
+            results.push({ kind: "note", noteId: entry.noteId, center: entry.center });
+        } else if (entry.kind === "place") {
+            results.push({ kind: "place", place: entry.result });
+        }
+    }
+
+    return results;
+}
+
+/** The key the row a result came from was listed under (see `placeEntry` and `matchMarkers`). */
+function keyOf(result: SearchResult) {
+    return result.kind === "note" ? `marker:${result.noteId}` : `place:${result.place.id}`;
+}
+
+/**
  * How far a row's place stands from where the map is looking, for the rows that stand anywhere: the
  * geocoder's row and its reports name no place, and a map that could not be drawn is looking nowhere.
  */
@@ -338,6 +358,7 @@ function matchMarkers(notes: FNote[], query: string): SearchEntry[] {
         matches.push({
             kind: "marker",
             key: `marker:${note.noteId}`,
+            noteId: note.noteId,
             label: note.title,
             icon: note.getIcon(),
             center

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -7,6 +7,8 @@ import type { Map as MapLibreGLMap } from "maplibre-gl";
 import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
 import { logError } from "../../../services/ws";
+import { getMeasurementSystem } from "../../../utils/formatters";
+import { formatDistance } from "../../../utils/units";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
@@ -32,6 +34,9 @@ const PLACE_PADDING = 60;
 
 /** The zoom level a marker is shown at, closer in since a note marks a spot rather than an area. */
 const MARKER_ZOOM = 15;
+
+/** The mean radius of the Earth, which is what a great-circle distance is measured on. */
+const EARTH_RADIUS_M = 6_371_008.8;
 
 /**
  * How wide the result list is drawn. The field is a corner of the map, while what it offers is whole
@@ -62,6 +67,8 @@ type SearchEntry = {
     label: string;
     /** A boxicons class, as `FNote.getIcon()` gives it. */
     icon: string;
+    /** How far the place is from the middle of the map, in metres. */
+    distance?: number;
 } & (
     | { kind: "marker"; center: [number, number] }
     /**
@@ -133,10 +140,14 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             return [];
         }
 
-        const entries = [ ...matchMarkers(notes, trimmed), ...geocodeEntries(geocodeRun, trimmed) ];
+        // Measured from the middle of what the map is showing, at the moment the list is built: two
+        // places of the same name are told apart by which of them is at hand.
+        const origin = map ? map.getCenter().toArray() : null;
+        const entries = [ ...matchMarkers(notes, trimmed), ...geocodeEntries(geocodeRun, trimmed) ]
+            .map((entry) => withDistance(entry, origin));
         entriesByKey.current = new Map(entries.map((entry) => [ entry.key, entry ]));
         return entries.map((entry) => entry.key);
-    }, [ notes, geocodeRun, dismissed ]);
+    }, [ notes, geocodeRun, dismissed, map ]);
 
     const changeQuery = useCallback((newQuery: string) => {
         setDismissed(false);
@@ -210,12 +221,18 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         return (
             <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
                 <Icon icon={entry.icon} />
-                {entry.kind === "place"
-                    ? <span className="geo-search-entry-lines">
-                        <span className="geo-search-entry-name">{entry.name}</span>
-                        {address && <span className="geo-search-entry-address">{address}</span>}
-                    </span>
-                    : entry.label}
+                <span className="geo-search-entry-lines">
+                    {entry.kind === "place"
+                        ? <>
+                            <span className="geo-search-entry-name">{entry.name}</span>
+                            {address && <span className="geo-search-entry-address">{address}</span>}
+                        </>
+                        : entry.label}
+                </span>
+                {entry.distance !== undefined &&
+                    <span className="geo-search-entry-distance">
+                        {formatDistance(entry.distance, getMeasurementSystem())}
+                    </span>}
             </span>
         );
     }, []);
@@ -246,6 +263,29 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             </OverlayToolbar>
         </>
     );
+}
+
+/**
+ * How far a row's place stands from where the map is looking, for the rows that stand anywhere: the
+ * geocoder's row and its reports name no place, and a map that could not be drawn is looking nowhere.
+ */
+function withDistance(entry: SearchEntry, origin: [number, number] | null): SearchEntry {
+    if (!origin || !("center" in entry)) {
+        return entry;
+    }
+
+    return { ...entry, distance: metresBetween(origin, entry.center) };
+}
+
+/** The great-circle metres between two `[lng, lat]` points. */
+function metresBetween([ lngA, latA ]: [number, number], [ lngB, latB ]: [number, number]) {
+    const toRadians = Math.PI / 180;
+    const deltaLat = (latB - latA) * toRadians;
+    const deltaLng = (lngB - lngA) * toRadians;
+    const h = Math.sin(deltaLat / 2) ** 2
+        + Math.cos(latA * toRadians) * Math.cos(latB * toRadians) * Math.sin(deltaLng / 2) ** 2;
+
+    return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
 }
 
 /** What the map is showing, as a geocoder reads a preferred area. */

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -60,7 +60,13 @@ type SearchEntry = {
      * A place from the geocoder: `name` is what its pin is labelled with, and `bounds` how much
      * ground it covers, where the geocoder says.
      */
-    | { kind: "place"; center: [number, number]; name: string; bounds?: GeoSearchResult["bounds"] }
+    | {
+        kind: "place";
+        center: [number, number];
+        name: string;
+        bounds?: GeoSearchResult["bounds"];
+        outline?: GeoSearchResult["outline"];
+    }
     /** Runs the geocoder for `query`. */
     | { kind: "geocode"; query: string }
     /** Reports on a geocoder run; picking it does nothing. */
@@ -98,7 +104,14 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
     // `keepOpenOnPick`. Typing again clears it.
     const [ dismissed, setDismissed ] = useState(false);
     // The geocoder's last answer, pinned where it stands; nothing while the map shows only its notes.
-    const [ pickedPlace, setPickedPlace ] = useState<{ center: [number, number]; name: string }>();
+    const [ pickedPlace, setPickedPlace ] = useState<{
+        center: [number, number];
+        name: string;
+        outline?: GeoJSON.Geometry;
+    }>();
+    // Which pick the map currently stands on, so a boundary arriving after a later pick is dropped
+    // rather than drawn around the place that replaced it.
+    const latestPick = useRef(0);
     const entriesByKey = useRef(new Map<string, SearchEntry>());
     // Discards a run superseded by a later one, since each reports through the same state.
     const latestRun = useRef(0);
@@ -121,6 +134,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         setQuery(newQuery);
         // Emptying the field is how the pin is taken back off the map.
         if (!newQuery.trim()) {
+            latestPick.current++;
             setPickedPlace(undefined);
         }
     }, []);
@@ -147,10 +161,23 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         if (entry.kind === "geocode") {
             runGeocoder(entry.query);
         } else if (entry.kind === "marker" || entry.kind === "place") {
+            const pickId = ++latestPick.current;
             setQuery(entry.label);
             setDismissed(true);
             // A note already has a marker of its own to fly to; only a place needs one put down.
             setPickedPlace(entry.kind === "place" ? { center: entry.center, name: entry.name } : undefined);
+
+            // The ground a country or a county covers, fetched only now that one of the places the
+            // search offered has been settled on. A place that is a point has none, and one whose
+            // boundary cannot be fetched keeps its pin.
+            if (entry.kind === "place" && entry.outline) {
+                entry.outline()
+                    .then((outline) => {
+                        if (!outline || latestPick.current !== pickId) return;
+                        setPickedPlace((current) => current && { ...current, outline });
+                    })
+                    .catch((e) => logError(`Fetching the boundary of "${entry.label}" failed: ${e}`));
+            }
             if (entry.kind === "place" && entry.bounds) {
                 // Framed by what the place covers rather than flown to at a level guessed for every
                 // place alike: one zoom that suits a city shows a street as the city around it.
@@ -178,7 +205,10 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
 
     return (
         <>
-            {pickedPlace && <PlaceMarker center={pickedPlace.center} name={pickedPlace.name} isDarkTheme={isDarkTheme} />}
+            {pickedPlace && <PlaceMarker
+                center={pickedPlace.center} name={pickedPlace.name}
+                outline={pickedPlace.outline} isDarkTheme={isDarkTheme}
+            />}
             <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
                 <Icon icon="bx bx-search" className="geo-search-icon" />
                 <FormAutocomplete
@@ -259,7 +289,8 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
         name: result.name,
         icon: "bx bx-map-pin",
         center: [ result.lng, result.lat ],
-        bounds: result.bounds
+        bounds: result.bounds,
+        outline: result.outline
     };
 }
 

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -13,7 +13,7 @@ import { formatDistance } from "../../../utils/units";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
 import OverlayToolbar, { OverlayToolbarButton } from "../../react/OverlayToolbar";
-import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
+import { DEFAULT_GEOCODING_PROVIDER_NAME, DEFAULT_PLACE_ICON, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { ParentMap } from "./map";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
 
@@ -403,7 +403,7 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
         kind: "place",
         key: `place:${result.id}`,
         label: result.label,
-        icon: "bx bx-map-pin",
+        icon: result.icon ?? DEFAULT_PLACE_ICON,
         center: [ result.lng, result.lat ],
         result
     };

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -16,8 +16,17 @@ import PlaceMarker from "./PlaceMarker";
 /** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
 
-/** The zoom level a place from the geocoder is shown at. */
+/** The zoom level a place is shown at where the geocoder does not say how much ground it covers. */
 const PLACE_ZOOM = 12;
+
+/**
+ * How close a place is framed at most. A house's extent is a few metres across, which on its own
+ * would fill the screen with the roof.
+ */
+const PLACE_MAX_ZOOM = 17;
+
+/** The room kept around a framed place, so its pin and name do not sit against the map's edge. */
+const PLACE_PADDING = 60;
 
 /** The zoom level a marker is shown at, closer in since a note marks a spot rather than an area. */
 const MARKER_ZOOM = 15;
@@ -47,8 +56,11 @@ type SearchEntry = {
     icon: string;
 } & (
     | { kind: "marker"; center: [number, number] }
-    /** A place from the geocoder, `name` being what its pin is labelled with. */
-    | { kind: "place"; center: [number, number]; name: string }
+    /**
+     * A place from the geocoder: `name` is what its pin is labelled with, and `bounds` how much
+     * ground it covers, where the geocoder says.
+     */
+    | { kind: "place"; center: [number, number]; name: string; bounds?: GeoSearchResult["bounds"] }
     /** Runs the geocoder for `query`. */
     | { kind: "geocode"; query: string }
     /** Reports on a geocoder run; picking it does nothing. */
@@ -139,7 +151,13 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             setDismissed(true);
             // A note already has a marker of its own to fly to; only a place needs one put down.
             setPickedPlace(entry.kind === "place" ? { center: entry.center, name: entry.name } : undefined);
-            map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
+            if (entry.kind === "place" && entry.bounds) {
+                // Framed by what the place covers rather than flown to at a level guessed for every
+                // place alike: one zoom that suits a city shows a street as the city around it.
+                map.fitBounds(entry.bounds, { padding: PLACE_PADDING, maxZoom: PLACE_MAX_ZOOM });
+            } else {
+                map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
+            }
         }
     }, [ map, runGeocoder ]);
 
@@ -240,7 +258,8 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
         label: result.label,
         name: result.name,
         icon: "bx bx-map-pin",
-        center: [ result.lng, result.lat ]
+        center: [ result.lng, result.lat ],
+        bounds: result.bounds
     };
 }
 

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -12,7 +12,7 @@ import { formatDistance } from "../../../utils/units";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
-import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
+import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { ParentMap } from "./map";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
 import PlaceMarker from "./PlaceMarker";
@@ -65,8 +65,8 @@ interface SearchBoxProps {
 type SearchEntry = {
     key: string;
     label: string;
-    /** A boxicons class, as `FNote.getIcon()` gives it. */
-    icon: string;
+    /** A boxicons class, as `FNote.getIcon()` gives it. Headings have none. */
+    icon?: string;
     /** How far the place is from the middle of the map, in metres. */
     distance?: number;
 } & (
@@ -82,6 +82,8 @@ type SearchEntry = {
         bounds?: GeoSearchResult["bounds"];
         outline?: GeoSearchResult["outline"];
     }
+    /** Names the run of rows below it; not a choice (see `isHeading` on FormAutocomplete). */
+    | { kind: "heading" }
     /** Runs the geocoder for `query`. */
     | { kind: "geocode"; query: string }
     /** Reports on a geocoder run; picking it does nothing. */
@@ -147,8 +149,10 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         // Measured from the middle of what the map is showing, at the moment the list is built: two
         // places of the same name are told apart by which of them is at hand.
         const origin = map ? map.getCenter().toArray() : null;
-        const entries = [ ...matchMarkers(notes, trimmed), ...geocodeEntries(geocodeRun, trimmed) ]
+        const { places, notice } = geocodeEntries(geocodeRun, trimmed);
+        const found = [ ...matchMarkers(notes, trimmed), ...places ]
             .map((entry) => withDistance(entry, origin));
+        const entries = [ ...byDistance(found), ...(notice ? [ notice ] : []) ];
         entriesByKey.current = new Map(entries.map((entry) => [ entry.key, entry ]));
         return entries.map((entry) => entry.key);
     }, [ notes, geocodeRun, dismissed, map ]);
@@ -214,9 +218,16 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         }
     }, [ map, runGeocoder ]);
 
+    const isHeading = useCallback(
+        (key: string) => entriesByKey.current.get(key)?.kind === "heading", []);
+
     const renderEntry = useCallback((key: string) => {
         const entry = entriesByKey.current.get(key);
         if (!entry) return key;
+
+        if (entry.kind === "heading") {
+            return entry.label;
+        }
 
         // A place reads over two lines: what it is called, and the address that places it. Every
         // other row is one thing said once.
@@ -259,6 +270,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
                     onPick={pickEntry}
                     source={source}
                     renderItem={renderEntry}
+                    isHeading={isHeading}
                     dropdownMinWidth={RESULT_LIST_WIDTH}
                     autoActivate
                     keepOpenOnPick
@@ -336,31 +348,69 @@ function matchMarkers(notes: FNote[], query: string): SearchEntry[] {
 }
 
 /**
- * What the list offers below the markers: the results of a run answering this query, or the row that
- * starts one. Typing never reaches the provider — picking that row is the only thing that does.
+ * What the geocoder has to offer for this query: the places a run answering it found, and whatever
+ * has to be said about the run — the row that starts one, or a word on how the last one went.
+ *
+ * The two are separated because they belong in different parts of the list: places are sorted in
+ * among the map's own notes, and a notice stands at the foot whatever the distances say.
  */
-function geocodeEntries(run: GeocodeRun | undefined, query: string): SearchEntry[] {
+function geocodeEntries(run: GeocodeRun | undefined, query: string): {
+    places: SearchEntry[];
+    notice: SearchEntry | null;
+} {
     if (run?.query !== query) {
-        return [ {
-            kind: "geocode",
-            key: "geocode",
-            label: t("geo-map.search-online", { query }),
-            icon: "bx bx-search-alt",
-            query
-        } ];
+        return {
+            places: [],
+            notice: {
+                kind: "geocode",
+                key: "geocode",
+                label: t("geo-map.search-online", { query }),
+                icon: "bx bx-search-alt",
+                query
+            }
+        };
     }
 
     if (run.status === "loading") {
-        return [ infoEntry(t("geo-map.searching-online"), "bx bx-loader-alt") ];
+        return { places: [], notice: infoEntry(t("geo-map.searching-online"), "bx bx-loader-alt") };
     }
     if (run.status === "failed") {
-        return [ infoEntry(t("geo-map.search-failed"), "bx bx-error-circle") ];
+        return { places: [], notice: infoEntry(t("geo-map.search-failed"), "bx bx-error-circle") };
     }
     if (!run.results.length) {
-        return [ infoEntry(t("geo-map.no-places-found"), "bx bx-info-circle") ];
+        return { places: [], notice: infoEntry(t("geo-map.no-places-found"), "bx bx-info-circle") };
     }
 
-    return run.results;
+    return { places: run.results, notice: null };
+}
+
+/**
+ * The places found, nearest first, under headings that say which are at hand and which are not — a
+ * shop down the road and one on another continent are both answers to the same name, and the list
+ * used to run them together.
+ *
+ * Headings only where there is something on both sides of {@link SEARCH_RADIUS_M}: one name over one
+ * run of rows distinguishes it from nothing.
+ */
+function byDistance(entries: SearchEntry[]): SearchEntry[] {
+    const sorted = [ ...entries ].sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
+    const atHand = sorted.filter((entry) => (entry.distance ?? Infinity) <= SEARCH_RADIUS_M);
+    const further = sorted.slice(atHand.length);
+
+    if (!atHand.length || !further.length) {
+        return sorted;
+    }
+
+    return [
+        headingEntry("nearby", t("geo-map.results-nearby")),
+        ...atHand,
+        headingEntry("far", t("geo-map.results-far")),
+        ...further
+    ];
+}
+
+function headingEntry(key: string, label: string): SearchEntry {
+    return { kind: "heading", key: `heading:${key}`, label };
 }
 
 function placeEntry(result: GeoSearchResult): SearchEntry {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -15,7 +15,6 @@ import OverlayToolbar from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { ParentMap } from "./map";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
-import PlaceMarker from "./PlaceMarker";
 
 /** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
@@ -54,8 +53,12 @@ const STATUS_KEY = "geocode-status";
 interface SearchBoxProps {
     /** The notes on the map, searched by title. */
     notes: FNote[];
-    /** Whether the map's style is a dark one, which a pinned place is labelled against. */
-    isDarkTheme: boolean;
+    /**
+     * Reports the place picked from the list, or none where the reader has moved on from it — a note
+     * of the map's own taken instead, or the field emptied. What is done with it is the map's (see
+     * `pickPlace` in index.tsx).
+     */
+    onPickPlace(place: GeoSearchResult | null): void;
 }
 
 /**
@@ -71,17 +74,8 @@ type SearchEntry = {
     distance?: number;
 } & (
     | { kind: "marker"; center: [number, number] }
-    /**
-     * A place from the geocoder: `name` is what its pin is labelled with, and `bounds` how much
-     * ground it covers, where the geocoder says.
-     */
-    | {
-        kind: "place";
-        center: [number, number];
-        name: string;
-        bounds?: GeoSearchResult["bounds"];
-        outline?: GeoSearchResult["outline"];
-    }
+    /** A place from the geocoder, carried whole for whoever the pick is reported to. */
+    | { kind: "place"; center: [number, number]; result: GeoSearchResult }
     /** Names the run of rows below it; not a choice (see `isHeading` on FormAutocomplete). */
     | { kind: "heading" }
     /** Runs the geocoder for `query`. */
@@ -118,22 +112,13 @@ interface GeocodeRun {
  * geocoder row can replace itself with results, so closing it after a marker or place is taken is
  * this component's job — see `dismissed`.
  */
-export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
+export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
     const map = useContext(ParentMap);
     const [ query, setQuery ] = useState("");
     const [ geocodeRun, setGeocodeRun ] = useState<GeocodeRun>();
     // Empties the list once a marker or place has been taken, which is what closes the dropdown under
     // `keepOpenOnPick`. Typing again clears it.
     const [ dismissed, setDismissed ] = useState(false);
-    // The geocoder's last answer, pinned where it stands; nothing while the map shows only its notes.
-    const [ pickedPlace, setPickedPlace ] = useState<{
-        center: [number, number];
-        name: string;
-        outline?: GeoJSON.Geometry;
-    }>();
-    // Which pick the map currently stands on, so a boundary arriving after a later pick is dropped
-    // rather than drawn around the place that replaced it.
-    const latestPick = useRef(0);
     const entriesByKey = useRef(new Map<string, SearchEntry>());
     // Discards a run superseded by a later one, since each reports through the same state.
     const latestRun = useRef(0);
@@ -162,10 +147,9 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         setQuery(newQuery);
         // Emptying the field is how the pin is taken back off the map.
         if (!newQuery.trim()) {
-            latestPick.current++;
-            setPickedPlace(undefined);
+            onPickPlace(null);
         }
-    }, []);
+    }, [ onPickPlace ]);
 
     const runGeocoder = useCallback(async (searchQuery: string) => {
         const runId = ++latestRun.current;
@@ -191,32 +175,21 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         if (entry.kind === "geocode") {
             runGeocoder(entry.query);
         } else if (entry.kind === "marker" || entry.kind === "place") {
-            const pickId = ++latestPick.current;
             setQuery(entry.label);
             setDismissed(true);
-            // A note already has a marker of its own to fly to; only a place needs one put down.
-            setPickedPlace(entry.kind === "place" ? { center: entry.center, name: entry.name } : undefined);
+            // A note of the map's own has a marker already; only a place needs one put down for it.
+            onPickPlace(entry.kind === "place" ? entry.result : null);
 
-            // The ground a country or a county covers, fetched only now that one of the places the
-            // search offered has been settled on. A place that is a point has none, and one whose
-            // boundary cannot be fetched keeps its pin.
-            if (entry.kind === "place" && entry.outline) {
-                entry.outline()
-                    .then((outline) => {
-                        if (!outline || latestPick.current !== pickId) return;
-                        setPickedPlace((current) => current && { ...current, outline });
-                    })
-                    .catch((e) => logError(`Fetching the boundary of "${entry.label}" failed: ${e}`));
-            }
-            if (entry.kind === "place" && entry.bounds) {
+            const bounds = entry.kind === "place" ? entry.result.bounds : undefined;
+            if (bounds) {
                 // Framed by what the place covers rather than flown to at a level guessed for every
                 // place alike: one zoom that suits a city shows a street as the city around it.
-                map.fitBounds(entry.bounds, { padding: PLACE_PADDING, maxZoom: PLACE_MAX_ZOOM });
+                map.fitBounds(bounds, { padding: PLACE_PADDING, maxZoom: PLACE_MAX_ZOOM });
             } else {
                 map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
             }
         }
-    }, [ map, runGeocoder ]);
+    }, [ map, runGeocoder, onPickPlace ]);
 
     const isHeading = useCallback(
         (key: string) => entriesByKey.current.get(key)?.kind === "heading", []);
@@ -231,7 +204,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
 
         // A place reads over two lines: what it is called, and the address that places it. Every
         // other row is one thing said once.
-        const address = entry.kind === "place" ? addressOf(entry.label, entry.name) : null;
+        const address = entry.kind === "place" ? addressOf(entry.label, entry.result.name) : null;
 
         return (
             <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
@@ -239,7 +212,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
                 <span className="geo-search-entry-lines">
                     {entry.kind === "place"
                         ? <>
-                            <span className="geo-search-entry-name">{entry.name}</span>
+                            <span className="geo-search-entry-name">{entry.result.name}</span>
                             {address && <span className="geo-search-entry-address">{address}</span>}
                         </>
                         : entry.label}
@@ -256,12 +229,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
     if (!map) return null;
 
     return (
-        <>
-            {pickedPlace && <PlaceMarker
-                center={pickedPlace.center} name={pickedPlace.name}
-                outline={pickedPlace.outline} isDarkTheme={isDarkTheme}
-            />}
-            <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
+        <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
                 <Icon icon="bx bx-search" className="geo-search-icon" />
                 <FormAutocomplete
                     className="geo-search-input"
@@ -276,9 +244,8 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
                     keepOpenOnPick
                     placeholder={t("geo-map.search-placeholder")}
                     aria-label={t("geo-map.search")}
-                />
-            </OverlayToolbar>
-        </>
+            />
+        </OverlayToolbar>
     );
 }
 
@@ -418,11 +385,9 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
         kind: "place",
         key: `place:${result.id}`,
         label: result.label,
-        name: result.name,
         icon: "bx bx-map-pin",
         center: [ result.lng, result.lat ],
-        bounds: result.bounds,
-        outline: result.outline
+        result
     };
 }
 

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,7 +1,6 @@
 import "./SearchBox.css";
 
-import { Marker } from "maplibre-gl";
-import { useCallback, useContext, useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
 import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
@@ -11,7 +10,8 @@ import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
-import { drawMarkerImage, LOCATION_ATTRIBUTE, MARKER_SHADOW_PADDING, parseLocation } from "./Markers";
+import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
+import PlaceMarker from "./PlaceMarker";
 
 /** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
@@ -28,15 +28,12 @@ const MAX_MARKER_RESULTS = 8;
 /** The key of the row reporting on a geocoder run, which only ever appears once. */
 const STATUS_KEY = "geocode-status";
 
-/** The colour the pin for a searched place is drawn in, so it is not read as one of the map's notes. */
-const PLACE_MARKER_COLOR = "#E8833A";
-
-/** The icon that pin wears, naming where it came from. */
-const PLACE_MARKER_ICON = "bx bx-search";
 
 interface SearchBoxProps {
     /** The notes on the map, searched by title. */
     notes: FNote[];
+    /** Whether the map's style is a dark one, which a pinned place is labelled against. */
+    isDarkTheme: boolean;
 }
 
 /**
@@ -49,7 +46,9 @@ type SearchEntry = {
     /** A boxicons class, as `FNote.getIcon()` gives it. */
     icon: string;
 } & (
-    | { kind: "marker" | "place"; center: [number, number] }
+    | { kind: "marker"; center: [number, number] }
+    /** A place from the geocoder, `name` being what its pin is labelled with. */
+    | { kind: "place"; center: [number, number]; name: string }
     /** Runs the geocoder for `query`. */
     | { kind: "geocode"; query: string }
     /** Reports on a geocoder run; picking it does nothing. */
@@ -79,15 +78,15 @@ interface GeocodeRun {
  * geocoder row can replace itself with results, so closing it after a marker or place is taken is
  * this component's job — see `dismissed`.
  */
-export default function SearchBox({ notes }: SearchBoxProps) {
+export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
     const map = useContext(ParentMap);
     const [ query, setQuery ] = useState("");
     const [ geocodeRun, setGeocodeRun ] = useState<GeocodeRun>();
     // Empties the list once a marker or place has been taken, which is what closes the dropdown under
     // `keepOpenOnPick`. Typing again clears it.
     const [ dismissed, setDismissed ] = useState(false);
-    // Where the geocoder's last answer is pinned, and nothing while the map shows only its own notes.
-    const [ pickedPlace, setPickedPlace ] = useState<[number, number]>();
+    // The geocoder's last answer, pinned where it stands; nothing while the map shows only its notes.
+    const [ pickedPlace, setPickedPlace ] = useState<{ center: [number, number]; name: string }>();
     const entriesByKey = useRef(new Map<string, SearchEntry>());
     // Discards a run superseded by a later one, since each reports through the same state.
     const latestRun = useRef(0);
@@ -139,7 +138,7 @@ export default function SearchBox({ notes }: SearchBoxProps) {
             setQuery(entry.label);
             setDismissed(true);
             // A note already has a marker of its own to fly to; only a place needs one put down.
-            setPickedPlace(entry.kind === "place" ? entry.center : undefined);
+            setPickedPlace(entry.kind === "place" ? { center: entry.center, name: entry.name } : undefined);
             map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
         }
     }, [ map, runGeocoder ]);
@@ -161,7 +160,7 @@ export default function SearchBox({ notes }: SearchBoxProps) {
 
     return (
         <>
-            {pickedPlace && <PlaceMarker center={pickedPlace} />}
+            {pickedPlace && <PlaceMarker center={pickedPlace.center} name={pickedPlace.name} isDarkTheme={isDarkTheme} />}
             <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
                 <Icon icon="bx bx-search" className="geo-search-icon" />
                 <FormAutocomplete
@@ -178,48 +177,6 @@ export default function SearchBox({ notes }: SearchBoxProps) {
             </OverlayToolbar>
         </>
     );
-}
-
-/**
- * The pin standing on a place taken from the geocoder, for as long as that place is the one searched
- * for.
- *
- * A MapLibre `Marker` rather than a feature in the notes' symbol layer: that layer is built from the
- * notes and reloaded with them, and this pin belongs to neither. It wears the image the symbol layer
- * stamps (see `drawMarkerImage`), in a colour and an icon no note marker uses.
- */
-function PlaceMarker({ center }: { center: [number, number] }) {
-    const map = useContext(ParentMap);
-
-    useEffect(() => {
-        if (!map) return;
-
-        const element = document.createElement("div");
-        element.className = "geo-place-marker";
-        // The pin names nothing the search field does not already say, and a click at the place has
-        // the map to reach (see the armed click in index.tsx).
-        element.ariaHidden = "true";
-
-        // `icon-offset` on the symbol layer, as a marker offset: the tip of the pin sits a shadow's
-        // padding above the bottom edge of the image it is drawn in.
-        const marker = new Marker({ element, anchor: "bottom", offset: [ 0, MARKER_SHADOW_PADDING ] })
-            .setLngLat(center)
-            .addTo(map);
-
-        let cancelled = false;
-        drawMarkerImage(PLACE_MARKER_COLOR, PLACE_MARKER_ICON).then((image) => {
-            if (!cancelled && image) {
-                element.replaceChildren(image);
-            }
-        });
-
-        return () => {
-            cancelled = true;
-            marker.remove();
-        };
-    }, [ map, center ]);
-
-    return null;
 }
 
 /** The notes on the map whose title contains the query and that are drawn somewhere. */
@@ -281,6 +238,7 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
         kind: "place",
         key: `place:${result.id}`,
         label: result.label,
+        name: result.name,
         icon: "bx bx-map-pin",
         center: [ result.lng, result.lat ]
     };

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -175,7 +175,6 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
         if (entry.kind === "geocode") {
             runGeocoder(entry.query);
         } else if (entry.kind === "marker" || entry.kind === "place") {
-            setQuery(entry.label);
             setDismissed(true);
             // A note of the map's own has a marker already; only a place needs one put down for it.
             onPickPlace(entry.kind === "place" ? entry.result : null);

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,6 +1,7 @@
 import "./SearchBox.css";
 
 import clsx from "clsx";
+import type { TargetedKeyboardEvent } from "preact";
 import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
 import type { Map as MapLibreGLMap } from "maplibre-gl";
@@ -170,6 +171,25 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
         }
     }, [ provider, map ]);
 
+    /**
+     * Puts the rows back on offer, so a query that was right can be looked at again without being
+     * retyped: the field is come back to, or Enter is pressed on it with nothing on offer.
+     *
+     * Only where there is nothing on offer, since the Enter that takes a row arrives here too and
+     * would otherwise undo the dismissal it has just caused.
+     */
+    const offerRowsAgain = useCallback(() => {
+        if (!entriesByKey.current.size) {
+            setDismissed(false);
+        }
+    }, []);
+
+    const offerRowsOnEnter = useCallback((e: TargetedKeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            offerRowsAgain();
+        }
+    }, [ offerRowsAgain ]);
+
     /** Empties the field, which is also what takes a searched place off the map (see `changeQuery`). */
     const clearSearch = useCallback(() => {
         changeQuery("");
@@ -250,7 +270,11 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
                 isHeading={isHeading}
                 dropdownMinWidth={RESULT_LIST_WIDTH}
                 autoActivate
+                openOnFocus
+                openOnEnter
                 keepOpenOnPick
+                onFocus={offerRowsAgain}
+                onKeyDown={offerRowsOnEnter}
                 placeholder={t("geo-map.search-placeholder")}
                 aria-label={t("geo-map.search")}
             />

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -107,6 +107,10 @@ interface GeocodeRun {
  * nothing at otherwise leaves the user to work out which patch of ground was meant. The pin stands
  * until another is taken or the field is emptied.
  *
+ * The rows are the choices themselves rather than help with typing, so the first stands ready and
+ * Enter takes it — `autoActivate`, as the attribute pickers use it. From a field holding nothing but
+ * a name, that is: Enter, which runs the geocoder, and Enter again, which takes what it found.
+ *
  * `FormAutocomplete` handles the debounce, the stale-response guard, keyboard navigation and a
  * dropdown portalled out of the map's scrolling container. `keepOpenOnPick` keeps the list up so the
  * geocoder row can replace itself with results, so closing it after a marker or place is taken is
@@ -256,6 +260,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
                     source={source}
                     renderItem={renderEntry}
                     dropdownMinWidth={RESULT_LIST_WIDTH}
+                    autoActivate
                     keepOpenOnPick
                     placeholder={t("geo-map.search-placeholder")}
                     aria-label={t("geo-map.search")}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,6 +1,7 @@
 import "./SearchBox.css";
 
-import { useCallback, useContext, useRef, useState } from "preact/hooks";
+import { Marker } from "maplibre-gl";
+import { useCallback, useContext, useEffect, useRef, useState } from "preact/hooks";
 
 import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
@@ -10,7 +11,7 @@ import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
-import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
+import { drawMarkerImage, LOCATION_ATTRIBUTE, MARKER_SHADOW_PADDING, parseLocation } from "./Markers";
 
 /** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
@@ -26,6 +27,12 @@ const MAX_MARKER_RESULTS = 8;
 
 /** The key of the row reporting on a geocoder run, which only ever appears once. */
 const STATUS_KEY = "geocode-status";
+
+/** The colour the pin for a searched place is drawn in, so it is not read as one of the map's notes. */
+const PLACE_MARKER_COLOR = "#E8833A";
+
+/** The icon that pin wears, naming where it came from. */
+const PLACE_MARKER_ICON = "bx bx-search";
 
 interface SearchBoxProps {
     /** The notes on the map, searched by title. */
@@ -63,6 +70,10 @@ interface GeocodeRun {
  * to a third party, and providers rate-limit and discourage per-keystroke lookups, so it sits at the
  * bottom of the list as a row that runs it when picked.
  *
+ * A place taken from the geocoder is pinned where it stands, since flying to a spot the map has
+ * nothing at otherwise leaves the user to work out which patch of ground was meant. The pin stands
+ * until another is taken or the field is emptied.
+ *
  * `FormAutocomplete` handles the debounce, the stale-response guard, keyboard navigation and a
  * dropdown portalled out of the map's scrolling container. `keepOpenOnPick` keeps the list up so the
  * geocoder row can replace itself with results, so closing it after a marker or place is taken is
@@ -75,6 +86,8 @@ export default function SearchBox({ notes }: SearchBoxProps) {
     // Empties the list once a marker or place has been taken, which is what closes the dropdown under
     // `keepOpenOnPick`. Typing again clears it.
     const [ dismissed, setDismissed ] = useState(false);
+    // Where the geocoder's last answer is pinned, and nothing while the map shows only its own notes.
+    const [ pickedPlace, setPickedPlace ] = useState<[number, number]>();
     const entriesByKey = useRef(new Map<string, SearchEntry>());
     // Discards a run superseded by a later one, since each reports through the same state.
     const latestRun = useRef(0);
@@ -95,6 +108,10 @@ export default function SearchBox({ notes }: SearchBoxProps) {
     const changeQuery = useCallback((newQuery: string) => {
         setDismissed(false);
         setQuery(newQuery);
+        // Emptying the field is how the pin is taken back off the map.
+        if (!newQuery.trim()) {
+            setPickedPlace(undefined);
+        }
     }, []);
 
     const runGeocoder = useCallback(async (searchQuery: string) => {
@@ -121,6 +138,8 @@ export default function SearchBox({ notes }: SearchBoxProps) {
         } else if (entry.kind === "marker" || entry.kind === "place") {
             setQuery(entry.label);
             setDismissed(true);
+            // A note already has a marker of its own to fly to; only a place needs one put down.
+            setPickedPlace(entry.kind === "place" ? entry.center : undefined);
             map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
         }
     }, [ map, runGeocoder ]);
@@ -141,21 +160,66 @@ export default function SearchBox({ notes }: SearchBoxProps) {
     if (!map) return null;
 
     return (
-        <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
-            <Icon icon="bx bx-search" className="geo-search-icon" />
-            <FormAutocomplete
-                className="geo-search-input"
-                currentValue={query}
-                onChange={changeQuery}
-                onPick={pickEntry}
-                source={source}
-                renderItem={renderEntry}
-                keepOpenOnPick
-                placeholder={t("geo-map.search-placeholder")}
-                aria-label={t("geo-map.search")}
-            />
-        </OverlayToolbar>
+        <>
+            {pickedPlace && <PlaceMarker center={pickedPlace} />}
+            <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
+                <Icon icon="bx bx-search" className="geo-search-icon" />
+                <FormAutocomplete
+                    className="geo-search-input"
+                    currentValue={query}
+                    onChange={changeQuery}
+                    onPick={pickEntry}
+                    source={source}
+                    renderItem={renderEntry}
+                    keepOpenOnPick
+                    placeholder={t("geo-map.search-placeholder")}
+                    aria-label={t("geo-map.search")}
+                />
+            </OverlayToolbar>
+        </>
     );
+}
+
+/**
+ * The pin standing on a place taken from the geocoder, for as long as that place is the one searched
+ * for.
+ *
+ * A MapLibre `Marker` rather than a feature in the notes' symbol layer: that layer is built from the
+ * notes and reloaded with them, and this pin belongs to neither. It wears the image the symbol layer
+ * stamps (see `drawMarkerImage`), in a colour and an icon no note marker uses.
+ */
+function PlaceMarker({ center }: { center: [number, number] }) {
+    const map = useContext(ParentMap);
+
+    useEffect(() => {
+        if (!map) return;
+
+        const element = document.createElement("div");
+        element.className = "geo-place-marker";
+        // The pin names nothing the search field does not already say, and a click at the place has
+        // the map to reach (see the armed click in index.tsx).
+        element.ariaHidden = "true";
+
+        // `icon-offset` on the symbol layer, as a marker offset: the tip of the pin sits a shadow's
+        // padding above the bottom edge of the image it is drawn in.
+        const marker = new Marker({ element, anchor: "bottom", offset: [ 0, MARKER_SHADOW_PADDING ] })
+            .setLngLat(center)
+            .addTo(map);
+
+        let cancelled = false;
+        drawMarkerImage(PLACE_MARKER_COLOR, PLACE_MARKER_ICON).then((image) => {
+            if (!cancelled && image) {
+                element.replaceChildren(image);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+            marker.remove();
+        };
+    }, [ map, center ]);
+
+    return null;
 }
 
 /** The notes on the map whose title contains the query and that are drawn somewhere. */

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -16,6 +16,7 @@ import Icon from "../../react/Icon";
 import OverlayToolbar, { OverlayToolbarButton } from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, DEFAULT_PLACE_ICON, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { ParentMap } from "./map";
+import { describePlace } from "./place_address";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
 
 /** Shorter queries are not searched. */
@@ -232,7 +233,7 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
 
         // A place reads over two lines: what it is called, and the address that places it. Every
         // other row is one thing said once.
-        const address = entry.kind === "place" ? addressOf(entry.label, entry.result.name) : null;
+        const address = entry.kind === "place" ? describePlace(entry.result) : null;
 
         return (
             <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
@@ -318,16 +319,6 @@ function metresBetween([ lngA, latA ]: [number, number], [ lngB, latB ]: [number
 function viewportOf(map: MapLibreGLMap): GeoBounds {
     const bounds = map.getBounds();
     return [ [ bounds.getWest(), bounds.getSouth() ], [ bounds.getEast(), bounds.getNorth() ] ];
-}
-
-/**
- * What a label says beyond the place's own name, which is the address around it — "Ōta, Japan" of
- * "Tokyo, Ōta, Japan". A label that does not begin with the name is left whole, having nothing to
- * repeat.
- */
-function addressOf(label: string, name: string) {
-    const rest = label.startsWith(name) ? label.slice(name.length) : label;
-    return rest.replace(/^[\s,]+/, "");
 }
 
 /** The notes on the map whose title contains the query and that are drawn somewhere. */

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,5 +1,6 @@
 import "./SearchBox.css";
 
+import clsx from "clsx";
 import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
 import type { Map as MapLibreGLMap } from "maplibre-gl";
@@ -11,7 +12,7 @@ import { getMeasurementSystem } from "../../../utils/formatters";
 import { formatDistance } from "../../../utils/units";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
-import OverlayToolbar from "../../react/OverlayToolbar";
+import OverlayToolbar, { OverlayToolbarButton } from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { ParentMap } from "./map";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
@@ -119,6 +120,7 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
     // Empties the list once a marker or place has been taken, which is what closes the dropdown under
     // `keepOpenOnPick`. Typing again clears it.
     const [ dismissed, setDismissed ] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
     const entriesByKey = useRef(new Map<string, SearchEntry>());
     // Discards a run superseded by a later one, since each reports through the same state.
     const latestRun = useRef(0);
@@ -167,6 +169,13 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
             setGeocodeRun({ query: searchQuery, status: "failed", results: [] });
         }
     }, [ provider, map ]);
+
+    /** Empties the field, which is also what takes a searched place off the map (see `changeQuery`). */
+    const clearSearch = useCallback(() => {
+        changeQuery("");
+        // The field is where the reader was, and clearing it is rarely the end of searching.
+        inputRef.current?.focus();
+    }, [ changeQuery ]);
 
     const pickEntry = useCallback((key: string) => {
         const entry = entriesByKey.current.get(key);
@@ -229,20 +238,30 @@ export default function SearchBox({ notes, onPickPlace }: SearchBoxProps) {
 
     return (
         <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
-                <Icon icon="bx bx-search" className="geo-search-icon" />
-                <FormAutocomplete
-                    className="geo-search-input"
-                    currentValue={query}
-                    onChange={changeQuery}
-                    onPick={pickEntry}
-                    source={source}
-                    renderItem={renderEntry}
-                    isHeading={isHeading}
-                    dropdownMinWidth={RESULT_LIST_WIDTH}
-                    autoActivate
-                    keepOpenOnPick
-                    placeholder={t("geo-map.search-placeholder")}
-                    aria-label={t("geo-map.search")}
+            <Icon icon="bx bx-search" className="geo-search-icon" />
+            <FormAutocomplete
+                className="geo-search-input"
+                inputRef={inputRef}
+                currentValue={query}
+                onChange={changeQuery}
+                onPick={pickEntry}
+                source={source}
+                renderItem={renderEntry}
+                isHeading={isHeading}
+                dropdownMinWidth={RESULT_LIST_WIDTH}
+                autoActivate
+                keepOpenOnPick
+                placeholder={t("geo-map.search-placeholder")}
+                aria-label={t("geo-map.search")}
+            />
+            {/* Kept in the bar whether or not there is anything to clear, and only shown when there
+                is: a button coming and going would take the bar's width with it, moving the field
+                under the reader mid-word. */}
+            <OverlayToolbarButton
+                className={clsx("geo-search-clear", query && "shown")}
+                icon="bx bx-x"
+                text={t("options.search_clear")}
+                onClick={clearSearch}
             />
         </OverlayToolbar>
     );

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -2,54 +2,140 @@ import "./SearchBox.css";
 
 import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
+import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
+import { logError } from "../../../services/ws";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
 import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
+import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
 
-/** Shorter queries are not looked up. */
+/** Shorter queries are not searched. */
 const MIN_QUERY_LENGTH = 2;
 
-/** The zoom level a picked result is shown at. */
-const RESULT_ZOOM = 12;
+/** The zoom level a place from the geocoder is shown at. */
+const PLACE_ZOOM = 12;
+
+/** The zoom level a marker is shown at, closer in since a note marks a spot rather than an area. */
+const MARKER_ZOOM = 15;
+
+/** Caps how many of the map's own notes the list offers. */
+const MAX_MARKER_RESULTS = 8;
+
+/** The key of the row reporting on a geocoder run, which only ever appears once. */
+const STATUS_KEY = "geocode-status";
+
+interface SearchBoxProps {
+    /** The notes on the map, searched by title. */
+    notes: FNote[];
+}
 
 /**
- * A search bar over a geo map that flies the map to the place picked from it.
+ * One row of the result list. `key` identifies it, since `FormAutocomplete` items are strings and two
+ * rows can read the same.
+ */
+type SearchEntry = {
+    key: string;
+    label: string;
+    /** A boxicons class, as `FNote.getIcon()` gives it. */
+    icon: string;
+} & (
+    | { kind: "marker" | "place"; center: [number, number] }
+    /** Runs the geocoder for `query`. */
+    | { kind: "geocode"; query: string }
+    /** Reports on a geocoder run; picking it does nothing. */
+    | { kind: "info" }
+);
+
+/** A geocoder run, kept so its results can be listed under the query they answer. */
+interface GeocodeRun {
+    query: string;
+    status: "loading" | "done" | "failed";
+    results: SearchEntry[];
+}
+
+/**
+ * A search bar over a geo map, which flies the map to the marker or place picked from it.
  *
- * Results come from a `GeocodingProvider`, currently the dummy one.
+ * The map's own notes are matched by title as the user types. The geocoder is not: it costs a request
+ * to a third party, and providers rate-limit and discourage per-keystroke lookups, so it sits at the
+ * bottom of the list as a row that runs it when picked.
  *
  * `FormAutocomplete` handles the debounce, the stale-response guard, keyboard navigation and a
- * dropdown portalled out of the map's scrolling container. Its items are strings, so `resultsByLabel`
- * holds the matching `GeoSearchResult` to look up on pick. Results with the same label collapse to
- * one, since they read identically in the list.
+ * dropdown portalled out of the map's scrolling container. `keepOpenOnPick` keeps the list up so the
+ * geocoder row can replace itself with results, so closing it after a marker or place is taken is
+ * this component's job — see `dismissed`.
  */
-export default function SearchBox() {
+export default function SearchBox({ notes }: SearchBoxProps) {
     const map = useContext(ParentMap);
     const [ query, setQuery ] = useState("");
-    const resultsByLabel = useRef(new Map<string, GeoSearchResult>());
+    const [ geocodeRun, setGeocodeRun ] = useState<GeocodeRun>();
+    // Empties the list once a marker or place has been taken, which is what closes the dropdown under
+    // `keepOpenOnPick`. Typing again clears it.
+    const [ dismissed, setDismissed ] = useState(false);
+    const entriesByKey = useRef(new Map<string, SearchEntry>());
+    // Discards a run superseded by a later one, since each reports through the same state.
+    const latestRun = useRef(0);
     const provider = GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME];
 
     const source = useCallback(async (currentQuery: string) => {
         const trimmed = currentQuery.trim();
-        if (trimmed.length < MIN_QUERY_LENGTH) {
-            resultsByLabel.current = new Map();
+        if (dismissed || trimmed.length < MIN_QUERY_LENGTH) {
+            entriesByKey.current = new Map();
             return [];
         }
 
-        const results = await provider.search(trimmed);
-        resultsByLabel.current = new Map(results.map((result) => [ result.label, result ]));
-        return [ ...resultsByLabel.current.keys() ];
+        const entries = [ ...matchMarkers(notes, trimmed), ...geocodeEntries(geocodeRun, trimmed) ];
+        entriesByKey.current = new Map(entries.map((entry) => [ entry.key, entry ]));
+        return entries.map((entry) => entry.key);
+    }, [ notes, geocodeRun, dismissed ]);
+
+    const changeQuery = useCallback((newQuery: string) => {
+        setDismissed(false);
+        setQuery(newQuery);
+    }, []);
+
+    const runGeocoder = useCallback(async (searchQuery: string) => {
+        const runId = ++latestRun.current;
+        setGeocodeRun({ query: searchQuery, status: "loading", results: [] });
+
+        try {
+            const results = await provider.search(searchQuery);
+            if (latestRun.current !== runId) return;
+            setGeocodeRun({ query: searchQuery, status: "done", results: results.map(placeEntry) });
+        } catch (e) {
+            logError(`Geocoding with "${provider.name}" failed: ${e}`);
+            if (latestRun.current !== runId) return;
+            setGeocodeRun({ query: searchQuery, status: "failed", results: [] });
+        }
     }, [ provider ]);
 
-    const flyToResult = useCallback((label: string) => {
-        const result = resultsByLabel.current.get(label);
-        if (!result || !map) return;
+    const pickEntry = useCallback((key: string) => {
+        const entry = entriesByKey.current.get(key);
+        if (!entry || !map) return;
 
-        setQuery(label);
-        map.flyTo({ center: [ result.lng, result.lat ], zoom: RESULT_ZOOM });
-    }, [ map ]);
+        if (entry.kind === "geocode") {
+            runGeocoder(entry.query);
+        } else if (entry.kind === "marker" || entry.kind === "place") {
+            setQuery(entry.label);
+            setDismissed(true);
+            map.flyTo({ center: entry.center, zoom: entry.kind === "marker" ? MARKER_ZOOM : PLACE_ZOOM });
+        }
+    }, [ map, runGeocoder ]);
+
+    const renderEntry = useCallback((key: string) => {
+        const entry = entriesByKey.current.get(key);
+        if (!entry) return key;
+
+        return (
+            <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
+                <Icon icon={entry.icon} />
+                {entry.label}
+            </span>
+        );
+    }, []);
 
     // The map failed to initialize, e.g. WebGL is unavailable (see map.tsx).
     if (!map) return null;
@@ -60,12 +146,83 @@ export default function SearchBox() {
             <FormAutocomplete
                 className="geo-search-input"
                 currentValue={query}
-                onChange={setQuery}
-                onPick={flyToResult}
+                onChange={changeQuery}
+                onPick={pickEntry}
                 source={source}
+                renderItem={renderEntry}
+                keepOpenOnPick
                 placeholder={t("geo-map.search-placeholder")}
                 aria-label={t("geo-map.search")}
             />
         </OverlayToolbar>
     );
+}
+
+/** The notes on the map whose title contains the query and that are drawn somewhere. */
+function matchMarkers(notes: FNote[], query: string): SearchEntry[] {
+    const needle = query.toLowerCase();
+    const matches: SearchEntry[] = [];
+
+    for (const note of notes) {
+        if (matches.length >= MAX_MARKER_RESULTS) break;
+        if (!note.title.toLowerCase().includes(needle)) continue;
+
+        // A note without a readable location has no marker to fly to. GPX tracks are skipped for the
+        // same reason: their route is in the file rather than on a label.
+        const center = parseLocation(note.getLabelValue(LOCATION_ATTRIBUTE));
+        if (!center) continue;
+
+        matches.push({
+            kind: "marker",
+            key: `marker:${note.noteId}`,
+            label: note.title,
+            icon: note.getIcon(),
+            center
+        });
+    }
+
+    return matches;
+}
+
+/**
+ * What the list offers below the markers: the results of a run answering this query, or the row that
+ * starts one. Typing never reaches the provider — picking that row is the only thing that does.
+ */
+function geocodeEntries(run: GeocodeRun | undefined, query: string): SearchEntry[] {
+    if (run?.query !== query) {
+        return [ {
+            kind: "geocode",
+            key: "geocode",
+            label: t("geo-map.search-online", { query }),
+            icon: "bx bx-search-alt",
+            query
+        } ];
+    }
+
+    if (run.status === "loading") {
+        return [ infoEntry(t("geo-map.searching-online"), "bx bx-loader-alt") ];
+    }
+    if (run.status === "failed") {
+        return [ infoEntry(t("geo-map.search-failed"), "bx bx-error-circle") ];
+    }
+    if (!run.results.length) {
+        return [ infoEntry(t("geo-map.no-places-found"), "bx bx-info-circle") ];
+    }
+
+    return run.results;
+}
+
+function placeEntry(result: GeoSearchResult): SearchEntry {
+    return {
+        kind: "place",
+        key: `place:${result.id}`,
+        label: result.label,
+        icon: "bx bx-map-pin",
+        center: [ result.lng, result.lat ]
+    };
+}
+
+/** A row that reports on the geocoder rather than offering a place. */
+function infoEntry(label: string, icon: string): SearchEntry {
+    return { kind: "info", key: STATUS_KEY, label, icon };
 }

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -142,7 +142,7 @@ export default function SearchBox({ notes, onPickResult }: SearchBoxProps) {
         const { places, notice } = geocodeEntries(geocodeRun, trimmed);
         const found = [ ...matchMarkers(notes, trimmed), ...places ]
             .map((entry) => withDistance(entry, origin));
-        const entries = [ ...byDistance(found), ...(notice ? [ notice ] : []) ];
+        const entries = [ ...grouped(found), ...(notice ? [ notice ] : []) ];
         entriesByKey.current = new Map(entries.map((entry) => [ entry.key, entry ]));
         return entries.map((entry) => entry.key);
     }, [ notes, geocodeRun, dismissed, map ]);
@@ -406,28 +406,32 @@ function geocodeEntries(run: GeocodeRun | undefined, query: string): {
 }
 
 /**
- * The places found, nearest first, under headings that say which are at hand and which are not — a
- * shop down the road and one on another continent are both answers to the same name, and the list
- * used to run them together.
+ * What was found, under headings naming what each run of rows is: the map's own notes first, then
+ * the geocoder's places, split by whether they are at hand.
  *
- * Headings only where there is something on both sides of {@link SEARCH_RADIUS_M}: one name over one
- * run of rows distinguishes it from nothing.
+ * Nearest first within each. A note already standing on the map, a shop down the road and one on
+ * another continent are three different answers to the same name, and the list used to run them
+ * together.
+ *
+ * Headings only where more than one of the three was found: one name over the whole list
+ * distinguishes it from nothing.
  */
-function byDistance(entries: SearchEntry[]): SearchEntry[] {
+function grouped(entries: SearchEntry[]): SearchEntry[] {
     const sorted = [ ...entries ].sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
-    const atHand = sorted.filter((entry) => (entry.distance ?? Infinity) <= SEARCH_RADIUS_M);
-    const further = sorted.slice(atHand.length);
+    const places = sorted.filter((entry) => entry.kind === "place");
+    const isAtHand = (entry: SearchEntry) => (entry.distance ?? Infinity) <= SEARCH_RADIUS_M;
 
-    if (!atHand.length || !further.length) {
-        return sorted;
+    const groups: { key: string; label: string; rows: SearchEntry[] }[] = [
+        { key: "on-map", label: t("geo-map.results-on-map"), rows: sorted.filter((entry) => entry.kind === "marker") },
+        { key: "nearby", label: t("geo-map.results-nearby"), rows: places.filter(isAtHand) },
+        { key: "far", label: t("geo-map.results-far"), rows: places.filter((entry) => !isAtHand(entry)) }
+    ].filter((group) => group.rows.length);
+
+    if (groups.length < 2) {
+        return groups.flatMap((group) => group.rows);
     }
 
-    return [
-        headingEntry("nearby", t("geo-map.results-nearby")),
-        ...atHand,
-        headingEntry("far", t("geo-map.results-far")),
-        ...further
-    ];
+    return groups.flatMap((group) => [ headingEntry(group.key, group.label), ...group.rows ]);
 }
 
 function headingEntry(key: string, label: string): SearchEntry {

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -76,6 +76,8 @@ type SearchEntry = {
     icon?: string;
     /** How far the place is from the middle of the map, in metres. */
     distance?: number;
+    /** A second line under the first: the address that places a place, or whose answer a row is. */
+    detail?: string;
 } & (
     | { kind: "marker"; center: [number, number]; noteId: string }
     /** A place from the geocoder, carried whole for whoever the pick is reported to. */
@@ -139,13 +141,13 @@ export default function SearchBox({ notes, onPickResult }: SearchBoxProps) {
         // Measured from the middle of what the map is showing, at the moment the list is built: two
         // places of the same name are told apart by which of them is at hand.
         const origin = map ? map.getCenter().toArray() : null;
-        const { places, notice } = geocodeEntries(geocodeRun, trimmed);
+        const { places, notice } = geocodeEntries(geocodeRun, trimmed, provider.name);
         const found = [ ...matchMarkers(notes, trimmed), ...places ]
             .map((entry) => withDistance(entry, origin));
         const entries = [ ...grouped(found), ...(notice ? [ notice ] : []) ];
         entriesByKey.current = new Map(entries.map((entry) => [ entry.key, entry ]));
         return entries.map((entry) => entry.key);
-    }, [ notes, geocodeRun, dismissed, map ]);
+    }, [ notes, geocodeRun, dismissed, map, provider ]);
 
     const changeQuery = useCallback((newQuery: string) => {
         setDismissed(false);
@@ -228,20 +230,18 @@ export default function SearchBox({ notes, onPickResult }: SearchBoxProps) {
             return entry.label;
         }
 
-        // A place reads over two lines: what it is called, and the address that places it. Every
-        // other row is one thing said once.
-        const address = entry.kind === "place" ? describePlace(entry.result) : null;
+        // Two lines: what the row is, and under it what places it — the address of a place, and the
+        // geocoder's name on the rows that are its to answer for.
+        const [ name, detail ] = entry.kind === "place"
+            ? [ entry.result.name, describePlace(entry.result) ]
+            : [ entry.label, entry.detail ];
 
         return (
             <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
                 <Icon icon={entry.icon} />
                 <span className="geo-search-entry-lines">
-                    {entry.kind === "place"
-                        ? <>
-                            <span className="geo-search-entry-name">{entry.result.name}</span>
-                            {address && <span className="geo-search-entry-address">{address}</span>}
-                        </>
-                        : entry.label}
+                    <span className="geo-search-entry-name">{name}</span>
+                    {detail && <span className="geo-search-entry-address">{detail}</span>}
                 </span>
                 {entry.distance !== undefined &&
                     <span className="geo-search-entry-distance">
@@ -375,10 +375,13 @@ function matchMarkers(notes: FNote[], query: string): SearchEntry[] {
  * The two are separated because they belong in different parts of the list: places are sorted in
  * among the map's own notes, and a notice stands at the foot whatever the distances say.
  */
-function geocodeEntries(run: GeocodeRun | undefined, query: string): {
+function geocodeEntries(run: GeocodeRun | undefined, query: string, provider: string): {
     places: SearchEntry[];
     notice: SearchEntry | null;
 } {
+    // Named under every row that is the geocoder's to answer for — the offer to ask it, and whatever
+    // came of the asking — so that what is about to leave the map, and where the places on it came
+    // from, is said where it is read rather than in a setting somewhere.
     if (run?.query !== query) {
         return {
             places: [],
@@ -386,6 +389,7 @@ function geocodeEntries(run: GeocodeRun | undefined, query: string): {
                 kind: "geocode",
                 key: "geocode",
                 label: t("geo-map.search-online", { query }),
+                detail: provider,
                 icon: "bx bx-search-alt",
                 query
             }
@@ -393,13 +397,13 @@ function geocodeEntries(run: GeocodeRun | undefined, query: string): {
     }
 
     if (run.status === "loading") {
-        return { places: [], notice: infoEntry(t("geo-map.searching-online"), "bx bx-loader-alt") };
+        return { places: [], notice: infoEntry(t("geo-map.searching-online"), "bx bx-loader-alt", provider) };
     }
     if (run.status === "failed") {
-        return { places: [], notice: infoEntry(t("geo-map.search-failed"), "bx bx-error-circle") };
+        return { places: [], notice: infoEntry(t("geo-map.search-failed"), "bx bx-error-circle", provider) };
     }
     if (!run.results.length) {
-        return { places: [], notice: infoEntry(t("geo-map.no-places-found"), "bx bx-info-circle") };
+        return { places: [], notice: infoEntry(t("geo-map.no-places-found"), "bx bx-info-circle", provider) };
     }
 
     return { places: run.results, notice: null };
@@ -450,6 +454,6 @@ function placeEntry(result: GeoSearchResult): SearchEntry {
 }
 
 /** A row that reports on the geocoder rather than offering a place. */
-function infoEntry(label: string, icon: string): SearchEntry {
-    return { kind: "info", key: STATUS_KEY, label, icon };
+function infoEntry(label: string, icon: string, detail: string): SearchEntry {
+    return { kind: "info", key: STATUS_KEY, label, icon, detail };
 }

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,0 +1,71 @@
+import "./SearchBox.css";
+
+import { useCallback, useContext, useRef, useState } from "preact/hooks";
+
+import { t } from "../../../services/i18n";
+import FormAutocomplete from "../../react/FormAutocomplete";
+import Icon from "../../react/Icon";
+import OverlayToolbar from "../../react/OverlayToolbar";
+import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
+import { ParentMap } from "./map";
+
+/** Shorter queries are not looked up. */
+const MIN_QUERY_LENGTH = 2;
+
+/** The zoom level a picked result is shown at. */
+const RESULT_ZOOM = 12;
+
+/**
+ * A search bar over a geo map that flies the map to the place picked from it.
+ *
+ * Results come from a `GeocodingProvider`, currently the dummy one.
+ *
+ * `FormAutocomplete` handles the debounce, the stale-response guard, keyboard navigation and a
+ * dropdown portalled out of the map's scrolling container. Its items are strings, so `resultsByLabel`
+ * holds the matching `GeoSearchResult` to look up on pick. Results with the same label collapse to
+ * one, since they read identically in the list.
+ */
+export default function SearchBox() {
+    const map = useContext(ParentMap);
+    const [ query, setQuery ] = useState("");
+    const resultsByLabel = useRef(new Map<string, GeoSearchResult>());
+    const provider = GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME];
+
+    const source = useCallback(async (currentQuery: string) => {
+        const trimmed = currentQuery.trim();
+        if (trimmed.length < MIN_QUERY_LENGTH) {
+            resultsByLabel.current = new Map();
+            return [];
+        }
+
+        const results = await provider.search(trimmed);
+        resultsByLabel.current = new Map(results.map((result) => [ result.label, result ]));
+        return [ ...resultsByLabel.current.keys() ];
+    }, [ provider ]);
+
+    const flyToResult = useCallback((label: string) => {
+        const result = resultsByLabel.current.get(label);
+        if (!result || !map) return;
+
+        setQuery(label);
+        map.flyTo({ center: [ result.lng, result.lat ], zoom: RESULT_ZOOM });
+    }, [ map ]);
+
+    // The map failed to initialize, e.g. WebGL is unavailable (see map.tsx).
+    if (!map) return null;
+
+    return (
+        <OverlayToolbar className="geo-search-toolbar" titlePosition="bottom">
+            <Icon icon="bx bx-search" className="geo-search-icon" />
+            <FormAutocomplete
+                className="geo-search-input"
+                currentValue={query}
+                onChange={setQuery}
+                onPick={flyToResult}
+                source={source}
+                placeholder={t("geo-map.search-placeholder")}
+                aria-label={t("geo-map.search")}
+            />
+        </OverlayToolbar>
+    );
+}

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -2,13 +2,15 @@ import "./SearchBox.css";
 
 import { useCallback, useContext, useRef, useState } from "preact/hooks";
 
+import type { Map as MapLibreGLMap } from "maplibre-gl";
+
 import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
 import { logError } from "../../../services/ws";
 import FormAutocomplete from "../../react/FormAutocomplete";
 import Icon from "../../react/Icon";
 import OverlayToolbar from "../../react/OverlayToolbar";
-import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
+import { DEFAULT_GEOCODING_PROVIDER_NAME, type GeoBounds, GEOCODING_PROVIDERS, type GeoSearchResult } from "./geocoding";
 import { ParentMap } from "./map";
 import { LOCATION_ATTRIBUTE, parseLocation } from "./Markers";
 import PlaceMarker from "./PlaceMarker";
@@ -91,7 +93,8 @@ interface GeocodeRun {
  *
  * The map's own notes are matched by title as the user types. The geocoder is not: it costs a request
  * to a third party, and providers rate-limit and discourage per-keystroke lookups, so it sits at the
- * bottom of the list as a row that runs it when picked.
+ * bottom of the list as a row that runs it when picked. It is told what the map is showing, so that
+ * what is nearby is preferred to what merely shares a name.
  *
  * A place taken from the geocoder is pinned where it stands, since flying to a spot the map has
  * nothing at otherwise leaves the user to work out which patch of ground was meant. The pin stands
@@ -150,7 +153,9 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         setGeocodeRun({ query: searchQuery, status: "loading", results: [] });
 
         try {
-            const results = await provider.search(searchQuery);
+            // Where the map is looking, so a shop searched for from Corfu is answered with the one in
+            // Corfu rather than the one in Finland.
+            const results = await provider.search(searchQuery, { viewport: map ? viewportOf(map) : undefined });
             if (latestRun.current !== runId) return;
             setGeocodeRun({ query: searchQuery, status: "done", results: results.map(placeEntry) });
         } catch (e) {
@@ -158,7 +163,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             if (latestRun.current !== runId) return;
             setGeocodeRun({ query: searchQuery, status: "failed", results: [] });
         }
-    }, [ provider ]);
+    }, [ provider, map ]);
 
     const pickEntry = useCallback((key: string) => {
         const entry = entriesByKey.current.get(key);
@@ -241,6 +246,12 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             </OverlayToolbar>
         </>
     );
+}
+
+/** What the map is showing, as a geocoder reads a preferred area. */
+function viewportOf(map: MapLibreGLMap): GeoBounds {
+    const bounds = map.getBounds();
+    return [ [ bounds.getWest(), bounds.getSouth() ], [ bounds.getEast(), bounds.getNorth() ] ];
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -1,10 +1,9 @@
 import "./SearchBox.css";
 
 import clsx from "clsx";
+import type { Map as MapLibreGLMap } from "maplibre-gl";
 import type { TargetedKeyboardEvent } from "preact";
 import { useCallback, useContext, useRef, useState } from "preact/hooks";
-
-import type { Map as MapLibreGLMap } from "maplibre-gl";
 
 import type FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";

--- a/apps/client/src/widgets/collections/geomap/SearchBox.tsx
+++ b/apps/client/src/widgets/collections/geomap/SearchBox.tsx
@@ -31,6 +31,12 @@ const PLACE_PADDING = 60;
 /** The zoom level a marker is shown at, closer in since a note marks a spot rather than an area. */
 const MARKER_ZOOM = 15;
 
+/**
+ * How wide the result list is drawn. The field is a corner of the map, while what it offers is whole
+ * addresses, which at the field's own width is mostly an ellipsis.
+ */
+const RESULT_LIST_WIDTH = 500;
+
 /** Caps how many of the map's own notes the list offers. */
 const MAX_MARKER_RESULTS = 8;
 
@@ -192,10 +198,19 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
         const entry = entriesByKey.current.get(key);
         if (!entry) return key;
 
+        // A place reads over two lines: what it is called, and the address that places it. Every
+        // other row is one thing said once.
+        const address = entry.kind === "place" ? addressOf(entry.label, entry.name) : null;
+
         return (
             <span className={`geo-search-entry geo-search-entry-${entry.kind}`}>
                 <Icon icon={entry.icon} />
-                {entry.label}
+                {entry.kind === "place"
+                    ? <span className="geo-search-entry-lines">
+                        <span className="geo-search-entry-name">{entry.name}</span>
+                        {address && <span className="geo-search-entry-address">{address}</span>}
+                    </span>
+                    : entry.label}
             </span>
         );
     }, []);
@@ -218,6 +233,7 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
                     onPick={pickEntry}
                     source={source}
                     renderItem={renderEntry}
+                    dropdownMinWidth={RESULT_LIST_WIDTH}
                     keepOpenOnPick
                     placeholder={t("geo-map.search-placeholder")}
                     aria-label={t("geo-map.search")}
@@ -225,6 +241,16 @@ export default function SearchBox({ notes, isDarkTheme }: SearchBoxProps) {
             </OverlayToolbar>
         </>
     );
+}
+
+/**
+ * What a label says beyond the place's own name, which is the address around it — "Ōta, Japan" of
+ * "Tokyo, Ōta, Japan". A label that does not begin with the name is left whole, having nothing to
+ * repeat.
+ */
+function addressOf(label: string, name: string) {
+    const rest = label.startsWith(name) ? label.slice(name.length) : label;
+    return rest.replace(/^[\s,]+/, "");
 }
 
 /** The notes on the map whose title contains the query and that are drawn somewhere. */

--- a/apps/client/src/widgets/collections/geomap/api.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/api.spec.ts
@@ -1,19 +1,34 @@
 /**
- * What the geo map writes when something is put on it (see api.ts): the note a placement click
- * creates, and the note a GPX file is brought in as. Both go through the ordinary note-creation
- * service; what is checked here is what they ask it for.
+ * What the geo map writes when something is put on it or taken off it (see api.ts): the note a
+ * placement click creates, the note a searched place is kept as, the note a GPX file is brought in
+ * as, and what becomes of a marker the reader is done with. All go through the ordinary note
+ * services; what is checked here is what they are asked for.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import attributes from "../../../services/attributes";
+import dialog from "../../../services/dialog";
 import note_create from "../../../services/note_create";
+import { deleteNoteOrBranch } from "../../../services/note_deletion";
 import { buildNote } from "../../../test/easy-froca";
-import { createNewNote, importGpxTrack } from "./api";
+import { createNewNote, createNoteForPlace, importGpxTrack, moveMarker, removeFromMap } from "./api";
 
 vi.mock("../../../services/note_create", () => ({
     default: { createNote: vi.fn(async () => ({ note: { noteId: "created" }, branch: null })) }
 }));
 
+vi.mock("../../../services/attributes", () => ({ default: { setLabel: vi.fn(async () => {}) } }));
+vi.mock("../../../services/note_deletion", () => ({ deleteNoteOrBranch: vi.fn(async () => {}) }));
+vi.mock("../../../services/dialog", () => ({
+    default: { confirmDeleteNoteBoxWithNote: vi.fn() }
+}));
+
 const createNote = vi.mocked(note_create.createNote);
+const setLabel = vi.mocked(attributes.setLabel);
+const confirmDelete = vi.mocked(dialog.confirmDeleteNoteBoxWithNote);
+
+// What each of these asks for is what is checked, so what an earlier one asked for is noise.
+beforeEach(() => vi.clearAllMocks());
 
 describe("geo map api", () => {
     it("creates a placed note under the stock name, located where the click landed", async () => {
@@ -38,6 +53,24 @@ describe("geo map api", () => {
         }));
     });
 
+    it("names a note for a searched place as the place is named, and stands it there", async () => {
+        const parent = buildNote({ title: "The map" });
+
+        const created = await createNoteForPlace(parent, { name: "Jumbo", lat: 45.796, lng: 24.147 });
+
+        expect(created).toEqual({ noteId: "created" });
+        expect(createNote).toHaveBeenCalledWith(parent.noteId, expect.objectContaining({
+            // Named already, unlike a note dropped by clicking: the geocoder named the place.
+            title: "Jumbo",
+            type: "text",
+            activate: false,
+            attributes: expect.arrayContaining([
+                { type: "label", name: "geolocation", value: "45.796,24.147" },
+                { type: "label", name: "iconClass", value: "bx bx-pin" }
+            ])
+        }));
+    });
+
     it("brings a GPX file in as a file note the map draws tracks by", async () => {
         const parent = buildNote({ title: "The map" });
         const file = new File([ "<gpx><trk/></gpx>" ], "sunday-ride.gpx");
@@ -55,5 +88,48 @@ describe("geo map api", () => {
             activate: false,
             attributes: [ { type: "label", name: "originalFileName", value: "sunday-ride.gpx" } ]
         }));
+    });
+
+    it("writes a marker's location, and empties it to take the marker off the map", async () => {
+        await moveMarker("note1", { lat: 45.796, lng: 24.147 });
+        expect(setLabel).toHaveBeenLastCalledWith("note1", "geolocation", "45.796,24.147");
+
+        // An empty value is what leaves the note in place with no marker standing for it.
+        await moveMarker("note1", null);
+        expect(setLabel).toHaveBeenLastCalledWith("note1", "geolocation", "");
+    });
+
+    describe("taking a marker off the map", () => {
+        it("deletes the note where that is what the reader agreed to", async () => {
+            const map = buildNote({ title: "The map" });
+            const note = buildNote({ title: "A place" });
+            confirmDelete.mockResolvedValue({ confirmed: true, isDeleteNoteChecked: true });
+
+            await removeFromMap(note, map);
+
+            expect(deleteNoteOrBranch).toHaveBeenCalledWith(note.noteId, null);
+            expect(setLabel).not.toHaveBeenCalledWith(note.noteId, "geolocation", "");
+        });
+
+        it("keeps the note and clears its location where the reader only wanted it off the map", async () => {
+            const map = buildNote({ title: "The map" });
+            const note = buildNote({ title: "A place" });
+            confirmDelete.mockResolvedValue({ confirmed: true, isDeleteNoteChecked: false });
+
+            await removeFromMap(note, map);
+
+            expect(setLabel).toHaveBeenLastCalledWith(note.noteId, "geolocation", "");
+        });
+
+        it("leaves the marker alone where the reader changed their mind", async () => {
+            const map = buildNote({ title: "The map" });
+            const note = buildNote({ title: "A place" });
+            confirmDelete.mockResolvedValue({ confirmed: false, isDeleteNoteChecked: false });
+
+            await removeFromMap(note, map);
+
+            expect(deleteNoteOrBranch).not.toHaveBeenCalled();
+            expect(setLabel).not.toHaveBeenCalled();
+        });
     });
 });

--- a/apps/client/src/widgets/collections/geomap/api.ts
+++ b/apps/client/src/widgets/collections/geomap/api.ts
@@ -57,14 +57,6 @@ export async function removeFromMap(note: FNote, mapNote: FNote) {
 }
 
 /**
- * Creates a note where the click landed, and hands it back for the pane to open on.
- *
- * No title is asked for first. A modal between the click and the note was the wrong way round: it
- * blocked the map to ask for the one thing the detail pane is made for editing. The note is created
- * under the stock name instead, and the caller opens the pane on it with that name selected — naming
- * the place is typing over it (see index.tsx).
- */
-/**
  * Brings a GPX file onto the map as a child note, and hands the note back.
  *
  * Created directly rather than sent through the import pipeline: an import's success is announced
@@ -93,15 +85,38 @@ export async function importGpxTrack(parentNote: FNote, file: File) {
     return note;
 }
 
+/**
+ * Creates a note where the click landed, and hands it back for the pane to open on.
+ *
+ * No title is asked for first. A modal between the click and the note was the wrong way round: it
+ * blocked the map to ask for the one thing the detail pane is made for editing. The note is created
+ * under the stock name instead, and the caller opens the pane on it with that name selected — naming
+ * the place is typing over it (see index.tsx).
+ */
 export async function createNewNote(parentNote: FNote, e: GeoMouseEvent) {
+    return createNoteAt(parentNote, [ e.latlng.lat, e.latlng.lng ], t("relation_map.default_new_note_title"));
+}
+
+/**
+ * Turns a place found by searching into a note of the map's own, named as the geocoder names it.
+ *
+ * Unlike a note dropped by clicking the map, this one arrives with a name worth keeping, so the
+ * detail pane opens on it as it stands rather than with the title picked out to be typed over (see
+ * `isNew` in DetailPane).
+ */
+export async function createNoteForPlace(parentNote: FNote, place: { name: string; lat: number; lng: number }) {
+    return createNoteAt(parentNote, [ place.lat, place.lng ], place.name);
+}
+
+async function createNoteAt(parentNote: FNote, [ lat, lng ]: [number, number], title: string) {
     const { note } = await note_create.createNote(parentNote.noteId, {
-        title: t("relation_map.default_new_note_title"),
+        title,
         content: "",
         type: "text",
         activate: false,
         isProtected: parentNote.isProtected,
         attributes: [
-            { type: "label", name: LOCATION_ATTRIBUTE, value: [e.latlng.lat, e.latlng.lng].join(",") },
+            { type: "label", name: LOCATION_ATTRIBUTE, value: [ lat, lng ].join(",") },
             { type: "label", name: "iconClass", value: CHILD_NOTE_ICON }
         ]
     });

--- a/apps/client/src/widgets/collections/geomap/geocoding.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * The Nominatim geocoder: the request it makes, what it makes of the answer, and the rate its usage
+ * policy holds it to.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS } from "./geocoding";
+
+vi.mock("../../../services/i18n", () => ({ getCurrentLanguage: () => "pt_br" }));
+
+const provider = GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME];
+
+/** One entry as Nominatim's `jsonv2` answer carries it. */
+function place(overrides: Record<string, unknown> = {}) {
+    return {
+        place_id: 240109189,
+        display_name: "Berlin, Germany",
+        lat: "52.5170365",
+        lon: "13.3888599",
+        ...overrides
+    };
+}
+
+function respondWith(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+    const fetchMock = vi.fn(async (_url: string) => ({
+        ok: init.ok ?? true,
+        status: init.status ?? 200,
+        statusText: "",
+        json: async () => body
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
+
+/** Runs a search, letting the rate limiter's wait elapse rather than sitting through it. */
+async function search(query: string) {
+    const results = provider.search(query);
+    await vi.runAllTimersAsync();
+    return results;
+}
+
+function requestedUrl(fetchMock: ReturnType<typeof respondWith>) {
+    return new URL(fetchMock.mock.calls[0][0]);
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe("Nominatim geocoding", () => {
+    it("asks Nominatim for the query, capped, in the language the app runs in", async () => {
+        const fetchMock = respondWith([]);
+
+        await search("berlin");
+
+        const url = requestedUrl(fetchMock);
+        expect(url.origin + url.pathname).toBe("https://nominatim.openstreetmap.org/search");
+        expect(url.searchParams.get("q")).toBe("berlin");
+        expect(url.searchParams.get("format")).toBe("jsonv2");
+        expect(Number(url.searchParams.get("limit"))).toBeGreaterThan(0);
+        // Written as a language tag rather than as Trilium's own locale id.
+        expect(url.searchParams.get("accept-language")).toBe("pt-br");
+    });
+
+    it("takes the places from the answer, and leaves out any without a readable position", async () => {
+        respondWith([
+            place(),
+            place({ place_id: 2, display_name: "Nowhere", lat: "not a number" }),
+            place({ place_id: 3, display_name: undefined }),
+            place({ place_id: 4, display_name: "Paris, France", lat: "48.8566", lon: "2.3522" })
+        ]);
+
+        expect(await search("anywhere")).toEqual([
+            { id: "240109189", label: "Berlin, Germany", lat: 52.5170365, lng: 13.3888599 },
+            { id: "4", label: "Paris, France", lat: 48.8566, lng: 2.3522 }
+        ]);
+    });
+
+    it("reports a refused request rather than answering with no places", async () => {
+        respondWith([], { ok: false, status: 429 });
+
+        // The expectation is attached before the timers run, so the rejection is never loose.
+        const refused = expect(provider.search("berlin")).rejects.toThrow("429");
+        await vi.runAllTimersAsync();
+        await refused;
+    });
+
+    it("holds searches to the one request a second the usage policy allows", async () => {
+        const requestedAt: number[] = [];
+        vi.stubGlobal("fetch", vi.fn(async () => {
+            requestedAt.push(Date.now());
+            return { ok: true, status: 200, statusText: "", json: async () => [] };
+        }));
+
+        const first = provider.search("berlin");
+        const second = provider.search("paris");
+        await vi.runAllTimersAsync();
+        await Promise.all([ first, second ]);
+
+        expect(requestedAt[1] - requestedAt[0]).toBeGreaterThanOrEqual(1000);
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,3 +1,5 @@
+import { getCurrentLanguage } from "../../../services/i18n";
+
 /** A single place returned by a geocoder. */
 export interface GeoSearchResult {
     /** Unique within one result set. */
@@ -11,55 +13,112 @@ export interface GeoSearchResult {
 export interface GeocodingProvider {
     /** Display name, shown where the user picks a provider. */
     name: string;
-    /** Returns matches, best first, or an empty array when nothing matches. */
+    /**
+     * Returns matches, best first, or an empty array when nothing matches. Throws when the provider
+     * cannot be reached or refuses the request.
+     */
     search(query: string): Promise<GeoSearchResult[]>;
 }
 
 /**
  * The geocoders a map can search, keyed by the name a note selects one by.
  *
- * Same shape as `MAP_LAYERS` in map_layer.ts, so both are read the same way. Only the dummy provider
- * exists so far; a real one is a new entry here.
+ * Same shape as `MAP_LAYERS` in map_layer.ts, so both are read the same way.
  */
 export const GEOCODING_PROVIDERS: Record<string, GeocodingProvider> = {
-    "dummy": {
-        name: "Dummy",
-        search: searchDummyPlaces
+    "nominatim": {
+        name: "Nominatim (OpenStreetMap)",
+        search: searchNominatim
     }
 };
 
-export const DEFAULT_GEOCODING_PROVIDER_NAME: keyof typeof GEOCODING_PROVIDERS = "dummy";
+export const DEFAULT_GEOCODING_PROVIDER_NAME: keyof typeof GEOCODING_PROVIDERS = "nominatim";
 
-/** The places `searchDummyPlaces()` matches against. */
-const DUMMY_PLACES: GeoSearchResult[] = [
-    { id: "dummy-amsterdam", label: "Amsterdam, Netherlands", lat: 52.3676, lng: 4.9041 },
-    { id: "dummy-berlin", label: "Berlin, Germany", lat: 52.52, lng: 13.405 },
-    { id: "dummy-bucharest", label: "Bucharest, Romania", lat: 44.4268, lng: 26.1025 },
-    { id: "dummy-cluj", label: "Cluj-Napoca, Cluj, Romania", lat: 46.7712, lng: 23.6236 },
-    { id: "dummy-lisbon", label: "Lisbon, Portugal", lat: 38.7223, lng: -9.1393 },
-    { id: "dummy-london", label: "London, England, United Kingdom", lat: 51.5072, lng: -0.1276 },
-    { id: "dummy-london-on", label: "London, Ontario, Canada", lat: 42.9849, lng: -81.2453 },
-    { id: "dummy-new-york", label: "New York, New York, United States", lat: 40.7128, lng: -74.006 },
-    { id: "dummy-paris", label: "Paris, Île-de-France, France", lat: 48.8566, lng: 2.3522 },
-    { id: "dummy-reykjavik", label: "Reykjavík, Iceland", lat: 64.1466, lng: -21.9426 },
-    { id: "dummy-sydney", label: "Sydney, New South Wales, Australia", lat: -33.8688, lng: 151.2093 },
-    { id: "dummy-tokyo", label: "Tokyo, Japan", lat: 35.6762, lng: 139.6503 }
-];
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 
 /** Caps how many results one search returns. */
 const MAX_RESULTS = 8;
 
 /**
- * Matches `DUMMY_PLACES` by substring, so the search bar works before a real geocoder is wired up.
- * Async like a real provider, so callers cannot depend on results arriving in the same tick.
+ * Nominatim's usage policy allows at most one request per second, and blocks clients that exceed it.
+ * See https://operations.osmfoundation.org/policies/nominatim/.
  */
-async function searchDummyPlaces(query: string): Promise<GeoSearchResult[]> {
-    const needle = query.trim().toLowerCase();
-    if (!needle) {
-        return [];
+const MIN_REQUEST_INTERVAL = 1000;
+
+/** When the next request is allowed to go out, moved forward by every request that is queued. */
+let nextRequestAt = 0;
+
+/**
+ * Looks a query up through Nominatim, the geocoder run by the OpenStreetMap Foundation.
+ *
+ * No API key, and it answers with `Access-Control-Allow-Origin: *`, so the browser can ask it
+ * directly — which matters on desktop, where the page is served from `trilium-app://`. Its policy
+ * also asks that clients identify themselves, which a browser can only do through the `Referer` it
+ * sends of its own accord.
+ *
+ * The same policy rules out searching as the user types, which is why a search runs only when the
+ * user asks for one (see SearchBox).
+ */
+async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
+    const params = new URLSearchParams({
+        q: query,
+        format: "jsonv2",
+        limit: String(MAX_RESULTS)
+    });
+
+    // Place names in the language the app runs in, where Nominatim holds one. Trilium writes some
+    // locale ids with an underscore (`pt_br`), which is not what a language tag looks like.
+    const language = getCurrentLanguage();
+    if (language) {
+        params.set("accept-language", language.replace("_", "-"));
     }
 
-    return DUMMY_PLACES
-        .filter((place) => place.label.toLowerCase().includes(needle))
-        .slice(0, MAX_RESULTS);
+    await waitForRequestSlot();
+    const response = await fetch(`${NOMINATIM_URL}?${params}`);
+    if (!response.ok) {
+        throw new Error(`Nominatim answered ${response.status} ${response.statusText}`);
+    }
+
+    const places: NominatimPlace[] = await response.json();
+    return places.map(toSearchResult).filter((result) => result !== null);
+}
+
+/** One entry of a Nominatim `jsonv2` response, narrowed to the fields a result is built from. */
+interface NominatimPlace {
+    place_id?: number;
+    display_name?: string;
+    lat?: string;
+    lon?: string;
+}
+
+/** A place as the app holds one, or `null` where the entry carries no readable position. */
+function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
+    const lat = Number(place.lat);
+    const lng = Number(place.lon);
+    if (!place.display_name || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+        return null;
+    }
+
+    return {
+        id: String(place.place_id ?? `${lat},${lng}`),
+        label: place.display_name,
+        lat,
+        lng
+    };
+}
+
+/**
+ * Holds a request back until the interval the policy asks for has passed since the last one.
+ *
+ * The slot is claimed before the wait rather than after it, so two searches started at once queue
+ * behind each other instead of both finding the same slot free.
+ */
+async function waitForRequestSlot() {
+    const now = Date.now();
+    const slot = Math.max(now, nextRequestAt);
+    nextRequestAt = slot + MIN_REQUEST_INTERVAL;
+
+    if (slot > now) {
+        await new Promise((resolve) => setTimeout(resolve, slot - now));
+    }
 }

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -10,6 +10,12 @@ export interface GeoSearchResult {
     name: string;
     lat: number;
     lng: number;
+    /**
+     * What the place covers, as `[[west, south], [east, north]]`, where the geocoder says. A street
+     * and the city around it are told apart by their extent rather than by one zoom level guessed
+     * for both.
+     */
+    bounds?: [[number, number], [number, number]];
 }
 
 export interface GeocodingProvider {

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,5 +1,19 @@
 import { nominatim } from "./nominatim";
 
+/** A rectangle of ground, as `[[west, south], [east, north]]`. */
+export type GeoBounds = [[number, number], [number, number]];
+
+export interface GeoSearchOptions {
+    /**
+     * What the map is showing. A place inside it is preferred to one of the same name elsewhere —
+     * searching for a shop while looking at Corfu should not answer with the branch in Finland.
+     *
+     * A preference rather than a restriction: the only match for a query is worth offering wherever
+     * it stands.
+     */
+    viewport?: GeoBounds;
+}
+
 /** A single place returned by a geocoder. */
 export interface GeoSearchResult {
     /** Unique within one result set. */
@@ -11,11 +25,10 @@ export interface GeoSearchResult {
     lat: number;
     lng: number;
     /**
-     * What the place covers, as `[[west, south], [east, north]]`, where the geocoder says. A street
-     * and the city around it are told apart by their extent rather than by one zoom level guessed
-     * for both.
+     * What the place covers, where the geocoder says. A street and the city around it are told apart
+     * by their extent rather than by one zoom level guessed for both.
      */
-    bounds?: [[number, number], [number, number]];
+    bounds?: GeoBounds;
     /**
      * Fetches the boundary of the place — a country's coastline, a county's border — or `null` where
      * it has none worth drawing. Absent where the provider cannot supply one at all.
@@ -33,7 +46,7 @@ export interface GeocodingProvider {
      * Returns matches, best first, or an empty array when nothing matches. Throws when the provider
      * cannot be reached or refuses the request.
      */
-    search(query: string): Promise<GeoSearchResult[]>;
+    search(query: string, options?: GeoSearchOptions): Promise<GeoSearchResult[]>;
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -59,8 +59,11 @@ export interface GeoSearchResult {
      *
      * A call rather than a value, so the boundary is asked for only once a place has been picked: a
      * search returns several places and at most one of them is ever looked at.
+     *
+     * A lookup given up on through `signal` answers `null` and gives up its place in the provider's
+     * request queue, so what is asked for next is not held behind it.
      */
-    outline?: () => Promise<GeoJSON.Geometry | null>;
+    outline?: (signal?: AbortSignal) => Promise<GeoJSON.Geometry | null>;
 }
 
 export interface GeocodingProvider {

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,5 +1,15 @@
 import { nominatim } from "./nominatim";
 
+/**
+ * How much ground counts as here: what a search treats as the area around the reader, and what a
+ * result is called nearby for standing within.
+ *
+ * A map zoomed into a neighbourhood shows a few hundred metres across, and a search restricted to
+ * exactly that answers nothing for a shop three streets away. What the reader means by searching from
+ * where they are standing is the town they are looking at, not the block.
+ */
+export const SEARCH_RADIUS_M = 25_000;
+
 /** A rectangle of ground, as `[[west, south], [east, north]]`. */
 export type GeoBounds = [[number, number], [number, number]];
 

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -6,6 +6,8 @@ export interface GeoSearchResult {
     id: string;
     /** Display text, with enough context to tell two places of the same name apart. */
     label: string;
+    /** The place's own name, for labelling it on the map where the full label would be a paragraph. */
+    name: string;
     lat: number;
     lng: number;
 }

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -16,6 +16,14 @@ export interface GeoSearchResult {
      * for both.
      */
     bounds?: [[number, number], [number, number]];
+    /**
+     * Fetches the boundary of the place — a country's coastline, a county's border — or `null` where
+     * it has none worth drawing. Absent where the provider cannot supply one at all.
+     *
+     * A call rather than a value, so the boundary is asked for only once a place has been picked: a
+     * search returns several places and at most one of them is ever looked at.
+     */
+    outline?: () => Promise<GeoJSON.Geometry | null>;
 }
 
 export interface GeocodingProvider {

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,4 +1,4 @@
-import { getCurrentLanguage } from "../../../services/i18n";
+import { nominatim } from "./nominatim";
 
 /** A single place returned by a geocoder. */
 export interface GeoSearchResult {
@@ -26,99 +26,7 @@ export interface GeocodingProvider {
  * Same shape as `MAP_LAYERS` in map_layer.ts, so both are read the same way.
  */
 export const GEOCODING_PROVIDERS: Record<string, GeocodingProvider> = {
-    "nominatim": {
-        name: "Nominatim (OpenStreetMap)",
-        search: searchNominatim
-    }
+    "nominatim": nominatim
 };
 
 export const DEFAULT_GEOCODING_PROVIDER_NAME: keyof typeof GEOCODING_PROVIDERS = "nominatim";
-
-const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
-
-/** Caps how many results one search returns. */
-const MAX_RESULTS = 8;
-
-/**
- * Nominatim's usage policy allows at most one request per second, and blocks clients that exceed it.
- * See https://operations.osmfoundation.org/policies/nominatim/.
- */
-const MIN_REQUEST_INTERVAL = 1000;
-
-/** When the next request is allowed to go out, moved forward by every request that is queued. */
-let nextRequestAt = 0;
-
-/**
- * Looks a query up through Nominatim, the geocoder run by the OpenStreetMap Foundation.
- *
- * No API key, and it answers with `Access-Control-Allow-Origin: *`, so the browser can ask it
- * directly — which matters on desktop, where the page is served from `trilium-app://`. Its policy
- * also asks that clients identify themselves, which a browser can only do through the `Referer` it
- * sends of its own accord.
- *
- * The same policy rules out searching as the user types, which is why a search runs only when the
- * user asks for one (see SearchBox).
- */
-async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
-    const params = new URLSearchParams({
-        q: query,
-        format: "jsonv2",
-        limit: String(MAX_RESULTS)
-    });
-
-    // Place names in the language the app runs in, where Nominatim holds one. Trilium writes some
-    // locale ids with an underscore (`pt_br`), which is not what a language tag looks like.
-    const language = getCurrentLanguage();
-    if (language) {
-        params.set("accept-language", language.replace("_", "-"));
-    }
-
-    await waitForRequestSlot();
-    const response = await fetch(`${NOMINATIM_URL}?${params}`);
-    if (!response.ok) {
-        throw new Error(`Nominatim answered ${response.status} ${response.statusText}`);
-    }
-
-    const places: NominatimPlace[] = await response.json();
-    return places.map(toSearchResult).filter((result) => result !== null);
-}
-
-/** One entry of a Nominatim `jsonv2` response, narrowed to the fields a result is built from. */
-interface NominatimPlace {
-    place_id?: number;
-    display_name?: string;
-    lat?: string;
-    lon?: string;
-}
-
-/** A place as the app holds one, or `null` where the entry carries no readable position. */
-function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
-    const lat = Number(place.lat);
-    const lng = Number(place.lon);
-    if (!place.display_name || !Number.isFinite(lat) || !Number.isFinite(lng)) {
-        return null;
-    }
-
-    return {
-        id: String(place.place_id ?? `${lat},${lng}`),
-        label: place.display_name,
-        lat,
-        lng
-    };
-}
-
-/**
- * Holds a request back until the interval the policy asks for has passed since the last one.
- *
- * The slot is claimed before the wait rather than after it, so two searches started at once queue
- * behind each other instead of both finding the same slot free.
- */
-async function waitForRequestSlot() {
-    const now = Date.now();
-    const slot = Math.max(now, nextRequestAt);
-    nextRequestAt = slot + MIN_REQUEST_INTERVAL;
-
-    if (slot > now) {
-        await new Promise((resolve) => setTimeout(resolve, slot - now));
-    }
-}

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -24,6 +24,9 @@ export interface GeoSearchOptions {
     viewport?: GeoBounds;
 }
 
+/** The icon for a place whose kind the geocoder says nothing about. */
+export const DEFAULT_PLACE_ICON = "bx bx-map-pin";
+
 /** A single place returned by a geocoder. */
 export interface GeoSearchResult {
     /** Unique within one result set. */
@@ -32,6 +35,11 @@ export interface GeoSearchResult {
     label: string;
     /** The place's own name, for labelling it on the map where the full label would be a paragraph. */
     name: string;
+    /**
+     * A boxicons class saying what kind of place it is, as `FNote.getIcon()` gives one — a cart for a
+     * supermarket, a flag for a country. Absent where the provider says nothing about the kind.
+     */
+    icon?: string;
     lat: number;
     lng: number;
     /**

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,0 +1,65 @@
+/** A single place returned by a geocoder. */
+export interface GeoSearchResult {
+    /** Unique within one result set. */
+    id: string;
+    /** Display text, with enough context to tell two places of the same name apart. */
+    label: string;
+    lat: number;
+    lng: number;
+}
+
+export interface GeocodingProvider {
+    /** Display name, shown where the user picks a provider. */
+    name: string;
+    /** Returns matches, best first, or an empty array when nothing matches. */
+    search(query: string): Promise<GeoSearchResult[]>;
+}
+
+/**
+ * The geocoders a map can search, keyed by the name a note selects one by.
+ *
+ * Same shape as `MAP_LAYERS` in map_layer.ts, so both are read the same way. Only the dummy provider
+ * exists so far; a real one is a new entry here.
+ */
+export const GEOCODING_PROVIDERS: Record<string, GeocodingProvider> = {
+    "dummy": {
+        name: "Dummy",
+        search: searchDummyPlaces
+    }
+};
+
+export const DEFAULT_GEOCODING_PROVIDER_NAME: keyof typeof GEOCODING_PROVIDERS = "dummy";
+
+/** The places `searchDummyPlaces()` matches against. */
+const DUMMY_PLACES: GeoSearchResult[] = [
+    { id: "dummy-amsterdam", label: "Amsterdam, Netherlands", lat: 52.3676, lng: 4.9041 },
+    { id: "dummy-berlin", label: "Berlin, Germany", lat: 52.52, lng: 13.405 },
+    { id: "dummy-bucharest", label: "Bucharest, Romania", lat: 44.4268, lng: 26.1025 },
+    { id: "dummy-cluj", label: "Cluj-Napoca, Cluj, Romania", lat: 46.7712, lng: 23.6236 },
+    { id: "dummy-lisbon", label: "Lisbon, Portugal", lat: 38.7223, lng: -9.1393 },
+    { id: "dummy-london", label: "London, England, United Kingdom", lat: 51.5072, lng: -0.1276 },
+    { id: "dummy-london-on", label: "London, Ontario, Canada", lat: 42.9849, lng: -81.2453 },
+    { id: "dummy-new-york", label: "New York, New York, United States", lat: 40.7128, lng: -74.006 },
+    { id: "dummy-paris", label: "Paris, Île-de-France, France", lat: 48.8566, lng: 2.3522 },
+    { id: "dummy-reykjavik", label: "Reykjavík, Iceland", lat: 64.1466, lng: -21.9426 },
+    { id: "dummy-sydney", label: "Sydney, New South Wales, Australia", lat: -33.8688, lng: 151.2093 },
+    { id: "dummy-tokyo", label: "Tokyo, Japan", lat: 35.6762, lng: 139.6503 }
+];
+
+/** Caps how many results one search returns. */
+const MAX_RESULTS = 8;
+
+/**
+ * Matches `DUMMY_PLACES` by substring, so the search bar works before a real geocoder is wired up.
+ * Async like a real provider, so callers cannot depend on results arriving in the same tick.
+ */
+async function searchDummyPlaces(query: string): Promise<GeoSearchResult[]> {
+    const needle = query.trim().toLowerCase();
+    if (!needle) {
+        return [];
+    }
+
+    return DUMMY_PLACES
+        .filter((place) => place.label.toLowerCase().includes(needle))
+        .slice(0, MAX_RESULTS);
+}

--- a/apps/client/src/widgets/collections/geomap/geocoding.ts
+++ b/apps/client/src/widgets/collections/geomap/geocoding.ts
@@ -1,4 +1,5 @@
 import { nominatim } from "./nominatim";
+import type { PlaceAddress } from "./place_address";
 
 /**
  * How much ground counts as here: what a search treats as the area around the reader, and what a
@@ -42,6 +43,11 @@ export interface GeoSearchResult {
     icon?: string;
     lat: number;
     lng: number;
+    /**
+     * Where the place stands, in parts, for naming it and for saying where it is without reciting the
+     * whole label. Absent where the provider breaks an address into nothing.
+     */
+    address?: PlaceAddress;
     /**
      * What the place covers, where the geocoder says. A street and the city around it are told apart
      * by their extent rather than by one zoom level guessed for both.

--- a/apps/client/src/widgets/collections/geomap/index.css
+++ b/apps/client/src/widgets/collections/geomap/index.css
@@ -51,6 +51,11 @@
      navigator placed from it (see ResultNavigator.css). Overridden for mobile below. */
   --geo-map-search-top: var(--geo-map-inset-top);
 
+  /* Where the foot of the map stops anything reaching down towards it: the room kept from the
+     bottom, the height of the bars standing there (MapToolbar, EditToolbar), and as much air again.
+     Read by the detail pane and by the place panel on mobile. */
+  --geo-map-foot: calc(var(--geo-map-inset-bottom) + var(--geo-map-toolbar-height) + var(--geo-map-inset));
+
   /*
    * What everything standing over the map is dressed in — our own control groups and MapLibre's
    * scale and attribution alike, so that they read as one set rather than as ours beside theirs.

--- a/apps/client/src/widgets/collections/geomap/index.css
+++ b/apps/client/src/widgets/collections/geomap/index.css
@@ -47,6 +47,10 @@
      height where no theme names one. */
   --geo-map-toolbar-height: var(--overlay-button-height, 28px);
 
+  /* Where the head of the leading column stands: the search bar (see SearchBox.css) and the result
+     navigator placed from it (see ResultNavigator.css). Overridden for mobile below. */
+  --geo-map-search-top: var(--geo-map-inset-top);
+
   /*
    * What everything standing over the map is dressed in — our own control groups and MapLibre's
    * scale and attribution alike, so that they read as one set rather than as ours beside theirs.
@@ -95,6 +99,12 @@
     margin-left: var(--geo-map-inset-left);
     margin-right: var(--geo-map-inset-right);
   }
+}
+
+/* On mobile the attribution takes the top leading corner (see map.tsx), so the column starts below
+   it: the room kept from the top, the attribution's own height, and as much air again. */
+body.mobile .geo-map-container {
+  --geo-map-search-top: calc(var(--geo-map-inset-top) * 2 + var(--geo-map-toolbar-height));
 }
 
 /* Read the other way round, the trailing corner is the left one. Only which side is which changes;

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -244,7 +244,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 onClick={onClick}
                 scale={hasScale}
             >
-                <SearchBox />
+                <SearchBox notes={notes} />
                 <MapToolbar />
                 <EditToolbar
                     isReadOnly={isReadOnly}

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -244,7 +244,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 onClick={onClick}
                 scale={hasScale}
             >
-                <SearchBox notes={notes} />
+                <SearchBox notes={notes} isDarkTheme={layerData.isDarkTheme ?? false} />
                 <MapToolbar />
                 <EditToolbar
                     isReadOnly={isReadOnly}

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -305,7 +305,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 <SearchBox notes={notes} onPickPlace={pickPlace} />
                 {pickedPlace && placeCenter && <>
                     <PlaceMarker
-                        center={placeCenter} name={pickedPlace.name}
+                        center={placeCenter} name={pickedPlace.name} icon={pickedPlace.icon}
                         outline={placeOutline} isDarkTheme={layerData.isDarkTheme ?? false}
                     />
                     <PlacePanel

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -23,6 +23,7 @@ import Map, { DEFAULT_ZOOM, GeoMouseEvent } from "./map";
 import { DEFAULT_MAP_LAYER_NAME, MAP_LAYERS, MapLayer } from "./map_layer";
 import MapToolbar from "./MapToolbar";
 import Markers, { DEFAULT_MARKER_COLOR, LOCATION_ATTRIBUTE } from "./Markers";
+import SearchBox from "./SearchBox";
 import Tooltips from "./Tooltips";
 
 const DEFAULT_COORDINATES: [number, number] = [3.878638227135724, 446.6630455551659];
@@ -243,6 +244,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 onClick={onClick}
                 scale={hasScale}
             >
+                <SearchBox />
                 <MapToolbar />
                 <EditToolbar
                     isReadOnly={isReadOnly}

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -27,6 +27,8 @@ import type { GeoSearchResult } from "./geocoding";
 import Markers, { DEFAULT_MARKER_COLOR, LOCATION_ATTRIBUTE } from "./Markers";
 import PlaceMarker from "./PlaceMarker";
 import PlacePanel from "./PlacePanel";
+import ResultNavigator from "./ResultNavigator";
+import type { SearchResult } from "./results";
 import SearchBox from "./SearchBox";
 import Tooltips from "./Tooltips";
 
@@ -71,6 +73,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // map is currently standing on, and both are shown in the same corner.
     const [ pickedPlace, setPickedPlace ] = useState<GeoSearchResult>();
     const [ placeOutline, setPlaceOutline ] = useState<GeoJSON.Geometry>();
+    // What the last search offered and which of it the map stands on, so the rest can be stepped
+    // through once the list has stood down (see ResultNavigator).
+    const [ walk, setWalk ] = useState<{ results: SearchResult[]; index: number }>();
     // Which pick the map stands on, so a boundary arriving after a later one is dropped rather than
     // drawn around whatever took its place.
     const latestPlacePick = useRef(0);
@@ -142,6 +147,30 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 }
             })
             .catch((e) => logError(`Fetching the boundary of "${place.label}" failed: ${e}`));
+    }, []);
+
+    /**
+     * Stands the map on one of a search's results: a place under a pin of its own, or a note of the
+     * map's own in the detail pane. Where the map is pointed is the caller's, which is the one thing
+     * that differs between taking a result from the list and stepping onto it.
+     */
+    const showResult = useCallback((results: SearchResult[], index: number) => {
+        setWalk({ results, index });
+
+        const result = results[index];
+        if (result.kind === "place") {
+            pickPlace(result.place);
+        } else {
+            selectNote({ noteId: result.noteId });
+        }
+    }, [ pickPlace, selectNote ]);
+
+    /** Takes the search off the map altogether: what it was standing on, and the rest it offered. */
+    const clearSearch = useCallback(() => {
+        latestPlacePick.current++;
+        setWalk(undefined);
+        setPickedPlace(undefined);
+        setPlaceOutline(undefined);
     }, []);
 
     /** Keeps the place the map stands on as a note of its own, which is what turns its pin into a
@@ -302,7 +331,14 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 onClick={onClick}
                 scale={hasScale}
             >
-                <SearchBox notes={notes} onPickPlace={pickPlace} />
+                <SearchBox
+                    notes={notes}
+                    onPickResult={(picked) => picked ? showResult(picked.results, picked.index) : clearSearch()}
+                />
+                {walk && <ResultNavigator
+                    results={walk.results} index={walk.index}
+                    onStep={(index) => showResult(walk.results, index)}
+                />}
                 {pickedPlace && placeCenter && <>
                     <PlaceMarker
                         center={placeCenter} name={pickedPlace.name} icon={pickedPlace.icon}

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -86,6 +86,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // drawn around whatever took its place.
     const latestPlacePick = useRef(0);
     const outlineTimer = useRef<ReturnType<typeof setTimeout>>();
+    // Gives up a boundary lookup already under way, which hands back its place in the geocoder's
+    // request queue: the next search would otherwise wait out a boundary nobody is looking at.
+    const outlineRequest = useRef<AbortController>();
     // Held still between renders: the pin's layer is rebuilt whenever it is handed a different one,
     // and an array literal is different every time (see PlaceMarker).
     const placeCenter = useMemo<[number, number] | null>(
@@ -130,12 +133,16 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     const forgetPlace = useCallback(() => {
         latestPlacePick.current++;
         clearTimeout(outlineTimer.current);
+        outlineRequest.current?.abort();
         setPickedPlace(undefined);
         setPlaceOutline(undefined);
     }, []);
 
     // Nothing is left waiting to be fetched for a map that is no longer on the screen.
-    useEffect(() => () => clearTimeout(outlineTimer.current), []);
+    useEffect(() => () => {
+        clearTimeout(outlineTimer.current);
+        outlineRequest.current?.abort();
+    }, []);
 
     /** Opens the pane on a note, which sends away the searched place the panel would otherwise share
      *  a corner with. */
@@ -151,6 +158,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     const pickPlace = useCallback((place: GeoSearchResult | null) => {
         const pickId = ++latestPlacePick.current;
         clearTimeout(outlineTimer.current);
+        outlineRequest.current?.abort();
         setPickedPlace(place ?? undefined);
         setPlaceOutline(undefined);
         if (place) {
@@ -164,7 +172,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
         // pass. The geocoder answers one request a second and the searches queue behind the same
         // count, so a boundary nobody waited to see would be waited out by the next search.
         outlineTimer.current = setTimeout(() => {
-            fetchOutline()
+            const request = new AbortController();
+            outlineRequest.current = request;
+            fetchOutline(request.signal)
                 .then((outline) => {
                     if (outline && latestPlacePick.current === pickId) {
                         setPlaceOutline(outline);

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -8,8 +8,8 @@ import branches from "../../../services/branches";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
 import server from "../../../services/server";
-import { logError } from "../../../services/ws";
 import toast from "../../../services/toast";
+import { logError } from "../../../services/ws";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import { useCollectionTreeDrag, useEffectiveReadOnly, useNoteBlob, useNoteContext, useNoteLabel, useNoteLabelBoolean, useNoteProperty, useSpacedUpdate } from "../../react/hooks";
 import { ViewModeProps } from "../interface";
@@ -40,6 +40,12 @@ const DEFAULT_COORDINATES: [number, number] = [3.878638227135724, 446.6630455551
  * rewrites that toast rather than stacking a second one under it.
  */
 const PLACEMENT_TOAST_ID = "geo-placement";
+
+/**
+ * How long a place is stood on before its boundary is asked for. Long enough that stepping through
+ * results asks for nothing on the way past, short enough not to be waited on once the stepping stops.
+ */
+const OUTLINE_DELAY_MS = 250;
 
 export { LOCATION_ATTRIBUTE };
 
@@ -79,6 +85,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // Which pick the map stands on, so a boundary arriving after a later one is dropped rather than
     // drawn around whatever took its place.
     const latestPlacePick = useRef(0);
+    const outlineTimer = useRef<ReturnType<typeof setTimeout>>();
     // Held still between renders: the pin's layer is rebuilt whenever it is handed a different one,
     // and an array literal is different every time (see PlaceMarker).
     const placeCenter = useMemo<[number, number] | null>(
@@ -119,34 +126,52 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // pressing it again is the visible way out of it — the counterpart of the toast's Escape. It
     // also takes over a map armed to move a marker, a press on + saying what the next click is for
     // more plainly than whatever was armed before.
+    /** Forgets the place the map was standing on, and whatever was still to be fetched for it. */
+    const forgetPlace = useCallback(() => {
+        latestPlacePick.current++;
+        clearTimeout(outlineTimer.current);
+        setPickedPlace(undefined);
+        setPlaceOutline(undefined);
+    }, []);
+
+    // Nothing is left waiting to be fetched for a map that is no longer on the screen.
+    useEffect(() => () => clearTimeout(outlineTimer.current), []);
+
     /** Opens the pane on a note, which sends away the searched place the panel would otherwise share
      *  a corner with. */
     const selectNote = useCallback((next: PaneSelection | null) => {
         setSelection(next);
         if (next) {
-            latestPlacePick.current++;
-            setPickedPlace(undefined);
-            setPlaceOutline(undefined);
+            forgetPlace();
         }
-    }, []);
+    }, [ forgetPlace ]);
 
     /** Stands the map on a place found by searching, and fetches the ground it covers where it covers
      *  any (see PlaceMarker). */
     const pickPlace = useCallback((place: GeoSearchResult | null) => {
         const pickId = ++latestPlacePick.current;
+        clearTimeout(outlineTimer.current);
         setPickedPlace(place ?? undefined);
         setPlaceOutline(undefined);
         if (place) {
             setSelection(null);
         }
 
-        place?.outline?.()
-            .then((outline) => {
-                if (outline && latestPlacePick.current === pickId) {
-                    setPlaceOutline(outline);
-                }
-            })
-            .catch((e) => logError(`Fetching the boundary of "${place.label}" failed: ${e}`));
+        const fetchOutline = place?.outline;
+        if (!fetchOutline) return;
+
+        // Held back until the reader has settled on a place rather than fetched for each one they
+        // pass. The geocoder answers one request a second and the searches queue behind the same
+        // count, so a boundary nobody waited to see would be waited out by the next search.
+        outlineTimer.current = setTimeout(() => {
+            fetchOutline()
+                .then((outline) => {
+                    if (outline && latestPlacePick.current === pickId) {
+                        setPlaceOutline(outline);
+                    }
+                })
+                .catch((e) => logError(`Fetching the boundary of "${place.label}" failed: ${e}`));
+        }, OUTLINE_DELAY_MS);
     }, []);
 
     /**
@@ -167,11 +192,9 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
 
     /** Takes the search off the map altogether: what it was standing on, and the rest it offered. */
     const clearSearch = useCallback(() => {
-        latestPlacePick.current++;
         setWalk(undefined);
-        setPickedPlace(undefined);
-        setPlaceOutline(undefined);
-    }, []);
+        forgetPlace();
+    }, [ forgetPlace ]);
 
     /** Keeps the place the map stands on as a note of its own, which is what turns its pin into a
      *  marker; the pane then opens on the note as any other newly created one. */

--- a/apps/client/src/widgets/collections/geomap/index.tsx
+++ b/apps/client/src/widgets/collections/geomap/index.tsx
@@ -8,11 +8,12 @@ import branches from "../../../services/branches";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
 import server from "../../../services/server";
+import { logError } from "../../../services/ws";
 import toast from "../../../services/toast";
 import CollectionProperties from "../../note_bars/CollectionProperties";
 import { useCollectionTreeDrag, useEffectiveReadOnly, useNoteBlob, useNoteContext, useNoteLabel, useNoteLabelBoolean, useNoteProperty, useSpacedUpdate } from "../../react/hooks";
 import { ViewModeProps } from "../interface";
-import { createNewNote, importGpxTrack, moveMarker } from "./api";
+import { createNewNote, createNoteForPlace, importGpxTrack, moveMarker } from "./api";
 import Buildings from "./Buildings";
 import ContextMenus from "./ContextMenus";
 import DetailPane, { PaneSelection } from "./DetailPane";
@@ -22,7 +23,10 @@ import { GPX_MIME, GpxTrack } from "./GpxTrack";
 import Map, { DEFAULT_ZOOM, GeoMouseEvent } from "./map";
 import { DEFAULT_MAP_LAYER_NAME, MAP_LAYERS, MapLayer } from "./map_layer";
 import MapToolbar from "./MapToolbar";
+import type { GeoSearchResult } from "./geocoding";
 import Markers, { DEFAULT_MARKER_COLOR, LOCATION_ATTRIBUTE } from "./Markers";
+import PlaceMarker from "./PlaceMarker";
+import PlacePanel from "./PlacePanel";
 import SearchBox from "./SearchBox";
 import Tooltips from "./Tooltips";
 
@@ -62,6 +66,18 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // Which marker the detail pane stands for. Held here rather than in the pane so that creating a
     // note can open the pane on it (see createNoteAt below).
     const [ selection, setSelection ] = useState<PaneSelection | null>(null);
+    // The place taken from the search, standing on the map under a pin of its own until it is kept as
+    // a note or dismissed. It and the selection above are one state between them: both are what the
+    // map is currently standing on, and both are shown in the same corner.
+    const [ pickedPlace, setPickedPlace ] = useState<GeoSearchResult>();
+    const [ placeOutline, setPlaceOutline ] = useState<GeoJSON.Geometry>();
+    // Which pick the map stands on, so a boundary arriving after a later one is dropped rather than
+    // drawn around whatever took its place.
+    const latestPlacePick = useRef(0);
+    // Held still between renders: the pin's layer is rebuilt whenever it is handed a different one,
+    // and an array literal is different every time (see PlaceMarker).
+    const placeCenter = useMemo<[number, number] | null>(
+        () => pickedPlace ? [ pickedPlace.lng, pickedPlace.lat ] : null, [ pickedPlace ]);
     // Whether that pane has been grown over the map. Held here for the reason the selection is: what
     // the map places around the pane has to know of it too (see the maximized pane in DetailPane).
     const [ paneMaximized, setPaneMaximized ] = useState(false);
@@ -98,6 +114,48 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
     // pressing it again is the visible way out of it — the counterpart of the toast's Escape. It
     // also takes over a map armed to move a marker, a press on + saying what the next click is for
     // more plainly than whatever was armed before.
+    /** Opens the pane on a note, which sends away the searched place the panel would otherwise share
+     *  a corner with. */
+    const selectNote = useCallback((next: PaneSelection | null) => {
+        setSelection(next);
+        if (next) {
+            latestPlacePick.current++;
+            setPickedPlace(undefined);
+            setPlaceOutline(undefined);
+        }
+    }, []);
+
+    /** Stands the map on a place found by searching, and fetches the ground it covers where it covers
+     *  any (see PlaceMarker). */
+    const pickPlace = useCallback((place: GeoSearchResult | null) => {
+        const pickId = ++latestPlacePick.current;
+        setPickedPlace(place ?? undefined);
+        setPlaceOutline(undefined);
+        if (place) {
+            setSelection(null);
+        }
+
+        place?.outline?.()
+            .then((outline) => {
+                if (outline && latestPlacePick.current === pickId) {
+                    setPlaceOutline(outline);
+                }
+            })
+            .catch((e) => logError(`Fetching the boundary of "${place.label}" failed: ${e}`));
+    }, []);
+
+    /** Keeps the place the map stands on as a note of its own, which is what turns its pin into a
+     *  marker; the pane then opens on the note as any other newly created one. */
+    const keepPlaceAsMarker = useCallback(async () => {
+        if (!pickedPlace) return;
+
+        const created = await createNoteForPlace(note, pickedPlace);
+        if (!created) return;
+
+        setNotes((current) => current.some((n) => n.noteId === created.noteId) ? current : [ ...current, created ]);
+        selectNote({ noteId: created.noteId });
+    }, [ note, pickedPlace, selectNote ]);
+
     const toggleNotePlacement = useCallback(() => {
         setPlacement((current) => current?.mode === "new" ? undefined : { mode: "new" });
     }, []);
@@ -118,7 +176,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
         if (!created) return;
 
         setNotes((current) => current.some((n) => n.noteId === created.noteId) ? current : [ ...current, created ]);
-        setSelection({ noteId: created.noteId, isNew: true });
+        selectNote({ noteId: created.noteId, isNew: true });
     }, [ note ]);
 
     /**
@@ -139,7 +197,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
         if (!created) return;
 
         setNotes((current) => current.some((n) => n.noteId === created.noteId) ? current : [ ...current, created ]);
-        setSelection({ noteId: created.noteId });
+        selectNote({ noteId: created.noteId });
     }, [ note ]);
 
     // Placement mode is armed by the button or by the context menu. Tying the instruction toast and
@@ -244,7 +302,17 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 onClick={onClick}
                 scale={hasScale}
             >
-                <SearchBox notes={notes} isDarkTheme={layerData.isDarkTheme ?? false} />
+                <SearchBox notes={notes} onPickPlace={pickPlace} />
+                {pickedPlace && placeCenter && <>
+                    <PlaceMarker
+                        center={placeCenter} name={pickedPlace.name}
+                        outline={placeOutline} isDarkTheme={layerData.isDarkTheme ?? false}
+                    />
+                    <PlacePanel
+                        place={pickedPlace} isReadOnly={isReadOnly}
+                        onAddMarker={keepPlaceAsMarker} onClose={() => pickPlace(null)}
+                    />
+                </>}
                 <MapToolbar />
                 <EditToolbar
                     isReadOnly={isReadOnly}
@@ -259,7 +327,7 @@ export default function GeoView({ note, noteIds, viewConfig, saveConfig }: ViewM
                 {placement && <GhostPin note={placement.mode === "move" ? notes.find((n) => n.noteId === placement.noteId) : undefined} />}
                 <DetailPane
                     notes={notes} parentNote={note} placing={!!placement} isReadOnly={isReadOnly}
-                    selection={selection} onSelect={setSelection} onRelocate={startMarkerRelocation}
+                    selection={selection} onSelect={selectNote} onRelocate={startMarkerRelocation}
                     maximized={paneMaximized} onMaximizedChange={setPaneMaximized}
                 />
                 <ContextMenus parentNote={note} isReadOnly={isReadOnly} onRelocate={startMarkerRelocation} onCreateNote={createNoteAt} />

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -12,6 +12,7 @@ vi.mock("../../../services/i18n", () => ({ getCurrentLanguage: () => "pt_br" }))
 function place(overrides: Record<string, unknown> = {}) {
     return {
         place_id: 240109189,
+        name: "Berlin",
         display_name: "Berlin, Germany",
         lat: "52.5170365",
         lon: "13.3888599",
@@ -67,12 +68,13 @@ describe("Nominatim geocoding", () => {
             place(),
             place({ place_id: 2, display_name: "Nowhere", lat: "not a number" }),
             place({ place_id: 3, display_name: undefined }),
-            place({ place_id: 4, display_name: "Paris, France", lat: "48.8566", lon: "2.3522" })
+            place({ place_id: 4, name: undefined, display_name: "Paris, France", lat: "48.8566", lon: "2.3522" })
         ]);
 
         expect(await search("anywhere")).toEqual([
-            { id: "240109189", label: "Berlin, Germany", lat: 52.5170365, lng: 13.3888599 },
-            { id: "4", label: "Paris, France", lat: 48.8566, lng: 2.3522 }
+            { id: "240109189", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599 },
+            // Named by the leading part of its label, Nominatim having named it nothing itself.
+            { id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522 }
         ]);
     });
 

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { nominatim as provider } from "./nominatim";
 
-vi.mock("../../../services/i18n", () => ({ getCurrentLanguage: () => "pt_br" }));
+/** The locale the app is running in, which a test can settle for itself. */
+let language = "pt_br";
+
+vi.mock("../../../services/i18n", () => ({ getCurrentLanguage: () => language }));
 
 /** One entry as Nominatim's `jsonv2` answer carries it. */
 function place(overrides: Record<string, unknown> = {}) {
@@ -58,7 +61,10 @@ function requestedUrl(fetchMock: ReturnType<typeof respondWith>, call = 0) {
     return new URL(fetchMock.mock.calls[call][0]);
 }
 
-beforeEach(() => vi.useFakeTimers());
+beforeEach(() => {
+    vi.useFakeTimers();
+    language = "pt_br";
+});
 afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
@@ -296,6 +302,83 @@ describe("Nominatim geocoding", () => {
         await vi.runAllTimersAsync();
 
         expect(await outlineFetch).toBeNull();
+    });
+
+    it("asks for no language in particular where the app has settled on none", async () => {
+        language = "";
+        const fetchMock = respondWith([]);
+
+        await search("berlin");
+
+        expect(requestedUrl(fetchMock).searchParams.get("accept-language")).toBeNull();
+    });
+
+    it("names a town and a region by whichever kind of place fills that role", async () => {
+        respondWith([
+            // A village has no city, and a county stands in for a state where a country has none.
+            place({ address: { village: "Rasinari", county: "Sibiu", country: "Romania", country_code: "RO" } })
+        ]);
+
+        const [ result ] = await search("rasinari");
+
+        expect(result.address).toMatchObject({
+            locality: "Rasinari",
+            region: "Sibiu",
+            country: "Romania",
+            // Lowercased, a flag being looked up by it.
+            countryCode: "ro"
+        });
+    });
+
+    it("holds no address for a result Nominatim broke into no parts of one", async () => {
+        // Distinct places: two that read the same are one answer, and only one survives.
+        respondWith([
+            place({ address: {} }),
+            place({ osm_id: 63, display_name: "Elsewhere", address: undefined })
+        ]);
+
+        const results = await search("nowhere");
+
+        expect(results.map((result) => result.address)).toEqual([ undefined, undefined ]);
+    });
+
+    it("falls back to Nominatim's numbering, and then to the position, to tell a place apart", async () => {
+        respondWith([
+            // No OSM object named at all, so its own numbering is all there is to go on.
+            place({ osm_type: undefined, osm_id: undefined, place_id: 111, display_name: "One" }),
+            // A kind of object without the id of one, which names nothing either.
+            place({ osm_type: "node", osm_id: undefined, place_id: 222, display_name: "Two" }),
+            // Not even that, and what is left is where it stands.
+            place({
+                osm_type: undefined, osm_id: undefined, place_id: undefined,
+                display_name: "Three", lat: "1.5", lon: "2.5"
+            })
+        ]);
+
+        const results = await search("anywhere");
+
+        expect(results.map((result) => result.id)).toEqual([ "111", "222", "1.5,2.5" ]);
+        // None of them can be asked for a boundary: that wants an OSM object to look up.
+        expect(results.map((result) => result.outline)).toEqual([ undefined, undefined, undefined ]);
+    });
+
+    it("frames nothing for a place whose extent runs the other way round the world", async () => {
+        // Reported west of east, which as a rectangle is the whole world the long way round.
+        respondWith([ place({ boundingbox: [ "-18", "-16", "177", "-179" ] }) ]);
+
+        const [ result ] = await search("fiji");
+
+        expect(result.bounds).toBeUndefined();
+    });
+
+    it("reports a refused boundary lookup rather than drawing nothing quietly", async () => {
+        respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+
+        respondWith([], { ok: false, status: 429 });
+        const refused = expect(berlin.outline?.()).rejects.toThrow("429");
+        await vi.runAllTimersAsync();
+        await refused;
     });
 
     it("holds searches to the one request a second the usage policy allows", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -211,11 +211,42 @@ describe("Nominatim geocoding", () => {
         expect(fetchMock).toHaveBeenCalledOnce();
 
         const boundary: GeoJSON.Geometry = { type: "MultiPolygon", coordinates: [] };
-        respondWith([ { geojson: boundary } ]);
+        const lookup = respondWith([ { geojson: boundary } ]);
         const outlineFetch = berlin.outline?.();
         await vi.runAllTimersAsync();
 
         expect(await outlineFetch).toEqual(boundary);
+        expect(requestedUrl(lookup).searchParams.get("osm_ids")).toBe("R62422");
+    });
+
+    it("simplifies a boundary by what the place itself measures", async () => {
+        // A city is wider than the cap, and is drawn as coarsely as anything is.
+        respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+        const cityLookup = respondWith([ {} ]);
+        berlin.outline?.();
+        await vi.runAllTimersAsync();
+        expect(requestedUrl(cityLookup).searchParams.get("polygon_threshold")).toBe("0.001000");
+
+        // A building measures tens of metres across, where that cap would flatten it to a triangle.
+        respondWith([ place({
+            osm_type: "way",
+            osm_id: 90,
+            boundingbox: [ "52.5170000", "52.5172000", "13.3888000", "13.3891000" ]
+        }) ]);
+        const [ shop ] = await search("shop");
+        const buildingLookup = respondWith([ {} ]);
+        shop.outline?.();
+        await vi.runAllTimersAsync();
+        expect(requestedUrl(buildingLookup).searchParams.get("polygon_threshold")).toBe("0.000002");
+
+        // A place Nominatim gave no readable extent for is drawn as coarsely as a country.
+        respondWith([ place({ boundingbox: undefined }) ]);
+        const [ unmeasured ] = await search("somewhere");
+        const unmeasuredLookup = respondWith([ {} ]);
+        unmeasured.outline?.();
+        await vi.runAllTimersAsync();
+        expect(requestedUrl(unmeasuredLookup).searchParams.get("polygon_threshold")).toBe("0.001000");
     });
 
     it("draws no boundary for a shape that is not one", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -35,8 +35,8 @@ function respondWith(body: unknown, init: { ok?: boolean; status?: number } = {}
 }
 
 /** Runs a search, letting the rate limiter's wait elapse rather than sitting through it. */
-async function search(query: string) {
-    const results = provider.search(query);
+async function search(query: string, options?: Parameters<typeof provider.search>[1]) {
+    const results = provider.search(query, options);
     await vi.runAllTimersAsync();
     return results;
 }
@@ -100,6 +100,30 @@ describe("Nominatim geocoding", () => {
         const refused = expect(provider.search("berlin")).rejects.toThrow("429");
         await vi.runAllTimersAsync();
         await refused;
+    });
+
+    it("prefers what the map is showing, without refusing what lies outside it", async () => {
+        const fetchMock = respondWith([]);
+
+        await search("jumbo", { viewport: [ [ 19.8, 39.5 ], [ 20.1, 39.8 ] ] });
+
+        // Two opposite corners, longitude first, as Nominatim reads a preferred area.
+        expect(requestedUrl(fetchMock).searchParams.get("viewbox")).toBe("19.8,39.5,20.1,39.8");
+        // A preference, not a restriction: `bounded` would answer nothing where the only match is
+        // somewhere else entirely.
+        expect(requestedUrl(fetchMock).searchParams.get("bounded")).toBeNull();
+    });
+
+    it("asks from nowhere in particular where the view says nothing usable", async () => {
+        const fromNowhere = respondWith([]);
+        await search("jumbo");
+        expect(requestedUrl(fromNowhere).searchParams.get("viewbox")).toBeNull();
+
+        // Panned across the antimeridian, where the view runs the other way round and no pair of
+        // corners describes it.
+        const wrapped = respondWith([]);
+        await search("jumbo", { viewport: [ [ 170, 39.5 ], [ -170, 39.8 ] ] });
+        expect(requestedUrl(wrapped).searchParams.get("viewbox")).toBeNull();
     });
 
     it("fetches the boundary of a place on its own, simplified, only when it is asked for", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -14,6 +14,7 @@ function place(overrides: Record<string, unknown> = {}) {
         place_id: 240109189,
         name: "Berlin",
         display_name: "Berlin, Germany",
+        boundingbox: [ "52.3382448", "52.6755087", "13.0883450", "13.7611609" ],
         lat: "52.5170365",
         lon: "13.3888599",
         ...overrides
@@ -68,13 +69,21 @@ describe("Nominatim geocoding", () => {
             place(),
             place({ place_id: 2, display_name: "Nowhere", lat: "not a number" }),
             place({ place_id: 3, display_name: undefined }),
-            place({ place_id: 4, name: undefined, display_name: "Paris, France", lat: "48.8566", lon: "2.3522" })
+            place({
+                place_id: 4, name: undefined, display_name: "Paris, France", lat: "48.8566", lon: "2.3522",
+                boundingbox: [ "not", "a", "box", "at all" ]
+            })
         ]);
 
         expect(await search("anywhere")).toEqual([
-            { id: "240109189", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599 },
-            // Named by the leading part of its label, Nominatim having named it nothing itself.
-            { id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522 }
+            {
+                id: "240109189", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
+                // Written south-north-west-east by Nominatim, and read as MapLibre frames one.
+                bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ]
+            },
+            // Named by the leading part of its label, Nominatim having named it nothing itself, and
+            // framed by nothing, its extent being unreadable.
+            { id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522, bounds: undefined }
         ]);
     });
 

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -13,6 +13,8 @@ function place(overrides: Record<string, unknown> = {}) {
     return {
         place_id: 240109189,
         name: "Berlin",
+        osm_type: "relation",
+        osm_id: 62422,
         display_name: "Berlin, Germany",
         boundingbox: [ "52.3382448", "52.6755087", "13.0883450", "13.7611609" ],
         lat: "52.5170365",
@@ -71,7 +73,7 @@ describe("Nominatim geocoding", () => {
             place({ place_id: 3, display_name: undefined }),
             place({
                 place_id: 4, name: undefined, display_name: "Paris, France", lat: "48.8566", lon: "2.3522",
-                boundingbox: [ "not", "a", "box", "at all" ]
+                boundingbox: [ "not", "a", "box", "at all" ], osm_type: "node", osm_id: 17807753
             })
         ]);
 
@@ -79,11 +81,15 @@ describe("Nominatim geocoding", () => {
             {
                 id: "240109189", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
                 // Written south-north-west-east by Nominatim, and read as MapLibre frames one.
-                bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ]
+                bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ],
+                outline: expect.any(Function)
             },
             // Named by the leading part of its label, Nominatim having named it nothing itself, and
-            // framed by nothing, its extent being unreadable.
-            { id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522, bounds: undefined }
+            // framed by nothing: its extent is unreadable, and a node has no boundary to fetch.
+            {
+                id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522,
+                bounds: undefined, outline: undefined
+            }
         ]);
     });
 
@@ -94,6 +100,31 @@ describe("Nominatim geocoding", () => {
         const refused = expect(provider.search("berlin")).rejects.toThrow("429");
         await vi.runAllTimersAsync();
         await refused;
+    });
+
+    it("fetches the boundary of a place on its own, simplified, only when it is asked for", async () => {
+        const fetchMock = respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+        expect(fetchMock).toHaveBeenCalledOnce();
+
+        const boundary: GeoJSON.Geometry = { type: "MultiPolygon", coordinates: [] };
+        respondWith([ { geojson: boundary } ]);
+        const outlineFetch = berlin.outline?.();
+        await vi.runAllTimersAsync();
+
+        expect(await outlineFetch).toEqual(boundary);
+    });
+
+    it("draws no boundary for a shape that is not one", async () => {
+        respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+
+        // A point is what the pin already says; there is nothing to ring.
+        respondWith([ { geojson: { type: "Point", coordinates: [ 13.4, 52.5 ] } } ]);
+        const outlineFetch = berlin.outline?.();
+        await vi.runAllTimersAsync();
+
+        expect(await outlineFetch).toBeNull();
     });
 
     it("holds searches to the one request a second the usage policy allows", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -395,4 +395,49 @@ describe("Nominatim geocoding", () => {
 
         expect(requestedAt[1] - requestedAt[0]).toBeGreaterThanOrEqual(1000);
     });
+
+    it("moves the requests behind a boundary lookup up when it is given up on", async () => {
+        respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+
+        const requestedAt: number[] = [];
+        vi.stubGlobal("fetch", vi.fn(async () => {
+            requestedAt.push(Date.now());
+            return { ok: true, status: 200, statusText: "", json: async () => [] };
+        }));
+
+        // A lookup between two searches, given up on before its slot comes up — which is what
+        // stepping onto another result does.
+        const first = provider.search("paris");
+        const abandoned = new AbortController();
+        const outline = berlin.outline?.(abandoned.signal);
+        const second = provider.search("rome");
+        abandoned.abort();
+
+        await vi.runAllTimersAsync();
+        await Promise.all([ first, second ]);
+
+        expect(await outline).toBeNull();
+        // The searches, a second apart: the lookup neither goes out nor is waited out.
+        expect(requestedAt).toHaveLength(2);
+        expect(requestedAt[1] - requestedAt[0]).toBeGreaterThanOrEqual(1000);
+        expect(requestedAt[1] - requestedAt[0]).toBeLessThan(2000);
+    });
+
+    it("gives up a boundary lookup already out without reporting it as a failure", async () => {
+        respondWith([ place() ]);
+        const [ berlin ] = await search("berlin");
+
+        // Never answers of its own accord, so the lookup is still out when it is given up on.
+        vi.stubGlobal("fetch", vi.fn((_url: string, init?: { signal?: AbortSignal }) => new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+        })));
+
+        const request = new AbortController();
+        const outline = berlin.outline?.(request.signal);
+        await vi.runAllTimersAsync();
+        request.abort();
+
+        expect(await outline).toBeNull();
+    });
 });

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -120,18 +120,18 @@ describe("Nominatim geocoding", () => {
         const inTheUnitedStates = place({ place_id: 2, name: "Jumbo", display_name: "Jumbo, Ohio, USA" });
         const fetchMock = respondInTurn([ [ inSibiu ], [ inTheUnitedStates, inSibiu ] ]);
 
-        const results = await search("jumbo", { viewport: [ [ 24.0, 45.7 ], [ 24.3, 45.9 ] ] });
+        const results = await search("jumbo", { viewport: [ [ 23, 45 ], [ 25, 47 ] ] });
 
         // Restricted to the view first: a viewbox alone is only a nudge next to how well known a
         // place is, so a shop in Sibiu would otherwise stay under every Jumbo in the United States.
         const nearby = requestedUrl(fetchMock, 0).searchParams;
         // Two opposite corners, longitude first, as Nominatim reads a preferred area.
-        expect(nearby.get("viewbox")).toBe("24,45.7,24.3,45.9");
+        expect(nearby.get("viewbox")).toBe("23,45,25,47");
         expect(nearby.get("bounded")).toBe("1");
 
         // Then unrestricted, so a place nowhere near the map is still found.
         const elsewhere = requestedUrl(fetchMock, 1).searchParams;
-        expect(elsewhere.get("viewbox")).toBe("24,45.7,24.3,45.9");
+        expect(elsewhere.get("viewbox")).toBe("23,45,25,47");
         expect(elsewhere.get("bounded")).toBeNull();
 
         // What is at hand comes first, and is not offered twice for being in both answers.
@@ -141,11 +141,31 @@ describe("Nominatim geocoding", () => {
         ]);
     });
 
+    it("searches the town around a view of one neighbourhood, not the neighbourhood alone", async () => {
+        const fetchMock = respondWith([]);
+
+        // A few streets of Sibiu, some 500 m across.
+        await search("jumbo", { viewport: [ [ 24.147, 45.796 ], [ 24.153, 45.800 ] ] });
+
+        const [ west, south, east, north ] = (requestedUrl(fetchMock).searchParams.get("viewbox") ?? "")
+            .split(",").map(Number);
+
+        // Grown about the same middle rather than shifted off it.
+        expect((west + east) / 2).toBeCloseTo(24.15, 4);
+        expect((south + north) / 2).toBeCloseTo(45.798, 4);
+
+        // Wide enough to hold the town: a degree of latitude is about 111 km, so 25 km either way of
+        // the middle is a little over 0.2 degrees.
+        expect(north - south).toBeGreaterThan(0.4);
+        // Longitude is shorter this far north, so the box is wider in degrees than it is tall.
+        expect(east - west).toBeGreaterThan(north - south);
+    });
+
     it("does not go looking further afield where the view already fills the list", async () => {
         const local = Array.from({ length: 8 }, (_, index) => place({ place_id: index, display_name: `Jumbo ${index}` }));
         const fetchMock = respondInTurn([ local, [] ]);
 
-        const results = await search("jumbo", { viewport: [ [ 24.0, 45.7 ], [ 24.3, 45.9 ] ] });
+        const results = await search("jumbo", { viewport: [ [ 23, 45 ], [ 25, 47 ] ] });
 
         expect(fetchMock).toHaveBeenCalledOnce();
         expect(results).toHaveLength(8);

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -92,7 +92,8 @@ describe("Nominatim geocoding", () => {
 
         expect(await search("anywhere")).toEqual([
             {
-                id: "240109189", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
+                // What OSM calls it, not what Nominatim numbered it.
+                id: "R62422", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
                 // Written south-north-west-east by Nominatim, and read as MapLibre frames one.
                 bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ],
                 outline: expect.any(Function)
@@ -100,7 +101,7 @@ describe("Nominatim geocoding", () => {
             // Named by the leading part of its label, Nominatim having named it nothing itself, and
             // framed by nothing: its extent is unreadable, and a node has no boundary to fetch.
             {
-                id: "4", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522,
+                id: "N17807753", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522,
                 bounds: undefined, outline: undefined
             }
         ]);
@@ -116,8 +117,8 @@ describe("Nominatim geocoding", () => {
     });
 
     it("asks what the map is showing first, then the wider world", async () => {
-        const inSibiu = place({ place_id: 1, name: "Jumbo", display_name: "Jumbo, Sibiu, Romania" });
-        const inTheUnitedStates = place({ place_id: 2, name: "Jumbo", display_name: "Jumbo, Ohio, USA" });
+        const inSibiu = place({ osm_type: "node", osm_id: 1, name: "Jumbo", display_name: "Jumbo, Sibiu, Romania" });
+        const inTheUnitedStates = place({ osm_type: "node", osm_id: 2, name: "Jumbo", display_name: "Jumbo, Ohio, USA" });
         const fetchMock = respondInTurn([ [ inSibiu ], [ inTheUnitedStates, inSibiu ] ]);
 
         const results = await search("jumbo", { viewport: [ [ 23, 45 ], [ 25, 47 ] ] });
@@ -159,6 +160,25 @@ describe("Nominatim geocoding", () => {
         expect(north - south).toBeGreaterThan(0.4);
         // Longitude is shorter this far north, so the box is wider in degrees than it is tall.
         expect(east - west).toBeGreaterThan(north - south);
+    });
+
+    it("offers a place once, however many ways the two passes name it", async () => {
+        const shop = { osm_type: "node", osm_id: 5, name: "Jumbo", display_name: "Jumbo, Sibiu, Romania" };
+        const fetchMock = respondInTurn([
+            // Nominatim's own numbering differs between the instances the public service runs behind,
+            // so the same shop comes back under two place ids.
+            [ place({ ...shop, place_id: 111 }) ],
+            [
+                place({ ...shop, place_id: 222 }),
+                // The building around the shop: another OSM object under the same name and address.
+                place({ ...shop, place_id: 333, osm_type: "way", osm_id: 6 })
+            ]
+        ]);
+
+        const results = await search("jumbo", { viewport: [ [ 23, 45 ], [ 25, 47 ] ] });
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(results.map((result) => result.id)).toEqual([ "N5" ]);
     });
 
     it("does not go looking further afield where the view already fills the list", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -34,6 +34,19 @@ function respondWith(body: unknown, init: { ok?: boolean; status?: number } = {}
     return fetchMock;
 }
 
+/** Answers each request in turn, for a search that makes more than one (see the two passes). */
+function respondInTurn(bodies: unknown[]) {
+    let call = 0;
+    const fetchMock = vi.fn(async (_url: string) => ({
+        ok: true,
+        status: 200,
+        statusText: "",
+        json: async () => bodies[Math.min(call++, bodies.length - 1)]
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
+
 /** Runs a search, letting the rate limiter's wait elapse rather than sitting through it. */
 async function search(query: string, options?: Parameters<typeof provider.search>[1]) {
     const results = provider.search(query, options);
@@ -41,8 +54,8 @@ async function search(query: string, options?: Parameters<typeof provider.search
     return results;
 }
 
-function requestedUrl(fetchMock: ReturnType<typeof respondWith>) {
-    return new URL(fetchMock.mock.calls[0][0]);
+function requestedUrl(fetchMock: ReturnType<typeof respondWith>, call = 0) {
+    return new URL(fetchMock.mock.calls[call][0]);
 }
 
 beforeEach(() => vi.useFakeTimers());
@@ -102,27 +115,53 @@ describe("Nominatim geocoding", () => {
         await refused;
     });
 
-    it("prefers what the map is showing, without refusing what lies outside it", async () => {
-        const fetchMock = respondWith([]);
+    it("asks what the map is showing first, then the wider world", async () => {
+        const inSibiu = place({ place_id: 1, name: "Jumbo", display_name: "Jumbo, Sibiu, Romania" });
+        const inTheUnitedStates = place({ place_id: 2, name: "Jumbo", display_name: "Jumbo, Ohio, USA" });
+        const fetchMock = respondInTurn([ [ inSibiu ], [ inTheUnitedStates, inSibiu ] ]);
 
-        await search("jumbo", { viewport: [ [ 19.8, 39.5 ], [ 20.1, 39.8 ] ] });
+        const results = await search("jumbo", { viewport: [ [ 24.0, 45.7 ], [ 24.3, 45.9 ] ] });
 
+        // Restricted to the view first: a viewbox alone is only a nudge next to how well known a
+        // place is, so a shop in Sibiu would otherwise stay under every Jumbo in the United States.
+        const nearby = requestedUrl(fetchMock, 0).searchParams;
         // Two opposite corners, longitude first, as Nominatim reads a preferred area.
-        expect(requestedUrl(fetchMock).searchParams.get("viewbox")).toBe("19.8,39.5,20.1,39.8");
-        // A preference, not a restriction: `bounded` would answer nothing where the only match is
-        // somewhere else entirely.
-        expect(requestedUrl(fetchMock).searchParams.get("bounded")).toBeNull();
+        expect(nearby.get("viewbox")).toBe("24,45.7,24.3,45.9");
+        expect(nearby.get("bounded")).toBe("1");
+
+        // Then unrestricted, so a place nowhere near the map is still found.
+        const elsewhere = requestedUrl(fetchMock, 1).searchParams;
+        expect(elsewhere.get("viewbox")).toBe("24,45.7,24.3,45.9");
+        expect(elsewhere.get("bounded")).toBeNull();
+
+        // What is at hand comes first, and is not offered twice for being in both answers.
+        expect(results.map((result) => result.label)).toEqual([
+            "Jumbo, Sibiu, Romania",
+            "Jumbo, Ohio, USA"
+        ]);
     });
 
-    it("asks from nowhere in particular where the view says nothing usable", async () => {
+    it("does not go looking further afield where the view already fills the list", async () => {
+        const local = Array.from({ length: 8 }, (_, index) => place({ place_id: index, display_name: `Jumbo ${index}` }));
+        const fetchMock = respondInTurn([ local, [] ]);
+
+        const results = await search("jumbo", { viewport: [ [ 24.0, 45.7 ], [ 24.3, 45.9 ] ] });
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(results).toHaveLength(8);
+    });
+
+    it("asks once, from nowhere in particular, where the view says nothing usable", async () => {
         const fromNowhere = respondWith([]);
         await search("jumbo");
+        expect(fromNowhere).toHaveBeenCalledOnce();
         expect(requestedUrl(fromNowhere).searchParams.get("viewbox")).toBeNull();
 
         // Panned across the antimeridian, where the view runs the other way round and no pair of
         // corners describes it.
         const wrapped = respondWith([]);
         await search("jumbo", { viewport: [ [ 170, 39.5 ], [ -170, 39.8 ] ] });
+        expect(wrapped).toHaveBeenCalledOnce();
         expect(requestedUrl(wrapped).searchParams.get("viewbox")).toBeNull();
     });
 

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -96,15 +96,41 @@ describe("Nominatim geocoding", () => {
                 id: "R62422", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
                 // Written south-north-west-east by Nominatim, and read as MapLibre frames one.
                 bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ],
-                icon: undefined, outline: expect.any(Function)
+                icon: undefined, address: undefined, outline: expect.any(Function)
             },
             // Named by the leading part of its label, Nominatim having named it nothing itself, and
             // framed by nothing: its extent is unreadable, and a node has no boundary to fetch.
             {
                 id: "N17807753", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522,
-                bounds: undefined, icon: undefined, outline: undefined
+                bounds: undefined, icon: undefined, address: undefined, outline: undefined
             }
         ]);
+    });
+
+    it("names a house by its street and number, which is what it has instead of a name", async () => {
+        // As Nominatim answers for a plain address: no name of its own, and a label led by the number.
+        respondWith([ place({
+            name: "", osm_type: "way", osm_id: 90,
+            display_name: "25, Lankwitzer Straße, Mariendorf, Berlin, 12107, Deutschland",
+            address: {
+                house_number: "25", road: "Lankwitzer Straße", suburb: "Mariendorf",
+                city: "Berlin", state: "Berlin", postcode: "12107",
+                country: "Deutschland", country_code: "DE"
+            }
+        }) ]);
+
+        const [ house ] = await search("lankwitzer strasse 25");
+        expect(house.name).toBe("Lankwitzer Straße 25");
+        expect(house.address).toEqual({
+            street: "Lankwitzer Straße 25", locality: "Berlin", region: "Berlin",
+            country: "Deutschland", countryCode: "de"
+        });
+    });
+
+    it("asks for the address in parts", async () => {
+        const fetchMock = respondWith([]);
+        await search("berlin");
+        expect(requestedUrl(fetchMock).searchParams.get("addressdetails")).toBe("1");
     });
 
     it("carries the kind of place through, for the icon it is drawn with", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -4,11 +4,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_GEOCODING_PROVIDER_NAME, GEOCODING_PROVIDERS } from "./geocoding";
+import { nominatim as provider } from "./nominatim";
 
 vi.mock("../../../services/i18n", () => ({ getCurrentLanguage: () => "pt_br" }));
-
-const provider = GEOCODING_PROVIDERS[DEFAULT_GEOCODING_PROVIDER_NAME];
 
 /** One entry as Nominatim's `jsonv2` answer carries it. */
 function place(overrides: Record<string, unknown> = {}) {

--- a/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.spec.ts
@@ -96,15 +96,26 @@ describe("Nominatim geocoding", () => {
                 id: "R62422", label: "Berlin, Germany", name: "Berlin", lat: 52.5170365, lng: 13.3888599,
                 // Written south-north-west-east by Nominatim, and read as MapLibre frames one.
                 bounds: [ [ 13.088345, 52.3382448 ], [ 13.7611609, 52.6755087 ] ],
-                outline: expect.any(Function)
+                icon: undefined, outline: expect.any(Function)
             },
             // Named by the leading part of its label, Nominatim having named it nothing itself, and
             // framed by nothing: its extent is unreadable, and a node has no boundary to fetch.
             {
                 id: "N17807753", label: "Paris, France", name: "Paris", lat: 48.8566, lng: 2.3522,
-                bounds: undefined, outline: undefined
+                bounds: undefined, icon: undefined, outline: undefined
             }
         ]);
+    });
+
+    it("carries the kind of place through, for the icon it is drawn with", async () => {
+        respondWith([
+            place({ category: "shop", type: "supermarket", addresstype: "shop" }),
+            place({ osm_id: 62423, display_name: "Berlin, Germany, the city", category: "boundary", type: "administrative", addresstype: "city" })
+        ]);
+
+        const [ shop, city ] = await search("berlin");
+        expect(shop.icon).toBe("bx bx-cart");
+        expect(city.icon).toBe("bx bx-buildings");
     });
 
     it("reports a refused request rather than answering with no places", async () => {

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -59,6 +59,7 @@ async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
 interface NominatimPlace {
     place_id?: number;
     display_name?: string;
+    name?: string;
     lat?: string;
     lon?: string;
 }
@@ -74,6 +75,9 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
     return {
         id: String(place.place_id ?? `${lat},${lng}`),
         label: place.display_name,
+        // Nominatim leaves `name` empty for a result that is an address rather than a named place,
+        // where the leading part of the label is what names it.
+        name: place.name || place.display_name.split(",")[0].trim(),
         lat,
         lng
     };

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -10,11 +10,11 @@ const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
  */
 const POLYGON_THRESHOLD = 0.001;
 
-/**
- * How a lookup names an OSM object, from how a search result names one. Nodes are left out: a place
- * that is a single point has no boundary, and its pin already says where it is.
- */
-const OSM_TYPE_PREFIX: Record<string, string> = { relation: "R", way: "W" };
+/** How a lookup names an OSM object, from how a search result names one. */
+const OSM_TYPE_PREFIX: Record<string, string> = { node: "N", way: "W", relation: "R" };
+
+/** The kinds of OSM object that can enclose ground. A node is a single point and has no boundary. */
+const OSM_TYPES_WITH_A_BOUNDARY = new Set([ "way", "relation" ]);
 
 /**
  * The least ground a search treats as here, as a half-span in metres.
@@ -74,9 +74,30 @@ async function searchNominatim(query: string, { viewport }: GeoSearchOptions = {
     // Then the wider world, so that a place nowhere near the map is still found, and a view holding
     // one match is not the whole answer. What is at hand stands above it either way.
     const elsewhere = await searchPlaces(query, viewbox ? { viewbox } : {});
-    const nearbyIds = new Set(nearby.map((place) => place.id));
 
-    return [ ...nearby, ...elsewhere.filter((place) => !nearbyIds.has(place.id)) ].slice(0, MAX_RESULTS);
+    return dedupe([ ...nearby, ...elsewhere ]).slice(0, MAX_RESULTS);
+}
+
+/**
+ * Drops a place already offered, keeping the first of them — which is the nearest, the passes running
+ * that way round.
+ *
+ * By what it says as well as by which place it is. A shop and the building around it are two OSM
+ * objects under one name and one address, and two rows a reader cannot tell apart are one answer
+ * given twice.
+ */
+function dedupe(places: GeoSearchResult[]): GeoSearchResult[] {
+    const seen = new Set<string>();
+
+    return places.filter((place) => {
+        if (seen.has(place.id) || seen.has(place.label)) {
+            return false;
+        }
+
+        seen.add(place.id);
+        seen.add(place.label);
+        return true;
+    });
 }
 
 /** One request to Nominatim's search, asked in the language the app runs in. */
@@ -128,9 +149,13 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
 
     const prefix = OSM_TYPE_PREFIX[place.osm_type ?? ""];
     const osmId = prefix && place.osm_id ? `${prefix}${place.osm_id}` : null;
+    const hasBoundary = OSM_TYPES_WITH_A_BOUNDARY.has(place.osm_type ?? "");
 
     return {
-        id: String(place.place_id ?? `${lat},${lng}`),
+        // What OSM calls the place, where it says: `place_id` is Nominatim's own numbering, and the
+        // public service runs several instances that number independently, so the same place comes
+        // back under two of them and is offered twice.
+        id: osmId ?? String(place.place_id ?? `${lat},${lng}`),
         label: place.display_name,
         // Nominatim leaves `name` empty for a result that is an address rather than a named place,
         // where the leading part of the label is what names it.
@@ -138,7 +163,7 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         lat,
         lng,
         bounds: toBounds(place.boundingbox),
-        outline: osmId ? () => fetchOutline(osmId) : undefined
+        outline: osmId && hasBoundary ? () => fetchOutline(osmId) : undefined
     };
 }
 

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -2,6 +2,19 @@ import { getCurrentLanguage } from "../../../services/i18n";
 import type { GeocodingProvider, GeoSearchResult } from "./geocoding";
 
 const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
+const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
+
+/**
+ * How coarsely a boundary is simplified, in degrees — roughly 100 m. At full detail a country runs to
+ * megabytes, and a border drawn over a map is not read to the metre.
+ */
+const POLYGON_THRESHOLD = 0.001;
+
+/**
+ * How a lookup names an OSM object, from how a search result names one. Nodes are left out: a place
+ * that is a single point has no boundary, and its pin already says where it is.
+ */
+const OSM_TYPE_PREFIX: Record<string, string> = { relation: "R", way: "W" };
 
 /** Caps how many results one search returns. */
 const MAX_RESULTS = 8;
@@ -58,6 +71,8 @@ async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
 /** One entry of a Nominatim `jsonv2` response, narrowed to the fields a result is built from. */
 interface NominatimPlace {
     place_id?: number;
+    osm_type?: string;
+    osm_id?: number;
     display_name?: string;
     name?: string;
     lat?: string;
@@ -74,6 +89,9 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         return null;
     }
 
+    const prefix = OSM_TYPE_PREFIX[place.osm_type ?? ""];
+    const osmId = prefix && place.osm_id ? `${prefix}${place.osm_id}` : null;
+
     return {
         id: String(place.place_id ?? `${lat},${lng}`),
         label: place.display_name,
@@ -82,7 +100,8 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         name: place.name || place.display_name.split(",")[0].trim(),
         lat,
         lng,
-        bounds: toBounds(place.boundingbox)
+        bounds: toBounds(place.boundingbox),
+        outline: osmId ? () => fetchOutline(osmId) : undefined
     };
 }
 
@@ -104,6 +123,32 @@ function toBounds(boundingbox: string[] | undefined): GeoSearchResult["bounds"] 
     }
 
     return [ [ west, south ], [ east, north ] ];
+}
+
+/**
+ * The boundary of one OSM object, simplified, or `null` where it has none to draw.
+ *
+ * A lookup of its own rather than `polygon_geojson` on the search: a search answers with eight places
+ * and the boundaries of the seven that go unlooked-at are the bulk of what would be carried.
+ */
+async function fetchOutline(osmId: string): Promise<GeoJSON.Geometry | null> {
+    const params = new URLSearchParams({
+        osm_ids: osmId,
+        format: "jsonv2",
+        polygon_geojson: "1",
+        polygon_threshold: String(POLYGON_THRESHOLD)
+    });
+
+    await waitForRequestSlot();
+    const response = await fetch(`${NOMINATIM_LOOKUP_URL}?${params}`);
+    if (!response.ok) {
+        throw new Error(`Nominatim answered ${response.status} ${response.statusText}`);
+    }
+
+    const [ place ]: { geojson?: GeoJSON.Geometry }[] = await response.json();
+    const geometry = place?.geojson;
+    // A shape that is a point or a line is what the pin already says, drawn again.
+    return geometry?.type === "Polygon" || geometry?.type === "MultiPolygon" ? geometry : null;
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -1,5 +1,6 @@
 import { getCurrentLanguage } from "../../../services/i18n";
 import { type GeoBounds, type GeocodingProvider, type GeoSearchOptions, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
+import { placeIcon } from "./osm_icons";
 
 const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
@@ -135,6 +136,12 @@ interface NominatimPlace {
     lon?: string;
     /** `[south, north, west, east]`, as strings, which is the order Nominatim writes it in. */
     boundingbox?: string[];
+    /** The OSM key the place is filed under: `shop`, `amenity`, `boundary`. */
+    category?: string;
+    /** The OSM value under that key: `supermarket`, `restaurant`, `administrative`. */
+    type?: string;
+    /** What kind of address the place is: `city`, `country`, `road`, `shop`. */
+    addresstype?: string;
 }
 
 /** A place as the app holds one, or `null` where the entry carries no readable position. */
@@ -162,6 +169,7 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         lat,
         lng,
         bounds,
+        icon: placeIcon({ category: place.category, type: place.type, addressType: place.addresstype }),
         outline: osmId && hasBoundary ? () => fetchOutline(osmId, bounds) : undefined
     };
 }

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -38,8 +38,14 @@ const MAX_RESULTS = 8;
  */
 const MIN_REQUEST_INTERVAL = 1000;
 
-/** When the next request is allowed to go out, moved forward by every request that is queued. */
+/** When the next request may go out, moved forward as each one is let through. */
 let nextRequestAt = 0;
+
+/** The requests waiting for a slot, in the order they asked for one. */
+const waiting: { resolve(letThrough: boolean): void }[] = [];
+
+/** Holds the wait of whichever request stands at the head of {@link waiting}. */
+let releaseTimer: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * Nominatim, the geocoder run by the OpenStreetMap Foundation.
@@ -200,7 +206,7 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         lng,
         bounds,
         icon: placeIcon({ category: place.category, type: place.type, addressType: place.addresstype }),
-        outline: osmId && hasBoundary ? () => fetchOutline(osmId, bounds) : undefined
+        outline: osmId && hasBoundary ? (signal?: AbortSignal) => fetchOutline(osmId, bounds, signal) : undefined
     };
 }
 
@@ -294,7 +300,7 @@ function clamp(value: number, least: number, most: number) {
  * A lookup of its own rather than `polygon_geojson` on the search: a search answers with eight places
  * and the boundaries of the seven that go unlooked-at are the bulk of what would be carried.
  */
-async function fetchOutline(osmId: string, bounds: GeoBounds | undefined): Promise<GeoJSON.Geometry | null> {
+async function fetchOutline(osmId: string, bounds: GeoBounds | undefined, signal?: AbortSignal): Promise<GeoJSON.Geometry | null> {
     const params = new URLSearchParams({
         osm_ids: osmId,
         format: "jsonv2",
@@ -302,8 +308,21 @@ async function fetchOutline(osmId: string, bounds: GeoBounds | undefined): Promi
         polygon_threshold: polygonThreshold(bounds)
     });
 
-    await waitForRequestSlot();
-    const response = await fetch(`${NOMINATIM_LOOKUP_URL}?${params}`);
+    if (!await waitForRequestSlot(signal)) {
+        return null;
+    }
+
+    let response: Response;
+    try {
+        response = await fetch(`${NOMINATIM_LOOKUP_URL}?${params}`, { signal });
+    } catch (e) {
+        // Given up on while in flight, which is the caller's own doing rather than a failure.
+        if (signal?.aborted) {
+            return null;
+        }
+        throw e;
+    }
+
     if (!response.ok) {
         throw new Error(`Nominatim answered ${response.status} ${response.statusText}`);
     }
@@ -340,17 +359,54 @@ function polygonThreshold(bounds: GeoBounds | undefined) {
 }
 
 /**
- * Holds a request back until the interval the policy asks for has passed since the last one.
+ * Holds a request back until the interval the policy asks for has passed since the last one, and
+ * answers whether it may go out.
  *
- * The slot is claimed before the wait rather than after it, so two searches started at once queue
- * behind each other instead of both finding the same slot free.
+ * Requests are let through in the order they asked, so two started at once queue behind each other
+ * instead of both finding the same slot free. One given up on through `signal` leaves the queue and
+ * answers `false`: the requests behind it move up rather than waiting out a request never sent,
+ * which is what keeps a search from queueing behind boundaries nobody is looking at any more.
  */
-async function waitForRequestSlot() {
-    const now = Date.now();
-    const slot = Math.max(now, nextRequestAt);
-    nextRequestAt = slot + MIN_REQUEST_INTERVAL;
-
-    if (slot > now) {
-        await new Promise((resolve) => setTimeout(resolve, slot - now));
+async function waitForRequestSlot(signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) {
+        return false;
     }
+
+    // The slot at hand is taken there and then, so a lone request is not held for a turn of the
+    // event loop before going out.
+    const now = Date.now();
+    if (!waiting.length && now >= nextRequestAt) {
+        nextRequestAt = now + MIN_REQUEST_INTERVAL;
+        return true;
+    }
+
+    return new Promise<boolean>((resolve) => {
+        const request = { resolve };
+        waiting.push(request);
+        signal?.addEventListener("abort", () => {
+            const queued = waiting.indexOf(request);
+            if (queued >= 0) {
+                waiting.splice(queued, 1);
+                resolve(false);
+            }
+        }, { once: true });
+        releaseNextRequest();
+    });
+}
+
+/** Lets the request at the head of the queue through once its slot comes up, and then the next. */
+function releaseNextRequest() {
+    if (releaseTimer !== undefined || !waiting.length) {
+        return;
+    }
+
+    releaseTimer = setTimeout(() => {
+        releaseTimer = undefined;
+        const request = waiting.shift();
+        if (request) {
+            nextRequestAt = Date.now() + MIN_REQUEST_INTERVAL;
+            request.resolve(true);
+        }
+        releaseNextRequest();
+    }, Math.max(0, nextRequestAt - Date.now()));
 }

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -38,6 +38,9 @@ let nextRequestAt = 0;
  *
  * The same policy rules out searching as the user types, which is why a search runs only when the
  * user asks for one (see SearchBox).
+ *
+ * A search is answered in two passes where the map says what it is showing, so that what is at hand
+ * comes first and what is far off still comes at all (see searchNominatim).
  */
 export const nominatim: GeocodingProvider = {
     name: "Nominatim (OpenStreetMap)",
@@ -45,10 +48,31 @@ export const nominatim: GeocodingProvider = {
 };
 
 async function searchNominatim(query: string, { viewport }: GeoSearchOptions = {}): Promise<GeoSearchResult[]> {
+    const viewbox = toViewbox(viewport);
+
+    // What the map is showing, and nothing else. A viewbox on its own is only a nudge next to how
+    // well known a place is, so a supermarket in the town on screen stays buried under the towns of
+    // that name across the world — restricting the search to the view is what brings it up.
+    const nearby = viewbox ? await searchPlaces(query, { viewbox, bounded: "1" }) : [];
+    if (nearby.length >= MAX_RESULTS) {
+        return nearby;
+    }
+
+    // Then the wider world, so that a place nowhere near the map is still found, and a view holding
+    // one match is not the whole answer. What is at hand stands above it either way.
+    const elsewhere = await searchPlaces(query, viewbox ? { viewbox } : {});
+    const nearbyIds = new Set(nearby.map((place) => place.id));
+
+    return [ ...nearby, ...elsewhere.filter((place) => !nearbyIds.has(place.id)) ].slice(0, MAX_RESULTS);
+}
+
+/** One request to Nominatim's search, asked in the language the app runs in. */
+async function searchPlaces(query: string, extraParams: Record<string, string>): Promise<GeoSearchResult[]> {
     const params = new URLSearchParams({
         q: query,
         format: "jsonv2",
-        limit: String(MAX_RESULTS)
+        limit: String(MAX_RESULTS),
+        ...extraParams
     });
 
     // Place names in the language the app runs in, where Nominatim holds one. Trilium writes some
@@ -56,11 +80,6 @@ async function searchNominatim(query: string, { viewport }: GeoSearchOptions = {
     const language = getCurrentLanguage();
     if (language) {
         params.set("accept-language", language.replace("_", "-"));
-    }
-
-    const viewbox = toViewbox(viewport);
-    if (viewbox) {
-        params.set("viewbox", viewbox);
     }
 
     await waitForRequestSlot();

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -5,10 +5,16 @@ const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
 
 /**
- * How coarsely a boundary is simplified, in degrees — roughly 100 m. At full detail a country runs to
- * megabytes, and a border drawn over a map is not read to the metre.
+ * The coarsest a boundary is simplified to, in degrees — roughly 100 m. At full detail a country runs
+ * to megabytes, and a border drawn over a map is not read to the metre.
  */
-const POLYGON_THRESHOLD = 0.001;
+const MAX_POLYGON_THRESHOLD = 0.001;
+
+/**
+ * How small a part of a place's own extent the simplification is allowed to lose. A fixed threshold
+ * that suits a country flattens a building to a triangle, so it is scaled to what is being drawn.
+ */
+const POLYGON_THRESHOLD_RATIO = 1 / 100;
 
 /** How a lookup names an OSM object, from how a search result names one. */
 const OSM_TYPE_PREFIX: Record<string, string> = { node: "N", way: "W", relation: "R" };
@@ -142,6 +148,7 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
     const prefix = OSM_TYPE_PREFIX[place.osm_type ?? ""];
     const osmId = prefix && place.osm_id ? `${prefix}${place.osm_id}` : null;
     const hasBoundary = OSM_TYPES_WITH_A_BOUNDARY.has(place.osm_type ?? "");
+    const bounds = toBounds(place.boundingbox);
 
     return {
         // What OSM calls the place, where it says: `place_id` is Nominatim's own numbering, and the
@@ -154,8 +161,8 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         name: place.name || place.display_name.split(",")[0].trim(),
         lat,
         lng,
-        bounds: toBounds(place.boundingbox),
-        outline: osmId && hasBoundary ? () => fetchOutline(osmId) : undefined
+        bounds,
+        outline: osmId && hasBoundary ? () => fetchOutline(osmId, bounds) : undefined
     };
 }
 
@@ -225,12 +232,12 @@ function clamp(value: number, least: number, most: number) {
  * A lookup of its own rather than `polygon_geojson` on the search: a search answers with eight places
  * and the boundaries of the seven that go unlooked-at are the bulk of what would be carried.
  */
-async function fetchOutline(osmId: string): Promise<GeoJSON.Geometry | null> {
+async function fetchOutline(osmId: string, bounds: GeoBounds | undefined): Promise<GeoJSON.Geometry | null> {
     const params = new URLSearchParams({
         osm_ids: osmId,
         format: "jsonv2",
         polygon_geojson: "1",
-        polygon_threshold: String(POLYGON_THRESHOLD)
+        polygon_threshold: polygonThreshold(bounds)
     });
 
     await waitForRequestSlot();
@@ -243,6 +250,31 @@ async function fetchOutline(osmId: string): Promise<GeoJSON.Geometry | null> {
     const geometry = place?.geojson;
     // A shape that is a point or a line is what the pin already says, drawn again.
     return geometry?.type === "Polygon" || geometry?.type === "MultiPolygon" ? geometry : null;
+}
+
+/**
+ * How coarsely to simplify a place of the given extent, in degrees.
+ *
+ * Douglas-Peucker drops every corner standing less than the threshold off the line between its
+ * neighbours, so one wide enough to thin a coastline squares off a street corner and leaves a
+ * building as the triangle that is the least a ring can be. The threshold is taken from the place's
+ * narrower side — the one that collapses first — and capped at {@link MAX_POLYGON_THRESHOLD}, which
+ * is what a country or a county gets.
+ *
+ * A place whose extent is unknown is one Nominatim reported no readable box for, and gets the cap.
+ *
+ * Written out to six decimals rather than stringified, which would send a threshold under a
+ * millionth of a degree in exponential notation.
+ */
+function polygonThreshold(bounds: GeoBounds | undefined) {
+    if (!bounds) {
+        return MAX_POLYGON_THRESHOLD.toFixed(6);
+    }
+
+    const [ [ west, south ], [ east, north ] ] = bounds;
+    const narrowerSide = Math.min(east - west, north - south);
+
+    return Math.min(narrowerSide * POLYGON_THRESHOLD_RATIO, MAX_POLYGON_THRESHOLD).toFixed(6);
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -1,5 +1,5 @@
 import { getCurrentLanguage } from "../../../services/i18n";
-import type { GeocodingProvider, GeoSearchResult } from "./geocoding";
+import type { GeoBounds, GeocodingProvider, GeoSearchOptions, GeoSearchResult } from "./geocoding";
 
 const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
@@ -44,7 +44,7 @@ export const nominatim: GeocodingProvider = {
     search: searchNominatim
 };
 
-async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
+async function searchNominatim(query: string, { viewport }: GeoSearchOptions = {}): Promise<GeoSearchResult[]> {
     const params = new URLSearchParams({
         q: query,
         format: "jsonv2",
@@ -56,6 +56,11 @@ async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
     const language = getCurrentLanguage();
     if (language) {
         params.set("accept-language", language.replace("_", "-"));
+    }
+
+    const viewbox = toViewbox(viewport);
+    if (viewbox) {
+        params.set("viewbox", viewbox);
     }
 
     await waitForRequestSlot();
@@ -123,6 +128,27 @@ function toBounds(boundingbox: string[] | undefined): GeoSearchResult["bounds"] 
     }
 
     return [ [ west, south ], [ east, north ] ];
+}
+
+/**
+ * What the map is showing, as Nominatim reads a preferred area: two opposite corners, longitude
+ * first. Sent without `bounded`, so a place is ranked up for being in view rather than a place out
+ * of view being refused.
+ *
+ * A view running the other way round has been panned across the antimeridian, which no pair of
+ * corners describes; nothing is sent for one, and the search is answered as if from nowhere.
+ */
+function toViewbox(viewport: GeoBounds | undefined) {
+    if (!viewport) {
+        return null;
+    }
+
+    const [ [ west, south ], [ east, north ] ] = viewport;
+    if (!(west < east)) {
+        return null;
+    }
+
+    return [ west, south, east, north ].join(",");
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -16,6 +16,19 @@ const POLYGON_THRESHOLD = 0.001;
  */
 const OSM_TYPE_PREFIX: Record<string, string> = { relation: "R", way: "W" };
 
+/**
+ * The least ground a search treats as here, as a half-span in metres.
+ *
+ * A map zoomed into a neighbourhood shows a few hundred metres across, and a search restricted to
+ * exactly that answers nothing for a shop three streets away. What the reader means by searching from
+ * where they are standing is the town they are looking at, not the block.
+ */
+const MIN_SEARCH_RADIUS_M = 25_000;
+
+/** Metres to a degree of latitude, the same the world over. A degree of longitude is this shortened
+ *  by the cosine of the latitude. */
+const METRES_PER_DEGREE = 111_320;
+
 /** Caps how many results one search returns. */
 const MAX_RESULTS = 8;
 
@@ -151,8 +164,11 @@ function toBounds(boundingbox: string[] | undefined): GeoSearchResult["bounds"] 
 
 /**
  * What the map is showing, as Nominatim reads a preferred area: two opposite corners, longitude
- * first. Sent without `bounded`, so a place is ranked up for being in view rather than a place out
- * of view being refused.
+ * first. Sent without `bounded` on the wider pass, so a place is ranked up for being in view rather
+ * than a place out of view being refused.
+ *
+ * Grown to at least {@link MIN_SEARCH_RADIUS_M} about its middle, since a view of one neighbourhood
+ * restricts a search to that neighbourhood and answers nothing for the next street over.
  *
  * A view running the other way round has been panned across the antimeridian, which no pair of
  * corners describes; nothing is sent for one, and the search is answered as if from nowhere.
@@ -167,7 +183,23 @@ function toViewbox(viewport: GeoBounds | undefined) {
         return null;
     }
 
-    return [ west, south, east, north ].join(",");
+    const middleLat = (south + north) / 2;
+    const middleLng = (west + east) / 2;
+    const latitudePad = MIN_SEARCH_RADIUS_M / METRES_PER_DEGREE;
+    // A degree of longitude shortens towards the poles, where it is short enough that padding by one
+    // would reach around the world; the cosine is floored to keep the padding finite.
+    const longitudePad = latitudePad / Math.max(Math.cos(middleLat * Math.PI / 180), 0.01);
+
+    return [
+        clamp(Math.min(west, middleLng - longitudePad), -180, 180),
+        clamp(Math.min(south, middleLat - latitudePad), -90, 90),
+        clamp(Math.max(east, middleLng + longitudePad), -180, 180),
+        clamp(Math.max(north, middleLat + latitudePad), -90, 90)
+    ].map((degrees) => Number(degrees.toFixed(5))).join(",");
+}
+
+function clamp(value: number, least: number, most: number) {
+    return Math.min(Math.max(value, least), most);
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -1,0 +1,96 @@
+import { getCurrentLanguage } from "../../../services/i18n";
+import type { GeocodingProvider, GeoSearchResult } from "./geocoding";
+
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
+
+/** Caps how many results one search returns. */
+const MAX_RESULTS = 8;
+
+/**
+ * Nominatim's usage policy allows at most one request per second, and blocks clients that exceed it.
+ * See https://operations.osmfoundation.org/policies/nominatim/.
+ */
+const MIN_REQUEST_INTERVAL = 1000;
+
+/** When the next request is allowed to go out, moved forward by every request that is queued. */
+let nextRequestAt = 0;
+
+/**
+ * Nominatim, the geocoder run by the OpenStreetMap Foundation.
+ *
+ * No API key, and it answers with `Access-Control-Allow-Origin: *`, so the browser can ask it
+ * directly — which matters on desktop, where the page is served from `trilium-app://`. Its policy
+ * also asks that clients identify themselves, which a browser can only do through the `Referer` it
+ * sends of its own accord.
+ *
+ * The same policy rules out searching as the user types, which is why a search runs only when the
+ * user asks for one (see SearchBox).
+ */
+export const nominatim: GeocodingProvider = {
+    name: "Nominatim (OpenStreetMap)",
+    search: searchNominatim
+};
+
+async function searchNominatim(query: string): Promise<GeoSearchResult[]> {
+    const params = new URLSearchParams({
+        q: query,
+        format: "jsonv2",
+        limit: String(MAX_RESULTS)
+    });
+
+    // Place names in the language the app runs in, where Nominatim holds one. Trilium writes some
+    // locale ids with an underscore (`pt_br`), which is not what a language tag looks like.
+    const language = getCurrentLanguage();
+    if (language) {
+        params.set("accept-language", language.replace("_", "-"));
+    }
+
+    await waitForRequestSlot();
+    const response = await fetch(`${NOMINATIM_URL}?${params}`);
+    if (!response.ok) {
+        throw new Error(`Nominatim answered ${response.status} ${response.statusText}`);
+    }
+
+    const places: NominatimPlace[] = await response.json();
+    return places.map(toSearchResult).filter((result) => result !== null);
+}
+
+/** One entry of a Nominatim `jsonv2` response, narrowed to the fields a result is built from. */
+interface NominatimPlace {
+    place_id?: number;
+    display_name?: string;
+    lat?: string;
+    lon?: string;
+}
+
+/** A place as the app holds one, or `null` where the entry carries no readable position. */
+function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
+    const lat = Number(place.lat);
+    const lng = Number(place.lon);
+    if (!place.display_name || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+        return null;
+    }
+
+    return {
+        id: String(place.place_id ?? `${lat},${lng}`),
+        label: place.display_name,
+        lat,
+        lng
+    };
+}
+
+/**
+ * Holds a request back until the interval the policy asks for has passed since the last one.
+ *
+ * The slot is claimed before the wait rather than after it, so two searches started at once queue
+ * behind each other instead of both finding the same slot free.
+ */
+async function waitForRequestSlot() {
+    const now = Date.now();
+    const slot = Math.max(now, nextRequestAt);
+    nextRequestAt = slot + MIN_REQUEST_INTERVAL;
+
+    if (slot > now) {
+        await new Promise((resolve) => setTimeout(resolve, slot - now));
+    }
+}

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -1,6 +1,7 @@
 import { getCurrentLanguage } from "../../../services/i18n";
 import { type GeoBounds, type GeocodingProvider, type GeoSearchOptions, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 import { placeIcon } from "./osm_icons";
+import { formatStreet, type PlaceAddress } from "./place_address";
 
 const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
@@ -105,6 +106,8 @@ async function searchPlaces(query: string, extraParams: Record<string, string>):
         q: query,
         format: "jsonv2",
         limit: String(MAX_RESULTS),
+        // The address in parts, which is what names a house and places a shop (see place_address).
+        addressdetails: "1",
         ...extraParams
     });
 
@@ -142,6 +145,30 @@ interface NominatimPlace {
     type?: string;
     /** What kind of address the place is: `city`, `country`, `road`, `shop`. */
     addresstype?: string;
+    /** The address in parts, asked for with `addressdetails`. */
+    address?: NominatimAddress;
+}
+
+/**
+ * Nominatim's breakdown of an address, narrowed to the parts a result is named and placed by.
+ *
+ * It names the town by what kind of settlement it is, so a place in a village carries `village` and
+ * no `city`; the same goes for the region around it (see toAddress).
+ */
+interface NominatimAddress {
+    house_number?: string;
+    road?: string;
+    city?: string;
+    town?: string;
+    village?: string;
+    hamlet?: string;
+    municipality?: string;
+    county?: string;
+    state?: string;
+    province?: string;
+    region?: string;
+    country?: string;
+    country_code?: string;
 }
 
 /** A place as the app holds one, or `null` where the entry carries no readable position. */
@@ -152,6 +179,7 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         return null;
     }
 
+    const address = toAddress(place.address);
     const prefix = OSM_TYPE_PREFIX[place.osm_type ?? ""];
     const osmId = prefix && place.osm_id ? `${prefix}${place.osm_id}` : null;
     const hasBoundary = OSM_TYPES_WITH_A_BOUNDARY.has(place.osm_type ?? "");
@@ -163,15 +191,41 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         // back under two of them and is offered twice.
         id: osmId ?? String(place.place_id ?? `${lat},${lng}`),
         label: place.display_name,
-        // Nominatim leaves `name` empty for a result that is an address rather than a named place,
-        // where the leading part of the label is what names it.
-        name: place.name || place.display_name.split(",")[0].trim(),
+        // Nominatim leaves `name` empty for a result that is an address rather than a named place.
+        // Its street and number name it; the leading part of the label, which is the house number on
+        // its own, is what is left when even those are missing.
+        name: place.name || address?.street || place.display_name.split(",")[0].trim(),
+        address,
         lat,
         lng,
         bounds,
         icon: placeIcon({ category: place.category, type: place.type, addressType: place.addresstype }),
         outline: osmId && hasBoundary ? () => fetchOutline(osmId, bounds) : undefined
     };
+}
+
+/**
+ * Nominatim's address, in the parts a result is named and placed by, or nothing where it broke the
+ * address into none.
+ *
+ * The town and the region are each named by whichever kind of place fills that role here: a village
+ * has no `city`, and a county stands in for a state where a country has no states.
+ */
+function toAddress(address: NominatimAddress | undefined): PlaceAddress | undefined {
+    if (!address) {
+        return undefined;
+    }
+
+    const countryCode = address.country_code?.toLowerCase();
+    const place: PlaceAddress = {
+        street: formatStreet(address.house_number, address.road, countryCode),
+        locality: address.city ?? address.town ?? address.village ?? address.hamlet ?? address.municipality,
+        region: address.state ?? address.province ?? address.region ?? address.county,
+        country: address.country,
+        countryCode
+    };
+
+    return Object.values(place).some(Boolean) ? place : undefined;
 }
 
 /** The extent Nominatim reports, as MapLibre reads one, or nothing where it cannot be read. */

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -1,5 +1,5 @@
 import { getCurrentLanguage } from "../../../services/i18n";
-import type { GeoBounds, GeocodingProvider, GeoSearchOptions, GeoSearchResult } from "./geocoding";
+import { type GeoBounds, type GeocodingProvider, type GeoSearchOptions, type GeoSearchResult, SEARCH_RADIUS_M } from "./geocoding";
 
 const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
 const NOMINATIM_LOOKUP_URL = "https://nominatim.openstreetmap.org/lookup";
@@ -16,14 +16,6 @@ const OSM_TYPE_PREFIX: Record<string, string> = { node: "N", way: "W", relation:
 /** The kinds of OSM object that can enclose ground. A node is a single point and has no boundary. */
 const OSM_TYPES_WITH_A_BOUNDARY = new Set([ "way", "relation" ]);
 
-/**
- * The least ground a search treats as here, as a half-span in metres.
- *
- * A map zoomed into a neighbourhood shows a few hundred metres across, and a search restricted to
- * exactly that answers nothing for a shop three streets away. What the reader means by searching from
- * where they are standing is the town they are looking at, not the block.
- */
-const MIN_SEARCH_RADIUS_M = 25_000;
 
 /** Metres to a degree of latitude, the same the world over. A degree of longitude is this shortened
  *  by the cosine of the latitude. */
@@ -192,7 +184,7 @@ function toBounds(boundingbox: string[] | undefined): GeoSearchResult["bounds"] 
  * first. Sent without `bounded` on the wider pass, so a place is ranked up for being in view rather
  * than a place out of view being refused.
  *
- * Grown to at least {@link MIN_SEARCH_RADIUS_M} about its middle, since a view of one neighbourhood
+ * Grown to at least {@link SEARCH_RADIUS_M} about its middle, since a view of one neighbourhood
  * restricts a search to that neighbourhood and answers nothing for the next street over.
  *
  * A view running the other way round has been panned across the antimeridian, which no pair of
@@ -210,7 +202,7 @@ function toViewbox(viewport: GeoBounds | undefined) {
 
     const middleLat = (south + north) / 2;
     const middleLng = (west + east) / 2;
-    const latitudePad = MIN_SEARCH_RADIUS_M / METRES_PER_DEGREE;
+    const latitudePad = SEARCH_RADIUS_M / METRES_PER_DEGREE;
     // A degree of longitude shortens towards the poles, where it is short enough that padding by one
     // would reach around the world; the cosine is floored to keep the padding finite.
     const longitudePad = latitudePad / Math.max(Math.cos(middleLat * Math.PI / 180), 0.01);

--- a/apps/client/src/widgets/collections/geomap/nominatim.ts
+++ b/apps/client/src/widgets/collections/geomap/nominatim.ts
@@ -62,6 +62,8 @@ interface NominatimPlace {
     name?: string;
     lat?: string;
     lon?: string;
+    /** `[south, north, west, east]`, as strings, which is the order Nominatim writes it in. */
+    boundingbox?: string[];
 }
 
 /** A place as the app holds one, or `null` where the entry carries no readable position. */
@@ -79,8 +81,29 @@ function toSearchResult(place: NominatimPlace): GeoSearchResult | null {
         // where the leading part of the label is what names it.
         name: place.name || place.display_name.split(",")[0].trim(),
         lat,
-        lng
+        lng,
+        bounds: toBounds(place.boundingbox)
     };
+}
+
+/** The extent Nominatim reports, as MapLibre reads one, or nothing where it cannot be read. */
+function toBounds(boundingbox: string[] | undefined): GeoSearchResult["bounds"] {
+    if (boundingbox?.length !== 4) {
+        return undefined;
+    }
+
+    const [ south, north, west, east ] = boundingbox.map(Number);
+    if (![ south, north, west, east ].every(Number.isFinite)) {
+        return undefined;
+    }
+
+    // A place spanning the antimeridian is reported west of east, which frames the whole world the
+    // long way round. Rare enough to be left to the fallback zoom rather than split in two.
+    if (west > east) {
+        return undefined;
+    }
+
+    return [ [ west, south ], [ east, north ] ];
 }
 
 /**

--- a/apps/client/src/widgets/collections/geomap/osm_icons.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/osm_icons.spec.ts
@@ -1,0 +1,35 @@
+/** Which icon a place is drawn with, from how OpenStreetMap classifies it. */
+import { describe, expect, it } from "vitest";
+
+import { placeIcon } from "./osm_icons";
+
+describe("Place icons", () => {
+    it("draws a place by its own kind, where OSM names one", () => {
+        expect(placeIcon({ category: "shop", type: "supermarket", addressType: "shop" })).toBe("bx bx-cart");
+        expect(placeIcon({ category: "amenity", type: "cafe", addressType: "amenity" })).toBe("bx bx-coffee");
+        expect(placeIcon({ category: "amenity", type: "parking", addressType: "amenity" })).toBe("bx bxs-parking");
+        expect(placeIcon({ category: "natural", type: "volcano", addressType: "volcano" })).toBe("bx bx-landscape");
+        expect(placeIcon({ category: "aeroway", type: "aerodrome", addressType: "aeroway" })).toBe("bx bx-paper-plane");
+    });
+
+    it("tells administrative areas apart by their address type, which is all that distinguishes them", () => {
+        // Every one of these is filed under the same category and type.
+        const boundary = { category: "boundary", type: "administrative" };
+
+        expect(placeIcon({ ...boundary, addressType: "country" })).toBe("bx bx-flag");
+        expect(placeIcon({ ...boundary, addressType: "county" })).toBe("bx bx-map-alt");
+        expect(placeIcon({ ...boundary, addressType: "city" })).toBe("bx bx-buildings");
+        expect(placeIcon({ ...boundary, addressType: "village" })).toBe("bx bx-home-alt");
+        expect(placeIcon({ ...boundary, addressType: "suburb" })).toBe("bx bx-building-house");
+    });
+
+    it("falls back on what a place broadly is, then on nothing at all", () => {
+        // A trade no table names is still a shop, and a road is still a road.
+        expect(placeIcon({ category: "shop", type: "locksmith", addressType: "shop" })).toBe("bx bx-store");
+        expect(placeIcon({ category: "highway", type: "secondary", addressType: "road" })).toBe("bx bx-directions");
+
+        // Nothing here claims these, so the caller falls back on DEFAULT_PLACE_ICON in their stead.
+        expect(placeIcon({ category: "sport", type: "curling" })).toBeUndefined();
+        expect(placeIcon({})).toBeUndefined();
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/osm_icons.ts
+++ b/apps/client/src/widgets/collections/geomap/osm_icons.ts
@@ -1,0 +1,173 @@
+/**
+ * The icon a place found by searching wears, taken from how OpenStreetMap classifies it.
+ *
+ * The tables here speak OSM's vocabulary, which is what geocoders built on OSM data report — see
+ * nominatim.ts, the only caller. A geocoder classifying places its own way, by Maki icon name or by
+ * a list of Google place types, maps that vocabulary itself and fills in `GeoSearchResult.icon`.
+ *
+ * OSM describes a place with a key and a value — `shop`=`supermarket`, `natural`=`volcano` — which a
+ * geocoder passes on as a category and a type. Every administrative area from a hamlet to a country
+ * shares one pair, `boundary`=`administrative`, so what tells those apart is the address type the
+ * geocoder works out alongside it.
+ *
+ * A pair the tables below do not name is still drawn by its category, a shop as a shop; what not even
+ * that claims is left without an icon, for the caller to fall back on DEFAULT_PLACE_ICON.
+ */
+
+/** How a geocoder classifies a place, in the terms OpenStreetMap uses. */
+export interface OsmClassification {
+    /** The OSM key: `shop`, `amenity`, `natural`, `boundary`. */
+    category?: string;
+    /** The OSM value: `supermarket`, `restaurant`, `volcano`, `administrative`. */
+    type?: string;
+    /**
+     * What kind of address the place is: `city`, `country`, `road`, `shop`. Worked out by the
+     * geocoder rather than tagged in OSM, so one that reports no such thing leaves it out.
+     */
+    addressType?: string;
+}
+
+/**
+ * The boxicons class for a place, from the most specific of its classifications that is known, or
+ * nothing where none of them says what kind of place it is.
+ *
+ * The address type is read before the bare category so that a city is drawn as a city rather than as
+ * the boundary it is filed under.
+ */
+export function placeIcon({ category, type, addressType }: OsmClassification): string | undefined {
+    const icon = BY_CATEGORY_AND_TYPE[`${category}/${type}`]
+        ?? BY_ADDRESS_TYPE[addressType ?? ""]
+        ?? BY_CATEGORY[category ?? ""];
+
+    return icon ? `bx ${icon}` : undefined;
+}
+
+/** What a place is, where its own kind is worth drawing: `<key>/<value>`, as OSM tags it. */
+const BY_CATEGORY_AND_TYPE: Record<string, string> = {
+    "shop/supermarket": "bx-cart",
+    "shop/convenience": "bx-basket",
+    "shop/bakery": "bx-cake",
+    "shop/mall": "bx-shopping-bag",
+    "shop/department_store": "bx-shopping-bag",
+
+    "amenity/restaurant": "bx-restaurant",
+    "amenity/fast_food": "bx-bowl-hot",
+    "amenity/cafe": "bx-coffee",
+    "amenity/bar": "bx-beer",
+    "amenity/pub": "bx-beer",
+    "amenity/biergarten": "bx-beer",
+    "amenity/bank": "bx-money",
+    "amenity/atm": "bx-credit-card",
+    "amenity/pharmacy": "bx-plus-medical",
+    "amenity/hospital": "bx-clinic",
+    "amenity/clinic": "bx-clinic",
+    "amenity/doctors": "bx-clinic",
+    "amenity/school": "bx-book",
+    "amenity/kindergarten": "bx-book",
+    "amenity/college": "bx-book",
+    "amenity/university": "bx-book",
+    "amenity/library": "bx-library",
+    "amenity/police": "bx-shield",
+    "amenity/fire_station": "bx-first-aid",
+    "amenity/post_office": "bx-envelope",
+    "amenity/fuel": "bx-gas-pump",
+    "amenity/parking": "bxs-parking",
+    "amenity/place_of_worship": "bx-church",
+    "amenity/cinema": "bx-movie",
+    "amenity/theatre": "bx-movie",
+    "amenity/bus_station": "bx-bus",
+
+    "tourism/hotel": "bx-hotel",
+    "tourism/motel": "bx-hotel",
+    "tourism/hostel": "bx-hotel",
+    "tourism/guest_house": "bx-hotel",
+    "tourism/apartment": "bx-hotel",
+    "tourism/museum": "bx-library",
+    "tourism/gallery": "bx-palette",
+    "tourism/artwork": "bx-palette",
+    "tourism/camp_site": "bx-leaf",
+
+    "leisure/park": "bx-leaf",
+    "leisure/garden": "bx-leaf",
+    "leisure/nature_reserve": "bx-leaf",
+    "leisure/pitch": "bx-football",
+    "leisure/stadium": "bx-football",
+    "leisure/sports_centre": "bx-football",
+    "leisure/swimming_pool": "bx-swim",
+    "leisure/fitness_centre": "bx-dumbbell",
+
+    "natural/peak": "bx-landscape",
+    "natural/volcano": "bx-landscape",
+    "natural/water": "bx-water",
+    "natural/bay": "bx-water",
+    "natural/spring": "bx-water",
+    "natural/wood": "bx-leaf",
+    "natural/tree": "bx-leaf",
+    "natural/beach": "bx-sun",
+
+    "railway/station": "bx-train",
+    "railway/halt": "bx-train",
+    "railway/tram_stop": "bx-train",
+    "railway/subway_entrance": "bx-train",
+
+    "highway/bus_stop": "bx-bus",
+    "highway/footway": "bx-walk",
+    "highway/path": "bx-walk",
+    "highway/pedestrian": "bx-walk",
+    "highway/cycleway": "bx-cycling",
+
+    "aeroway/aerodrome": "bx-paper-plane",
+    "aeroway/terminal": "bx-paper-plane"
+};
+
+/** How big a place is, for the areas OSM files under one category and type. */
+const BY_ADDRESS_TYPE: Record<string, string> = {
+    "continent": "bx-world",
+    "country": "bx-flag",
+    "state": "bx-map-alt",
+    "province": "bx-map-alt",
+    "region": "bx-map-alt",
+    "county": "bx-map-alt",
+    "district": "bx-map-alt",
+    "municipality": "bx-map-alt",
+    "island": "bx-landscape",
+    "islet": "bx-landscape",
+    "city": "bx-buildings",
+    "town": "bx-buildings",
+    "village": "bx-home-alt",
+    "hamlet": "bx-home-alt",
+    "isolated_dwelling": "bx-home-alt",
+    "borough": "bx-building-house",
+    "city_district": "bx-building-house",
+    "suburb": "bx-building-house",
+    "neighbourhood": "bx-building-house",
+    "quarter": "bx-building-house",
+    "road": "bx-directions",
+    "house": "bx-home",
+    "building": "bx-home",
+    "residential": "bx-home",
+    "postcode": "bx-envelope"
+};
+
+/** What a place broadly is, for a kind too rare to name above. */
+const BY_CATEGORY: Record<string, string> = {
+    "shop": "bx-store",
+    "amenity": "bx-building",
+    "tourism": "bx-camera",
+    "leisure": "bx-football",
+    "natural": "bx-leaf",
+    "waterway": "bx-water",
+    "highway": "bx-directions",
+    "railway": "bx-train",
+    "aeroway": "bx-paper-plane",
+    "building": "bx-building",
+    "historic": "bx-library",
+    "office": "bx-briefcase",
+    "craft": "bx-wrench",
+    "man_made": "bx-wrench",
+    "healthcare": "bx-plus-medical",
+    "military": "bx-shield",
+    "emergency": "bx-first-aid",
+    "landuse": "bx-map-alt",
+    "boundary": "bx-map-alt"
+};

--- a/apps/client/src/widgets/collections/geomap/place_address.spec.ts
+++ b/apps/client/src/widgets/collections/geomap/place_address.spec.ts
@@ -1,0 +1,53 @@
+/** An address held in parts: how a street is written, and how few parts place a result. */
+import { describe, expect, it } from "vitest";
+
+import { describePlace, formatStreet } from "./place_address";
+
+describe("Place addresses", () => {
+    it("writes the number on the side of the street the country writes it", () => {
+        expect(formatStreet("25", "Lankwitzer Straße", "de")).toBe("Lankwitzer Straße 25");
+        expect(formatStreet("28", "Strada Memorandumului", "ro")).toBe("Strada Memorandumului 28");
+        expect(formatStreet("1600", "Pennsylvania Avenue", "us")).toBe("1600 Pennsylvania Avenue");
+        expect(formatStreet("10", "Downing Street", "gb")).toBe("10 Downing Street");
+
+        // A country not named reads the way most of the world writes an address.
+        expect(formatStreet("7", "Šeříková", "cz")).toBe("Šeříková 7");
+        expect(formatStreet("7", "Šeříková", undefined)).toBe("Šeříková 7");
+    });
+
+    it("has nothing to write without a road, and writes the road alone without a number", () => {
+        expect(formatStreet("25", undefined, "de")).toBeUndefined();
+        expect(formatStreet(undefined, "Lankwitzer Straße", "de")).toBe("Lankwitzer Straße");
+    });
+
+    it("places a result by its street and its town, leaving out what places nothing", () => {
+        // The postcode and the boroughs between are never among the parts.
+        expect(describePlace({
+            name: "REWE",
+            label: "REWE, 19-24, Lankwitzer Straße, Lichterfelde, Steglitz-Zehlendorf, Berlin, 12209, Deutschland",
+            address: {
+                street: "Lankwitzer Straße 19-24", locality: "Berlin", region: "Berlin",
+                country: "Deutschland", countryCode: "de"
+            }
+        })).toBe("Lankwitzer Straße 19-24, Berlin, Deutschland");
+    });
+
+    it("does not place a city inside itself", () => {
+        expect(describePlace({
+            name: "Berlin",
+            label: "Berlin, Deutschland",
+            address: { locality: "Berlin", region: "Berlin", country: "Deutschland", countryCode: "de" }
+        })).toBe("Deutschland");
+
+        // A country is placed by nothing: it is the last part there is, and it is its own name.
+        expect(describePlace({
+            name: "Deutschland", label: "Deutschland",
+            address: { country: "Deutschland", countryCode: "de" }
+        })).toBe("");
+    });
+
+    it("falls back on the label where a provider breaks an address into no parts", () => {
+        expect(describePlace({ name: "Tokyo", label: "Tokyo, Ōta, Japan" })).toBe("Ōta, Japan");
+        expect(describePlace({ name: "Nowhere", label: "Somewhere else" })).toBe("Somewhere else");
+    });
+});

--- a/apps/client/src/widgets/collections/geomap/place_address.ts
+++ b/apps/client/src/widgets/collections/geomap/place_address.ts
@@ -1,0 +1,81 @@
+/**
+ * A place's address broken into the parts worth showing, and how those parts are put back together.
+ *
+ * A geocoder answers with the whole address written out — house number, street, quarter, borough,
+ * city, postcode, country — which is more than a row of a result list can hold and more than a reader
+ * needs to tell two places apart. Held in parts, the address can be named by its street and placed by
+ * its town without the postcode and the boroughs in between.
+ *
+ * The parts themselves are what any geocoder reports, under whatever keys it uses; mapping its keys
+ * onto these is the provider's own work (see nominatim.ts).
+ */
+
+/** A place's address, in the parts a result is named and placed by. */
+export interface PlaceAddress {
+    /** The street and its number, in the order the country writes them (see {@link formatStreet}). */
+    street?: string;
+    /** The town the place stands in: a city, a town, a village, or the nearest thing to one. */
+    locality?: string;
+    /** The state, province or county around that town, which is what tells two towns of one name apart. */
+    region?: string;
+    /** The country's name, in the language the search was made in. */
+    country?: string;
+    /** The country's ISO 3166-1 alpha-2 code, lowercased — `de`, `ro`, `us`. */
+    countryCode?: string;
+}
+
+/**
+ * The street line of an address: a road and the number on it, or nothing where there is no road.
+ *
+ * Which side the number goes is a matter of where the place is rather than of what language the app
+ * runs in — a Berlin address reads `Lankwitzer Straße 25` to every reader there is. Most of the world
+ * writes the number after the street, so that is what a country not named below gets.
+ */
+export function formatStreet(houseNumber: string | undefined, road: string | undefined, countryCode?: string) {
+    if (!road) {
+        return undefined;
+    }
+    if (!houseNumber) {
+        return road;
+    }
+
+    return NUMBER_BEFORE_STREET.has(countryCode ?? "")
+        ? `${houseNumber} ${road}`
+        : `${road} ${houseNumber}`;
+}
+
+/**
+ * Where a place stands, said in as few parts as tell it from another of the same name.
+ *
+ * The street, the town, the region around it and the country — dropping the postcode and the quarters
+ * and boroughs between them, which place nothing for a reader. A part that repeats what the place is
+ * already called is dropped as well, so a city named `Berlin` is placed in `Deutschland` rather than
+ * in `Berlin, Berlin, Deutschland`.
+ *
+ * The whole label, less the name at the front of it, for a provider that reports no parts at all.
+ */
+export function describePlace({ name, label, address }: { name: string; label: string; address?: PlaceAddress }) {
+    if (!address) {
+        const rest = label.startsWith(name) ? label.slice(name.length) : label;
+        return rest.replace(/^[\s,]+/, "");
+    }
+
+    const parts: string[] = [];
+    for (const part of [ address.street, address.locality, address.region, address.country ]) {
+        if (part && part !== name && part !== parts[parts.length - 1]) {
+            parts.push(part);
+        }
+    }
+
+    return parts.join(", ");
+}
+
+/**
+ * The countries that write the number before the street.
+ *
+ * Kept to the ones whose convention is not in doubt; a country left out reads the other way round,
+ * which is what most of the world does and what a wrong guess should fall back on.
+ */
+const NUMBER_BEFORE_STREET = new Set([
+    "au", "ca", "fr", "gb", "hk", "ie", "in", "my", "nz", "ph", "sg", "th", "us", "za"
+]);

--- a/apps/client/src/widgets/collections/geomap/results.ts
+++ b/apps/client/src/widgets/collections/geomap/results.ts
@@ -1,0 +1,43 @@
+import type { Map as MapLibreGLMap } from "maplibre-gl";
+
+import type { GeoSearchResult } from "./geocoding";
+
+/** One of the things a search turned up: a note of the map's own, or a place from the geocoder. */
+export type SearchResult =
+    | { kind: "note"; noteId: string; center: [number, number] }
+    | { kind: "place"; place: GeoSearchResult };
+
+/** The zoom level a place is shown at where the geocoder does not say how much ground it covers. */
+const PLACE_ZOOM = 12;
+
+/** The zoom level a note is shown at, closer in since it marks a spot rather than an area. */
+const NOTE_ZOOM = 15;
+
+/**
+ * How close a place is framed at most. A house's extent is a few metres across, which on its own
+ * would fill the screen with the roof.
+ */
+const PLACE_MAX_ZOOM = 17;
+
+/** The room kept around a framed place, so its pin and name do not sit against the map's edge. */
+const PLACE_PADDING = 60;
+
+/**
+ * Points the map at one of a search's results.
+ *
+ * A place is framed on the ground it covers, where the geocoder says how much that is: one zoom
+ * level suited to a city shows a street as the city around it. A note marks a spot and has no extent
+ * to frame, and neither has a place the geocoder gave no bounding box for.
+ */
+export function frameResult(map: MapLibreGLMap, result: SearchResult) {
+    if (result.kind === "place" && result.place.bounds) {
+        map.fitBounds(result.place.bounds, { padding: PLACE_PADDING, maxZoom: PLACE_MAX_ZOOM });
+        return;
+    }
+
+    const center: [number, number] = result.kind === "place"
+        ? [ result.place.lng, result.place.lat ]
+        : result.center;
+
+    map.flyTo({ center, zoom: result.kind === "place" ? PLACE_ZOOM : NOTE_ZOOM });
+}

--- a/apps/client/src/widgets/react/FormAutocomplete.css
+++ b/apps/client/src/widgets/react/FormAutocomplete.css
@@ -44,3 +44,18 @@
     color: var(--active-item-text-color);
     background-color: var(--active-item-background-color);
 }
+
+/* A heading over the entries below it, not one of them (see `isHeading`). */
+.form-autocomplete-dropdown .form-autocomplete-heading {
+    padding: 8px 8px 2px;
+    font-size: 0.8em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.55;
+    cursor: default;
+}
+
+.form-autocomplete-dropdown .form-autocomplete-heading:first-child {
+    padding-top: 2px;
+}

--- a/apps/client/src/widgets/react/FormAutocomplete.spec.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.spec.tsx
@@ -5,7 +5,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { computeDropdownPosition } from "./FormAutocomplete";
+import { computeDropdownPosition, stepOver } from "./FormAutocomplete";
 
 /** The room the placement keeps between the list and the edge of the screen. */
 const MARGIN = 8;
@@ -29,6 +29,26 @@ afterEach(() => {
     for (const name of [ "clientWidth", "clientHeight" ]) {
         Reflect.deleteProperty(document.documentElement, name);
     }
+});
+
+describe("stepping through a list with headings in it", () => {
+    const items = [ "Nearby", "a", "b", "Far away", "c" ];
+    const isHeading = (item: string) => item === "Nearby" || item === "Far away";
+
+    it("steps over the headings, in either direction, wrapping at the ends", () => {
+        // Opening the list lands on the first entry that can be taken, not on the heading over it.
+        expect(stepOver(items, -1, 1, isHeading)).toBe(1);
+        expect(stepOver(items, 1, 1, isHeading)).toBe(2);
+        // Past the last of one group is the first of the next, the heading between them stepped over.
+        expect(stepOver(items, 2, 1, isHeading)).toBe(4);
+        // And round the end, back to the top.
+        expect(stepOver(items, 4, 1, isHeading)).toBe(1);
+        expect(stepOver(items, 1, -1, isHeading)).toBe(4);
+    });
+
+    it("highlights nothing in a list that is headings alone", () => {
+        expect(stepOver([ "Nearby" ], -1, 1, isHeading)).toBe(-1);
+    });
 });
 
 describe("computeDropdownPosition", () => {

--- a/apps/client/src/widgets/react/FormAutocomplete.spec.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.spec.tsx
@@ -1,0 +1,77 @@
+/**
+ * Where the suggestion list is placed and how wide it is drawn. Everything the placement reads is
+ * measured from the layout, which a headless DOM has none of, so the field and the viewport are
+ * given the measurements a browser would have taken.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { computeDropdownPosition } from "./FormAutocomplete";
+
+/** The room the placement keeps between the list and the edge of the screen. */
+const MARGIN = 8;
+
+function fieldAt({ left = 20, top = 100, width = 240, height = 30 } = {}) {
+    const element = document.createElement("div");
+    element.getBoundingClientRect = () => ({
+        left, top, width, height, right: left + width, bottom: top + height,
+        x: left, y: top, toJSON: () => ({})
+    });
+    return element;
+}
+
+function setViewport(width: number, height: number) {
+    for (const [ name, value ] of [ [ "clientWidth", width ], [ "clientHeight", height ] ] as const) {
+        Object.defineProperty(document.documentElement, name, { value, configurable: true });
+    }
+}
+
+afterEach(() => {
+    for (const name of [ "clientWidth", "clientHeight" ]) {
+        Reflect.deleteProperty(document.documentElement, name);
+    }
+});
+
+describe("computeDropdownPosition", () => {
+    it("hangs the list under the field, at the field's own width", () => {
+        setViewport(1200, 800);
+
+        expect(computeDropdownPosition(fieldAt())).toMatchObject({
+            left: "20px",
+            top: "130px",
+            width: "240px"
+        });
+    });
+
+    it("draws the list wider where the caller asks for more than the field", () => {
+        setViewport(1200, 800);
+
+        expect(computeDropdownPosition(fieldAt({ width: 240 }), 440)).toMatchObject({ width: "440px" });
+        // The field is the floor: a minimum under it asks for nothing.
+        expect(computeDropdownPosition(fieldAt({ width: 240 }), 100)).toMatchObject({ width: "240px" });
+    });
+
+    it("keeps a wider list on the screen rather than running it off the far edge", () => {
+        setViewport(600, 800);
+
+        // Asked for more than there is room for, it takes the room there is.
+        expect(computeDropdownPosition(fieldAt({ left: 20 }), 2000)).toMatchObject({
+            left: `${MARGIN}px`,
+            width: `${600 - 2 * MARGIN}px`
+        });
+
+        // Wide enough to fit, but not where the field stands, so it is pulled back to fit.
+        expect(computeDropdownPosition(fieldAt({ left: 400 }), 440)).toMatchObject({
+            left: `${600 - MARGIN - 440}px`,
+            width: "440px"
+        });
+    });
+
+    it("flips above the field only where the room below is too little to be useful", () => {
+        setViewport(1200, 800);
+        expect(computeDropdownPosition(fieldAt({ top: 100 }))).toMatchObject({ top: "130px" });
+
+        // Near the foot of the screen, where what is under the field would show barely an entry.
+        setViewport(1200, 200);
+        expect(computeDropdownPosition(fieldAt({ top: 150 })).top).not.toBe("180px");
+    });
+});

--- a/apps/client/src/widgets/react/FormAutocomplete.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.tsx
@@ -29,6 +29,15 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
     /** Opens the dropdown as soon as the field receives focus, not just on typing. */
     openOnFocus?: boolean;
     /**
+     * Opens the list on Enter where it is closed, for a box whose entries are what the field is for.
+     * A list sent away — by Escape, or by taking something from it — is otherwise only brought back
+     * by typing, which means editing a query that was already right.
+     *
+     * The key is not consumed when it only opens the list, so a form around the field is submitted by
+     * it as before.
+     */
+    openOnEnter?: boolean;
+    /**
      * Receives a suggestion picked from the dropdown (click or Enter) instead of `onChange`, for a
      * host that treats a made choice differently from typing — both otherwise arrive as the same
      * string. Left out, picking reports through `onChange`, exactly like typing. (Not `onSelect`,
@@ -85,7 +94,7 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
  * The dropdown is portalled to the body and positioned over everything else, so it is not clipped
  * by scrolling ancestors. Selecting a suggestion reports it through `onChange`, exactly like typing.
  */
-export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, onPick, keepOpenOnPick, renderItem, leading, autoActivate, isHeading, dropdownMinWidth, inputRef, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
+export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, openOnEnter, onPick, keepOpenOnPick, renderItem, leading, autoActivate, isHeading, dropdownMinWidth, inputRef, onFocus, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
     const ownInputRef = useRef<HTMLInputElement>(null);
     const inputEl = inputRef ?? ownInputRef;
     const fieldRef = useRef<HTMLDivElement>(null);
@@ -202,6 +211,8 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
                     e.preventDefault();
                     e.stopPropagation();
                     selectItem(items[activeIndex]);
+                } else if (openOnEnter && !isDisabled) {
+                    setIsOpen(true);
                 }
                 break;
 
@@ -236,7 +247,12 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
                     setIsOpen(true);
                 }
             }}
-            onFocus={openOnFocus && !isDisabled ? () => setIsOpen(true) : undefined}
+            onFocus={(e) => {
+                if (openOnFocus && !isDisabled) {
+                    setIsOpen(true);
+                }
+                onFocus?.(e);
+            }}
             onBlur={(newValue) => {
                 close();
                 onBlur?.(newValue);

--- a/apps/client/src/widgets/react/FormAutocomplete.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.tsx
@@ -58,6 +58,12 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
      */
     leading?: ComponentChildren;
     /**
+     * The least the list is drawn at, in pixels, for a field too narrow for what its entries have to
+     * say — a search box in the corner of a map offering whole addresses. The field's own width is
+     * still the floor and the viewport the ceiling, so the list never runs off the screen.
+     */
+    dropdownMinWidth?: number;
+    /**
      * Opens the list with an entry already picked out — the one the field's text names, or failing
      * that the first — so that Enter takes it without arrowing down to it first.
      *
@@ -74,7 +80,7 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
  * The dropdown is portalled to the body and positioned over everything else, so it is not clipped
  * by scrolling ancestors. Selecting a suggestion reports it through `onChange`, exactly like typing.
  */
-export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, onPick, keepOpenOnPick, renderItem, leading, autoActivate, inputRef, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
+export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, onPick, keepOpenOnPick, renderItem, leading, autoActivate, dropdownMinWidth, inputRef, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
     const ownInputRef = useRef<HTMLInputElement>(null);
     const inputEl = inputRef ?? ownInputRef;
     const fieldRef = useRef<HTMLDivElement>(null);
@@ -140,7 +146,7 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
             // The wrapper where there is one, so a field carrying chips is spanned whole.
             const anchor = fieldRef.current ?? inputEl.current;
             if (anchor) {
-                setPosition(computeDropdownPosition(anchor));
+                setPosition(computeDropdownPosition(anchor, dropdownMinWidth));
             }
         };
 
@@ -152,7 +158,7 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
             window.removeEventListener("resize", reposition);
             window.removeEventListener("scroll", reposition, true);
         };
-    }, [ isOpen, items.length, inputEl ]);
+    }, [ isOpen, items.length, inputEl, dropdownMinWidth ]);
 
     function selectItem(item: string) {
         (onPick ?? onChange)(item);
@@ -287,20 +293,32 @@ function bestMatchIndex(items: string[], text: string) {
  * Places the dropdown under the input, flipping above it only when the space below is too small to
  * be useful. Preferring below matters for inputs sitting in a panel docked to the bottom of the
  * screen: the room under them is limited but ample, while flipping would cover the panel itself.
+ *
+ * As wide as the field, or as wide as `minWidth` asks where that is more, and never wider than the
+ * viewport. A list grown past the far edge is pulled back onto the screen rather than left running
+ * off it, since it is placed from the field's leading edge.
+ *
+ * Exported for its own tests: everything it reads is measured from the layout, which is what a
+ * component test in a headless DOM has none of.
  */
-function computeDropdownPosition(input: HTMLElement): CSSProperties {
+export function computeDropdownPosition(input: HTMLElement, minWidth = 0): CSSProperties {
     const rect = input.getBoundingClientRect();
     const viewportHeight = document.documentElement.clientHeight;
+    const viewportWidth = document.documentElement.clientWidth;
     const spaceBelow = viewportHeight - rect.bottom - VIEWPORT_MARGIN;
     const spaceAbove = rect.top - VIEWPORT_MARGIN;
     const flipAbove = spaceBelow < MIN_DROPDOWN_HEIGHT && spaceAbove > spaceBelow;
     const available = flipAbove ? spaceAbove : spaceBelow;
     const maxHeight = Math.min(MAX_DROPDOWN_HEIGHT, Math.max(available, 0));
 
+    const room = Math.max(viewportWidth - 2 * VIEWPORT_MARGIN, 0);
+    const width = Math.min(Math.max(rect.width, minWidth), room);
+    const left = Math.max(VIEWPORT_MARGIN, Math.min(rect.left, viewportWidth - VIEWPORT_MARGIN - width));
+
     return {
-        left: `${rect.left}px`,
+        left: `${left}px`,
         top: `${flipAbove ? rect.top - maxHeight : rect.bottom}px`,
-        width: `${rect.width}px`,
+        width: `${width}px`,
         maxHeight: `${maxHeight}px`
     };
 }

--- a/apps/client/src/widgets/react/FormAutocomplete.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.tsx
@@ -58,6 +58,11 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
      */
     leading?: ComponentChildren;
     /**
+     * Marks an entry as a heading over the ones below it rather than a choice of its own: it takes no
+     * click, is stepped over on the way through the list, and is never what Enter takes.
+     */
+    isHeading?(item: string): boolean;
+    /**
      * The least the list is drawn at, in pixels, for a field too narrow for what its entries have to
      * say — a search box in the corner of a map offering whole addresses. The field's own width is
      * still the floor and the viewport the ceiling, so the list never runs off the screen.
@@ -80,7 +85,7 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
  * The dropdown is portalled to the body and positioned over everything else, so it is not clipped
  * by scrolling ancestors. Selecting a suggestion reports it through `onChange`, exactly like typing.
  */
-export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, onPick, keepOpenOnPick, renderItem, leading, autoActivate, dropdownMinWidth, inputRef, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
+export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, onPick, keepOpenOnPick, renderItem, leading, autoActivate, isHeading, dropdownMinWidth, inputRef, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
     const ownInputRef = useRef<HTMLInputElement>(null);
     const inputEl = inputRef ?? ownInputRef;
     const fieldRef = useRef<HTMLDivElement>(null);
@@ -120,12 +125,12 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
             // A newer query (or a close) happened while awaiting.
             if (latestQuery.current === queryId) {
                 setItems(suggestions);
-                setActiveIndex(autoActivate ? bestMatchIndex(suggestions, currentValue) : -1);
+                setActiveIndex(autoActivate ? bestMatchIndex(suggestions, currentValue, isHeading) : -1);
             }
         }, DEBOUNCE_MS);
 
         return () => clearTimeout(timeout);
-    }, [ isOpen, currentValue, source, autoActivate ]);
+    }, [ isOpen, currentValue, source, autoActivate, isHeading ]);
 
     // Keep the highlighted entry in sight: it can be picked out on opening, or arrowed past the
     // bottom of a list taller than the room the dropdown was given.
@@ -161,6 +166,10 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
     }, [ isOpen, items.length, inputEl, dropdownMinWidth ]);
 
     function selectItem(item: string) {
+        if (isHeading?.(item)) {
+            return;
+        }
+
         (onPick ?? onChange)(item);
         if (keepOpenOnPick) {
             // Nothing is highlighted until the refreshed entries arrive, so Enter cannot take twice
@@ -183,7 +192,7 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
                     setIsOpen(true);
                 } else {
                     const delta = e.key === "ArrowDown" ? 1 : -1;
-                    setActiveIndex((index) => (index + delta + items.length) % items.length);
+                    setActiveIndex((index) => stepOver(items, index, delta, isHeading));
                 }
                 break;
 
@@ -257,17 +266,21 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
                     onMouseDown={(e) => e.preventDefault()}
                 >
                     {items.map((item, index) => (
-                        <li
-                            key={item}
-                            id={`${itemIdPrefix}-${index}`}
-                            className={`form-autocomplete-item ${index === activeIndex ? "active" : ""}`}
-                            role="option"
-                            aria-selected={index === activeIndex}
-                            onMouseEnter={() => setActiveIndex(index)}
-                            onClick={() => selectItem(item)}
-                        >
-                            {renderItem ? renderItem(item) : item}
-                        </li>
+                        isHeading?.(item)
+                            ? <li key={item} className="form-autocomplete-heading" role="presentation">
+                                {renderItem ? renderItem(item) : item}
+                            </li>
+                            : <li
+                                key={item}
+                                id={`${itemIdPrefix}-${index}`}
+                                className={`form-autocomplete-item ${index === activeIndex ? "active" : ""}`}
+                                role="option"
+                                aria-selected={index === activeIndex}
+                                onMouseEnter={() => setActiveIndex(index)}
+                                onClick={() => selectItem(item)}
+                            >
+                                {renderItem ? renderItem(item) : item}
+                            </li>
                     ))}
                 </ul>,
                 document.body)}
@@ -276,17 +289,38 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
 }
 
 /**
- * Which entry a list opens on: the one the field's text names, or the first, so that a field whose
- * text stands for a choice already made opens on it and one being typed into opens on its best
- * candidate. Matched the way the sources filter — ignoring case and surrounding space.
+ * Which entry a list opens on: the one the field's text names, or the first that can be taken, so
+ * that a field whose text stands for a choice already made opens on it and one being typed into
+ * opens on its best candidate. Matched the way the sources filter — ignoring case and surrounding
+ * space.
  */
-function bestMatchIndex(items: string[], text: string) {
-    if (!items.length) {
-        return -1;
-    }
+function bestMatchIndex(items: string[], text: string, isHeading?: (item: string) => boolean) {
+    const canBeTaken = (item: string) => !isHeading?.(item);
     const trimmed = text.trim().toLowerCase();
-    const exact = items.findIndex((item) => item.toLowerCase() === trimmed);
-    return exact >= 0 ? exact : 0;
+    const exact = items.findIndex((item) => canBeTaken(item) && item.toLowerCase() === trimmed);
+
+    return exact >= 0 ? exact : items.findIndex(canBeTaken);
+}
+
+/**
+ * The next entry that can be taken, in the direction asked for, wrapping at either end and stepping
+ * over the headings in between. Nothing to step to — a list of headings alone — leaves nothing
+ * highlighted.
+ *
+ * Exported for its own tests, the alternative being to drive a dropdown by keystrokes to find out
+ * which row a heading was skipped for.
+ */
+export function stepOver(items: string[], from: number, delta: number, isHeading?: (item: string) => boolean) {
+    let index = from;
+
+    for (let step = 0; step < items.length; step++) {
+        index = (index + delta + items.length) % items.length;
+        if (!isHeading?.(items[index])) {
+            return index;
+        }
+    }
+
+    return -1;
 }
 
 /**

--- a/apps/client/src/widgets/react/OverlayToolbar.tsx
+++ b/apps/client/src/widgets/react/OverlayToolbar.tsx
@@ -1,5 +1,6 @@
 import "./OverlayToolbar.css";
 
+import clsx from "clsx";
 import { type ComponentChildren, createContext } from "preact";
 import { useContext } from "preact/hooks";
 
@@ -43,12 +44,12 @@ export default function OverlayToolbar({ className, titlePosition, children }: O
  * open its tooltips off the bottom edge — overridable per button where one of them is placed
  * differently from its neighbours.
  */
-export function OverlayToolbarButton({ titlePosition, ...props }: ActionButtonProps) {
+export function OverlayToolbarButton({ titlePosition, className, ...props }: ActionButtonProps) {
     const barDirection = useContext(TooltipDirection);
 
     return <ActionButton
         {...props}
-        className="tn-tool-button"
+        className={clsx("tn-tool-button", className)}
         noIconActionClass
         titlePosition={titlePosition ?? barDirection}
     />;

--- a/apps/client/src/widgets/type_widgets/file/GpxPreview.tsx
+++ b/apps/client/src/widgets/type_widgets/file/GpxPreview.tsx
@@ -8,10 +8,10 @@ import { GpxElevationSample, GpxJourney, GpxStats, parseGpxStats } from "../../.
 import { t } from "../../../services/i18n";
 import server from "../../../services/server";
 import { formatDateTime, getMeasurementSystem } from "../../../utils/formatters";
+import { formatDistance, formatElevation, formatSpeed, type MeasurementSystem } from "../../../utils/units";
 import Alert from "../../react/Alert";
 import Collapsible from "../../react/Collapsible";
 
-type MeasurementSystem = ReturnType<typeof getMeasurementSystem>;
 
 interface GpxPreviewProps {
     note: FNote;
@@ -296,33 +296,6 @@ function nearestSample(profile: GpxElevationSample[], distance: number): GpxElev
     return distance - profile[lo].distance <= profile[hi].distance - distance ? profile[lo] : profile[hi];
 }
 
-const METERS_PER_MILE = 1609.344;
-const FEET_PER_METER = 3.28084;
-
-function formatDistance(meters: number, system: MeasurementSystem): string {
-    if (system === "imperial") {
-        return t("gpx_preview.unit_mi", { value: round(meters / METERS_PER_MILE) });
-    }
-    if (meters < 1000) {
-        return t("gpx_preview.unit_m", { value: Math.round(meters).toLocaleString() });
-    }
-    return t("gpx_preview.unit_km", { value: round(meters / 1000) });
-}
-
-function formatElevation(meters: number, system: MeasurementSystem): string {
-    if (system === "imperial") {
-        return t("gpx_preview.unit_ft", { value: Math.round(meters * FEET_PER_METER).toLocaleString() });
-    }
-    return t("gpx_preview.unit_m", { value: Math.round(meters).toLocaleString() });
-}
-
-function formatSpeed(kmh: number, system: MeasurementSystem): string {
-    if (system === "imperial") {
-        return t("gpx_preview.unit_mph", { value: round(kmh * 1000 / METERS_PER_MILE) });
-    }
-    return t("gpx_preview.unit_kmh", { value: round(kmh) });
-}
-
 function formatTravelDuration(milliseconds: number): string {
     const totalMinutes = Math.round(milliseconds / 60_000);
     const hours = Math.floor(totalMinutes / 60);
@@ -331,10 +304,4 @@ function formatTravelDuration(milliseconds: number): string {
         return t("gpx_preview.duration_minutes", { minutes });
     }
     return t("gpx_preview.duration_hours_minutes", { hours, minutes });
-}
-
-/** A magnitude-appropriate rounding: two decimals close up, none once they would say nothing. */
-function round(value: number): string {
-    const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2;
-    return value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: decimals });
 }

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
@@ -97,8 +97,10 @@
   framed by the ground the place covers, so a country fills the view while a
   house is shown at street level. Where the service reports a boundary — a
   country, a county, a park — that boundary is outlined under the pin.</p>
-<p>A panel then opens in the top-right corner with the place's full address and
-  its coordinates. Pressing the coordinates copies them to the clipboard.</p>
+<p>A panel then opens with the place's full address and its coordinates: in the
+  top-right corner on desktop, and at the bottom of the map on mobile, where the
+  top is kept for the search bar and the result counter. Pressing the
+  coordinates copies them to the clipboard.</p>
 <h3>Keeping a place as a marker</h3>
 <p>Press <em>Add as marker</em> in that panel to keep the place. A child note
   is created under the map, named as the place is named and with its

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
@@ -9,6 +9,8 @@
 <ul>
   <li>Add markers on the map, which can be customized with icons, colors and
     text.</li>
+  <li>Search the notes already on the map, and look up places anywhere in the
+    world.</li>
   <li>Display tracks on the map using <code spellcheck="false">.gpx</code> files.</li>
   <li>3D view of the map, which displays buildings when using a vector map.</li>
 </ul>
@@ -20,6 +22,10 @@
   an error message will appear instead of the map (<em>This map can't be drawn because WebGL isn't available…</em>).</p>
 <h2>Interaction</h2>
 <ul>
+  <li>At the top-left there is the search bar, which looks through the notes
+    already on the map and, when asked, through an online place search. While
+    a search's results are being stepped through, a counter with previous/next
+    buttons appears under it.</li>
   <li>At the bottom-center there is a central toolbar which provides editing
     features: adding new markers on the map and importing GPX tracks.</li>
   <li>At the bottom-right there are the viewport items:
@@ -47,6 +53,79 @@
 </ul>
 <p>The position on the map and the zoom are saved inside the map note and
   restored when visiting again the note.</p>
+<h2>Searching the map</h2>
+<p>The search bar at the top-left of the map looks in two places: the notes
+  already on the map, and — when asked — an online place search.</p>
+<h3>Searching the notes already on the map</h3>
+<p>Type in the search bar and the map's own notes are matched by their title as
+  you type. Notes without a <code spellcheck="false">#geolocation</code> attribute are not offered,
+  since there would be nowhere to go; GPS tracks are left out for the same
+  reason.</p>
+<h3>Searching for places online</h3>
+<p>Looking up a place sends what you typed to a third-party service, so it is
+  never done while typing. Instead, the last row of the result list offers it
+  — <em>Search online for "…"</em>, with the name of the service underneath —
+  and the search runs when that row is pressed or selected with Enter.</p>
+<p>Trilium uses Nominatim, the place search run by the OpenStreetMap
+  Foundation. It needs no account and no API key, and it is named on every row
+  that belongs to it: the row that offers the search, the one that says a
+  search is running, and the one that reports that nothing was found or that
+  the service could not be reached.</p>
+<p>The search prefers what the map is showing. Places inside the current view
+  are looked for first and listed above the rest, so searching for a shop
+  while looking at your own town finds the branch in that town rather than one
+  of the same name on another continent. The view is treated as at least 25 km
+  across, so searching while zoomed into a single street still covers the town
+  around it.</p>
+<h3>Reading the results</h3>
+<p>Results are gathered under headings, and each group is ordered by distance
+  from the middle of the map:</p>
+<ul>
+  <li><em>On this map</em> — notes already on the map, whatever their distance.</li>
+  <li><em>Nearby</em> — places found within about 25 km of the view.</li>
+  <li><em>Far away</em> — everything else.</li>
+</ul>
+<p>The headings only appear when more than one of the three has anything in it.
+  Every row that stands somewhere shows how far off it is, in kilometres or
+  miles according to your locale, and a place found online is given its name
+  on the first line and its address on the second.</p>
+<h3>Selecting a result</h3>
+<p>Selecting a note already on the map moves to its marker and opens the note
+  beside the map, as clicking the marker would.</p>
+<p>Selecting a place found online moves the map to it and marks it with a
+  temporary pin, distinct in colour from the map's own markers. The map is
+  framed by the ground the place covers, so a country fills the view while a
+  house is shown at street level. Where the service reports a boundary — a
+  country, a county, a park — that boundary is outlined under the pin.</p>
+<p>A panel then opens in the top-right corner with the place's full address and
+  its coordinates. Pressing the coordinates copies them to the clipboard.</p>
+<h3>Keeping a place as a marker</h3>
+<p>Press <em>Add as marker</em> in that panel to keep the place. A child note
+  is created under the map, named as the place is named and with its
+  <code spellcheck="false">#geolocation</code> attribute already set, and the note opens beside the
+  map so it can be edited straight away. The temporary pin goes, the place now
+  being a marker like any other.</p>
+<p>The button is not offered on a map that cannot be edited, where the panel
+  can still be read.</p>
+<p>Press the panel's close button, or the Escape key, to send the place away
+  without keeping it. The pin goes with it.</p>
+<h3>Stepping through the results</h3>
+<p>Once a result has been selected, a counter appears under the search bar with
+  a previous and a next button. These step through everything the search
+  offered, in the order it was listed, so several results can be compared
+  without asking for the list again. Pressing the counter itself returns the
+  map to the result it is standing on, which is useful after moving the map
+  away from it.</p>
+<h3>The keyboard</h3>
+<ul>
+  <li><strong>Enter</strong> runs the online search when its row is the one
+    selected, and otherwise moves to the highlighted result. Pressed after a
+    result has been taken, it brings the list back.</li>
+  <li><strong>Escape</strong> closes the result list, and closes the place panel.</li>
+  <li>Returning to the search bar reopens the list it was showing.</li>
+  <li>The <strong>X</strong> at the end of the bar empties it, which also takes a
+    searched place, its pin and its panel off the map.</li>
+</ul>
 <h2>Adding a marker using the map</h2>
 <h3>Adding a new note using the plus button</h3>
 <ol>
@@ -204,6 +283,9 @@ class="admonition note">
     <code
     spellcheck="false">#color</code>attribute such as <code spellcheck="false">#color=green</code>.</p>
   <h3>Adding the coordinates manually</h3>
+  <p>Searching for the place is usually quicker (see <em>Searching the map</em> above).
+    The steps below remain useful for a coordinate that is already to hand, or
+    for a place the search cannot find.</p>
   <p>In a nutshell, create a child note and set the <code spellcheck="false">#geolocation</code> attribute
     to the coordinates.</p>
   <p>The value of the attribute is made up of the latitude and longitude separated
@@ -276,6 +358,8 @@ class="admonition note">
     <li>The add button at the bottom of the map.</li>
     <li>Repositioning markers.</li>
     <li>Editing from the contextual menu (removing locations or adding new items).</li>
+  <li>Keeping a place found by searching as a marker. The search itself still
+    works, and a place can still be looked at and its coordinates copied.</li>
   </ul>
   <p>To set a map as read-only, go to&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Editable</em> → <em>Read-only</em> (on
     the new layout, or in Basic Properties on the&nbsp;<a class="reference-link"

--- a/docs/User Guide/User Guide/Collections/Geo Map.md
+++ b/docs/User Guide/User Guide/Collections/Geo Map.md
@@ -6,6 +6,7 @@ This note type displays the children notes on a geographical map, based on an at
 ## Features
 
 *   Add markers on the map, which can be customized with icons, colors and text.
+*   Search the notes already on the map, and look up places anywhere in the world.
 *   Display tracks on the map using `.gpx` files.
 *   3D view of the map, which displays buildings when using a vector map.
 
@@ -17,6 +18,7 @@ If the map could not be drawn because WebGL could not be initialized, an error m
 
 ## Interaction
 
+*   At the top-left there is the search bar, which looks through the notes already on the map and, when asked, through an online place search. While a search's results are being stepped through, a counter with previous/next buttons appears under it.
 *   At the bottom-center there is a central toolbar which provides editing features: adding new markers on the map and importing GPX tracks.
 *   At the bottom-right there are the viewport items:
     *   Zoom in/out
@@ -36,6 +38,59 @@ By default the map will be empty and will show the entire world.
 *   Use the mouse wheel, two-finger gesture on a touchpad or the +/- buttons on the bottom-right to adjust the zoom.
 
 The position on the map and the zoom are saved inside the map note and restored when visiting again the note.
+
+## Searching the map
+
+The search bar at the top-left of the map looks in two places: the notes already on the map, and — when asked — an online place search.
+
+### Searching the notes already on the map
+
+Type in the search bar and the map's own notes are matched by their title as you type. Notes without a `#geolocation` attribute are not offered, since there would be nowhere to go; GPS tracks are left out for the same reason.
+
+### Searching for places online
+
+Looking up a place sends what you typed to a third-party service, so it is never done while typing. Instead, the last row of the result list offers it — _Search online for "…"_, with the name of the service underneath — and the search runs when that row is pressed or selected with Enter.
+
+Trilium uses Nominatim, the place search run by the OpenStreetMap Foundation. It needs no account and no API key, and it is named on every row that belongs to it: the row that offers the search, the one that says a search is running, and the one that reports that nothing was found or that the service could not be reached.
+
+The search prefers what the map is showing. Places inside the current view are looked for first and listed above the rest, so searching for a shop while looking at your own town finds the branch in that town rather than one of the same name on another continent. The view is treated as at least 25 km across, so searching while zoomed into a single street still covers the town around it.
+
+### Reading the results
+
+Results are gathered under headings, and each group is ordered by distance from the middle of the map:
+
+*   _On this map_ — notes already on the map, whatever their distance.
+*   _Nearby_ — places found within about 25 km of the view.
+*   _Far away_ — everything else.
+
+The headings only appear when more than one of the three has anything in it. Every row that stands somewhere shows how far off it is, in kilometres or miles according to your locale, and a place found online is given its name on the first line and its address on the second.
+
+### Selecting a result
+
+Selecting a note already on the map moves to its marker and opens the note beside the map, as clicking the marker would.
+
+Selecting a place found online moves the map to it and marks it with a temporary pin, distinct in colour from the map's own markers. The map is framed by the ground the place covers, so a country fills the view while a house is shown at street level. Where the service reports a boundary — a country, a county, a park — that boundary is outlined under the pin.
+
+A panel then opens in the top-right corner with the place's full address and its coordinates. Pressing the coordinates copies them to the clipboard.
+
+### Keeping a place as a marker
+
+Press _Add as marker_ in that panel to keep the place. A child note is created under the map, named as the place is named and with its `#geolocation` attribute already set, and the note opens beside the map so it can be edited straight away. The temporary pin goes, the place now being a marker like any other.
+
+The button is not offered on a map that cannot be edited, where the panel can still be read.
+
+Press the panel's close button, or the Escape key, to send the place away without keeping it. The pin goes with it.
+
+### Stepping through the results
+
+Once a result has been selected, a counter appears under the search bar with a previous and a next button. These step through everything the search offered, in the order it was listed, so several results can be compared without asking for the list again. Pressing the counter itself returns the map to the result it is standing on, which is useful after moving the map away from it.
+
+### The keyboard
+
+*   **Enter** runs the online search when its row is the one selected, and otherwise moves to the highlighted result. Pressed after a result has been taken, it brings the list back.
+*   **Escape** closes the result list, and closes the place panel.
+*   Returning to the search bar reopens the list it was showing.
+*   The **X** at the end of the bar empties it, which also takes a searched place, its pin and its panel off the map.
 
 ## Adding a marker using the map
 
@@ -144,6 +199,8 @@ It's possible to add a custom color to a marker by assigning them a `#color` att
 
 ### Adding the coordinates manually
 
+Searching for the place is usually quicker (see _Searching the map_ above). The steps below remain useful for a coordinate that is already to hand, or for a place the search cannot find.
+
 In a nutshell, create a child note and set the `#geolocation` attribute to the coordinates.
 
 The value of the attribute is made up of the latitude and longitude separated by a comma.
@@ -195,6 +252,7 @@ When a map is [read-only](../Basic%20Concepts%20and%20Features/Notes/Read-Only%2
 *   The add button at the bottom of the map.
 *   Repositioning markers.
 *   Editing from the contextual menu (removing locations or adding new items).
+*   Keeping a place found by searching as a marker. The search itself still works, and a place can still be looked at and its coordinates copied.
 
 To set a map as read-only, go to <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Note%20buttons.md">Note buttons</a> → _Editable_ → _Read-only_ (on the new layout, or in Basic Properties on the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Ribbon.md">Ribbon</a> for the old layout).
 

--- a/docs/User Guide/User Guide/Collections/Geo Map.md
+++ b/docs/User Guide/User Guide/Collections/Geo Map.md
@@ -71,7 +71,7 @@ Selecting a note already on the map moves to its marker and opens the note besid
 
 Selecting a place found online moves the map to it and marks it with a temporary pin, distinct in colour from the map's own markers. The map is framed by the ground the place covers, so a country fills the view while a house is shown at street level. Where the service reports a boundary — a country, a county, a park — that boundary is outlined under the pin.
 
-A panel then opens in the top-right corner with the place's full address and its coordinates. Pressing the coordinates copies them to the clipboard.
+A panel then opens with the place's full address and its coordinates: in the top-right corner on desktop, and at the bottom of the map on mobile, where the top is kept for the search bar and the result counter. Pressing the coordinates copies them to the clipboard.
 
 ### Keeping a place as a marker
 


### PR DESCRIPTION
Adds a search bar to the geo map. It matches the map's own notes by title as you type, and looks up places through Nominatim when asked to.

### What it does

- **Two sources, three groups.** Results are gathered under *On this map*, *Nearby* and *Far away*, each ordered by distance from the middle of the view, with the distance shown on every row.
- **The geocoder is asked, not assumed.** Nominatim's usage policy rules out per-keystroke lookups, so a row at the foot of the list runs the search when picked. That row, and every report about the run, names the service.
- **Nearby first.** A viewbox alone is only a nudge against how well known a place is, so the search runs restricted to the view and then unrestricted, nearby results first. The view is padded to 25 km, or searching from a street finds nothing in its own town.
- **Places are pinned and framed.** A result is framed by the ground it covers, so a country fills the view and a house is shown at street level. Countries and counties have their boundary outlined.
- **Kept as a marker.** A panel offers the address, the coordinates and *Add as marker*, which creates a child note already named and located.
- **Stepped through.** A counter under the bar walks the results without reopening the list.

### Shared components

`FormAutocomplete` gained `dropdownMinWidth`, `isHeading` and `openOnEnter`, and three bugs were fixed where it dropped a caller's `className`, `onFocus` or handler by setting its own after spreading props. `OverlayToolbarButton` had the same className bug. `formatDistance` and friends moved out of `GpxPreview` into `utils/units`.

### Testing

226 tests across the geo map, `FormAutocomplete` and its other consumers; `pnpm typecheck` clean.

### Docs

The user guide gains a *Searching the map* section; the manual-coordinates instructions now point at the search first. Written into both the Markdown and the shipped HTML by hand, since `edit-docs` needs a desktop session.

Not included: release notes (v0.105.0 is already tagged, so this belongs in the next version's file), and screenshots for the new section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)