### PR TITLE
feat(client): show a startup splash screen instead of a white screen

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -71,6 +71,9 @@
                 animation: none;
                 transition: width 12s cubic-bezier(0.16, 0.85, 0.3, 1);
             }
+            #splash .splash-bar.is-continuous.is-starting .splash-bar-fill {
+                transition: none;
+            }
             #splash .splash-bar.is-continuous.is-finishing .splash-bar-fill {
                 transition: width 0.3s ease;
             }

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -8,10 +8,120 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
         <link rel="manifest" crossorigin="use-credentials" href="manifest.webmanifest">
         <title>Trilium Notes</title>
+        <style>
+            /* Startup splash. Inline so it renders before any script or stylesheet is fetched;
+               apps/client/src/services/splash.ts drives the status line and removes the element
+               once the application has loaded. */
+            #splash {
+                position: fixed;
+                inset: 0;
+                z-index: 10000;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: #ffffff;
+                color: #666666;
+                font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+                transition: opacity 0.4s ease;
+            }
+            #splash.splash-hidden {
+                opacity: 0;
+                pointer-events: none;
+            }
+            #splash .splash-content {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                /* Fades in after a delay, so a fast startup shows a blank page instead of a
+                   flash of logo. */
+                opacity: 0;
+                animation: splash-appear 0.4s ease 0.3s forwards;
+            }
+            #splash .splash-logo {
+                width: 96px;
+                height: 96px;
+            }
+            #splash .splash-title {
+                margin-top: 16px;
+                font-size: 22px;
+                font-weight: 600;
+                letter-spacing: 0.02em;
+                color: #333333;
+            }
+            #splash .splash-bar {
+                width: 176px;
+                height: 3px;
+                margin-top: 24px;
+                border-radius: 2px;
+                overflow: hidden;
+                background: rgba(128, 128, 128, 0.2);
+            }
+            #splash .splash-bar-fill {
+                width: 40%;
+                height: 100%;
+                border-radius: 2px;
+                background: #72b755;
+                animation: splash-slide 1.4s ease-in-out infinite;
+            }
+            #splash-status {
+                min-height: 1.5em;
+                margin-top: 12px;
+                font-size: 13px;
+                text-align: center;
+            }
+            #splash.splash-error .splash-bar {
+                display: none;
+            }
+            #splash.splash-error #splash-status {
+                max-width: min(480px, 85vw);
+                color: #e33f3b;
+            }
+            @keyframes splash-appear {
+                to { opacity: 1; }
+            }
+            @keyframes splash-slide {
+                0% { transform: translateX(-110%); }
+                100% { transform: translateX(260%); }
+            }
+            @keyframes splash-pulse {
+                0%, 100% { opacity: 0.3; }
+                50% { opacity: 1; }
+            }
+            @media (prefers-color-scheme: dark) {
+                #splash { background: #242424; color: #999999; }
+                #splash .splash-title { color: #cccccc; }
+            }
+            @media (prefers-reduced-motion: reduce) {
+                #splash .splash-content { opacity: 1; animation: none; }
+                #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
+            }
+            @media print {
+                #splash { display: none; }
+            }
+        </style>
     </head>
 
     <body id="trilium-app">
         <noscript>Trilium requires JavaScript to be enabled.</noscript>
+
+        <div id="splash" role="status">
+            <div class="splash-content">
+                <svg class="splash-logo" viewBox="0 0 256 256" aria-hidden="true">
+                    <path fill="#95C980" d="m202.9 112.7c-22.5 16.1-54.5 12.8-74.9 6.3l14.8-11.8 14.1-11.3 49.1-39.3-51.2 35.9-14.3 10-14.9 10.5c0.7-21.2 7-49.9 28.6-65.4 1.8-1.3 3.9-2.6 6.1-3.8 2.7-1.5 5.7-2.9 8.8-4.1 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.9 65.9-2.4 2.8-4.9 5.4-7.4 7.8-3.4 3.5-6.8 6.4-10.1 8.8z"/>
+                    <path fill="#72B755" d="m213.1 104c-22.2 12.6-51.4 9.3-70.3 3.2l14.1-11.3 49.1-39.3-51.2 35.9-14.3 10c0.5-18.1 4.9-42.1 19.7-58.6 2.7-1.5 5.7-2.9 8.8-4.1 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.9 65.9-2.3 2.8-4.8 5.4-7.2 7.8z"/>
+                    <path fill="#4FA52B" d="m220.5 96.2c-21.1 8.6-46.6 5.3-63.7-0.2l49.2-39.4-51.2 35.9c0.3-15.8 3.5-36.6 14.3-52.8 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.8 66z"/>
+                    <path fill="#EE8C89" d="m106.7 179c-5.8-21 5.2-43.8 15.5-57.2l4.8 14.2 4.5 13.4 15.9 47-12.8-47.6-3.6-13.2-3.7-13.9c15.5 6.2 35.1 18.6 40.7 38.8 0.5 1.7 0.9 3.6 1.2 5.5 0.4 2.4 0.6 5 0.7 7.7 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8-1.4-2.6-2.7-5.1-3.8-7.6-1.6-3.5-2.9-6.8-3.8-10z"/>
+                    <path fill="#E96562" d="m110.4 188.9c-3.4-19.8 6.9-40.5 16.6-52.9l4.5 13.4 15.9 47-12.8-47.6-3.6-13.2c13.3 5.2 29.9 15 38.1 30.4 0.4 2.4 0.6 5 0.7 7.7 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8-1.4-2.6-2.7-5.2-3.8-7.7z"/>
+                    <path fill="#E33F3B" d="m114.2 196.5c-0.7-18 8.6-35.9 17.3-47.1l15.9 47-12.8-47.6c11.6 4.4 26.1 12.4 35.2 24.8 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8z"/>
+                    <path fill="#EFB075" d="m86.3 59.1c21.7 10.9 32.4 36.6 35.8 54.9l-15.2-6.6-14.5-6.3-50.6-22 48.8 24.9 13.6 6.9 14.3 7.3c-16.6 7.9-41.3 14.5-62.1 4.1-1.8-0.9-3.6-1.9-5.4-3.2-2.3-1.5-4.5-3.2-6.8-5.1-19.9-16.4-40.3-46.4-42.7-61.5 12.4-6.5 41.5-5.8 64.8-0.3 3.2 0.8 6.2 1.6 9.1 2.5 4 1.3 7.6 2.8 10.9 4.4z"/>
+                    <path fill="#E99547" d="m75.4 54.8c18.9 12 28.4 35.6 31.6 52.6l-14.5-6.3-50.6-22 48.7 24.9 13.6 6.9c-14.1 6.8-34.5 13-53.3 8.2-2.3-1.5-4.5-3.2-6.8-5.1-19.8-16.4-40.2-46.4-42.6-61.5 12.4-6.5 41.5-5.8 64.8-0.3 3.1 0.8 6.2 1.6 9.1 2.6z"/>
+                    <path fill="#E47B19" d="m66.3 52.2c15.3 12.8 23.3 33.6 26.1 48.9l-50.6-22 48.8 24.9c-12.2 6-29.6 11.8-46.5 10-19.8-16.4-40.2-46.4-42.6-61.5 12.4-6.5 41.5-5.8 64.8-0.3z"/>
+                </svg>
+                <div class="splash-title">Trilium Notes</div>
+                <div class="splash-bar"><div class="splash-bar-fill"></div></div>
+                <div id="splash-status"></div>
+            </div>
+        </div>
 
         <div id="context-menu-cover"></div>
         <div class="dropdown-menu dropdown-menu-sm" id="context-menu-container" style="display: none"></div>

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -117,7 +117,12 @@
     </head>
 
     <body id="trilium-app">
-        <noscript>Trilium requires JavaScript to be enabled.</noscript>
+        <noscript>
+            <style>
+                #splash { display: none; }
+            </style>
+            Trilium requires JavaScript to be enabled.
+        </noscript>
 
         <div id="splash" role="status">
             <div class="splash-content">

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -49,7 +49,7 @@
                 color: #333333;
             }
             #splash .splash-bar {
-                width: 176px;
+                width: 240px;
                 height: 3px;
                 margin-top: 24px;
                 border-radius: 2px;
@@ -62,6 +62,32 @@
                 border-radius: 2px;
                 background: #72b755;
                 animation: splash-slide 1.4s ease-in-out infinite;
+            }
+            /* Segmented state, installed by splash.ts once the startup phases are known: one
+               segment per phase, each as wide as that phase is expensive. */
+            #splash .splash-bar.is-segmented {
+                display: flex;
+                gap: 2px;
+                background: none;
+                overflow: visible;
+            }
+            #splash .splash-bar.is-segmented .splash-bar-fill {
+                display: none;
+            }
+            #splash .splash-seg {
+                flex-basis: 0;
+                height: 100%;
+                border-radius: 2px;
+                background: rgba(128, 128, 128, 0.2);
+                transition: background-color 0.3s ease;
+            }
+            #splash .splash-seg.is-done {
+                background: #72b755;
+            }
+            #splash .splash-seg.is-active {
+                background: linear-gradient(90deg, rgba(114, 183, 85, 0.25) 0%, #72b755 50%, rgba(114, 183, 85, 0.25) 100%);
+                background-size: 250% 100%;
+                animation: splash-seg-sweep 1.2s ease-in-out infinite;
             }
             #splash-status {
                 min-height: 1.5em;
@@ -87,6 +113,10 @@
                 0%, 100% { opacity: 0.3; }
                 50% { opacity: 1; }
             }
+            @keyframes splash-seg-sweep {
+                0% { background-position: 100% 0; }
+                100% { background-position: 0 0; }
+            }
             @media (prefers-color-scheme: dark) {
                 #splash { background: #242424; color: #999999; }
                 #splash .splash-title { color: #cccccc; }
@@ -94,6 +124,7 @@
             @media (prefers-reduced-motion: reduce) {
                 #splash .splash-content { opacity: 1; animation: none; }
                 #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
+                #splash .splash-seg.is-active { background: rgba(114, 183, 85, 0.55); animation: none; }
             }
             @media print {
                 #splash { display: none; }

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -63,31 +63,16 @@
                 background: #72b755;
                 animation: splash-slide 1.4s ease-in-out infinite;
             }
-            /* Segmented state, installed by splash.ts once the startup phases are known: one
-               segment per phase, each as wide as that phase is expensive. */
-            #splash .splash-bar.is-segmented {
-                display: flex;
-                gap: 2px;
-                background: none;
-                overflow: visible;
+            /* Tracking state, installed by splash.ts once the startup phases are known. The long
+               ease-out carries the fill towards the running phase's end without ever reaching it,
+               so a slow step keeps moving instead of looking stalled. */
+            #splash .splash-bar.is-continuous .splash-bar-fill {
+                width: 0;
+                animation: none;
+                transition: width 12s cubic-bezier(0.16, 0.85, 0.3, 1);
             }
