### PR TITLE
Canvas: fix file system access error on the desktop app

### DIFF
--- a/apps/desktop/src/services/web_contents_security.spec.ts
+++ b/apps/desktop/src/services/web_contents_security.spec.ts
@@ -290,12 +290,16 @@ describe("isPermissionAllowed", () => {
         expect(isPermissionAllowed("app", "clipboard-sanitized-write")).toBe(true);
         expect(isPermissionAllowed("app", "fullscreen")).toBe(true);
         expect(isPermissionAllowed("app", "notifications")).toBe(true);
+        // The Excalidraw canvas opens and saves files through the File System
+        // Access API instead of `electronApi`.
+        expect(isPermissionAllowed("app", "fileSystem")).toBe(true);
 
         // Guest session: only fullscreen (embedded video players). Remote
         // pages must not show OS notifications appearing to come from Trilium.
         expect(isPermissionAllowed("guest", "fullscreen")).toBe(true);
         expect(isPermissionAllowed("guest", "clipboard-sanitized-write")).toBe(false);
         expect(isPermissionAllowed("guest", "notifications")).toBe(false);
+        expect(isPermissionAllowed("guest", "fileSystem")).toBe(false);
 
         // Everything else is denied everywhere.
         for (const permission of ["media", "geolocation", "midi", "hid", "serial", "usb", "pointerLock", "clipboard-read", "openExternal"]) {
@@ -310,10 +314,12 @@ describe("isPermissionAllowedForOrigin", () => {
         // The app shell itself keeps its grants.
         expect(isPermissionAllowedForOrigin("app", "notifications", "trilium-app://app")).toBe(true);
         expect(isPermissionAllowedForOrigin("app", "clipboard-sanitized-write", "trilium-app://app/some/path")).toBe(true);
+        expect(isPermissionAllowedForOrigin("app", "fileSystem", "trilium-app://app")).toBe(true);
 
         // A remote <iframe> sharing the default session does not.
         expect(isPermissionAllowedForOrigin("app", "notifications", "https://www.youtube-nocookie.com/embed/x")).toBe(false);
         expect(isPermissionAllowedForOrigin("app", "clipboard-sanitized-write", "https://evil.example")).toBe(false);
+        expect(isPermissionAllowedForOrigin("app", "fileSystem", "https://evil.example")).toBe(false);
         // Another host under our own scheme is not the app shell.
         expect(isPermissionAllowedForOrigin("app", "notifications", "trilium-app://evil")).toBe(false);
         // A missing / unparseable origin is treated as untrusted.

--- a/apps/desktop/src/services/web_contents_security.ts
+++ b/apps/desktop/src/services/web_contents_security.ts
@@ -138,6 +138,12 @@ export function hardenWebviewPreferences(webPreferences: Electron.WebPreferences
  *   main-process `electronApi.clipboard.readText()` bridge, so the sensitive
  *   `clipboard-read` permission never has to be granted to the whole session
  *   (which would also expose it to embedded remote iframes).
+ *   `fileSystem` covers the File System Access API, which bundled third-party
+ *   editors call directly rather than through `electronApi` — the Excalidraw
+ *   canvas reaches `showOpenFilePicker()` / `showSaveFilePicker()` via
+ *   `browser-fs-access` to insert an image or export a drawing. Chromium only
+ *   hands out a handle for a file the user picked in an OS dialog, so the grant
+ *   cannot reach anything the user did not choose.
  * - `guest`: the `<webview>` partition hosting arbitrary remote pages from
  *   Web View notes. Fullscreen only (embedded video players) — a remote page
  *   must not show OS notifications that appear to come from Trilium.
@@ -148,7 +154,7 @@ export function hardenWebviewPreferences(webPreferences: Electron.WebPreferences
  * the default session. Fullscreen is the exception — granted for any origin.
  */
 const PERMISSION_ALLOWLIST = {
-    app: new Set(["clipboard-sanitized-write", "fullscreen", "notifications"]),
+    app: new Set(["clipboard-sanitized-write", "fileSystem", "fullscreen", "notifications"]),
     guest: new Set(["fullscreen"])
 } as const;
 


### PR DESCRIPTION
On the desktop app, inserting an image into a Canvas note or exporting a drawing failed silently with a permission error, leaving the feature unusable. Canvas notes on the web and standalone builds were never affected. Both actions now open the normal system file dialog and work as expected.

- Grant the `fileSystem` permission to the desktop app session, so the Excalidraw canvas can complete `showOpenFilePicker()` and `showSaveFilePicker()` calls that previously failed with `NotAllowedError` on `getFile()`
- Keep the grant behind the existing origin gate, so only the `trilium-app://app` shell receives it and remote `<iframe>` embeds sharing the default session do not
- Leave the `<webview>` guest partition unchanged, where `fullscreen` remains the only allowed permission
- Cover `fileSystem` in the per-session allowlist matrix and the origin-gate specs, for both the granted and the denied cases
