### PR TITLE
fix(client): strip styles from trimmed Markdown previews

### DIFF
--- a/apps/client/src/services/content_renderer_text.spec.ts
+++ b/apps/client/src/services/content_renderer_text.spec.ts
@@ -3,6 +3,7 @@
 // mishandles it and strips valid markup (surfaced by dompurify 3.4.8). Run the
 // sanitization-dependent specs under jsdom, which matches real-browser behavior.
 import { KATEX_MACROS, trimIndentation } from "@triliumnext/commons";
+import DOMPurify from "dompurify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FAttachment from "../entities/fattachment";
@@ -244,6 +245,23 @@ describe("Text content renderer", () => {
         // Should resolve without throwing even though there is no href to resolve.
         await expect(renderText(note, $(contentEl))).resolves.toBeUndefined();
         expect(contentEl.querySelector("a.reference-link")).not.toBeNull();
+    });
+
+    it("removes non-leading style tags from trimmed markdown previews", async () => {
+        const note = buildNote({ title: "Imported Markdown note" });
+        const markdownHtml = DOMPurify.sanitize(`
+            <p>Preview text</p>
+            <style>li { margin-bottom: 8pt; }</style>
+        `);
+        const $renderedContent = $("<div>").append(
+            $("<div class=\"ck-content\">").html(markdownHtml)
+        );
+        expect($renderedContent[0].querySelector("style")).not.toBeNull();
+
+        await postProcessRichContent(note, $renderedContent, { trim: true });
+
+        expect($renderedContent[0].querySelector("style")).toBeNull();
+        expect($renderedContent[0].textContent).toContain("Preview text");
     });
 });
 

--- a/apps/client/src/services/content_renderer_text.ts
+++ b/apps/client/src/services/content_renderer_text.ts
@@ -69,6 +69,10 @@ export async function postProcessRichContent(note: FNote | FAttachment, $rendere
     applyLinkEmbeds($renderedContent[0]);
     await rewriteMermaidDiagramsInContainer($renderedContent[0] as HTMLDivElement);
     await formatCodeBlocks($renderedContent);
+
+    if (options.trim) {
+        $renderedContent.find("style").remove();
+    }
 }
 
 async function renderIncludedNotes(contentEl: HTMLElement, seenNoteIds: Set<string>, expandNested: boolean) {


### PR DESCRIPTION
## Why

PR #9633 reported that embedded note styles could escape trimmed previews and alter unrelated UI. PR #9296 later fixed the reported imported-HTML path by sanitizing text-note content, but Markdown rendering still uses DOMPurify's default configuration. A non-leading raw `<style>` element survives that sanitizer and enters the main document with a trimmed preview.

## What

- Remove descendant `<style>` elements after rich-content processing when `trim` is enabled.
- Add a regression test for the remaining non-leading Markdown style case.

Full-note rendering is unchanged. The stricter sanitizer already covers text notes, so this PR does not duplicate that work.

## Validation

- `pnpm --filter client test content_renderer_text.spec.ts --run`: 34 passed.
- `pnpm typecheck`: no errors.
- Focused V8 coverage for `content_renderer_text.ts`: 100% statements, functions, and lines; 98.57% branches.
- `git diff --check upstream/main...HEAD`: passed.

## Credit

This is the surviving part of #9633, cherry-picked from Allan Zyne's commit `ac1e890057a99fa90a1f0cb8f594a8d9586e716c` and adapted to current `main`. The new commit retains Allan as its author.

_amp-unknown-model-unknown-reasoning on behalf of maphew_