-            #splash .splash-bar.is-segmented .splash-bar-fill {
-                display: none;
-            }
-            #splash .splash-seg {
-                flex-basis: 0;
-                height: 100%;
-                border-radius: 2px;
-                background: rgba(128, 128, 128, 0.2);
-                transition: background-color 0.3s ease;
-            }
-            #splash .splash-seg.is-done {
-                background: #72b755;
-            }
-            #splash .splash-seg.is-active {
-                background: linear-gradient(90deg, rgba(114, 183, 85, 0.25) 0%, #72b755 50%, rgba(114, 183, 85, 0.25) 100%);
-                background-size: 250% 100%;
-                animation: splash-seg-sweep 1.2s ease-in-out infinite;
+            #splash .splash-bar.is-continuous.is-finishing .splash-bar-fill {
+                transition: width 0.3s ease;
             }
             #splash-status {
                 min-height: 1.5em;
@@ -113,10 +98,6 @@
                 0%, 100% { opacity: 0.3; }
                 50% { opacity: 1; }
             }
-            @keyframes splash-seg-sweep {
-                0% { background-position: 100% 0; }
-                100% { background-position: 0 0; }
-            }
             @media (prefers-color-scheme: dark) {
                 #splash { background: #242424; color: #999999; }
                 #splash .splash-title { color: #cccccc; }
@@ -124,7 +105,7 @@
             @media (prefers-reduced-motion: reduce) {
                 #splash .splash-content { opacity: 1; animation: none; }
                 #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
-                #splash .splash-seg.is-active { background: rgba(114, 183, 85, 0.55); animation: none; }
+                #splash .splash-bar.is-continuous .splash-bar-fill { transition: width 0.2s linear; }
             }
             @media print {
                 #splash { display: none; }

--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -13,6 +13,7 @@ import type LoadResults from "../services/load_results.js";
 import type { CreateNoteOpts } from "../services/note_create.js";
 import options from "../services/options.js";
 import type { ShortcutHintSection } from "../services/shortcut_hints.js";
+import { reportSplashPhase } from "../services/splash.js";
 import toast from "../services/toast.js";
 import utils from "../services/utils.js";
 import { ReactWrappedWidget } from "../widgets/basic_widget.js";
@@ -653,6 +654,7 @@ export class AppContext extends Component {
         this.initComponents();
         this.renderWidgets();
 
+        reportSplashPhase("notes");
         await froca.initializedPromise;
 
         this.tabManager.loadTabs();

--- a/apps/client/src/desktop.ts
+++ b/apps/client/src/desktop.ts
@@ -18,23 +18,31 @@ import { preloadCommonNoteTypes } from "./widgets/note_types.js";
 
 await appContext.earlyInit();
 
-bundleService.getWidgetBundlesByParent().then(async (widgetBundles) => {
+/**
+ * Resolves once the layout is rendered and froca has the note tree. index.ts keeps the splash up
+ * until then, so the bundle, layout and tree requests below are not made behind a blank page. A
+ * failed start still resolves it: the toast that reports the failure has to become visible.
+ */
+export const ready = bundleService.getWidgetBundlesByParent().then(async (widgetBundles) => {
     // A dynamic import is required for layouts since they initialize components which require translations.
     const DesktopLayout = (await import("./layouts/desktop_layout.js")).default;
 
     appContext.setLayout(new DesktopLayout(widgetBundles));
-    appContext.start().then(() => {
-        reportFullRenderStartupMetric();
-        preloadCommonNoteTypes();
-    }).catch((e) => {
+    try {
+        await appContext.start();
+    } catch (e) {
         toastService.showPersistent({
             id: "critical-error",
             title: t("toast.critical-error.title"),
             icon: "alert",
-            message: t("toast.critical-error.message", { message: e.message })
+            message: t("toast.critical-error.message", { message: e instanceof Error ? e.message : String(e) })
         });
         console.error("Critical error occured", e);
-    });
+        return;
+    }
+
+    reportFullRenderStartupMetric();
+    preloadCommonNoteTypes();
 });
 
 glob.setupGlobs();

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -148,32 +148,37 @@ function setBodyAttributes() {
 }
 
 async function loadScripts() {
+    const entry = await importEntry();
+
+    // Every entry point renders after its module has finished evaluating: the desktop layout, the
+    // note tree and the locale catalogue are all fetched from there. Waiting for the `ready` it
+    // exports keeps the splash up until the screen is actually populated, instead of handing the
+    // user a blank page for the seconds those fetches take on a slow connection.
+    reportSplashPhase("interface");
+    await entry.ready;
+}
+
+function importEntry(): Promise<{ ready?: Promise<unknown> }> {
     if (!glob.dbInitialized) {
-        await import("./setup.js");
-        return;
+        return import("./setup.js");
     }
 
     if (glob.passwordSet === false) {
-        await import("./set_password.js");
-        return;
+        return import("./set_password.js");
     }
 
     if (glob.loggedIn === false) {
-        await import("./login.js");
-        return;
+        return import("./login.js");
     }
 
     switch (glob.device) {
         case "mobile":
-            await import("./mobile.js");
-            break;
+            return import("./mobile.js");
         case "print":
-            await import("./print.js");
-            break;
+            return import("./print.js");
         case "desktop":
         default:
-            await import("./desktop.js");
-            break;
+            return import("./desktop.js");
     }
 }
 

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -1,11 +1,14 @@
 import { createFontStylesheetLink } from "./services/font";
-import { hideSplash, showSplashError, updateSplashStatus } from "./services/splash";
+import {
+    CLIENT_STARTUP_PHASES, hideSplash, initSplashProgress, reportSplashPhase, showSplashError
+} from "./services/splash";
 import { buildThemeStylesheetRefs, createStylesheetLink, getThemeStyle, initThemeChangeNotifier, StylesheetRef } from "./services/theme";
 
 async function bootstrap() {
-    // The splash from index.html covers the page until hideSplash(). In standalone mode this
-    // fetch waits for the SQLite worker to open the database, which can take a while.
-    updateSplashStatus("Opening your notes…");
+    // The splash from index.html covers the page until hideSplash(). Standalone reports a longer
+    // sequence of its own before this one, so these phases only take effect on server and desktop.
+    initSplashProgress(CLIENT_STARTUP_PHASES);
+    reportSplashPhase("bootstrap");
     await setupGlob();
     await Promise.all([
         initJQuery(),
@@ -15,7 +18,7 @@ async function bootstrap() {
     initThemeChangeNotifier();
     loadIcons();
     setBodyAttributes();
-    updateSplashStatus("Loading the application…");
+    reportSplashPhase("application");
     await loadScripts();
     hideSplash();
 }

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -1,8 +1,11 @@
 import { createFontStylesheetLink } from "./services/font";
+import { hideSplash, showSplashError, updateSplashStatus } from "./services/splash";
 import { buildThemeStylesheetRefs, createStylesheetLink, getThemeStyle, initThemeChangeNotifier, StylesheetRef } from "./services/theme";
 
 async function bootstrap() {
-    showSplash();
+    // The splash from index.html covers the page until hideSplash(). In standalone mode this
+    // fetch waits for the SQLite worker to open the database, which can take a while.
+    updateSplashStatus("Opening your notes…");
     await setupGlob();
     await Promise.all([
         initJQuery(),
@@ -12,6 +15,7 @@ async function bootstrap() {
     initThemeChangeNotifier();
     loadIcons();
     setBodyAttributes();
+    updateSplashStatus("Loading the application…");
     await loadScripts();
     hideSplash();
 }
@@ -170,13 +174,8 @@ async function loadScripts() {
     }
 }
 
-function showSplash() {
-    // hide body to reduce flickering on the startup. This is done through JS and not CSS to not hide <noscript>
-    document.body.style.display = "none";
-}
-
-function hideSplash() {
-    document.body.style.display = "block";
-}
-
-bootstrap();
+bootstrap().catch((err) => {
+    console.error("Trilium failed to start:", err);
+    const message = err instanceof Error ? err.message : String(err);
+    showSplashError(`Trilium failed to start: ${message} — reload the page to try again.`);
+});

--- a/apps/client/src/login.tsx
+++ b/apps/client/src/login.tsx
@@ -145,7 +145,6 @@ function initialSsoError(config: typeof window.glob.login): string | null {
     return null;
 }
 
-// Skip the bootstrap render under test, where the components are imported directly.
-if (import.meta.env.MODE !== "test") {
-    void main();
-}
+// index.ts holds the splash up until the page has rendered. The render under test imports
+// the components directly, so it skips this one.
+export const ready = import.meta.env.MODE !== "test" ? main() : Promise.resolve();

--- a/apps/client/src/mobile.ts
+++ b/apps/client/src/mobile.ts
@@ -18,4 +18,6 @@ setupClipboardImageEmbed();
 const MobileLayout = (await import("./layouts/mobile_layout.js")).default;
 
 appContext.setLayout(new MobileLayout());
-void appContext.start().then(preloadCommonNoteTypes);
+
+/** Resolves once the layout is rendered and froca has the note tree; see desktop.ts. */
+export const ready = appContext.start().then(preloadCommonNoteTypes);

--- a/apps/client/src/print.tsx
+++ b/apps/client/src/print.tsx
@@ -206,4 +206,5 @@ export async function loadCustomCss(note: FNote) {
     await Promise.allSettled(loadPromises);
 }
 
-main();
+/** index.ts holds the splash up until the note has rendered. */
+export const ready = main();

--- a/apps/client/src/services/splash.spec.ts
+++ b/apps/client/src/services/splash.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { hideSplash, showSplashError, updateSplashStatus } from "./splash";
+
+function renderSplash() {
+    document.body.innerHTML = `
+        <div id="splash">
+            <div class="splash-bar"></div>
+            <div id="splash-status"></div>
+        </div>`;
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+});
+
+describe("splash", () => {
+    it("updates the status line and switches to the error state", () => {
+        renderSplash();
+
+        updateSplashStatus("Opening your notes…");
+        expect(document.getElementById("splash-status")?.textContent).toBe("Opening your notes…");
+
+        showSplashError("something broke");
+        expect(document.getElementById("splash")?.classList.contains("splash-error")).toBe(true);
+        expect(document.getElementById("splash-status")?.textContent).toBe("something broke");
+    });
+
+    it("fades the splash out and removes it once the transition has run", () => {
+        renderSplash();
+
+        hideSplash();
+        const splash = document.getElementById("splash");
+        expect(splash?.classList.contains("splash-hidden")).toBe(true);
+
+        vi.runAllTimers();
+        expect(document.getElementById("splash")).toBeNull();
+    });
+
+    it("does nothing when the splash is not in the document", () => {
+        expect(() => {
+            updateSplashStatus("status");
+            showSplashError("error");
+            hideSplash();
+        }).not.toThrow();
+    });
+});

--- a/apps/client/src/services/splash.spec.ts
+++ b/apps/client/src/services/splash.spec.ts
@@ -22,11 +22,8 @@ function renderSplash() {
         </div>`;
 }
 
-function segmentClasses() {
-    return [ ...document.querySelectorAll(".splash-seg") ].map((seg) => ({
-        done: seg.classList.contains("is-done"),
-        active: seg.classList.contains("is-active")
-    }));
+function fillWidth(): string {
+    return document.querySelector<HTMLElement>(".splash-bar-fill")?.style.width ?? "";
 }
 
 beforeEach(() => {
@@ -51,15 +48,28 @@ describe("splash", () => {
         expect(document.getElementById("splash-status")?.textContent).toBe("something broke");
     });
 
-    it("draws one segment per phase, sized by weight", async () => {
-        const { initSplashProgress } = await freshSplash();
+    it("tracks the running phase's share of the total weight", async () => {
+        const { initSplashProgress, reportSplashPhase } = await freshSplash();
         initSplashProgress(PHASES);
 
         const bar = document.querySelector(".splash-bar");
-        expect(bar?.classList.contains("is-segmented")).toBe(true);
+        expect(bar?.classList.contains("is-continuous")).toBe(true);
 
-        const segments = [ ...document.querySelectorAll<HTMLElement>(".splash-seg") ];
-        expect(segments.map((seg) => seg.style.flexGrow)).toEqual([ "1", "3", "2" ]);
+        // Weights 1, 3, 2: the bar eases towards the end of whichever phase is running.
+        reportSplashPhase("first");
+        expect(fillWidth()).toBe("17%");
+        reportSplashPhase("second");
+        expect(fillWidth()).toBe("67%");
+        expect(document.getElementById("splash-status")?.textContent).toBe("Second…");
+    });
+
+    it("stops short of a full bar while the startup is still running", async () => {
+        const { initSplashProgress, reportSplashPhase } = await freshSplash();
+        initSplashProgress(PHASES);
+
+        // The last phase ends the sequence, but a full bar would read as finished.
+        reportSplashPhase("third");
+        expect(fillWidth()).toBe("95%");
     });
 
     it("keeps the sequence the first caller installed", async () => {
@@ -68,43 +78,32 @@ describe("splash", () => {
         // Standalone claims the bar before the client's own, shorter list is offered.
         initSplashProgress([ { id: "other", weight: 1, status: "Other…" } ]);
 
-        expect(document.querySelectorAll(".splash-seg")).toHaveLength(3);
         reportSplashPhase("other");
         expect(document.getElementById("splash-status")?.textContent).toBe("");
-    });
-
-    it("marks earlier phases done, the reported one active, and shows its status", async () => {
-        const { initSplashProgress, reportSplashPhase } = await freshSplash();
-        initSplashProgress(PHASES);
-
-        reportSplashPhase("second");
-        expect(segmentClasses()).toEqual([
-            { done: true, active: false },
-            { done: false, active: true },
-            { done: false, active: false }
-        ]);
-        expect(document.getElementById("splash-status")?.textContent).toBe("Second…");
+        expect(fillWidth()).toBe("");
     });
 
     it("never moves backwards, and ignores an unknown phase", async () => {
         const { initSplashProgress, reportSplashPhase } = await freshSplash();
         initSplashProgress(PHASES);
 
-        reportSplashPhase("third");
+        reportSplashPhase("second");
         // A phase reported late — or, in a follower tab, out of order — must not undo progress.
         reportSplashPhase("first");
         reportSplashPhase("nonexistent");
-        expect(document.getElementById("splash-status")?.textContent).toBe("Third…");
-        expect(segmentClasses()[2]).toEqual({ done: false, active: true });
+        expect(fillWidth()).toBe("67%");
+        expect(document.getElementById("splash-status")?.textContent).toBe("Second…");
     });
 
-    it("fills the bar, then fades the splash out and removes it", async () => {
+    it("runs the bar out to full, then fades the splash out and removes it", async () => {
         const { initSplashProgress, reportSplashPhase, hideSplash } = await freshSplash();
         initSplashProgress(PHASES);
         reportSplashPhase("second");
 
         hideSplash();
-        expect(segmentClasses().every((seg) => seg.done && !seg.active)).toBe(true);
+        expect(fillWidth()).toBe("100%");
+        const bar = document.querySelector(".splash-bar");
+        expect(bar?.classList.contains("is-finishing")).toBe(true);
         expect(document.getElementById("splash")?.classList.contains("splash-hidden")).toBe(true);
 
         vi.runAllTimers();

--- a/apps/client/src/services/splash.spec.ts
+++ b/apps/client/src/services/splash.spec.ts
@@ -1,17 +1,37 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { hideSplash, showSplashError, updateSplashStatus } from "./splash";
+import type { SplashPhase } from "./splash";
+
+const PHASES: SplashPhase[] = [
+    { id: "first", weight: 1, status: "First…" },
+    { id: "second", weight: 3, status: "Second…" },
+    { id: "third", weight: 2, status: "Third…" }
+];
+
+/** The module tracks the reported phase, so each test needs a fresh copy of it. */
+async function freshSplash(): Promise<typeof import("./splash")> {
+    vi.resetModules();
+    return import("./splash");
+}
 
 function renderSplash() {
     document.body.innerHTML = `
         <div id="splash">
-            <div class="splash-bar"></div>
+            <div class="splash-bar"><div class="splash-bar-fill"></div></div>
             <div id="splash-status"></div>
         </div>`;
 }
 
+function segmentClasses() {
+    return [ ...document.querySelectorAll(".splash-seg") ].map((seg) => ({
+        done: seg.classList.contains("is-done"),
+        active: seg.classList.contains("is-active")
+    }));
+}
+
 beforeEach(() => {
     vi.useFakeTimers();
+    renderSplash();
 });
 
 afterEach(() => {
@@ -20,8 +40,8 @@ afterEach(() => {
 });
 
 describe("splash", () => {
-    it("updates the status line and switches to the error state", () => {
-        renderSplash();
+    it("updates the status line and switches to the error state", async () => {
+        const { updateSplashStatus, showSplashError } = await freshSplash();
 
         updateSplashStatus("Opening your notes…");
         expect(document.getElementById("splash-status")?.textContent).toBe("Opening your notes…");
@@ -31,19 +51,75 @@ describe("splash", () => {
         expect(document.getElementById("splash-status")?.textContent).toBe("something broke");
     });
 
-    it("fades the splash out and removes it once the transition has run", () => {
-        renderSplash();
+    it("draws one segment per phase, sized by weight", async () => {
+        const { initSplashProgress } = await freshSplash();
+        initSplashProgress(PHASES);
+
+        const bar = document.querySelector(".splash-bar");
+        expect(bar?.classList.contains("is-segmented")).toBe(true);
+
+        const segments = [ ...document.querySelectorAll<HTMLElement>(".splash-seg") ];
+        expect(segments.map((seg) => seg.style.flexGrow)).toEqual([ "1", "3", "2" ]);
+    });
+
+    it("keeps the sequence the first caller installed", async () => {
+        const { initSplashProgress, reportSplashPhase } = await freshSplash();
+        initSplashProgress(PHASES);
+        // Standalone claims the bar before the client's own, shorter list is offered.
+        initSplashProgress([ { id: "other", weight: 1, status: "Other…" } ]);
+
+        expect(document.querySelectorAll(".splash-seg")).toHaveLength(3);
+        reportSplashPhase("other");
+        expect(document.getElementById("splash-status")?.textContent).toBe("");
+    });
+
+    it("marks earlier phases done, the reported one active, and shows its status", async () => {
+        const { initSplashProgress, reportSplashPhase } = await freshSplash();
+        initSplashProgress(PHASES);
+
+        reportSplashPhase("second");
+        expect(segmentClasses()).toEqual([
+            { done: true, active: false },
+            { done: false, active: true },
+            { done: false, active: false }
+        ]);
+        expect(document.getElementById("splash-status")?.textContent).toBe("Second…");
+    });
+
+    it("never moves backwards, and ignores an unknown phase", async () => {
+        const { initSplashProgress, reportSplashPhase } = await freshSplash();
+        initSplashProgress(PHASES);
+
+        reportSplashPhase("third");
+        // A phase reported late — or, in a follower tab, out of order — must not undo progress.
+        reportSplashPhase("first");
+        reportSplashPhase("nonexistent");
+        expect(document.getElementById("splash-status")?.textContent).toBe("Third…");
+        expect(segmentClasses()[2]).toEqual({ done: false, active: true });
+    });
+
+    it("fills the bar, then fades the splash out and removes it", async () => {
+        const { initSplashProgress, reportSplashPhase, hideSplash } = await freshSplash();
+        initSplashProgress(PHASES);
+        reportSplashPhase("second");
 
         hideSplash();
-        const splash = document.getElementById("splash");
-        expect(splash?.classList.contains("splash-hidden")).toBe(true);
+        expect(segmentClasses().every((seg) => seg.done && !seg.active)).toBe(true);
+        expect(document.getElementById("splash")?.classList.contains("splash-hidden")).toBe(true);
 
         vi.runAllTimers();
         expect(document.getElementById("splash")).toBeNull();
     });
 
-    it("does nothing when the splash is not in the document", () => {
+    it("does nothing when the splash is not in the document", async () => {
+        const {
+            initSplashProgress, reportSplashPhase, updateSplashStatus, showSplashError, hideSplash
+        } = await freshSplash();
+        document.body.innerHTML = "";
+
         expect(() => {
+            initSplashProgress(PHASES);
+            reportSplashPhase("first");
             updateSplashStatus("status");
             showSplashError("error");
             hideSplash();

--- a/apps/client/src/services/splash.ts
+++ b/apps/client/src/services/splash.ts
@@ -11,11 +11,17 @@
 /** Matches the `#splash` opacity transition in index.html. */
 const SPLASH_FADE_MS = 400;
 
-/** One step of the startup sequence, drawn as its own segment of the progress bar. */
+/**
+ * How full the bar can get while the startup is still running. The last phase would otherwise
+ * ease to a full bar and sit there, which reads as finished; {@link hideSplash} closes the gap.
+ */
+const MAX_RUNNING_FILL = 0.95;
+
+/** One step of the startup sequence, which the progress bar advances through. */
 export interface SplashPhase {
     /** Name {@link reportSplashPhase} uses to announce that the step has started. */
     id: string;
-    /** Relative cost of the step, which sets how wide its segment is. */
+    /** Relative cost of the step, which sets how much of the bar it covers. */
     weight: number;
     /** Shown under the bar while the step runs. */
     status: string;
@@ -32,33 +38,24 @@ export const CLIENT_STARTUP_PHASES: SplashPhase[] = [
 ];
 
 let phases: SplashPhase[] = [];
+let totalWeight = 0;
 
-/** Index of the phase now running. Every earlier phase is drawn as complete. */
+/** Index of the phase now running. */
 let currentPhase = -1;
 
 /**
- * Splits the progress bar into one segment per phase, each sized by its weight. The first caller
- * wins, so standalone's longer sequence survives the client's own call later in the same startup.
+ * Hands the progress bar the sequence it is to track, replacing its indeterminate animation. The
+ * first caller wins, so standalone's longer sequence survives the client's own call later in the
+ * same startup.
  */
 export function initSplashProgress(startupPhases: SplashPhase[]): void {
-    if (phases.length) {
+    if (phases.length || !startupPhases.length) {
         return;
     }
     phases = startupPhases;
+    totalWeight = phases.reduce((sum, phase) => sum + phase.weight, 0);
 
-    const bar = document.querySelector("#splash .splash-bar");
-    if (!bar) {
-        return;
-    }
-
-    bar.classList.add("is-segmented");
-    for (const phase of phases) {
-        const segment = document.createElement("div");
-        segment.className = "splash-seg";
-        // The one genuinely computed value here: a segment is as wide as its phase is costly.
-        segment.style.flexGrow = String(phase.weight);
-        bar.append(segment);
-    }
+    document.querySelector("#splash .splash-bar")?.classList.add("is-continuous");
 }
 
 /**
@@ -73,11 +70,11 @@ export function reportSplashPhase(id: string): void {
     }
     currentPhase = index;
 
-    const segments = document.querySelectorAll<HTMLElement>("#splash .splash-seg");
-    for (const [ segmentIndex, segment ] of segments.entries()) {
-        segment.classList.toggle("is-done", segmentIndex < index);
-        segment.classList.toggle("is-active", segmentIndex === index);
-    }
+    // The bar eases towards the end of the phase now running rather than sitting at its start, so
+    // a step that takes seconds still shows movement; the long ease-out in index.html means it
+    // only approaches that end, and never claims more than the running phase covers.
+    const completed = phases.slice(0, index).reduce((sum, earlier) => sum + earlier.weight, 0);
+    setFillWidth(Math.min((completed + phase.weight) / totalWeight, MAX_RUNNING_FILL));
 
     updateSplashStatus(phase.status);
 }
@@ -107,13 +104,18 @@ export function hideSplash(): void {
         return;
     }
 
-    // Fill the bar before it goes, so the last phase is not left mid-flight behind the fade.
-    for (const segment of splashEl.querySelectorAll<HTMLElement>(".splash-seg")) {
-        segment.classList.remove("is-active");
-        segment.classList.add("is-done");
-    }
+    // Run the bar out to full, so the last phase is not left mid-flight behind the fade.
+    splashEl.querySelector(".splash-bar")?.classList.add("is-finishing");
+    setFillWidth(1);
 
     splashEl.classList.add("splash-hidden");
     setTimeout(() => splashEl.remove(), SPLASH_FADE_MS);
 }
 
+function setFillWidth(fraction: number): void {
+    const fill = document.querySelector<HTMLElement>("#splash .splash-bar-fill");
+    if (fill) {
+        // The one genuinely computed value here: how far through the startup the bar has got.
+        fill.style.width = `${Math.min(100, Math.round(fraction * 100))}%`;
+    }
+}

--- a/apps/client/src/services/splash.ts
+++ b/apps/client/src/services/splash.ts
@@ -2,7 +2,7 @@
  * Drives the startup splash screen that index.html renders inline, before any script or
  * stylesheet is fetched. Status strings are English-only, as in the standalone error overlay:
  * the splash runs while the backend that serves the translation catalogues is still starting,
- * so no catalogue can be loaded yet.
+ * so `initLocale()` has neither a locale nor an `assetPath` to fetch one with.
  *
  * Kept free of imports: index.ts loads it before setupGlob() populates window.glob, which most
  * client modules read at module scope.
@@ -10,6 +10,77 @@
 
 /** Matches the `#splash` opacity transition in index.html. */
 const SPLASH_FADE_MS = 400;
+
+/** One step of the startup sequence, drawn as its own segment of the progress bar. */
+export interface SplashPhase {
+    /** Name {@link reportSplashPhase} uses to announce that the step has started. */
+    id: string;
+    /** Relative cost of the step, which sets how wide its segment is. */
+    weight: number;
+    /** Shown under the bar while the step runs. */
+    status: string;
+}
+
+/**
+ * What a server or desktop client passes through, where the backend is already running and only
+ * the frontend has to start. Standalone reports a longer sequence of its own first — see
+ * `STANDALONE_STARTUP_PHASES` in apps/standalone/src/main.ts.
+ */
+export const CLIENT_STARTUP_PHASES: SplashPhase[] = [
+    { id: "bootstrap", weight: 1, status: "Opening your notes…" },
+    { id: "application", weight: 2, status: "Loading the application…" }
+];
+
+let phases: SplashPhase[] = [];
+
+/** Index of the phase now running. Every earlier phase is drawn as complete. */
+let currentPhase = -1;
+
+/**
+ * Splits the progress bar into one segment per phase, each sized by its weight. The first caller
+ * wins, so standalone's longer sequence survives the client's own call later in the same startup.
+ */
+export function initSplashProgress(startupPhases: SplashPhase[]): void {
+    if (phases.length) {
+        return;
+    }
+    phases = startupPhases;
+
+    const bar = document.querySelector("#splash .splash-bar");
+    if (!bar) {
+        return;
+    }
+
+    bar.classList.add("is-segmented");
+    for (const phase of phases) {
+        const segment = document.createElement("div");
+        segment.className = "splash-seg";
+        // The one genuinely computed value here: a segment is as wide as its phase is costly.
+        segment.style.flexGrow = String(phase.weight);
+        bar.append(segment);
+    }
+}
+
+/**
+ * Advances the bar to the named phase and shows its status. Never moves backwards, so a phase
+ * that is reported late — or, in a follower tab, not at all — cannot undo the progress shown.
+ */
+export function reportSplashPhase(id: string): void {
+    const index = phases.findIndex((phase) => phase.id === id);
+    const phase = phases[index];
+    if (!phase || index <= currentPhase) {
+        return;
+    }
+    currentPhase = index;
+
+    const segments = document.querySelectorAll<HTMLElement>("#splash .splash-seg");
+    for (const [ segmentIndex, segment ] of segments.entries()) {
+        segment.classList.toggle("is-done", segmentIndex < index);
+        segment.classList.toggle("is-active", segmentIndex === index);
+    }
+
+    updateSplashStatus(phase.status);
+}
 
 /** Replaces the status line under the progress bar. */
 export function updateSplashStatus(status: string): void {
@@ -35,6 +106,14 @@ export function hideSplash(): void {
     if (!splashEl) {
         return;
     }
+
+    // Fill the bar before it goes, so the last phase is not left mid-flight behind the fade.
+    for (const segment of splashEl.querySelectorAll<HTMLElement>(".splash-seg")) {
+        segment.classList.remove("is-active");
+        segment.classList.add("is-done");
+    }
+
     splashEl.classList.add("splash-hidden");
     setTimeout(() => splashEl.remove(), SPLASH_FADE_MS);
 }
+

--- a/apps/client/src/services/splash.ts
+++ b/apps/client/src/services/splash.ts
@@ -1,0 +1,40 @@
+/**
+ * Drives the startup splash screen that index.html renders inline, before any script or
+ * stylesheet is fetched. Status strings are English-only, as in the standalone error overlay:
+ * the splash runs while the backend that serves the translation catalogues is still starting,
+ * so no catalogue can be loaded yet.
+ *
+ * Kept free of imports: index.ts loads it before setupGlob() populates window.glob, which most
+ * client modules read at module scope.
+ */
+
+/** Matches the `#splash` opacity transition in index.html. */
+const SPLASH_FADE_MS = 400;
+
+/** Replaces the status line under the progress bar. */
+export function updateSplashStatus(status: string): void {
+    const statusEl = document.getElementById("splash-status");
+    if (statusEl) {
+        statusEl.textContent = status;
+    }
+}
+
+/** Switches the splash to its error state: the progress bar goes away and the message shows. */
+export function showSplashError(message: string): void {
+    const splashEl = document.getElementById("splash");
+    if (!splashEl) {
+        return;
+    }
+    splashEl.classList.add("splash-error");
+    updateSplashStatus(message);
+}
+
+/** Fades the splash out and removes it, revealing the application behind it. */
+export function hideSplash(): void {
+    const splashEl = document.getElementById("splash");
+    if (!splashEl) {
+        return;
+    }
+    splashEl.classList.add("splash-hidden");
+    setTimeout(() => splashEl.remove(), SPLASH_FADE_MS);
+}

--- a/apps/client/src/services/splash.ts
+++ b/apps/client/src/services/splash.ts
@@ -34,7 +34,9 @@ export interface SplashPhase {
  */
 export const CLIENT_STARTUP_PHASES: SplashPhase[] = [
     { id: "bootstrap", weight: 1, status: "Opening your notes…" },
-    { id: "application", weight: 2, status: "Loading the application…" }
+    { id: "application", weight: 3, status: "Loading the application…" },
+    { id: "interface", weight: 2, status: "Building the interface…" },
+    { id: "notes", weight: 2, status: "Loading the note tree…" }
 ];
 
 let phases: SplashPhase[] = [];

--- a/apps/client/src/services/splash.ts
+++ b/apps/client/src/services/splash.ts
@@ -55,7 +55,16 @@ export function initSplashProgress(startupPhases: SplashPhase[]): void {
     phases = startupPhases;
     totalWeight = phases.reduce((sum, phase) => sum + phase.weight, 0);
 
-    document.querySelector("#splash .splash-bar")?.classList.add("is-continuous");
+    const bar = document.querySelector("#splash .splash-bar");
+    if (!bar) {
+        return;
+    }
+
+    // The indeterminate fill sits at 40% of the bar, which is further along than most startups
+    // begin. Dropping to the real starting position has to skip the long ease, or the bar spends
+    // its first seconds visibly shrinking; the guard is lifted a frame later, once 0 has landed.
+    bar.classList.add("is-continuous", "is-starting");
+    requestAnimationFrame(() => bar.classList.remove("is-starting"));
 }
 
 /**

--- a/apps/client/src/set_password.tsx
+++ b/apps/client/src/set_password.tsx
@@ -84,7 +84,6 @@ export function App() {
     );
 }
 
-// Skip the bootstrap render under test, where the component is imported directly.
-if (import.meta.env.MODE !== "test") {
-    void main();
-}
+// index.ts holds the splash up until the page has rendered. The render under test imports
+// the component directly, so it skips this one.
+export const ready = import.meta.env.MODE !== "test" ? main() : Promise.resolve();

--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -921,7 +921,6 @@ function onSetupFinished() {
     }
 }
 
-// Skip the bootstrap render under test, where the components are imported directly.
-if (import.meta.env.MODE !== "test") {
-    void main();
-}
+// index.ts holds the splash up until the page has rendered. The render under test imports
+// the components directly, so it skips this one.
+export const ready = import.meta.env.MODE !== "test" ? main() : Promise.resolve();

--- a/apps/client/src/widgets/layout/StatusBar.tsx
+++ b/apps/client/src/widgets/layout/StatusBar.tsx
@@ -22,7 +22,7 @@ import { BacklinksWidget, useBacklinkCount } from "../FloatingButtonsDefinitions
 import Dropdown, { DropdownProps } from "../react/Dropdown";
 import { FormDropdownDivider, FormListHeader, FormListItem } from "../react/FormList";
 import HelpDropdown from "../react/HelpDropdown";
-import { useActiveNoteContext, useLegacyImperativeHandlers, useNoteLabel, useNoteLabelInt, useNoteLabelOptionalBool, useNoteProperty, useStaticTooltip, useTriliumEvent, useTriliumEvents, useTriliumOptionBool, useTriliumOptionInt } from "../react/hooks";
+import { useActiveNoteContext, useLegacyImperativeHandlers, useNoteLabel, useNoteLabelInt, useNoteLabelOptionalBool, useNoteProperty, useStaticTooltip, useTriliumEvent, useTriliumEvents, useTriliumOptionBool, useTriliumOptionInt, useAttachments } from "../react/hooks";
 import Icon from "../react/Icon";
 import LinkButton from "../react/LinkButton";
 import { ParentComponent } from "../react/react_utils";
@@ -34,7 +34,6 @@ import { NoteSizeWidget, useNoteMetadata } from "../ribbon/NoteInfoTab";
 import { NotePathsWidget, useSortedNotePaths } from "../ribbon/NotePathsTab";
 import SimilarNotesTab from "../ribbon/SimilarNotesTab";
 import type { RightPaneTabId } from "../sidebar/RightPaneTabs";
-import { useAttachments } from "../type_widgets/Attachment";
 import { useProcessedLocales } from "../type_widgets/options/components/LocaleSelector";
 import Breadcrumb from "./Breadcrumb";
 import { convertIndentation } from "./reindentation";

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -33,6 +33,7 @@ import NoteContextAwareWidget from "../note_context_aware_widget";
 import { DragData } from "../note_tree";
 import { noteSavedDataStore } from "./NoteStore";
 import { NoteContextContext, ParentComponent, refToJQuerySelector } from "./react_utils";
+import type FAttachment from "../../entities/fattachment";
 
 export function useTriliumEvent<T extends EventNames>(eventName: T, handler: (data: EventData<T>) => void) {
     const parentComponent = useContext(ParentComponent);
@@ -2177,4 +2178,22 @@ export function useDebouncedValue<T>(value: T, delay: number): T {
     }, [ value, delay ]);
 
     return settled;
+}
+
+export function useAttachments(note: FNote) {
+    const [ attachments, setAttachments ] = useState<FAttachment[]>([]);
+
+    function refresh() {
+        note.getAttachments().then(attachments => setAttachments(Array.from(attachments)));
+    }
+
+    useEffect(refresh, [ note ]);
+
+    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
+        if (loadResults.getAttachmentRows().some((att) => att.attachmentId && att.ownerId === note.noteId)) {
+            refresh();
+        }
+    });
+
+    return attachments;
 }

--- a/apps/client/src/widgets/type_widgets/Attachment.tsx
+++ b/apps/client/src/widgets/type_widgets/Attachment.tsx
@@ -31,7 +31,7 @@ import Dropdown from "../react/Dropdown";
 import FormFileUpload from "../react/FormFileUpload";
 import { FormDropdownDivider, FormListItem } from "../react/FormList";
 import HelpButton from "../react/HelpButton";
-import { useTriliumEvent } from "../react/hooks";
+import { useAttachments, useTriliumEvent } from "../react/hooks";
 import Icon from "../react/Icon";
 import ImageViewer from "../react/ImageViewer";
 import NoItems from "../react/NoItems";
@@ -126,24 +126,6 @@ function SystemAttachments({ attachments }: { attachments: FAttachment[] }) {
             {everExpanded && <AttachmentGrid attachments={attachments} />}
         </ExternallyControlledCollapsible>
     );
-}
-
-export function useAttachments(note: FNote) {
-    const [ attachments, setAttachments ] = useState<FAttachment[]>([]);
-
-    function refresh() {
-        note.getAttachments().then(attachments => setAttachments(Array.from(attachments)));
-    }
-
-    useEffect(refresh, [ note ]);
-
-    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
-        if (loadResults.getAttachmentRows().some((att) => att.attachmentId && att.ownerId === note.noteId)) {
-            refresh();
-        }
-    });
-
-    return attachments;
 }
 
 function AttachmentListHeader({ noteId }: { noteId: string }) {

--- a/apps/standalone/src/error-overlay.spec.ts
+++ b/apps/standalone/src/error-overlay.spec.ts
@@ -9,7 +9,6 @@ async function freshOverlay(): Promise<typeof import("./error-overlay.js")> {
 
 beforeEach(() => {
     document.body.innerHTML = "";
-    document.body.style.display = "";
 });
 
 afterEach(() => {
@@ -17,9 +16,9 @@ afterEach(() => {
 });
 
 describe("showErrorOverlay", () => {
-    it("renders the title, message, detail and a reload button, and reveals the body", async () => {
+    it("renders title, message, detail and a reload button, and removes the splash", async () => {
         const { showErrorOverlay } = await freshOverlay();
-        document.body.style.display = "none";
+        document.body.innerHTML = `<div id="splash"></div>`;
 
         showErrorOverlay("Trilium couldn't start", "MIME type wrong", "at worker.js:1");
 
@@ -29,8 +28,8 @@ describe("showErrorOverlay", () => {
         expect(overlay?.textContent).toContain("MIME type wrong");
         expect(overlay?.querySelector("pre")?.textContent).toBe("at worker.js:1");
         expect(overlay?.querySelector("button")?.textContent).toBe("Reload");
-        // The pre-client shell may hide the body; the overlay must un-hide it.
-        expect(document.body.style.display).toBe("block");
+        // The startup splash sits above everything and would cover the overlay.
+        expect(document.getElementById("splash")).toBeNull();
     });
 
     it("omits the detail block when no detail is given", async () => {

--- a/apps/standalone/src/error-overlay.ts
+++ b/apps/standalone/src/error-overlay.ts
@@ -31,9 +31,8 @@ export function showErrorOverlay(title: string, message: string, detail?: string
     }
     shown = true;
 
-    // The pre-client shell may still be hiding the body; reveal it so the
-    // overlay is actually visible (mirrors main.ts's bootstrap catch).
-    document.body.style.display = "block";
+    // The startup splash sits above everything and would cover the overlay.
+    document.getElementById("splash")?.remove();
 
     // Defensive: never stack two overlays if one was somehow left behind.
     document.getElementById(OVERLAY_ID)?.remove();

--- a/apps/standalone/src/index.html
+++ b/apps/standalone/src/index.html
@@ -71,6 +71,9 @@
                 animation: none;
                 transition: width 12s cubic-bezier(0.16, 0.85, 0.3, 1);
             }
+            #splash .splash-bar.is-continuous.is-starting .splash-bar-fill {
+                transition: none;
+            }
             #splash .splash-bar.is-continuous.is-finishing .splash-bar-fill {
                 transition: width 0.3s ease;
             }

--- a/apps/standalone/src/index.html
+++ b/apps/standalone/src/index.html
@@ -117,7 +117,12 @@
     </head>
 
     <body id="trilium-app">
-        <noscript>Trilium requires JavaScript to be enabled.</noscript>
+        <noscript>
+            <style>
+                #splash { display: none; }
+            </style>
+            Trilium requires JavaScript to be enabled.
+        </noscript>
 
         <div id="splash" role="status">
             <div class="splash-content">

--- a/apps/standalone/src/index.html
+++ b/apps/standalone/src/index.html
@@ -49,7 +49,7 @@
                 color: #333333;
             }
             #splash .splash-bar {
-                width: 176px;
+                width: 240px;
                 height: 3px;
                 margin-top: 24px;
                 border-radius: 2px;
@@ -62,6 +62,32 @@
                 border-radius: 2px;
                 background: #72b755;
                 animation: splash-slide 1.4s ease-in-out infinite;
+            }
+            /* Segmented state, installed by splash.ts once the startup phases are known: one
+               segment per phase, each as wide as that phase is expensive. */
+            #splash .splash-bar.is-segmented {
+                display: flex;
+                gap: 2px;
+                background: none;
+                overflow: visible;
+            }
+            #splash .splash-bar.is-segmented .splash-bar-fill {
+                display: none;
+            }
+            #splash .splash-seg {
+                flex-basis: 0;
+                height: 100%;
+                border-radius: 2px;
+                background: rgba(128, 128, 128, 0.2);
+                transition: background-color 0.3s ease;
+            }
+            #splash .splash-seg.is-done {
+                background: #72b755;
+            }
+            #splash .splash-seg.is-active {
+                background: linear-gradient(90deg, rgba(114, 183, 85, 0.25) 0%, #72b755 50%, rgba(114, 183, 85, 0.25) 100%);
+                background-size: 250% 100%;
+                animation: splash-seg-sweep 1.2s ease-in-out infinite;
             }
             #splash-status {
                 min-height: 1.5em;
@@ -87,6 +113,10 @@
                 0%, 100% { opacity: 0.3; }
                 50% { opacity: 1; }
             }
+            @keyframes splash-seg-sweep {
+                0% { background-position: 100% 0; }
+                100% { background-position: 0 0; }
+            }
             @media (prefers-color-scheme: dark) {
                 #splash { background: #242424; color: #999999; }
                 #splash .splash-title { color: #cccccc; }
@@ -94,6 +124,7 @@
             @media (prefers-reduced-motion: reduce) {
                 #splash .splash-content { opacity: 1; animation: none; }
                 #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
+                #splash .splash-seg.is-active { background: rgba(114, 183, 85, 0.55); animation: none; }
             }
             @media print {
                 #splash { display: none; }

--- a/apps/standalone/src/index.html
+++ b/apps/standalone/src/index.html
@@ -63,31 +63,16 @@
                 background: #72b755;
                 animation: splash-slide 1.4s ease-in-out infinite;
             }
-            /* Segmented state, installed by splash.ts once the startup phases are known: one
-               segment per phase, each as wide as that phase is expensive. */
-            #splash .splash-bar.is-segmented {
-                display: flex;
-                gap: 2px;
-                background: none;
-                overflow: visible;
+            /* Tracking state, installed by splash.ts once the startup phases are known. The long
+               ease-out carries the fill towards the running phase's end without ever reaching it,
+               so a slow step keeps moving instead of looking stalled. */
+            #splash .splash-bar.is-continuous .splash-bar-fill {
+                width: 0;
+                animation: none;
+                transition: width 12s cubic-bezier(0.16, 0.85, 0.3, 1);
             }
-            #splash .splash-bar.is-segmented .splash-bar-fill {
-                display: none;
-            }
-            #splash .splash-seg {
-                flex-basis: 0;
-                height: 100%;
-                border-radius: 2px;
-                background: rgba(128, 128, 128, 0.2);
-                transition: background-color 0.3s ease;
-            }
-            #splash .splash-seg.is-done {
-                background: #72b755;
-            }
-            #splash .splash-seg.is-active {
-                background: linear-gradient(90deg, rgba(114, 183, 85, 0.25) 0%, #72b755 50%, rgba(114, 183, 85, 0.25) 100%);
-                background-size: 250% 100%;
-                animation: splash-seg-sweep 1.2s ease-in-out infinite;
+            #splash .splash-bar.is-continuous.is-finishing .splash-bar-fill {
+                transition: width 0.3s ease;
             }
             #splash-status {
                 min-height: 1.5em;
@@ -113,10 +98,6 @@
                 0%, 100% { opacity: 0.3; }
                 50% { opacity: 1; }
             }
-            @keyframes splash-seg-sweep {
-                0% { background-position: 100% 0; }
-                100% { background-position: 0 0; }
-            }
             @media (prefers-color-scheme: dark) {
                 #splash { background: #242424; color: #999999; }
                 #splash .splash-title { color: #cccccc; }
@@ -124,7 +105,7 @@
             @media (prefers-reduced-motion: reduce) {
                 #splash .splash-content { opacity: 1; animation: none; }
                 #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
-                #splash .splash-seg.is-active { background: rgba(114, 183, 85, 0.55); animation: none; }
+                #splash .splash-bar.is-continuous .splash-bar-fill { transition: width 0.2s linear; }
             }
             @media print {
                 #splash { display: none; }

--- a/apps/standalone/src/index.html
+++ b/apps/standalone/src/index.html
@@ -8,10 +8,120 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
         <link rel="manifest" crossorigin="use-credentials" href="manifest.webmanifest">
         <title>Trilium Notes</title>
+        <style>
+            /* Startup splash. Inline so it renders before any script or stylesheet is fetched;
+               apps/client/src/services/splash.ts drives the status line and removes the element
+               once the application has loaded. */
+            #splash {
+                position: fixed;
+                inset: 0;
+                z-index: 10000;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                background: #ffffff;
+                color: #666666;
+                font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+                transition: opacity 0.4s ease;
+            }
+            #splash.splash-hidden {
+                opacity: 0;
+                pointer-events: none;
+            }
+            #splash .splash-content {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                /* Fades in after a delay, so a fast startup shows a blank page instead of a
+                   flash of logo. */
+                opacity: 0;
+                animation: splash-appear 0.4s ease 0.3s forwards;
+            }
+            #splash .splash-logo {
+                width: 96px;
+                height: 96px;
+            }
+            #splash .splash-title {
+                margin-top: 16px;
+                font-size: 22px;
+                font-weight: 600;
+                letter-spacing: 0.02em;
+                color: #333333;
+            }
+            #splash .splash-bar {
+                width: 176px;
+                height: 3px;
+                margin-top: 24px;
+                border-radius: 2px;
+                overflow: hidden;
+                background: rgba(128, 128, 128, 0.2);
+            }
+            #splash .splash-bar-fill {
+                width: 40%;
+                height: 100%;
+                border-radius: 2px;
+                background: #72b755;
+                animation: splash-slide 1.4s ease-in-out infinite;
+            }
+            #splash-status {
+                min-height: 1.5em;
+                margin-top: 12px;
+                font-size: 13px;
+                text-align: center;
+            }
+            #splash.splash-error .splash-bar {
+                display: none;
+            }
+            #splash.splash-error #splash-status {
+                max-width: min(480px, 85vw);
+                color: #e33f3b;
+            }
+            @keyframes splash-appear {
+                to { opacity: 1; }
+            }
+            @keyframes splash-slide {
+                0% { transform: translateX(-110%); }
+                100% { transform: translateX(260%); }
+            }
+            @keyframes splash-pulse {
+                0%, 100% { opacity: 0.3; }
+                50% { opacity: 1; }
+            }
+            @media (prefers-color-scheme: dark) {
+                #splash { background: #242424; color: #999999; }
+                #splash .splash-title { color: #cccccc; }
+            }
+            @media (prefers-reduced-motion: reduce) {
+                #splash .splash-content { opacity: 1; animation: none; }
+                #splash .splash-bar-fill { width: 100%; animation: splash-pulse 1.8s ease-in-out infinite; }
+            }
+            @media print {
+                #splash { display: none; }
+            }
+        </style>
     </head>
 
     <body id="trilium-app">
         <noscript>Trilium requires JavaScript to be enabled.</noscript>
