### PR TITLE
fix(mermaid): update layout-elk to 0.2.3 and fix the flowchart e2e tests

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@excalidraw/excalidraw": "0.18.1",
     "@fullcalendar/rrule": "7.0.2",
-    "@mermaid-js/layout-elk": "0.2.2",
+    "@mermaid-js/layout-elk": "0.2.3",
     "@popperjs/core": "2.11.8",
     "@preact/signals": "2.11.1",
     "@triliumnext/ckeditor5": "workspace:*",

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@excalidraw/excalidraw": "0.18.1",
-    "@mermaid-js/layout-elk": "0.2.2",
+    "@mermaid-js/layout-elk": "0.2.3",
     "@popperjs/core": "2.11.8",
     "@preact/signals": "2.11.1",
     "@sqlite.org/sqlite-wasm": "3.51.1-build2",

--- a/packages/trilium-e2e/src/note_types/mermaid.spec.ts
+++ b/packages/trilium-e2e/src/note_types/mermaid.spec.ts
@@ -2,15 +2,12 @@ import { test, expect, Page, BrowserContext, Locator } from "@playwright/test";
 import App from "../support/app";
 
 test("renders ELK flowchart", async ({ page, context }) => {
-    await testAriaSnapshot({
+    const svg = await openDiagram({
         page,
         context,
         noteTitle: "Flowchart ELK on",
         snapshot: `
             - document:
-                - paragraph: A
-                - paragraph: B
-                - paragraph: C
                 - paragraph: Guarantee
                 - paragraph: User attributes
                 - paragraph: Master data
@@ -21,13 +18,21 @@ test("renders ELK flowchart", async ({ page, context }) => {
                 - paragraph: Customer
                 - paragraph: Profit Centers
                 - paragraph: Guarantee
+                - paragraph: A
+                - paragraph: B
+                - paragraph: C
                 - text: Interfaces for B
         `
     });
+
+    // ELK stacks A and C into a column and pushes B out to the right.
+    const { a, b, c } = await nodeCentres(svg);
+    expect(Math.abs(a.x - c.x)).toBeLessThan(Math.abs(a.y - c.y));
+    expect(b.x).toBeGreaterThan(Math.max(a.x, c.x));
 });
 
 test("renders standard flowchart", async ({ page, context }) => {
-    await testAriaSnapshot({
+    const svg = await openDiagram({
         page,
         context,
         noteTitle: "Flowchart ELK off",
@@ -49,16 +54,25 @@ test("renders standard flowchart", async ({ page, context }) => {
                 - text: Interfaces for B
         `
     });
+
+    // The default layout runs A, B and C left to right along a single row.
+    const { a, b, c } = await nodeCentres(svg);
+    const xSpread = Math.max(a.x, b.x, c.x) - Math.min(a.x, b.x, c.x);
+    const ySpread = Math.max(a.y, b.y, c.y) - Math.min(a.y, b.y, c.y);
+    expect(ySpread).toBeLessThan(xSpread / 2);
+    expect(a.x).toBeLessThan(b.x);
+    expect(b.x).toBeLessThan(c.x);
 });
 
-interface AriaTestOpts {
+interface DiagramTestOpts {
     page: Page;
     context: BrowserContext;
     noteTitle: string;
     snapshot: string;
 }
 
-async function testAriaSnapshot({ page, context, noteTitle, snapshot }: AriaTestOpts) {
+/** Opens a mermaid note, asserts the rendered labels, and returns the diagram's `<svg>`. */
+async function openDiagram({ page, context, noteTitle, snapshot }: DiagramTestOpts) {
     const app = new App(page, context);
     await app.goto();
     await app.goToNoteInNewTab(noteTitle);
@@ -66,6 +80,28 @@ async function testAriaSnapshot({ page, context, noteTitle, snapshot }: AriaTest
     const svgData = app.currentNoteSplit.locator(".render-container svg");
     await expect(svgData).toBeVisible();
     await expect(svgData).toMatchAriaSnapshot(snapshot);
+    return svgData;
+}
+
+/**
+ * Centres of the `A`, `B` and `C` nodes, in page coordinates. The ELK and the default layout
+ * emit the same labels in the same order, so the snapshot above matches either one and the
+ * positions are what tell them apart. Only the relative order and spread are compared, which
+ * holds whatever scale `svg-pan-zoom` fits the diagram to.
+ */
+async function nodeCentres(svg: Locator) {
+    return {
+        a: await nodeCentre(svg, "A"),
+        b: await nodeCentre(svg, "B"),
+        c: await nodeCentre(svg, "C")
+    };
+}
+
+async function nodeCentre(svg: Locator, label: string): Promise<{ x: number; y: number }> {
+    const node = svg.locator(".node").filter({ hasText: new RegExp(`^${label}$`) });
+    await expect(node).toBeVisible();
+    const box = requireBoundingBox(await node.boundingBox(), `flowchart node "${label}"`);
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
 }
 
 test("gantt diagram survives split divider drag (issue 9749)", async ({ page, context }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: 7.0.2
         version: 7.0.2(rrule@2.8.1)(temporal-polyfill@1.0.4)
       '@mermaid-js/layout-elk':
-        specifier: 0.2.2
-        version: 0.2.2(mermaid@11.17.0)
+        specifier: 0.2.3
+        version: 0.2.3(mermaid@11.17.0)
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -815,8 +815,8 @@ importers:
         specifier: 0.18.1
         version: 0.18.1(patch_hash=859531a8ff622291b895d36bcd33e07ced6fcb3bcc90631ccaf776789b03f0c2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mermaid-js/layout-elk':
-        specifier: 0.2.2
-        version: 0.2.2(mermaid@11.17.0)
+        specifier: 0.2.3
+        version: 0.2.3(mermaid@11.17.0)
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -3379,8 +3379,8 @@ packages:
   '@mdn/browser-compat-data@6.1.5':
     resolution: {integrity: sha512-PzdZZzRhcXvKB0begee28n5lvwAcinGKYuLZOVxHAZm+n7y01ddEGfdS1ZXRuVcV+ndG6mSEAE8vgudom5UjYg==}
 
-  '@mermaid-js/layout-elk@0.2.2':
-    resolution: {integrity: sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==}
+  '@mermaid-js/layout-elk@0.2.3':
+    resolution: {integrity: sha512-m46RVGfvKK1PSMdAFGDz2nksI4jusEkFxvf0lb48bYWmqLQxZpjtpruiw29MbOy9rlWJtuMf9EzG9fAF8CVZbg==}
     peerDependencies:
       mermaid: 11.17.0
 
@@ -15334,7 +15334,7 @@ snapshots:
 
   '@mdn/browser-compat-data@6.1.5': {}
 
-  '@mermaid-js/layout-elk@0.2.2(mermaid@11.17.0)':
+  '@mermaid-js/layout-elk@0.2.3(mermaid@11.17.0)':
     dependencies:
       d3: 7.9.0
       elkjs: 0.9.3


### PR DESCRIPTION
Supersedes #11153, which bumps the same dependency and fails E2E on all four jobs.

## The failure

`@mermaid-js/layout-elk` 0.2.3 appends the node groups after the edge-label groups rather than before them, so `renders ELK flowchart` failed its ARIA snapshot:

```
expected: A, B, C, Guarantee, User attributes, …
received: Guarantee, User attributes, …, A, B, C
```

Only the DOM order moved. Rendering the fixture diagram (`Flowchart ELK on`) under both versions gives the same `viewBox` (`4 -49 573.859375 512.5`) and the same node transforms, so the diagram looks identical. The two options the release adds — `elk.keepEntryNodeOnTop` and `elk.nodePlacementAlignment` — are opt-in.

## Why the snapshot alone is not enough

Reordering the snapshot would have made it character-for-character equal to the one `renders standard flowchart` asserts: under 0.2.3 both layouts emit the same labels in the same order. The ELK test would then still pass if the ELK loader broke and mermaid silently fell back to the default layout.

So each test now also compares where the nodes land:

- **ELK** stacks `A` and `C` into a column and pushes `B` out to the right.
- **Default** runs `A`, `B` and `C` left to right along a single row.

Only relative order and spread are compared, which holds whatever scale `svg-pan-zoom` fits the diagram to — and which also holds under 0.2.2, so only the snapshot is version-coupled.

`testAriaSnapshot` becomes `openDiagram`, returning the `<svg>` for those assertions.

## Verification

- `pnpm typecheck` — no errors.
- `pnpm --filter server e2e mermaid` — 4 passed.
- `pnpm --filter standalone e2e mermaid` — 4 passed.
- Ran each test's assertions against **both** rendered layouts: each passes its own and fails the other's, so a silent fallback to the default layout now fails the test.

`docs/User Guide/.../ELK layout.md` documents only the frontmatter syntax and two comparison SVGs; since the geometry is unchanged, the page and its images stay accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RC2eZKJJAVEvCCBi3wB7B7

---
_Generated by [Claude Code](https://claude.ai/code/session_01RC2eZKJJAVEvCCBi3wB7B7)_