### PR TITLE
fix(etapi): support base64-encoded binary content when creating attachments

### DIFF
--- a/apps/server/spec/etapi/attachment-content.spec.ts
+++ b/apps/server/spec/etapi/attachment-content.spec.ts
@@ -53,6 +53,64 @@ describe("etapi/attachment-content", () => {
         expect(response.text).toStrictEqual(text);
     });
 
+    it("creates an attachment with base64-encoded binary content", async () => {
+        const binary = Buffer.from([
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01, 0x02, 0x03
+        ]);
+
+        const createResponse = await supertest(app)
+            .post(`/etapi/attachments`)
+            .auth(USER, token, { "type": "basic"})
+            .send({
+                "ownerId": createdNoteId,
+                "role": "image",
+                "mime": "image/png",
+                "title": "binary attachment",
+                "content": binary.toString("base64"),
+                "encoding": "base64"
+            })
+            .expect(201);
+        const attachmentId = createResponse.body.attachmentId;
+        expect(attachmentId).toBeTruthy();
+
+        const contentResponse = await supertest(app)
+            .get(`/etapi/attachments/${attachmentId}/content`)
+            .auth(USER, token, { "type": "basic"})
+            .expect(200);
+        expect(Buffer.from(contentResponse.body).equals(binary)).toBe(true);
+    });
+
+    it("rejects an unsupported encoding", async () => {
+        await supertest(app)
+            .post(`/etapi/attachments`)
+            .auth(USER, token, { "type": "basic"})
+            .send({
+                "ownerId": createdNoteId,
+                "role": "file",
+                "mime": "text/plain",
+                "title": "bad encoding",
+                "content": "data",
+                "encoding": "hex"
+            })
+            .expect(400);
+    });
+
+    it("rejects malformed base64 content", async () => {
+        const response = await supertest(app)
+            .post(`/etapi/attachments`)
+            .auth(USER, token, { "type": "basic"})
+            .send({
+                "ownerId": createdNoteId,
+                "role": "image",
+                "mime": "image/png",
+                "title": "malformed base64",
+                "content": "%%%not-base64%%%",
+                "encoding": "base64"
+            })
+            .expect(400);
+        expect(response.body.code).toStrictEqual("INVALID_BASE64_CONTENT");
+    });
+
     it("supports binary content", async() => {
         await supertest(app)
             .put(`/etapi/attachments/${createdAttachmentId}/content`)

--- a/apps/server/src/assets/etapi.openapi.yaml
+++ b/apps/server/src/assets/etapi.openapi.yaml
@@ -1213,6 +1213,17 @@ components:
                     type: string
                 content:
                     type: string
+                    description: >
+                        Content of the attachment. JSON cannot carry raw binary data, so binary
+                        content must be base64-encoded and accompanied by `encoding: "base64"`;
+                        it is decoded before storage. Otherwise the value is stored as a plain string.
+                encoding:
+                    type: string
+                    enum:
+                        - base64
+                    description: >
+                        Optional content encoding. Only `base64` is supported; when set, `content`
+                        is decoded from base64 before storage.
                 position:
                     type: integer
                     format: int32

--- a/apps/server/src/etapi/attachments.ts
+++ b/apps/server/src/etapi/attachments.ts
@@ -1,7 +1,7 @@
 import type { AttachmentRow } from "@triliumnext/commons";
 import type { Router } from "express";
 
-import { becca } from "@triliumnext/core";
+import { becca, binary_utils } from "@triliumnext/core";
 import utils from "../services/utils.js";
 import eu from "./etapi_utils.js";
 import type { ValidatorMap } from "./etapi-interface.js";
@@ -21,23 +21,55 @@ function register(router: Router) {
         mime: [v.notNull, v.isString],
         title: [v.notNull, v.isString],
         position: [v.notNull, v.isInteger],
-        content: [v.isString]
+        content: [v.isString],
+        encoding: [v.isString]
     };
 
     eu.route(router, "post", "/etapi/attachments", (req, res, next) => {
-        const _params: Partial<AttachmentRow> = {};
+        const _params: Partial<AttachmentRow> & { encoding?: string } = {};
         eu.validateAndPatch(_params, req.body, ALLOWED_PROPERTIES_FOR_CREATE_ATTACHMENT);
-        const params = _params as AttachmentRow;
+        const params = _params as AttachmentRow & { encoding?: string };
 
         try {
             if (!params.ownerId) {
                 throw new Error("Missing owner ID.");
             }
+
+            const { encoding, ...attachmentParams } = params;
+
+            if (encoding !== undefined && encoding !== "base64") {
+                throw new eu.EtapiError(
+                    400,
+                    "INVALID_ENCODING",
+                    `Unsupported encoding '${encoding}'. Only 'base64' is supported.`
+                );
+            }
+
+            // JSON cannot carry raw binary data, so binary content is transmitted base64-encoded
+            // and decoded here before storage. This mirrors the `encoding` convention already used
+            // by the ZIP importer and the web API note-update path (see AttachmentRow.encoding).
+            const rawContent =
+                typeof attachmentParams.content === "string" ? attachmentParams.content : "";
+            if (encoding === "base64" && !isWellFormedBase64(rawContent)) {
+                throw new eu.EtapiError(
+                    400,
+                    "INVALID_BASE64_CONTENT",
+                    "Content is not valid base64."
+                );
+            }
+            const content =
+                encoding === "base64"
+                    ? binary_utils.decodeBase64(rawContent)
+                    : attachmentParams.content;
+
             const note = becca.getNoteOrThrow(params.ownerId);
-            const attachment = note.saveAttachment(params);
+            const attachment = note.saveAttachment({ ...attachmentParams, content });
 
             res.status(201).json(mappers.mapAttachmentToPojo(attachment));
         } catch (e: any) {
+            if (e instanceof eu.EtapiError) {
+                throw e;
+            }
             throw new eu.EtapiError(500, eu.GENERIC_CODE, e.message);
         }
     });
@@ -108,6 +140,11 @@ function register(router: Router) {
 
         res.sendStatus(204);
     });
+}
+
+/** RFC 4648 base64: 4-character groups with optional 0-2 trailing '=' padding. */
+function isWellFormedBase64(value: string): boolean {
+    return value.length % 4 === 0 && /^[A-Za-z0-9+/]*={0,2}$/.test(value);
 }
 
 export default {


### PR DESCRIPTION
## Problem

`POST /etapi/attachments` stores the `content` field verbatim as a string. Since JSON cannot carry raw binary data, binary payloads sent base64-encoded (the natural choice for API clients) were silently stored as the base64 *text*, producing corrupted attachments — e.g. images that fail to decode when served back with their `image/*` MIME type.

The `encoding` convention already exists elsewhere in the codebase:
- `AttachmentRow.encoding?: "base64"` documents "will be decoded from base64 to binary before storage"
- the ZIP importer decodes `encoding: "base64"` (see `packages/trilium-core/src/services/import/zip.ts`)
- the web API note-update path decodes it too (see `updateNoteData` in `packages/trilium-core/src/services/notes.ts`)

But the ETAPI attachment route rejected the property outright (`PROPERTY_NOT_ALLOWED`), so clients could not use the convention at all.

## Fix

- Accept an optional `encoding` property (`"base64"` only) on `POST /etapi/attachments`
- Decode `content` from base64 to bytes before storage (via `binary_utils.decodeBase64`)
- Reject unsupported encodings with `400 INVALID_ENCODING`
- Reject malformed base64 content with `400 INVALID_BASE64_CONTENT` (validated against the RFC 4648 grammar before decoding, so invalid payloads cannot silently persist truncated bytes)
- Document `content` / `encoding` in `etapi.openapi.yaml`
- Add spec tests: base64 binary round-trip, malformed-base64 rejection, unsupported-encoding rejection

## Testing

`pnpm vitest run --config apps/server/vite.config.mts spec/etapi/attachment-content.spec.ts` → **6/6 passed** (3 existing + 3 new cases).

## Usage

```bash
curl -X POST "$SERVER/etapi/attachments" -H "Authorization: $TOKEN" -H "Content-Type: application/json" -d '{
  "ownerId": "NOTE_ID",
  "role": "image",
  "mime": "image/png",
  "title": "screenshot.png",
  "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
  "encoding": "base64"
}'
```

> Supersedes the previously closed PR #11042 (its head fork was deleted, so GitHub no longer allows reopening it).