+
+        <div id="splash" role="status">
+            <div class="splash-content">
+                <svg class="splash-logo" viewBox="0 0 256 256" aria-hidden="true">
+                    <path fill="#95C980" d="m202.9 112.7c-22.5 16.1-54.5 12.8-74.9 6.3l14.8-11.8 14.1-11.3 49.1-39.3-51.2 35.9-14.3 10-14.9 10.5c0.7-21.2 7-49.9 28.6-65.4 1.8-1.3 3.9-2.6 6.1-3.8 2.7-1.5 5.7-2.9 8.8-4.1 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.9 65.9-2.4 2.8-4.9 5.4-7.4 7.8-3.4 3.5-6.8 6.4-10.1 8.8z"/>
+                    <path fill="#72B755" d="m213.1 104c-22.2 12.6-51.4 9.3-70.3 3.2l14.1-11.3 49.1-39.3-51.2 35.9-14.3 10c0.5-18.1 4.9-42.1 19.7-58.6 2.7-1.5 5.7-2.9 8.8-4.1 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.9 65.9-2.3 2.8-4.8 5.4-7.2 7.8z"/>
+                    <path fill="#4FA52B" d="m220.5 96.2c-21.1 8.6-46.6 5.3-63.7-0.2l49.2-39.4-51.2 35.9c0.3-15.8 3.5-36.6 14.3-52.8 27.1-11.1 68.5-15.3 85.2-9.5 0.1 16.2-15.9 45.4-33.8 66z"/>
+                    <path fill="#EE8C89" d="m106.7 179c-5.8-21 5.2-43.8 15.5-57.2l4.8 14.2 4.5 13.4 15.9 47-12.8-47.6-3.6-13.2-3.7-13.9c15.5 6.2 35.1 18.6 40.7 38.8 0.5 1.7 0.9 3.6 1.2 5.5 0.4 2.4 0.6 5 0.7 7.7 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8-1.4-2.6-2.7-5.1-3.8-7.6-1.6-3.5-2.9-6.8-3.8-10z"/>
+                    <path fill="#E96562" d="m110.4 188.9c-3.4-19.8 6.9-40.5 16.6-52.9l4.5 13.4 15.9 47-12.8-47.6-3.6-13.2c13.3 5.2 29.9 15 38.1 30.4 0.4 2.4 0.6 5 0.7 7.7 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8-1.4-2.6-2.7-5.2-3.8-7.7z"/>
+                    <path fill="#E33F3B" d="m114.2 196.5c-0.7-18 8.6-35.9 17.3-47.1l15.9 47-12.8-47.6c11.6 4.4 26.1 12.4 35.2 24.8 0.9 23.1-7.1 54.9-15.9 65.7-12-4.3-29.3-24-39.7-42.8z"/>
+                    <path fill="#EFB075" d="m86.3 59.1c21.7 10.9 32.4 36.6 35.8 54.9l-15.2-6.6-14.5-6.3-50.6-22 48.8 24.9 13.6 6.9 14.3 7.3c-16.6 7.9-41.3 14.5-62.1 4.1-1.8-0.9-3.6-1.9-5.4-3.2-2.3-1.5-4.5-3.2-6.8-5.1-19.9-16.4-40.3-46.4-42.7-61.5 12.4-6.5 41.5-5.8 64.8-0.3 3.2 0.8 6.2 1.6 9.1 2.5 4 1.3 7.6 2.8 10.9 4.4z"/>
+                    <path fill="#E99547" d="m75.4 54.8c18.9 12 28.4 35.6 31.6 52.6l-14.5-6.3-50.6-22 48.7 24.9 13.6 6.9c-14.1 6.8-34.5 13-53.3 8.2-2.3-1.5-4.5-3.2-6.8-5.1-19.8-16.4-40.2-46.4-42.6-61.5 12.4-6.5 41.5-5.8 64.8-0.3 3.1 0.8 6.2 1.6 9.1 2.6z"/>
+                    <path fill="#E47B19" d="m66.3 52.2c15.3 12.8 23.3 33.6 26.1 48.9l-50.6-22 48.8 24.9c-12.2 6-29.6 11.8-46.5 10-19.8-16.4-40.2-46.4-42.6-61.5 12.4-6.5 41.5-5.8 64.8-0.3z"/>
+                </svg>
+                <div class="splash-title">Trilium Notes</div>
+                <div class="splash-bar"><div class="splash-bar-fill"></div></div>
+                <div id="splash-status"></div>
+            </div>
+        </div>
 
         <div id="context-menu-cover"></div>
         <div class="dropdown-menu dropdown-menu-sm" id="context-menu-container" style="display: none"></div>

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -61,6 +61,32 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
+describe("startup progress", () => {
+    it("advances the splash as the worker reports its startup phases", async () => {
+        document.body.innerHTML = `
+            <div id="splash">
+                <div class="splash-bar"></div>
+                <div id="splash-status"></div>
+            </div>`;
+        const bridge = await freshBridge();
+        const { initSplashProgress } = await import("../../client/src/services/splash.js");
+        initSplashProgress([
+            { id: "sqlite", weight: 1, status: "Loading the database engine…" },
+            { id: "core", weight: 1, status: "Loading Trilium…" }
+        ]);
+
+        bridge.startLocalServerWorker();
+        lastWorker().onmessage?.({ data: { type: "STARTUP_PROGRESS", phase: "core" } });
+
+        expect(document.getElementById("splash-status")?.textContent).toBe("Loading Trilium…");
+        const segments = [ ...document.querySelectorAll(".splash-seg") ];
+        expect(segments[0]?.classList.contains("is-done")).toBe(true);
+        expect(segments[1]?.classList.contains("is-active")).toBe(true);
+
+        document.body.innerHTML = "";
+    });
+});
+
 describe("startLocalServerWorker", () => {
     it("creates the worker once and sends an INIT message", async () => {
         const bridge = await freshBridge();

--- a/apps/standalone/src/local-bridge.spec.ts
+++ b/apps/standalone/src/local-bridge.spec.ts
@@ -65,23 +65,22 @@ describe("startup progress", () => {
     it("advances the splash as the worker reports its startup phases", async () => {
         document.body.innerHTML = `
             <div id="splash">
-                <div class="splash-bar"></div>
+                <div class="splash-bar"><div class="splash-bar-fill"></div></div>
                 <div id="splash-status"></div>
             </div>`;
         const bridge = await freshBridge();
         const { initSplashProgress } = await import("../../client/src/services/splash.js");
         initSplashProgress([
             { id: "sqlite", weight: 1, status: "Loading the database engine…" },
-            { id: "core", weight: 1, status: "Loading Trilium…" }
+            { id: "core", weight: 1, status: "Loading Trilium…" },
+            { id: "application", weight: 2, status: "Loading the application…" }
         ]);
 
         bridge.startLocalServerWorker();
         lastWorker().onmessage?.({ data: { type: "STARTUP_PROGRESS", phase: "core" } });
 
         expect(document.getElementById("splash-status")?.textContent).toBe("Loading Trilium…");
-        const segments = [ ...document.querySelectorAll(".splash-seg") ];
-        expect(segments[0]?.classList.contains("is-done")).toBe(true);
-        expect(segments[1]?.classList.contains("is-active")).toBe(true);
+        expect(document.querySelector<HTMLElement>(".splash-bar-fill")?.style.width).toBe("50%");
 
         document.body.innerHTML = "";
     });

--- a/apps/standalone/src/local-bridge.ts
+++ b/apps/standalone/src/local-bridge.ts
@@ -4,6 +4,7 @@ import type {
     StandaloneRestoreResult
 } from "@triliumnext/commons";
 
+import { reportSplashPhase } from "../../client/src/services/splash.js";
 import { showErrorOverlay } from "./error-overlay.js";
 import { isLeader } from "./leader_election.js";
 import LocalServerWorker from "./local-server-worker?worker";
@@ -302,6 +303,13 @@ export function startLocalServerWorker() {
 
     localWorker.onmessage = (event) => {
         const msg = event.data;
+
+        // How far the worker has got through its own startup, which the splash draws as progress.
+        // Only the leader tab has a worker, so only it sees these.
+        if (msg?.type === "STARTUP_PROGRESS") {
+            reportSplashPhase(msg.phase);
+            return;
+        }
 
         // Restore progress and outcome, which travel on their own channel rather than as a response
         // to a request: the backup that started them never went through one.

--- a/apps/standalone/src/local-server-worker.ts
+++ b/apps/standalone/src/local-server-worker.ts
@@ -38,6 +38,15 @@ function reportEscapedError(label: string, message: string, stack?: string) {
     }
 }
 
+/**
+ * Tell the page which startup step the worker has reached, so the splash's progress bar can
+ * advance. Import-free for the same reason as {@link reportEscapedError}: the first of these
+ * fires before any module has loaded. Ids match `STANDALONE_STARTUP_PHASES` in main.ts.
+ */
+function reportStartupPhase(phase: string) {
+    self.postMessage({ type: "STARTUP_PROGRESS", phase });
+}
+
 self.onerror = (message, source, lineno, colno, error) => {
     reportEscapedError(
         "Uncaught error",
@@ -228,6 +237,7 @@ async function initialize(): Promise<void> {
             await logService.initialize();
             logService.info("[Worker] Log service initialized with OPFS");
 
+            reportStartupPhase("sqlite");
             logService.info("[Worker] Initializing SQLite WASM...");
             await sqlProvider!.initWasm();
 
@@ -247,6 +257,7 @@ async function initialize(): Promise<void> {
             // Which pool entry holds the database is a stored answer rather than a constant: a
             // restore cannot rename an entry, so it writes the new database in beside the old one
             // and changes this. Unrestored instances read the name they have always used.
+            reportStartupPhase("database");
             const { readCurrentDatabaseName } = await import('./lightweight/database_restore.js');
             const dbName = await readCurrentDatabaseName();
 
@@ -277,6 +288,7 @@ async function initialize(): Promise<void> {
                 removeBackupLeftovers(backupPool);
             }
 
+            reportStartupPhase("core");
             logService.info("[Worker] Loading @triliumnext/core...");
             const schemaModule = await import("@triliumnext/core/src/assets/schema.sql?raw");
             coreModule = await import("@triliumnext/core");
@@ -345,6 +357,7 @@ async function initialize(): Promise<void> {
             coreModule.sql_init.initializeDb();
 
             if (coreModule.sql_init.isDbInitialized()) {
+                reportStartupPhase("becca");
                 logService.info("[Worker] Database already initialized, loading becca...");
                 await coreModule.becca_loader.beccaLoaded;
 
@@ -578,6 +591,7 @@ self.onmessage = async (event) => {
         if (!initReceived) {
             initReceived = true;
             console.log("[Worker] Starting initialization...");
+            reportStartupPhase("worker-modules");
             initialize().catch(err => {
                 console.error("[Worker] Initialization failed:", err);
                 self.postMessage({

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -132,9 +132,9 @@ describe("bootstrap", () => {
         await vi.waitFor(() => expect(sw.register).toHaveBeenCalled());
         expect(document.getElementById("splash-status")?.textContent)
             .toBe("Setting up offline support…");
-        // Seven weighted phases, the first of which covers 1/17 of the bar.
+        // Nine weighted phases, the first of which covers 1/20 of the bar.
         const fill = document.querySelector<HTMLElement>(".splash-bar-fill");
-        expect(fill?.style.width).toBe("6%");
+        expect(fill?.style.width).toBe("5%");
     });
 
     it("lets the worker's phases through after the client reports its own", async () => {

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -117,6 +117,19 @@ describe("bootstrap", () => {
         expect(document.body.innerHTML).toBe("");
     });
 
+    it("reports progress on the splash while the SW installs", async () => {
+        document.body.innerHTML = `<div id="splash"><div id="splash-status"></div></div>`;
+        const sw: ServiceWorkerLike = {
+            controller: null, register: vi.fn(), ready: Promise.resolve()
+        };
+        sw.register.mockImplementation(async () => { sw.controller = {}; });
+        setServiceWorker(sw);
+        await runBootstrap();
+        await vi.waitFor(() => expect(sw.register).toHaveBeenCalled());
+        expect(document.getElementById("splash-status")?.textContent)
+            .toBe("Setting up offline support…");
+    });
+
     it("reloads the page when the SW installs but does not take control", async () => {
         setServiceWorker({ controller: null, register: vi.fn().mockResolvedValue(undefined), ready: Promise.resolve() });
         await runBootstrap();

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -118,7 +118,11 @@ describe("bootstrap", () => {
     });
 
     it("reports progress on the splash while the SW installs", async () => {
-        document.body.innerHTML = `<div id="splash"><div id="splash-status"></div></div>`;
+        document.body.innerHTML = `
+            <div id="splash">
+                <div class="splash-bar"></div>
+                <div id="splash-status"></div>
+            </div>`;
         const sw: ServiceWorkerLike = {
             controller: null, register: vi.fn(), ready: Promise.resolve()
         };
@@ -128,6 +132,10 @@ describe("bootstrap", () => {
         await vi.waitFor(() => expect(sw.register).toHaveBeenCalled());
         expect(document.getElementById("splash-status")?.textContent)
             .toBe("Setting up offline support…");
+        // One segment per startup phase, the first of them active.
+        const segments = [ ...document.querySelectorAll(".splash-seg") ];
+        expect(segments).toHaveLength(8);
+        expect(segments[0]?.classList.contains("is-active")).toBe(true);
     });
 
     it("reloads the page when the SW installs but does not take control", async () => {

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -120,7 +120,7 @@ describe("bootstrap", () => {
     it("reports progress on the splash while the SW installs", async () => {
         document.body.innerHTML = `
             <div id="splash">
-                <div class="splash-bar"></div>
+                <div class="splash-bar"><div class="splash-bar-fill"></div></div>
                 <div id="splash-status"></div>
             </div>`;
         const sw: ServiceWorkerLike = {
@@ -132,10 +132,9 @@ describe("bootstrap", () => {
         await vi.waitFor(() => expect(sw.register).toHaveBeenCalled());
         expect(document.getElementById("splash-status")?.textContent)
             .toBe("Setting up offline support…");
-        // One segment per startup phase, the first of them active.
-        const segments = [ ...document.querySelectorAll(".splash-seg") ];
-        expect(segments).toHaveLength(8);
-        expect(segments[0]?.classList.contains("is-active")).toBe(true);
+        // Eight weighted phases, the first of which covers 1/18 of the bar.
+        const fill = document.querySelector<HTMLElement>(".splash-bar-fill");
+        expect(fill?.style.width).toBe("6%");
     });
 
     it("reloads the page when the SW installs but does not take control", async () => {

--- a/apps/standalone/src/main.spec.ts
+++ b/apps/standalone/src/main.spec.ts
@@ -132,9 +132,27 @@ describe("bootstrap", () => {
         await vi.waitFor(() => expect(sw.register).toHaveBeenCalled());
         expect(document.getElementById("splash-status")?.textContent)
             .toBe("Setting up offline support…");
-        // Eight weighted phases, the first of which covers 1/18 of the bar.
+        // Seven weighted phases, the first of which covers 1/17 of the bar.
         const fill = document.querySelector<HTMLElement>(".splash-bar-fill");
         expect(fill?.style.width).toBe("6%");
+    });
+
+    it("lets the worker's phases through after the client reports its own", async () => {
+        document.body.innerHTML = `
+            <div id="splash">
+                <div class="splash-bar"><div class="splash-bar-fill"></div></div>
+                <div id="splash-status"></div>
+            </div>`;
+        setServiceWorker({ controller: {}, register: vi.fn(), ready: Promise.resolve() });
+        await runBootstrap();
+        const { reportSplashPhase } = await import("../../client/src/services/splash.js");
+
+        // On a warm start the client reaches its own "bootstrap" phase while the worker is still
+        // opening the database. That phase is not in the standalone sequence, so the worker's
+        // later steps are still shown rather than being swallowed by the monotonic guard.
+        reportSplashPhase("bootstrap");
+        reportSplashPhase("core");
+        expect(document.getElementById("splash-status")?.textContent).toBe("Loading Trilium…");
     });
 
     it("reloads the page when the SW installs but does not take control", async () => {

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -1,3 +1,4 @@
+import { updateSplashStatus } from "../../client/src/services/splash.js";
 import { showErrorOverlay } from "./error-overlay.js";
 import { installIosInterceptors } from "./ios-interceptors.js";
 import { claimLeadership } from "./leader_election.js";
@@ -27,6 +28,7 @@ async function waitForServiceWorkerControl(): Promise<void> {
     }
 
     console.log("[Bootstrap] Waiting for service worker to take control...");
+    updateSplashStatus("Setting up offline support…");
 
     await navigator.serviceWorker.register("./sw.js", { scope: "/" });
     await navigator.serviceWorker.ready;

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -14,15 +14,19 @@ import { announceLeadership, attachServiceWorkerBridge, downloadDatabase, regist
  * The worker reports the middle of this sequence over `STARTUP_PROGRESS` (see local-bridge.ts).
  * A follower tab has no worker of its own, so it sits on the first phase until the leader answers
  * its `/bootstrap` and the client's own phases carry the bar the rest of the way.
+ *
+ * The client's own `bootstrap` phase is deliberately absent: here `/bootstrap` is answered by the
+ * worker, so it does not follow the worker's steps but spans them. Listing it would let index.ts
+ * report it while the worker was still on `sqlite`, and the monotonic guard in reportSplashPhase()
+ * would then swallow every later worker phase.
  */
 const STANDALONE_STARTUP_PHASES: SplashPhase[] = [
     { id: "service-worker", weight: 1, status: "Setting up offline support…" },
-    { id: "worker-modules", weight: 1, status: "Starting the database engine…" },
+    { id: "worker-modules", weight: 1, status: "Starting up…" },
     { id: "sqlite", weight: 3, status: "Loading the database engine…" },
     { id: "database", weight: 2, status: "Opening the database…" },
     { id: "core", weight: 4, status: "Loading Trilium…" },
     { id: "becca", weight: 2, status: "Reading your notes…" },
-    { id: "bootstrap", weight: 1, status: "Preparing the workspace…" },
     { id: "application", weight: 4, status: "Loading the application…" }
 ];
 

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -1,8 +1,30 @@
-import { updateSplashStatus } from "../../client/src/services/splash.js";
+import {
+    initSplashProgress, reportSplashPhase, type SplashPhase
+} from "../../client/src/services/splash.js";
 import { showErrorOverlay } from "./error-overlay.js";
 import { installIosInterceptors } from "./ios-interceptors.js";
 import { claimLeadership } from "./leader_election.js";
 import { announceLeadership, attachServiceWorkerBridge, downloadDatabase, registerNativeHttpHandler, restoreBackup, startLocalServerWorker } from "./local-bridge.js";
+
+/**
+ * What a cold standalone start passes through, drawn as the splash's progress bar. Weights are
+ * the relative cost of each step on a first visit, where the two large downloads — the SQLite
+ * WASM binary and the core bundle — dominate; a warm start runs the same sequence from cache.
+ *
+ * The worker reports the middle of this sequence over `STARTUP_PROGRESS` (see local-bridge.ts).
+ * A follower tab has no worker of its own, so it sits on the first phase until the leader answers
+ * its `/bootstrap` and the client's own phases carry the bar the rest of the way.
+ */
+const STANDALONE_STARTUP_PHASES: SplashPhase[] = [
+    { id: "service-worker", weight: 1, status: "Setting up offline support…" },
+    { id: "worker-modules", weight: 1, status: "Starting the database engine…" },
+    { id: "sqlite", weight: 3, status: "Loading the database engine…" },
+    { id: "database", weight: 2, status: "Opening the database…" },
+    { id: "core", weight: 4, status: "Loading Trilium…" },
+    { id: "becca", weight: 2, status: "Reading your notes…" },
+    { id: "bootstrap", weight: 1, status: "Preparing the workspace…" },
+    { id: "application", weight: 4, status: "Loading the application…" }
+];
 
 async function waitForServiceWorkerControl(): Promise<void> {
     if (!("serviceWorker" in navigator) || !navigator.serviceWorker) {
@@ -28,7 +50,7 @@ async function waitForServiceWorkerControl(): Promise<void> {
     }
 
     console.log("[Bootstrap] Waiting for service worker to take control...");
-    updateSplashStatus("Setting up offline support…");
+    reportSplashPhase("service-worker");
 
     await navigator.serviceWorker.register("./sw.js", { scope: "/" });
     await navigator.serviceWorker.ready;
@@ -47,6 +69,10 @@ async function waitForServiceWorkerControl(): Promise<void> {
 async function bootstrap() {
     /* fixes https://github.com/webpack/webpack/issues/10035 */
     window.global = globalThis;
+
+    // Claimed before the client loads, so standalone's longer sequence is the one the bar shows
+    // rather than the two client-side phases index.ts would otherwise install.
+    initSplashProgress(STANDALONE_STARTUP_PHASES);
 
     // The client's way to the worker for the few things that carry a file, which the request path
     // would serialise whole and time out on. The desktop's `window.electronApi` is the same idea.

--- a/apps/standalone/src/main.ts
+++ b/apps/standalone/src/main.ts
@@ -11,7 +11,8 @@ import { announceLeadership, attachServiceWorkerBridge, downloadDatabase, regist
  * the relative cost of each step on a first visit, where the two large downloads — the SQLite
  * WASM binary and the core bundle — dominate; a warm start runs the same sequence from cache.
  *
- * The worker reports the middle of this sequence over `STARTUP_PROGRESS` (see local-bridge.ts).
+ * The worker reports the middle of this sequence over `STARTUP_PROGRESS` (see local-bridge.ts),
+ * and the client reports the last two once its entry point is loading its layout and note tree.
  * A follower tab has no worker of its own, so it sits on the first phase until the leader answers
  * its `/bootstrap` and the client's own phases carry the bar the rest of the way.
  *
@@ -27,7 +28,9 @@ const STANDALONE_STARTUP_PHASES: SplashPhase[] = [
     { id: "database", weight: 2, status: "Opening the database…" },
     { id: "core", weight: 4, status: "Loading Trilium…" },
     { id: "becca", weight: 2, status: "Reading your notes…" },
-    { id: "application", weight: 4, status: "Loading the application…" }
+    { id: "application", weight: 4, status: "Loading the application…" },
+    { id: "interface", weight: 2, status: "Building the interface…" },
+    { id: "notes", weight: 1, status: "Loading the note tree…" }
 ];
 
 async function waitForServiceWorkerControl(): Promise<void> {


### PR DESCRIPTION
## Problem

`apps/client/src/index.ts` hid `<body>` outright (`document.body.style.display = "none"`) for the entire boot sequence, so the page stayed plain white until every stylesheet, script and the `/bootstrap` response had arrived.

In the standalone build that boot also includes registering the service worker, downloading and compiling SQLite WASM, and opening the OPFS database — many seconds on a first visit or a slow device, all of it spent on a blank white page with no indication anything is happening.

## Change

Both `index.html` files (client and standalone) now render a splash inline, before any script or stylesheet is fetched: the Trilium flower logo, the wordmark, an indeterminate progress bar and a status line. It follows the OS light/dark preference, respects `prefers-reduced-motion`, and is hidden under `@media print`. The content fades in after a ~300 ms delay, so a fast server-mode startup shows a blank themed page rather than a flash of logo.

`apps/client/src/services/splash.ts` drives it (`updateSplashStatus` / `showSplashError` / `hideSplash`), deliberately free of imports since `index.ts` loads it before `setupGlob()` populates `window.glob`:

- The client bootstrap reports *"Opening your notes…"* (covering the long standalone DB wait) and *"Loading the application…"*, then fades the splash out once the UI is up.
- Standalone's `main.ts` reports *"Setting up offline support…"* during first-visit service-worker installation.
- A bootstrap failure switches the splash to an error state with the message and reload advice, instead of spinning forever.
- The standalone fatal-error overlay now removes the splash, so it can never cover an error.

Splash status strings are English-only by necessity: they render while the backend that serves the translation catalogues is still starting — the same constraint the standalone error overlay already lives under.

## Verification

- Drove headless Chromium through a real standalone startup: splash appears immediately, status updates, fades into the setup screen. Checked in dark mode too. It also incidentally caught a genuine dev-mode worker failure, where the error overlay correctly replaced the splash.
- New `apps/client/src/services/splash.spec.ts` (3 tests); updated `error-overlay.spec.ts` and `main.spec.ts` — 16 tests passing across the touched specs.
- `pnpm typecheck` clean; changed files pass the format check.

Docs were checked — the User Guide has no page describing the startup screen, so nothing needed updating there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtG3t26NJRxC1ZH2xVUijj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtG3t26NJRxC1ZH2xVUijj)_