### PR TITLE
fix(geomap): set marker paint properties by name

### DIFF
--- a/apps/client/src/widgets/collections/geomap/Markers.tsx
+++ b/apps/client/src/widgets/collections/geomap/Markers.tsx
@@ -351,12 +351,13 @@ export default function Markers({ notes, hideLabels, isDarkTheme, clustered, pla
         if (!map?.getLayer(MARKER_LAYER)) return;
 
         const labelPaint = LABEL_PAINT[isDarkTheme ? "dark" : "light"];
+        // The glow keeps the same bargain the titles do, so it changes sides with them.
+        const glowPaint = SELECTION_GLOW_PAINT[isDarkTheme ? "dark" : "light"];
 
         map.setLayoutProperty(MARKER_LAYER, "text-field", titleField(hideLabels, selectedNoteId));
         map.setPaintProperty(MARKER_LAYER, "text-color", labelPaint["text-color"]);
         map.setPaintProperty(MARKER_LAYER, "text-halo-color", labelPaint["text-halo-color"]);
-        // The glow keeps the same bargain the titles do, so it changes sides with them.
-        map.setPaintProperty(SELECTION_LAYER, "circle-color", SELECTION_GLOW_PAINT[isDarkTheme ? "dark" : "light"]["circle-color"]);
+        map.setPaintProperty(SELECTION_LAYER, "circle-color", glowPaint["circle-color"]);
     }, [ map, hideLabels, isDarkTheme, selectedNoteId ]);
 
     // The selected marker, told apart on the standing layers: its pin grown and raised above its

--- a/apps/client/src/widgets/collections/geomap/Markers.tsx
+++ b/apps/client/src/widgets/collections/geomap/Markers.tsx
@@ -1,4 +1,4 @@
-import { AddLayerObject, type ExpressionSpecification, type GeoJSONSource, type MapGeoJSONFeature, type Map as MapLibreGLMap, type MapMouseEvent } from "maplibre-gl";
+import { AddLayerObject, type CircleLayerSpecification, type ExpressionSpecification, type GeoJSONSource, type MapGeoJSONFeature, type Map as MapLibreGLMap, type MapMouseEvent, type SymbolLayerSpecification } from "maplibre-gl";
 import { useCallback, useContext, useEffect, useRef, useState } from "preact/hooks";
 
 import appContext from "../../../components/app_context";
@@ -72,7 +72,7 @@ export const LABEL_PAINT = {
         "text-color": "#fff",
         "text-halo-color": "rgba(0, 0, 0, 0.8)"
     }
-};
+} satisfies Record<"light" | "dark", NonNullable<SymbolLayerSpecification["paint"]>>;
 
 /**
  * The title of a marker whose titles are hidden.
@@ -101,7 +101,7 @@ const SELECTED_PIN_SCALE = 1.3;
 const SELECTION_GLOW_PAINT = {
     light: { "circle-color": "rgba(0, 0, 0, 0.35)" },
     dark: { "circle-color": "rgba(255, 255, 255, 0.4)" }
-};
+} satisfies Record<"light" | "dark", NonNullable<CircleLayerSpecification["paint"]>>;
 
 /** The glow's reach in screen pixels, a little wider than the grown pin standing over it. */
 const SELECTION_GLOW_RADIUS = 18;
@@ -350,14 +350,13 @@ export default function Markers({ notes, hideLabels, isDarkTheme, clustered, pla
     useEffect(() => {
         if (!map?.getLayer(MARKER_LAYER)) return;
 
+        const labelPaint = LABEL_PAINT[isDarkTheme ? "dark" : "light"];
+
         map.setLayoutProperty(MARKER_LAYER, "text-field", titleField(hideLabels, selectedNoteId));
-        for (const [ property, value ] of Object.entries(LABEL_PAINT[isDarkTheme ? "dark" : "light"])) {
-            map.setPaintProperty(MARKER_LAYER, property, value);
-        }
+        map.setPaintProperty(MARKER_LAYER, "text-color", labelPaint["text-color"]);
+        map.setPaintProperty(MARKER_LAYER, "text-halo-color", labelPaint["text-halo-color"]);
         // The glow keeps the same bargain the titles do, so it changes sides with them.
-        for (const [ property, value ] of Object.entries(SELECTION_GLOW_PAINT[isDarkTheme ? "dark" : "light"])) {
-            map.setPaintProperty(SELECTION_LAYER, property, value);
-        }
+        map.setPaintProperty(SELECTION_LAYER, "circle-color", SELECTION_GLOW_PAINT[isDarkTheme ? "dark" : "light"]["circle-color"]);
     }, [ map, hideLabels, isDarkTheme, selectedNoteId ]);
 
     // The selected marker, told apart on the standing layers: its pin grown and raised above its

--- a/apps/client/src/widgets/collections/geomap/Pois.tsx
+++ b/apps/client/src/widgets/collections/geomap/Pois.tsx
@@ -1,6 +1,6 @@
 import "./Pois.css";
 
-import { type Map as MapLibreGLMap, type MapGeoJSONFeature, type MapMouseEvent, Popup } from "maplibre-gl";
+import { type AllPaintProperties, type ExpressionSpecification, type InterpolationSpecification, type Map as MapLibreGLMap, type MapGeoJSONFeature, type MapMouseEvent, Popup } from "maplibre-gl";
 import { useContext, useEffect } from "preact/hooks";
 
 import { CLUSTER_LAYERS } from "./clusters";
@@ -232,7 +232,7 @@ export default function Pois({ placing, onPick }: PoisProps) {
         const map = parentMap;
         // What the style painted its places with, to be put back when this is taken off. Either
         // may be absent, a style being composable in one and not the other.
-        let painted: { layer: string; color?: unknown; opacity?: unknown }[] = [];
+        let painted: { layer: string; color?: AllPaintProperties["icon-color"]; opacity?: AllPaintProperties["icon-opacity"] }[] = [];
 
         /** Puts back what the style painted, for a map that keeps its layers after this goes. */
         function restore() {
@@ -354,7 +354,7 @@ function isOwnUnderPointer(map: MapLibreGLMap, point: MapMouseEvent["point"]) {
  * `["zoom"]` only as the input of an outermost `step` or `interpolate`. What each zoom is drawn in
  * is where the name is then asked about.
  */
-export function clickableTint(styleColor: string) {
+export function clickableTint(styleColor: string): ExpressionSpecification {
     return [
         "step",
         [ "zoom" ],
@@ -374,7 +374,7 @@ export function clickableTint(styleColor: string) {
  * style is fetched now rather than shipped (see map_layer), and one that lifts its places out of the
  * background on its own should not be argued with about how far.
  */
-export function clickableOpacity(styleOpacity: unknown) {
+export function clickableOpacity(styleOpacity: unknown): ExpressionSpecification | null {
     // A flat number has no zoom to it, so the raise is stepped in where the colour is (see
     // `clickableTint`) rather than standing at every zoom the style draws its places at.
     if (typeof styleOpacity === "number") {
@@ -392,7 +392,7 @@ export function clickableOpacity(styleOpacity: unknown) {
     }
 
     const { stops, interpolation } = ramp;
-    const raised: unknown[][] = stops.map(([ zoom, value ]) => [
+    const raised: (number | ExpressionSpecification)[][] = stops.map(([ zoom, value ]) => [
         zoom,
         zoom >= MIN_POI_ZOOM ? [ "case", namedPlace(), CLICKABLE_OPACITY, value ] : value
     ]);
@@ -408,7 +408,7 @@ export function clickableOpacity(styleOpacity: unknown) {
 }
 
 /** Whether a place carries a name, which is what it would be kept under (see `poiFromFeature`). */
-function namedPlace() {
+function namedPlace(): ExpressionSpecification {
     return [ "to-boolean", [ "coalesce", [ "get", "name_en" ], [ "get", "name" ] ] ];
 }
 
@@ -436,7 +436,7 @@ function readRamp(value: unknown) {
 
     // A base of one climbs evenly, which is what `linear` says; anything else is the curve the old
     // syntax spells `base`.
-    const interpolation = typeof base === "number" && base !== 1 ? [ "exponential", base ] : [ "linear" ];
+    const interpolation: InterpolationSpecification = typeof base === "number" && base !== 1 ? [ "exponential", base ] : [ "linear" ];
 
     return { stops: read, interpolation };
 }

--- a/apps/client/src/widgets/collections/geomap/Pois.tsx
+++ b/apps/client/src/widgets/collections/geomap/Pois.tsx
@@ -232,7 +232,11 @@ export default function Pois({ placing, onPick }: PoisProps) {
         const map = parentMap;
         // What the style painted its places with, to be put back when this is taken off. Either
         // may be absent, a style being composable in one and not the other.
-        let painted: { layer: string; color?: AllPaintProperties["icon-color"]; opacity?: AllPaintProperties["icon-opacity"] }[] = [];
+        let painted: {
+            layer: string;
+            color?: AllPaintProperties["icon-color"];
+            opacity?: AllPaintProperties["icon-opacity"];
+        }[] = [];
 
         /** Puts back what the style painted, for a map that keeps its layers after this goes. */
         function restore() {
@@ -436,7 +440,9 @@ function readRamp(value: unknown) {
 
     // A base of one climbs evenly, which is what `linear` says; anything else is the curve the old
     // syntax spells `base`.
-    const interpolation: InterpolationSpecification = typeof base === "number" && base !== 1 ? [ "exponential", base ] : [ "linear" ];
+    const interpolation: InterpolationSpecification = typeof base === "number" && base !== 1
+        ? [ "exponential", base ]
+        : [ "linear" ];
 
     return { stops: read, interpolation };
 }


### PR DESCRIPTION
Makes the client typecheck under `maplibre-gl` 6. Stacked on `renovate/maplibre-gl-6.x` (#10866), so CI here runs the bump and these fixes together.

## The failure

maplibre-gl 6 keys the paint accessors by property name:

```ts
// 5.24.0
setPaintProperty(layerId: string, name: string, value: any, options?): this;
getPaintProperty(layerId: string, name: string): unknown;
// 6.4.1
setPaintProperty<K extends keyof AllPaintProperties>(layerId: string, name: K, value: AllPaintProperties[K], options?): this;
getPaintProperty<K extends keyof AllPaintProperties>(layerId: string, name: K): AllPaintProperties[K];
```

Six call sites did not line up. On the bump alone, `Test development` reported 14 errors — six real, and eight cascade: `tsconfig.base.json` sets `noEmitOnError` alongside `composite` / `emitDeclarationOnly`, so a failing `apps/client/tsconfig.app.json` emits no declarations and the projects referencing it (`apps/client/tsconfig.spec.json`, `apps/build-docs`) report errors in files the bump never touched.

**`Markers.tsx`** fed the setter keys from `Object.entries()`, which TypeScript widens to `string`:

```
Markers.tsx(355,48): error TS2345: Argument of type 'string' is not assignable to parameter of type 'keyof AllPaintProperties'.
```

**`Pois.tsx`** had two problems: `painted` remembered the style's colour and opacity as `unknown`, which `!== undefined` narrows to `{} | null` — and `null` is not a paint value; and the expression builders returned inferred array types (`(string | number | ...)[]`, `unknown[]`) that no longer match an expression.

## The change

- `Markers.tsx` — name the three properties at the call site instead of looping, and pin `LABEL_PAINT` / `SELECTION_GLOW_PAINT` to their layer paint specs with `satisfies`, so a typo in a key is still caught. `satisfies` preserves the literal types, so the `...LABEL_PAINT[…]` spreads in `PlaceMarker.tsx` and `GpxTrack.tsx` and the `toMatchObject(LABEL_PAINT.dark)` assertions in their specs are unaffected.
- `Pois.tsx` — remember the paint values as what the getter returns, and declare `clickableTint`, `clickableOpacity` and `namedPlace` as `ExpressionSpecification` (with `readRamp`'s ramp as `InterpolationSpecification`).
- A third commit wraps three lines that ran past the 100-character limit.

Only declared types change. The expressions, the properties set and the values they carry are identical, and `Markers.spec.tsx` / `Pois.spec.tsx` record paint into keyed maps, so call order never mattered either.

## Verification

Each change was checked by compiling the patched code verbatim against the published maplibre-gl 6.4.1 before pushing. `pnpm typecheck` and the vitest suites were not run locally — `pnpm install` fails in the authoring environment with a proxy 403 fetching `@electron/node-gyp` (pulled via git by `@electron/rebuild`) — so CI is the real check; it is green here.

Note that the `Pois.tsx` commit is v6-only: under 5.24.0 `getPaintProperty` returns `unknown`, which the narrowed `painted` type rejects. This PR therefore belongs on top of the bump and should not be cherry-picked onto `main` ahead of it. (The `Markers.tsx` commit alone does compile under both.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAiJJmW3Ypdf79es2orBxB