### PR TITLE
Spreadsheet: improvements

### DIFF
--- a/apps/client/src/print.css
+++ b/apps/client/src/print.css
@@ -302,6 +302,13 @@ span[style] {
 .spreadsheet-table.show-gridlines td:not(.has-fill) {
     border: 0.5pt solid var(--spreadsheet-gridline-color, #ccc);
 }
+
+/* On paper a link cannot be followed, so it keeps the cell's own text color and the underline
+   is the only marker, matching how .ck-content links print. */
+.spreadsheet-table a {
+    text-decoration: underline;
+    color: inherit;
+}
 /* #endregion */
 
 /* #region AI chat */

--- a/apps/client/src/print.css
+++ b/apps/client/src/print.css
@@ -282,6 +282,9 @@ span[style] {
 /* #region Spreadsheet */
 .spreadsheet-table {
     border-collapse: collapse;
+    /* Honour the per-column widths in the colgroup, as the share renderer does, so the printed
+       grid keeps the editor's geometry and the floating images stay over the cells they belong to. */
+    table-layout: fixed;
     width: 100%;
     font-size: var(--print-font-size);
     print-color-adjust: exact;
@@ -290,8 +293,11 @@ span[style] {
 
 .spreadsheet-table td {
     padding: 2pt 4pt;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    /* Match the spreadsheet: long text runs into empty neighbouring cells instead of wrapping,
+       which keeps every row at its declared height. The renderer sets overflow:hidden on the cells
+       whose neighbour holds a value, so only those are cut. */
+    white-space: nowrap;
+    overflow: visible;
 }
 
 /* Gridlines: only when the sheet enables them, and only on unfilled cells (a background

--- a/packages/commons/src/lib/spreadsheet/extract_text.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/extract_text.spec.ts
@@ -505,3 +505,30 @@ describe("extractSpreadsheetText", () => {
         expect(text).toContain("This text is available only in the spreadsheet");
     });
 });
+
+describe("extractSpreadsheetText rich-text cells", () => {
+    it("indexes cells whose text lives only in the rich-text document, lowercased keys included", () => {
+        const sheet = (dataStreamKey: string) => JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        cellData: {
+                            "0": { "0": { p: { body: { [dataStreamKey]: "Senzor PIR\r\n" } } } },
+                            "1": { "0": { v: "plain" } }
+                        },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        });
+
+        expect(extractSpreadsheetText(sheet("dataStream"))).toBe("Senzor PIR plain");
+        expect(extractSpreadsheetText(sheet("datastream"))).toBe("Senzor PIR plain");
+    });
+});

--- a/packages/commons/src/lib/spreadsheet/extract_text.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/extract_text.spec.ts
@@ -518,7 +518,7 @@ describe("extractSpreadsheetText rich-text cells", () => {
                         name: "Sheet1",
                         hidden: 0,
                         cellData: {
-                            "0": { "0": { p: { body: { [dataStreamKey]: "Senzor PIR\r\n" } } } },
+                            "0": { "0": { p: { body: { [dataStreamKey]: "Notebook\r\n" } } } },
                             "1": { "0": { v: "plain" } }
                         },
                         rowData: {},
@@ -528,7 +528,7 @@ describe("extractSpreadsheetText rich-text cells", () => {
             }
         });
 
-        expect(extractSpreadsheetText(sheet("dataStream"))).toBe("Senzor PIR plain");
-        expect(extractSpreadsheetText(sheet("datastream"))).toBe("Senzor PIR plain");
+        expect(extractSpreadsheetText(sheet("dataStream"))).toBe("Notebook plain");
+        expect(extractSpreadsheetText(sheet("datastream"))).toBe("Notebook plain");
     });
 });

--- a/packages/commons/src/lib/spreadsheet/extract_text.ts
+++ b/packages/commons/src/lib/spreadsheet/extract_text.ts
@@ -10,6 +10,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { normalizeDataStream } from "./workbook_model.js";
+
 /** Read a property by trying the camelCase name first, then the lowercased form. */
 function prop(obj: any, camel: string): any {
     if (obj == null) return undefined;
@@ -71,9 +73,15 @@ function extractSheetText(sheet: any, parts: string[]): void {
             if (prop(columnData[col], "hd")) continue;
 
             const cell = cols[col];
-            if (cell?.v == null) continue;
+            if (!cell) continue;
 
-            if (typeof cell.v === "boolean") {
+            if (cell.v == null || cell.v === "") {
+                // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
+                const text = cellDocumentText(cell).trim();
+                if (text) {
+                    parts.push(text);
+                }
+            } else if (typeof cell.v === "boolean") {
                 parts.push(cell.v ? "TRUE" : "FALSE");
             } else {
                 const text = String(cell.v).trim();
@@ -83,4 +91,10 @@ function extractSheetText(sheet: any, parts: string[]): void {
             }
         }
     }
+}
+
+/** Reads a rich-text cell's document text, tolerating the lowercased keys `prop` handles. */
+function cellDocumentText(cell: any): string {
+    const body = prop(prop(cell, "p"), "body");
+    return normalizeDataStream(prop(body, "dataStream"));
 }

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.spec.ts
@@ -10,9 +10,11 @@ import {
     parseXlsxToWorkbook,
     toArrayBuffer
 } from "./parse_from_xlsx.js";
+import { renderSpreadsheetToXlsx } from "./render_to_xlsx.js";
 import {
     BorderStyle,
     CellValueType,
+    CustomRangeType,
     type DataValidationRule,
     HorizontalAlign,
     type ICellData,
@@ -968,5 +970,73 @@ describe("parseRange", () => {
         expect(parseRange("zzz")).toBeNull();
         // A malformed end endpoint yields null too (covers the `!end` half of the guard).
         expect(parseRange("A1:zz")).toBeNull();
+    });
+});
+
+describe("hyperlinks", () => {
+    it("carries the link into the document Univer stores it in", async () => {
+        const sheet = await roundTrip((wb) => {
+            const ws = wb.addWorksheet("Sheet1");
+            ws.getCell("A1").value = { text: "Supplier", hyperlink: "https://example.com/pen" };
+        });
+
+        const cell = cellA1(sheet);
+        expect(cell?.v).toBe("Supplier");
+        expect(cell?.t).toBe(CellValueType.STRING);
+        expect(cell?.p?.body).toEqual({
+            dataStream: "Supplier\r\n",
+            textRuns: [{ ts: {}, st: 0, ed: 8 }],
+            paragraphs: [{ startIndex: 8 }],
+            sectionBreaks: [{ startIndex: 9 }],
+            customRanges: [{
+                rangeId: "link-A1",
+                rangeType: CustomRangeType.HYPERLINK,
+                startIndex: 0,
+                endIndex: 7,
+                properties: { url: "https://example.com/pen", refId: "link-A1" }
+            }]
+        });
+    });
+
+    it("keeps the display text alone when the target is unsafe", async () => {
+        const sheet = await roundTrip((wb) => {
+            const ws = wb.addWorksheet("Sheet1");
+            ws.getCell("A1").value = { text: "Supplier", hyperlink: "javascript:alert(1)" };
+        });
+
+        expect(cellA1(sheet)?.v).toBe("Supplier");
+        expect(cellA1(sheet)?.p).toBeUndefined();
+    });
+
+    it("survives an export and re-import of the same workbook", async () => {
+        const exported = await renderSpreadsheetToXlsx(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1", name: "Sheet1", hidden: 0, mergeData: [], rowData: {}, columnData: {},
+                        cellData: {
+                            "0": {
+                                "0": {
+                                    p: {
+                                        body: {
+                                            dataStream: "Pen\r\n",
+                                            customRanges: [{ startIndex: 0, endIndex: 2, properties: { url: "https://example.com/pen" } }]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        const { workbook } = await parseXlsxToWorkbook(exported as ArrayBuffer);
+        const cell = cellA1(workbook.sheets[workbook.sheetOrder[0]]);
+        expect(cell?.v).toBe("Pen");
+        expect(cell?.p?.body?.customRanges?.[0]?.properties?.url).toBe("https://example.com/pen");
     });
 });

--- a/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/parse_from_xlsx.ts
@@ -11,8 +11,8 @@
  * Known fidelity gaps (Excel features Univer's cell model — and our exporter — don't carry):
  * conditional formatting, filters, charts, comments, frozen panes and defined names are dropped.
  * Data validation is carried for the common constraint types (dropdown lists, numeric/date/text
- * bounds) via the SHEET_DATA_VALIDATION_PLUGIN resource. Rich text is flattened to plain text and
- * hyperlinks keep their display text but lose the link. Theme/indexed colors are resolved
+ * bounds) via the SHEET_DATA_VALIDATION_PLUGIN resource. A hyperlink becomes the rich-text
+ * document Univer stores a link in. Rich text is flattened to plain text. Theme/indexed colors are resolved
  * against the standard Office palette (see `THEME_COLORS`), which is approximate when the
  * file ships a custom theme.
  */
@@ -23,6 +23,7 @@ import "./exceljs_augmentation.js";
 
 import {
     BorderStyle,
+    buildLinkedCellDocument,
     CellValueType,
     type DataValidationRule,
     HorizontalAlign,
@@ -506,10 +507,7 @@ function applyCellValue(data: ICellData, cell: ExcelJS.Cell): void {
             data.t = CellValueType.NUMBER;
             break;
         case ExcelJS.ValueType.Hyperlink:
-            // Keep the display text; the link itself has no inline Univer equivalent.
-            /* v8 ignore next -- defensive: a hyperlink cell always carries display text */
-            data.v = String((cell.value as ExcelJS.CellHyperlinkValue)?.text ?? "");
-            data.t = CellValueType.STRING;
+            applyHyperlink(data, cell);
             break;
         case ExcelJS.ValueType.RichText:
             data.v = flattenRichText(cell.value as ExcelJS.CellRichTextValue);
@@ -528,6 +526,23 @@ function applyCellValue(data: ICellData, cell: ExcelJS.Cell): void {
             // Null/Merge/empty — nothing to carry.
             break;
     }
+}
+
+/**
+ * Carries a hyperlink cell across as text plus the document Univer keeps its link in. The cell's
+ * address makes the range id unique within the workbook. An unsafe or missing target leaves the
+ * display text behind on its own.
+ */
+function applyHyperlink(data: ICellData, cell: ExcelJS.Cell): void {
+    const value = cell.value as ExcelJS.CellHyperlinkValue | null;
+    /* v8 ignore next -- defensive: a hyperlink cell always carries display text */
+    const text = String(value?.text ?? "");
+
+    data.v = text;
+    data.t = CellValueType.STRING;
+
+    const linkDocument = buildLinkedCellDocument(text, value?.hyperlink, `link-${cell.address}`);
+    if (linkDocument) data.p = linkDocument;
 }
 
 /** Maps a formula's cached result (number/bool/string/date) onto the cell value + type. */

--- a/packages/commons/src/lib/spreadsheet/render_to_csv.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_csv.spec.ts
@@ -348,8 +348,8 @@ describe("renderSpreadsheetToCsv (formatDate returns null)", () => {
 describe("rich-text cells", () => {
     it("exports the text of a cell that has no plain value", () => {
         const csv = renderSpreadsheetToCsv(workbook({
-            0: { 0: { p: { body: { dataStream: "Telecomand\u0103\r\n" } } }, 1: { v: 135.99 } }
+            0: { 0: { p: { body: { dataStream: "Caf\u00e9\r\n" } } }, 1: { v: 12.5 } }
         }));
-        expect(csv).toBe("Telecomand\u0103,135.99");
+        expect(csv).toBe("Caf\u00e9,12.5");
     });
 });

--- a/packages/commons/src/lib/spreadsheet/render_to_csv.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_csv.spec.ts
@@ -344,3 +344,12 @@ describe("renderSpreadsheetToCsv (formatDate returns null)", () => {
         expect(csv).toBe("46118");
     });
 });
+
+describe("rich-text cells", () => {
+    it("exports the text of a cell that has no plain value", () => {
+        const csv = renderSpreadsheetToCsv(workbook({
+            0: { 0: { p: { body: { dataStream: "Telecomand\u0103\r\n" } } }, 1: { v: 135.99 } }
+        }));
+        expect(csv).toBe("Telecomand\u0103,135.99");
+    });
+});

--- a/packages/commons/src/lib/spreadsheet/render_to_csv.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_csv.ts
@@ -23,6 +23,7 @@ import { format as formatNumfmt, getFormatDateInfo, isDateFormat } from "numfmt"
 
 import {
     computeBounds,
+    getCellDocumentText,
     getVisibleSheets,
     type ICellData,
     isFiniteNumber,
@@ -148,7 +149,10 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
  * serials (a numeric value with a date number format) are rendered as ISO 8601.
  */
 function cellText(cell: ICellData | undefined, styles: Record<string, IStyleData | null>): string {
-    if (!cell || cell.v == null) return "";
+    if (!cell) return "";
+
+    // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
+    if (cell.v == null || cell.v === "") return getCellDocumentText(cell);
     if (typeof cell.v === "boolean") return cell.v ? "TRUE" : "FALSE";
 
     const pattern = resolveCellStyle(cell.s, styles)?.n?.pattern;

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -766,8 +766,19 @@ describe("renderSpreadsheetToHtml", () => {
 
     it("omits vertical-align for an unknown vertical alignment", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", s: { vt: 9 } }));
-        expect(html).not.toContain("vertical-align");
+        // The cell contributes none, so it falls back to the row's.
         expect(html).toContain("<td>x</td>");
+        expect(html).toContain(`<tr style="height:24px;vertical-align:bottom">`);
+    });
+
+    it("defaults a row to the bottom, which a cell's own alignment overrides", () => {
+        // Univer leaves a cell at the bottom of its row unless it sets `vt`, unlike HTML.
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x" }));
+        expect(html).toContain(`<tr style="height:24px;vertical-align:bottom">`);
+        expect(html).toContain("<td>x</td>");
+
+        const middle = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", s: { vt: 2 } }));
+        expect(middle).toContain(`<td style="vertical-align:middle">x</td>`);
     });
 
     it("renders borders on all four sides with the correct Univer widths and styles", () => {
@@ -973,7 +984,7 @@ describe("renderSpreadsheetToHtml", () => {
         });
         const html = renderSpreadsheetToHtml(input);
         expect(html).toContain('<col style="width:200px">');
-        expect(html).toContain('<tr style="height:50px">');
+        expect(html).toContain('<tr style="height:50px;vertical-align:bottom">');
     });
 
     it("falls back to default column width and row height when absent", () => {
@@ -999,7 +1010,7 @@ describe("renderSpreadsheetToHtml", () => {
         });
         const html = renderSpreadsheetToHtml(input);
         expect(html).toContain('<col style="width:88px">');
-        expect(html).toContain('<tr style="height:24px">');
+        expect(html).toContain('<tr style="height:24px;vertical-align:bottom">');
     });
 
     it("renders an empty string for a cell with null value", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSpreadsheetToHtml } from "./render_to_html.js";
+import { HorizontalAlign } from "./workbook_model.js";
 
 describe("renderSpreadsheetToHtml", () => {
     it("renders a basic spreadsheet with values and styles", () => {
@@ -1044,7 +1045,22 @@ describe("renderSpreadsheetToHtml", () => {
 
     it("renders numeric cell values", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }));
-        expect(html).toContain("<td>42</td>");
+        expect(html).toContain(">42</td>");
+    });
+
+    it("aligns a cell by its value type when it sets no alignment of its own", () => {
+        // Univer right-aligns numbers and centers booleans; text keeps the table default.
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }))).toContain(`<td style="text-align:right">`);
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: true, t: 3 }))).toContain(`<td style="text-align:center">`);
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: "A", t: 1 }))).toContain("<td>A</td>");
+
+        // A number formatted and styled by the workbook still gets the fallback alignment.
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { bl: 1 } })))
+            .toContain(`<td style="text-align:right;font-weight:bold">`);
+
+        // An explicit alignment wins over the fallback.
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { ht: HorizontalAlign.LEFT } })))
+            .toContain(`<td style="text-align:left">`);
     });
 
     it("emits colspan only for a purely horizontal merge", () => {
@@ -1103,7 +1119,7 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(
             singleCellWorkbook({ v: 1234.5, t: 2, s: { n: { pattern: "#,##0.00" } } })
         );
-        expect(html).toContain("<td>1,234.50</td>");
+        expect(html).toContain(">1,234.50</td>");
         expect(html).not.toContain("1234.5<");
     });
 
@@ -1217,7 +1233,7 @@ describe("renderSpreadsheetToHtml", () => {
 
     it("renders an unformatted number when no pattern is set", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: 1234.5, t: 2 }));
-        expect(html).toContain("<td>1234.5</td>");
+        expect(html).toContain(">1234.5</td>");
     });
 
     it("marks the table with show-gridlines when the sheet has gridlines enabled", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -553,8 +553,8 @@ describe("renderSpreadsheetToHtml", () => {
     });
 
     describe("overflow into neighbouring cells", () => {
-        /** One row of `cells`, keyed by column. */
-        function row(cells: Record<number, unknown>): string {
+        /** A sheet from a `cellData` matrix, with optional sheet-level overrides. */
+        function grid(cellData: Record<number, unknown>, extra: Record<string, unknown> = {}): string {
             return JSON.stringify({
                 version: 1,
                 workbook: {
@@ -566,13 +566,19 @@ describe("renderSpreadsheetToHtml", () => {
                             name: "Sheet1",
                             hidden: 0,
                             mergeData: [],
-                            cellData: { "0": cells },
+                            cellData,
                             rowData: {},
-                            columnData: {}
+                            columnData: {},
+                            ...extra
                         }
                     }
                 }
             });
+        }
+
+        /** One row of `cells`, keyed by column. */
+        function row(cells: Record<number, unknown>, extra: Record<string, unknown> = {}): string {
+            return grid({ "0": cells }, extra);
         }
 
         /** Whether the workbook's cell at `column` clips its text. The render always starts at A1. */
@@ -608,6 +614,29 @@ describe("renderSpreadsheetToHtml", () => {
 
             expect(clips(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
             expect(clips(row({ 0: { s: { bl: 1 } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
+        });
+
+        it("judges adjacency on the rendered row rather than the cell matrix", () => {
+            const long = { v: "a long label", t: 1 };
+
+            // A hidden column reaches nobody, so the cell steps over it in both directions.
+            expect(clips(row({ 0: long, 1: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBe(false);
+            expect(clips(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBe(true);
+
+            // A merged cell starts looking past the last column its own range covers.
+            const merged = [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 }];
+            expect(clips(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { mergeData: merged }), 0)).toBe(true);
+            expect(clips(row({ 0: long, 1: {} }, { mergeData: merged }), 0)).toBe(false);
+        });
+
+        it("reads a column a merge spans into as holding that range's content", () => {
+            // The second row renders only the right-aligned cell; the range fills the column beside it.
+            const html = renderSpreadsheetToHtml(grid(
+                { "0": { 0: { v: "tall", t: 1 } }, "1": { 1: { v: "x", t: 1, s: { ht: HorizontalAlign.RIGHT } } } },
+                { mergeData: [{ startRow: 0, endRow: 1, startColumn: 0, endColumn: 0 }] }
+            ));
+
+            expect(html.split("</tr>")[1]).toContain(`<td style="text-align:right;overflow:hidden">x</td>`);
         });
 
         it("counts a cell whose text lives only in its rich-text document as occupied", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSpreadsheetToHtml } from "./render_to_html.js";
-import { HorizontalAlign } from "./workbook_model.js";
+import { BorderStyle, HorizontalAlign } from "./workbook_model.js";
 
 describe("renderSpreadsheetToHtml", () => {
     it("renders a basic spreadsheet with values and styles", () => {
@@ -550,6 +550,84 @@ describe("renderSpreadsheetToHtml", () => {
         }));
 
         expect(html).toContain(`Days left</span><img class="spreadsheet-cell-image"`);
+    });
+
+    describe("borders of a merged range", () => {
+        const THIN = { s: BorderStyle.THIN };
+
+        /** A sheet of `cellData` (keyed by row, then column) carrying the given merges. */
+        function mergedWorkbook(cellData: Record<number, Record<number, unknown>>, mergeData: unknown[]): string {
+            return JSON.stringify({
+                version: 1,
+                workbook: {
+                    sheetOrder: ["s1"],
+                    styles: {},
+                    sheets: {
+                        s1: {
+                            id: "s1",
+                            name: "Sheet1",
+                            hidden: 0,
+                            mergeData,
+                            cellData,
+                            rowData: {},
+                            columnData: {}
+                        }
+                    }
+                }
+            });
+        }
+
+        /** The border declarations of the first cell in the rendered row. */
+        function bordersOfFirstCell(html: string): string[] {
+            const style = (html.match(/<td[^>]*style="([^"]*)"/) ?? [])[1] ?? "";
+            return style.split(";").filter((part) => part.startsWith("border"));
+        }
+
+        it("takes the right edge from the range's last column and the bottom from its last row", () => {
+            // Excel spreads a range's outline over its member cells, so A1:B1 keeps its right
+            // border on B1 and A1:A2 keeps its bottom on A2.
+            const across = renderSpreadsheetToHtml(mergedWorkbook(
+                { 0: { 0: { v: "x", s: { bd: { l: THIN } } }, 1: { s: { bd: { r: THIN } } } } },
+                [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 }]
+            ));
+            expect(bordersOfFirstCell(across)).toEqual(["border-right:1px solid #000", "border-left:1px solid #000"]);
+
+            const down = renderSpreadsheetToHtml(mergedWorkbook(
+                { 0: { 0: { v: "x", s: { bd: { t: THIN } } } }, 1: { 0: { s: { bd: { b: THIN } } } } },
+                [{ startRow: 0, endRow: 1, startColumn: 0, endColumn: 0 }]
+            ));
+            expect(bordersOfFirstCell(down)).toEqual(["border-top:1px solid #000", "border-bottom:1px solid #000"]);
+        });
+
+        it("drops the anchor's own right and bottom when they fall inside the range", () => {
+            // In a 2x2 range the anchor's right and bottom are internal edges the merge hides.
+            const html = renderSpreadsheetToHtml(mergedWorkbook(
+                { 0: { 0: { v: "x", s: { bd: { t: THIN, r: THIN, b: THIN } } }, 1: {} }, 1: { 0: {}, 1: {} } },
+                [{ startRow: 0, endRow: 1, startColumn: 0, endColumn: 1 }]
+            ));
+            expect(bordersOfFirstCell(html)).toEqual(["border-top:1px solid #000"]);
+        });
+
+        it("leaves an unmerged cell's borders alone", () => {
+            const html = renderSpreadsheetToHtml(mergedWorkbook({ 0: { 0: { v: "x", s: { bd: { r: THIN, b: THIN } } } } }, []));
+            expect(bordersOfFirstCell(html)).toEqual(["border-right:1px solid #000", "border-bottom:1px solid #000"]);
+        });
+
+        it("keeps its own edges when the range is one cell wide and tall", () => {
+            const html = renderSpreadsheetToHtml(mergedWorkbook(
+                { 0: { 0: { v: "x", s: { bd: { r: THIN, b: THIN } } } } },
+                [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 0 }]
+            ));
+            expect(bordersOfFirstCell(html)).toEqual(["border-right:1px solid #000", "border-bottom:1px solid #000"]);
+        });
+
+        it("emits no border when neither the anchor nor the edge cells carry one", () => {
+            const html = renderSpreadsheetToHtml(mergedWorkbook(
+                { 0: { 0: { v: "x", s: { bl: 1 } }, 1: {} } },
+                [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 }]
+            ));
+            expect(bordersOfFirstCell(html)).toEqual([]);
+        });
     });
 
     // Helper to wrap a single styled cell into a complete workbook payload.

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -508,6 +508,50 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("42.0%");
     });
 
+    it("rotates a cell's text", () => {
+        const rotated = (tr: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s: { tr } }));
+
+        // A quarter turn either way becomes a vertical writing mode, so the row can grow to fit it.
+        expect(rotated({ a: 90 })).toContain(
+            `<span style="display:inline-block;writing-mode:vertical-rl;transform:rotate(180deg)">Days left</span>`);
+        expect(rotated({ a: -90 })).toContain(
+            `<span style="display:inline-block;writing-mode:vertical-rl">Days left</span>`);
+
+        // Stacked text reads downwards with upright characters.
+        expect(rotated({ v: 1 })).toContain(
+            `<span style="display:inline-block;writing-mode:vertical-rl;text-orientation:upright">Days left</span>`);
+
+        // Any other angle turns the glyphs; CSS rotates clockwise, so the sign flips.
+        expect(rotated({ a: 45 })).toContain(
+            `<span style="display:inline-block;transform:rotate(-45deg)">Days left</span>`);
+        expect(rotated({ a: -30.5 })).toContain(`transform:rotate(30.5deg)`);
+    });
+
+    it("leaves a cell unwrapped when it has no rotation to apply", () => {
+        const plain = (s: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s }));
+
+        expect(plain({})).toContain("<td>Days left</td>");
+        expect(plain({ tr: { a: 0, v: 0 } })).toContain("<td>Days left</td>");
+        expect(plain({ tr: { v: 0 } })).toContain("<td>Days left</td>");
+
+        // An empty cell gets no wrapper either, rotation or not.
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ s: { tr: { a: 90 } } }))).toContain("<td></td>");
+    });
+
+    it("keeps a cell's image upright when its text is rotated", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({
+            v: "Days left",
+            t: 1,
+            s: { tr: { a: 90 } },
+            p: {
+                drawings: { d1: { drawingId: "d1", source: "api/attachments/abc123/image/i.png" } },
+                drawingsOrder: ["d1"]
+            }
+        }));
+
+        expect(html).toContain(`Days left</span><img class="spreadsheet-cell-image"`);
+    });
+
     // Helper to wrap a single styled cell into a complete workbook payload.
     function singleCellWorkbook(cell: unknown, sheetExtra: Record<string, unknown> = {}): string {
         return JSON.stringify({

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSpreadsheetToHtml } from "./render_to_html.js";
-import { BorderStyle, HorizontalAlign } from "./workbook_model.js";
+import { BorderStyle, HorizontalAlign, WrapStrategy } from "./workbook_model.js";
 
 describe("renderSpreadsheetToHtml", () => {
     it("renders a basic spreadsheet with values and styles", () => {
@@ -552,6 +552,73 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain(`Days left</span><img class="spreadsheet-cell-image"`);
     });
 
+    describe("overflow into neighbouring cells", () => {
+        /** One row of `cells`, keyed by column. */
+        function row(cells: Record<number, unknown>): string {
+            return JSON.stringify({
+                version: 1,
+                workbook: {
+                    sheetOrder: ["s1"],
+                    styles: {},
+                    sheets: {
+                        s1: {
+                            id: "s1",
+                            name: "Sheet1",
+                            hidden: 0,
+                            mergeData: [],
+                            cellData: { "0": cells },
+                            rowData: {},
+                            columnData: {}
+                        }
+                    }
+                }
+            });
+        }
+
+        /** Whether the workbook's cell at `column` clips its text. The render always starts at A1. */
+        function clips(json: string, column: number): boolean {
+            const cells = renderSpreadsheetToHtml(json).match(/<td[^>]*>/g) ?? [];
+            return (cells[column] ?? "").includes("overflow:hidden");
+        }
+
+        it("clips text only when the neighbour it would spill over holds a value", () => {
+            const occupied = row({ 0: { v: "a long label", t: 1 }, 1: { v: "next", t: 1 } });
+            expect(clips(occupied, 0)).toBe(true);
+
+            // An empty neighbour, or one carrying only a style, is spilled over as in the editor.
+            expect(clips(row({ 0: { v: "a long label", t: 1 } }), 0)).toBe(false);
+            expect(clips(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toBe(false);
+            expect(clips(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toBe(false);
+        });
+
+        it("follows the alignment to decide which side the text spills towards", () => {
+            const rightAligned = { t: 1, s: { ht: HorizontalAlign.RIGHT } };
+            expect(clips(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...rightAligned } }), 1)).toBe(true);
+            expect(clips(row({ 1: { v: "x", ...rightAligned }, 2: { v: "after", t: 1 } }), 1)).toBe(false);
+
+            const centered = { t: 1, s: { ht: HorizontalAlign.CENTER } };
+            expect(clips(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...centered } }), 1)).toBe(true);
+            expect(clips(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toBe(true);
+            expect(clips(row({ 1: { v: "x", ...centered } }), 1)).toBe(false);
+        });
+
+        it("never spills a number, and never clips a wrapped or empty cell", () => {
+            expect(clips(row({ 0: { v: 42, t: 2 } }), 0)).toBe(true);
+            expect(clips(row({ 0: { v: true, t: 3 } }), 0)).toBe(true);
+
+            expect(clips(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
+            expect(clips(row({ 0: { s: { bl: 1 } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
+        });
+
+        it("counts a cell whose text lives only in its rich-text document as occupied", () => {
+            const html = row({
+                0: { v: "a long label", t: 1 },
+                1: { p: { body: { dataStream: "linked\r\n" } } }
+            });
+            expect(clips(html, 0)).toBe(true);
+        });
+    });
+
     describe("borders of a merged range", () => {
         const THIN = { s: BorderStyle.THIN };
 
@@ -1044,8 +1111,8 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("font-weight:bold");
         expect(html).toContain("color:#ff0000");
         expect(html).toContain("byId");
-        // null style id and empty style object -> plain <td>.
-        expect(html).toContain("<td>nulled</td>");
+        // null style id and empty style object -> no styling of their own.
+        expect(html).toContain(`<td style="overflow:hidden">nulled</td>`);
         expect(html).toContain("<td>emptyStyle</td>");
     });
 
@@ -1183,17 +1250,17 @@ describe("renderSpreadsheetToHtml", () => {
 
     it("aligns a cell by its value type when it sets no alignment of its own", () => {
         // Univer right-aligns numbers and centers booleans; text keeps the table default.
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }))).toContain(`<td style="text-align:right">`);
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: true, t: 3 }))).toContain(`<td style="text-align:center">`);
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }))).toContain(`<td style="text-align:right;overflow:hidden">`);
+        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: true, t: 3 }))).toContain(`<td style="text-align:center;overflow:hidden">`);
         expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: "A", t: 1 }))).toContain("<td>A</td>");
 
         // A number formatted and styled by the workbook still gets the fallback alignment.
         expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { bl: 1 } })))
-            .toContain(`<td style="text-align:right;font-weight:bold">`);
+            .toContain(`<td style="text-align:right;font-weight:bold;overflow:hidden">`);
 
         // An explicit alignment wins over the fallback.
         expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { ht: HorizontalAlign.LEFT } })))
-            .toContain(`<td style="text-align:left">`);
+            .toContain(`<td style="text-align:left;overflow:hidden">`);
     });
 
     it("emits colspan only for a purely horizontal merge", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -420,8 +420,8 @@ describe("renderSpreadsheetToHtml", () => {
     });
 
     it("renders a cell whose text lives only in its rich-text document", () => {
-        const html = renderSpreadsheetToHtml(singleCellWorkbook({ p: { body: { dataStream: "Senzor PIR\r\n" } } }));
-        expect(html).toContain("Senzor PIR");
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ p: { body: { dataStream: "Notebook\r\n" } } }));
+        expect(html).toContain("Notebook");
     });
 
     it("renders a hyperlink whether or not the cell also has a plain value", () => {
@@ -429,35 +429,35 @@ describe("renderSpreadsheetToHtml", () => {
             ...cell,
             p: {
                 body: {
-                    dataStream: "Kit\r\n",
-                    customRanges: [{ startIndex: 0, endIndex: 2, properties: { url: "https://example.com/kit" } }]
+                    dataStream: "Pen\r\n",
+                    customRanges: [{ startIndex: 0, endIndex: 2, properties: { url: "https://example.com/pen" } }]
                 }
             }
         }));
 
-        const expected = `<a href="https://example.com/kit" target="_blank" rel="noopener noreferrer">Kit</a>`;
+        const expected = `<a href="https://example.com/pen" target="_blank" rel="noopener noreferrer">Pen</a>`;
         expect(link({})).toContain(expected);
-        expect(link({ v: "Kit", t: 1 })).toContain(expected);
+        expect(link({ v: "Pen", t: 1 })).toContain(expected);
     });
 
     it("links only the run a range covers, leaving the rest as text", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({
             p: {
                 body: {
-                    dataStream: "see spy-shop now\r\n",
+                    dataStream: "see supplier now\r\n",
                     customRanges: [{ startIndex: 4, endIndex: 11, properties: { url: "https://example.com" } }]
                 }
             }
         }));
 
-        expect(html).toContain(`see <a href="https://example.com" target="_blank" rel="noopener noreferrer">spy-shop</a> now`);
+        expect(html).toContain(`see <a href="https://example.com" target="_blank" rel="noopener noreferrer">supplier</a> now`);
     });
 
     it("drops an unsafe or malformed link target, keeping its text", () => {
         const withUrl = (url: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({
             p: {
                 body: {
-                    dataStream: "Kit\r\n",
+                    dataStream: "Pen\r\n",
                     customRanges: [{ startIndex: 0, endIndex: 2, properties: { url } }]
                 }
             }
@@ -465,7 +465,7 @@ describe("renderSpreadsheetToHtml", () => {
 
         for (const url of ["javascript:alert(1)", "data:text/html,<script>", " ", 42, undefined]) {
             const html = withUrl(url);
-            expect(html, String(url)).toContain("Kit");
+            expect(html, String(url)).toContain("Pen");
             expect(html, String(url)).not.toContain("<a ");
         }
     });

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -419,6 +419,11 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("transparent");
     });
 
+    it("renders a cell whose text lives only in its rich-text document", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ p: { body: { dataStream: "Senzor PIR\r\n" } } }));
+        expect(html).toContain("Senzor PIR");
+    });
+
     // Helper to wrap a single styled cell into a complete workbook payload.
     function singleCellWorkbook(cell: unknown, sheetExtra: Record<string, unknown> = {}): string {
         return JSON.stringify({

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -424,6 +424,89 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("Senzor PIR");
     });
 
+    it("renders a hyperlink whether or not the cell also has a plain value", () => {
+        const link = (cell: Record<string, unknown>) => renderSpreadsheetToHtml(singleCellWorkbook({
+            ...cell,
+            p: {
+                body: {
+                    dataStream: "Kit\r\n",
+                    customRanges: [{ startIndex: 0, endIndex: 2, properties: { url: "https://example.com/kit" } }]
+                }
+            }
+        }));
+
+        const expected = `<a href="https://example.com/kit" target="_blank" rel="noopener noreferrer">Kit</a>`;
+        expect(link({})).toContain(expected);
+        expect(link({ v: "Kit", t: 1 })).toContain(expected);
+    });
+
+    it("links only the run a range covers, leaving the rest as text", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({
+            p: {
+                body: {
+                    dataStream: "see spy-shop now\r\n",
+                    customRanges: [{ startIndex: 4, endIndex: 11, properties: { url: "https://example.com" } }]
+                }
+            }
+        }));
+
+        expect(html).toContain(`see <a href="https://example.com" target="_blank" rel="noopener noreferrer">spy-shop</a> now`);
+    });
+
+    it("drops an unsafe or malformed link target, keeping its text", () => {
+        const withUrl = (url: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({
+            p: {
+                body: {
+                    dataStream: "Kit\r\n",
+                    customRanges: [{ startIndex: 0, endIndex: 2, properties: { url } }]
+                }
+            }
+        }));
+
+        for (const url of ["javascript:alert(1)", "data:text/html,<script>", " ", 42, undefined]) {
+            const html = withUrl(url);
+            expect(html, String(url)).toContain("Kit");
+            expect(html, String(url)).not.toContain("<a ");
+        }
+    });
+
+    it("ignores link ranges that are out of order, overlapping or out of bounds", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({
+            p: {
+                body: {
+                    dataStream: "abcdef\r\n",
+                    customRanges: [
+                        { startIndex: 3, endIndex: 99, properties: { url: "https://example.com/second" } },
+                        { startIndex: 0, endIndex: 1, properties: { url: "https://example.com/first" } },
+                        { startIndex: 4, endIndex: 5, properties: { url: "https://example.com/overlapping" } },
+                        { startIndex: 2, properties: { url: "https://example.com/unbounded" } }
+                    ]
+                }
+            }
+        }));
+
+        expect(html).toContain(">ab</a>c<a ");
+        expect(html).toContain(">def</a>");
+        expect(html).not.toContain("overlapping");
+        expect(html).not.toContain("unbounded");
+    });
+
+    it("keeps the number format of a linked numeric cell", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({
+            v: 0.42,
+            t: 2,
+            s: { n: { pattern: "0.0%" } },
+            p: {
+                body: {
+                    dataStream: "42%\r\n",
+                    customRanges: [{ startIndex: 0, endIndex: 2, properties: { url: "https://example.com" } }]
+                }
+            }
+        }));
+
+        expect(html).toContain("42.0%");
+    });
+
     // Helper to wrap a single styled cell into a complete workbook payload.
     function singleCellWorkbook(cell: unknown, sheetExtra: Record<string, unknown> = {}): string {
         return JSON.stringify({

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -561,22 +561,12 @@ function formatCellDocument(cell: ICellData): string | null {
 
     const parts: string[] = [];
     for (const segment of segments) {
-        const href = sanitizeLinkHref(segment.url);
         const text = escapeHtml(segment.text);
-        parts.push(href ? `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${text}</a>` : text);
+        parts.push(segment.url
+            ? `<a href="${escapeHtml(segment.url)}" target="_blank" rel="noopener noreferrer">${text}</a>`
+            : text);
     }
     return parts.join("");
-}
-
-/**
- * Validates a hyperlink target for inclusion in shared/exported HTML. Accepts the absolute
- * `http`, `https` and `mailto` URLs Univer's link dialog writes; anything else, `javascript:`
- * among them, returns `null` so the run renders as plain text.
- */
-function sanitizeLinkHref(url: string | undefined): string | null {
-    if (typeof url !== "string") return null;
-    const trimmed = url.trim();
-    return /^(?:https?:\/\/|mailto:)[^\u0000-\u0020\u007F]+$/i.test(trimmed) ? trimmed : null;
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -15,6 +15,7 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 import {
     BorderStyle,
     computeBounds,
+    getCellDocumentText,
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
@@ -520,7 +521,10 @@ function sanitizeCssColor(value: string): string {
 // #region Value formatting
 
 function formatCellValue(cell: ICellData | undefined, style: IStyleData | null): string {
-    if (!cell || cell.v == null) return "";
+    if (!cell) return "";
+
+    // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
+    if (cell.v == null || cell.v === "") return escapeHtml(getCellDocumentText(cell));
 
     if (typeof cell.v === "boolean") {
         return cell.v ? "TRUE" : "FALSE";

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -27,6 +27,7 @@ import {
     type IRange,
     type ISheetDrawing,
     type IStyleData,
+    type ITextRotation,
     type IWorksheetData,
     parseWorkbookData,
     resolveCellStyle,
@@ -295,7 +296,8 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
             const cell = cellData[row]?.[col];
             const cellStyle = resolveCellStyle(cell?.s, styles);
             const cssText = buildCssText(cellStyle, cell);
-            const value = formatCellValue(cell, cellStyle) + (cell ? renderCellImages(cell) : "");
+            const value = rotate(formatCellValue(cell, cellStyle), cellStyle?.tr)
+                + (cell ? renderCellImages(cell) : "");
 
             const attrs: string[] = [];
             // Cells with a background fill carry `has-fill` so the stylesheet can suppress
@@ -561,6 +563,36 @@ function formatCellValue(cell: ICellData | undefined, style: IStyleData | null):
     }
 
     return escapeHtml(String(cell.v));
+}
+
+/**
+ * Wraps a cell's text in the element that carries its rotation. The wrapper keeps the rotation off
+ * the `td` itself, which would take the background and borders with it, and images anchored in the
+ * cell stay upright as they do in the editor.
+ */
+function rotate(html: string, rotation: ITextRotation | null | undefined): string {
+    if (!html) return html;
+
+    const css = rotationCss(rotation);
+    return css ? `<span style="${css}">${html}</span>` : html;
+}
+
+/**
+ * The CSS for Univer's text rotation. A quarter turn and stacked text become a vertical writing
+ * mode, which gives the text a real vertical box the row grows to fit; any other angle falls back
+ * to a transform, which turns the glyphs without reserving room for them. Excel measures the angle
+ * counter-clockwise and CSS turns clockwise, so the sign flips.
+ */
+function rotationCss(rotation: ITextRotation | null | undefined): string | null {
+    if (!rotation) return null;
+    // Stacked text: upright characters reading downwards.
+    if (rotation.v) return "display:inline-block;writing-mode:vertical-rl;text-orientation:upright";
+
+    const angle = isFiniteNumber(rotation.a) ? rotation.a : 0;
+    if (angle === 0) return null;
+    if (angle === 90) return "display:inline-block;writing-mode:vertical-rl;transform:rotate(180deg)";
+    if (angle === -90) return "display:inline-block;writing-mode:vertical-rl";
+    return `display:inline-block;transform:rotate(${px(-angle)}deg)`;
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -14,8 +14,9 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 
 import {
     BorderStyle,
+    type CellDocumentSegment,
     computeBounds,
-    getCellDocumentText,
+    getCellDocumentSegments,
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
@@ -523,8 +524,8 @@ function sanitizeCssColor(value: string): string {
 function formatCellValue(cell: ICellData | undefined, style: IStyleData | null): string {
     if (!cell) return "";
 
-    // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
-    if (cell.v == null || cell.v === "") return escapeHtml(getCellDocumentText(cell));
+    const rendered = formatCellDocument(cell);
+    if (rendered != null) return rendered;
 
     if (typeof cell.v === "boolean") {
         return cell.v ? "TRUE" : "FALSE";
@@ -543,6 +544,39 @@ function formatCellValue(cell: ICellData | undefined, style: IStyleData | null):
     }
 
     return escapeHtml(String(cell.v));
+}
+
+/**
+ * Renders a cell from its rich-text document, or returns `null` when the plain value is the
+ * better source. The document wins when the cell has no plain value, which is how Univer stores
+ * some cells, and when it carries hyperlinks that the plain value cannot express. A formatted
+ * number keeps its own rendering, since the document holds a display string that can go stale.
+ */
+function formatCellDocument(cell: ICellData): string | null {
+    const segments = getCellDocumentSegments(cell);
+    const hasPlainValue = cell.v != null && cell.v !== "";
+    if (hasPlainValue && (isFiniteNumber(cell.v) || !segments.some((segment) => segment.url))) {
+        return null;
+    }
+
+    const parts: string[] = [];
+    for (const segment of segments) {
+        const href = sanitizeLinkHref(segment.url);
+        const text = escapeHtml(segment.text);
+        parts.push(href ? `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">${text}</a>` : text);
+    }
+    return parts.join("");
+}
+
+/**
+ * Validates a hyperlink target for inclusion in shared/exported HTML. Accepts the absolute
+ * `http`, `https` and `mailto` URLs Univer's link dialog writes; anything else, `javascript:`
+ * among them, returns `null` so the run renders as plain text.
+ */
+function sanitizeLinkHref(url: string | undefined): string | null {
+    if (typeof url !== "string") return null;
+    const trimmed = url.trim();
+    return /^(?:https?:\/\/|mailto:)[^\u0000-\u0020\u007F]+$/i.test(trimmed) ? trimmed : null;
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -15,6 +15,7 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 import {
     BorderStyle,
     type CellDocumentSegment,
+    type CellMatrix,
     CellValueType,
     computeBounds,
     getCellDocumentSegments,
@@ -22,10 +23,10 @@ import {
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
-    type CellMatrix,
     type IBorderData,
     type IBorderStyleData,
     type ICellData,
+    type IColumnData,
     isFiniteNumber,
     type IRange,
     type ISheetDrawing,
@@ -290,16 +291,18 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
         // sets its own still wins.
         lines.push(`<tr style="height:${height}px;vertical-align:bottom">`);
 
+        const neighbours: RowNeighbours = { row, minCol, maxCol, cellData, columnData, mergeMap };
+
         for (let col = minCol; col <= maxCol; col++) {
             if (columnData[col]?.hd) continue;
 
             const mergeInfo = mergeMap.get(cellKey(row, col));
-            if (mergeInfo === "hidden") continue;
+            if (mergeInfo?.kind === "member") continue;
 
             const cell = cellData[row]?.[col];
             const cellStyle = mergeAwareStyle(resolveCellStyle(cell?.s, styles), mergeInfo, row, col, cellData, styles);
             const declarations = [buildCssText(cellStyle, cell)];
-            if (clipsOverflow(cell, cellStyle, row, col, cellData)) declarations.push("overflow:hidden");
+            if (clipsOverflow(cell, cellStyle, col, mergeInfo, neighbours)) declarations.push("overflow:hidden");
             const cssText = declarations.filter(Boolean).join(";");
             const value = rotate(formatCellValue(cell, cellStyle), cellStyle?.tr)
                 + (cell ? renderCellImages(cell) : "");
@@ -350,12 +353,21 @@ function buildTableTag(sheet: IWorksheetData, totalWidth: number): string {
 
 // #region Merge handling
 
+/** The cell a merged range is rendered from, carrying the span it covers. */
 interface MergeOrigin {
+    kind: "origin";
     rowSpan: number;
     colSpan: number;
     /** Last row and column of the range, clamped to the rendered bounds. */
     endRow: number;
     endColumn: number;
+}
+
+/** A cell the range covers. It is not rendered; the anchor's content fills its place. */
+interface MergeMember {
+    kind: "member";
+    anchorRow: number;
+    anchorColumn: number;
 }
 
 /**
@@ -383,7 +395,7 @@ function mergeAwareStyle(
     return { ...style, bd };
 }
 
-type MergeInfo = MergeOrigin | "hidden";
+type MergeInfo = MergeOrigin | MergeMember;
 
 function cellKey(row: number, col: number): string {
     return `${row},${col}`;
@@ -399,6 +411,7 @@ function buildMergeMap(mergeData: IRange[], minRow: number, maxRow: number, minC
         const endCol = Math.min(range.endColumn, maxCol);
 
         map.set(cellKey(range.startRow, range.startColumn), {
+            kind: "origin",
             rowSpan: endRow - startRow + 1,
             colSpan: endCol - startCol + 1,
             endRow,
@@ -408,7 +421,7 @@ function buildMergeMap(mergeData: IRange[], minRow: number, maxRow: number, minC
         for (let r = startRow; r <= endRow; r++) {
             for (let c = startCol; c <= endCol; c++) {
                 if (r === range.startRow && c === range.startColumn) continue;
-                map.set(cellKey(r, c), "hidden");
+                map.set(cellKey(r, c), { kind: "member", anchorRow: range.startRow, anchorColumn: range.startColumn });
             }
         }
     }
@@ -475,6 +488,16 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
     return parts.join(";");
 }
 
+/** One row's rendered layout, which is what decides whose value a cell's text would spill over. */
+interface RowNeighbours {
+    row: number;
+    minCol: number;
+    maxCol: number;
+    cellData: CellMatrix;
+    columnData: Record<number, IColumnData>;
+    mergeMap: Map<string, MergeInfo>;
+}
+
 /**
  * Whether a cell has to clip its text at its own edge. A spreadsheet spills text into a
  * neighbouring cell only while that neighbour is empty, and never spills a number or a boolean
@@ -485,20 +508,40 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
 function clipsOverflow(
     cell: ICellData | undefined,
     style: IStyleData | null,
-    row: number,
     col: number,
-    cellData: CellMatrix
+    merge: MergeOrigin | undefined,
+    neighbours: RowNeighbours
 ): boolean {
     if (!hasContent(cell) || style?.tb === WrapStrategy.WRAP) return false;
     if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN) return true;
 
-    const before = hasContent(cellData[row]?.[col - 1]);
-    const after = hasContent(cellData[row]?.[col + 1]);
+    // Rightwards, a merged cell starts looking past the last column its own range covers.
+    const before = () => neighbourHasContent(col, -1, neighbours);
+    const after = () => neighbourHasContent(merge?.endColumn ?? col, 1, neighbours);
     switch (style?.ht) {
-        case HorizontalAlign.RIGHT: return before;
-        case HorizontalAlign.CENTER: return before || after;
-        default: return after;
+        case HorizontalAlign.RIGHT: return before();
+        case HorizontalAlign.CENTER: return before() || after();
+        default: return after();
     }
+}
+
+/**
+ * Whether the cell rendered beside `from` shows anything. Adjacency follows the rendered row, not
+ * the cell matrix: hidden columns are stepped over because nothing of them reaches the page, and a
+ * column a merge covers reports that range's anchor, whose text is what fills the space there.
+ */
+function neighbourHasContent(from: number, step: -1 | 1, neighbours: RowNeighbours): boolean {
+    const { row, minCol, maxCol, cellData, columnData, mergeMap } = neighbours;
+
+    for (let col = from + step; col >= minCol && col <= maxCol; col += step) {
+        if (columnData[col]?.hd) continue;
+
+        const info = mergeMap.get(cellKey(row, col));
+        return hasContent(info?.kind === "member"
+            ? cellData[info.anchorRow]?.[info.anchorColumn]
+            : cellData[row]?.[col]);
+    }
+    return false;
 }
 
 /** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -15,6 +15,7 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 import {
     BorderStyle,
     type CellDocumentSegment,
+    CellValueType,
     computeBounds,
     getCellDocumentSegments,
     getFloatingDrawings,
@@ -380,9 +381,15 @@ function buildMergeMap(mergeData: IRange[], minRow: number, maxRow: number, minC
 // #region Style resolution
 
 function buildCssText(style: IStyleData | null, cell?: ICellData): string {
-    if (!style) return "";
-
     const parts: string[] = [];
+
+    const ht = style?.ht ?? defaultHorizontalAlign(cell);
+    if (ht != null) {
+        const align = horizontalAlignToCss(ht);
+        if (align) parts.push(`text-align:${align}`);
+    }
+
+    if (!style) return parts.join(";");
 
     if (style.bl) parts.push("font-weight:bold");
     if (style.it) parts.push("font-style:italic");
@@ -406,10 +413,6 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
     const textColor = patternColor ?? style.cl?.rgb;
     if (textColor) parts.push(`color:${sanitizeCssColor(textColor)}`);
 
-    if (style.ht != null) {
-        const align = horizontalAlignToCss(style.ht);
-        if (align) parts.push(`text-align:${align}`);
-    }
     if (style.vt != null) {
         const valign = verticalAlignToCss(style.vt);
         if (valign) parts.push(`vertical-align:${valign}`);
@@ -430,6 +433,17 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
     }
 
     return parts.join(";");
+}
+
+/**
+ * The alignment Univer falls back to for a cell that sets none: numbers to the right, booleans
+ * centered, everything else left (`_horizontalHandler` in `@univerjs/engine-render`). Returns
+ * `undefined` for the left case so no `text-align` is emitted and the table default stands.
+ */
+function defaultHorizontalAlign(cell: ICellData | undefined): HorizontalAlign | undefined {
+    if (cell?.t === CellValueType.NUMBER) return HorizontalAlign.RIGHT;
+    if (cell?.t === CellValueType.BOOLEAN) return HorizontalAlign.CENTER;
+    return undefined;
 }
 
 function horizontalAlignToCss(align: number): string | null {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -281,7 +281,10 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
         if (rowMeta?.hd) continue;
 
         const height = isFiniteNumber(rowMeta?.h) ? rowMeta.h : defaultHeight;
-        lines.push(`<tr style="height:${height}px">`);
+        // Univer leaves a cell at the bottom of its row unless it sets `vt`, while HTML centres it.
+        // The row carries that default because a `td` inherits `vertical-align`, so a cell that
+        // sets its own still wins.
+        lines.push(`<tr style="height:${height}px;vertical-align:bottom">`);
 
         for (let col = minCol; col <= maxCol; col++) {
             if (columnData[col]?.hd) continue;

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -21,6 +21,8 @@ import {
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
+    type CellMatrix,
+    type IBorderData,
     type IBorderStyleData,
     type ICellData,
     isFiniteNumber,
@@ -294,7 +296,7 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
             if (mergeInfo === "hidden") continue;
 
             const cell = cellData[row]?.[col];
-            const cellStyle = resolveCellStyle(cell?.s, styles);
+            const cellStyle = mergeAwareStyle(resolveCellStyle(cell?.s, styles), mergeInfo, row, col, cellData, styles);
             const cssText = buildCssText(cellStyle, cell);
             const value = rotate(formatCellValue(cell, cellStyle), cellStyle?.tr)
                 + (cell ? renderCellImages(cell) : "");
@@ -348,6 +350,34 @@ function buildTableTag(sheet: IWorksheetData, totalWidth: number): string {
 interface MergeOrigin {
     rowSpan: number;
     colSpan: number;
+    /** Last row and column of the range, clamped to the rendered bounds. */
+    endRow: number;
+    endColumn: number;
+}
+
+/**
+ * Replaces a merged range's border with the one composed from the cells on its edges. Excel keeps
+ * a range's outline on the member cell each edge belongs to: the anchor holds the top and the
+ * left, the cell in the range's last column holds the right, and the one in its last row holds the
+ * bottom. Reading only the anchor drops the two far edges, so the range renders with no line
+ * between it and the range beside it. An unmerged cell is returned untouched.
+ */
+function mergeAwareStyle(
+    style: IStyleData | null,
+    merge: MergeOrigin | undefined,
+    row: number,
+    col: number,
+    cellData: CellMatrix,
+    styles: Record<string, IStyleData | null>
+): IStyleData | null {
+    if (!merge) return style;
+
+    const bd: IBorderData = {
+        ...style?.bd,
+        r: resolveCellStyle(cellData[row]?.[merge.endColumn]?.s, styles)?.bd?.r,
+        b: resolveCellStyle(cellData[merge.endRow]?.[col]?.s, styles)?.bd?.b
+    };
+    return { ...style, bd };
 }
 
 type MergeInfo = MergeOrigin | "hidden";
@@ -367,7 +397,9 @@ function buildMergeMap(mergeData: IRange[], minRow: number, maxRow: number, minC
 
         map.set(cellKey(range.startRow, range.startColumn), {
             rowSpan: endRow - startRow + 1,
-            colSpan: endCol - startCol + 1
+            colSpan: endCol - startCol + 1,
+            endRow,
+            endColumn: endCol
         });
 
         for (let r = startRow; r <= endRow; r++) {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -18,6 +18,7 @@ import {
     CellValueType,
     computeBounds,
     getCellDocumentSegments,
+    getCellDocumentText,
     getFloatingDrawings,
     getVisibleSheets,
     HorizontalAlign,
@@ -297,7 +298,9 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
 
             const cell = cellData[row]?.[col];
             const cellStyle = mergeAwareStyle(resolveCellStyle(cell?.s, styles), mergeInfo, row, col, cellData, styles);
-            const cssText = buildCssText(cellStyle, cell);
+            const declarations = [buildCssText(cellStyle, cell)];
+            if (clipsOverflow(cell, cellStyle, row, col, cellData)) declarations.push("overflow:hidden");
+            const cssText = declarations.filter(Boolean).join(";");
             const value = rotate(formatCellValue(cell, cellStyle), cellStyle?.tr)
                 + (cell ? renderCellImages(cell) : "");
 
@@ -470,6 +473,39 @@ function buildCssText(style: IStyleData | null, cell?: ICellData): string {
     }
 
     return parts.join(";");
+}
+
+/**
+ * Whether a cell has to clip its text at its own edge. A spreadsheet spills text into a
+ * neighbouring cell only while that neighbour is empty, and never spills a number or a boolean
+ * (the overflow check in `@univerjs/engine-render`). The stylesheets let every cell spill, so
+ * without this a long value is drawn over the value beside it. The spill direction follows the
+ * alignment, and a wrapped cell never spills to begin with.
+ */
+function clipsOverflow(
+    cell: ICellData | undefined,
+    style: IStyleData | null,
+    row: number,
+    col: number,
+    cellData: CellMatrix
+): boolean {
+    if (!hasContent(cell) || style?.tb === WrapStrategy.WRAP) return false;
+    if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN) return true;
+
+    const before = hasContent(cellData[row]?.[col - 1]);
+    const after = hasContent(cellData[row]?.[col + 1]);
+    switch (style?.ht) {
+        case HorizontalAlign.RIGHT: return before;
+        case HorizontalAlign.CENTER: return before || after;
+        default: return after;
+    }
+}
+
+/** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */
+function hasContent(cell: ICellData | undefined): boolean {
+    if (!cell) return false;
+    if (cell.v != null && cell.v !== "") return true;
+    return getCellDocumentText(cell) !== "";
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -839,8 +839,73 @@ function workbookWithSheetNames(names: string[]): string {
 }
 
 describe("rich-text cells", () => {
+    /** Wrap a document with one link range covering `endIndex` characters from the start. */
+    function linkedCell(url: unknown, dataStream = "Pen\r\n", endIndex = 2, extra: Record<string, unknown> = {}) {
+        return singleCellWorkbook(
+            {
+                ...extra,
+                p: { body: { dataStream, customRanges: [{ startIndex: 0, endIndex, properties: { url } }] } }
+            },
+            {},
+            { s1: { ff: "Georgia", bl: 1, cl: { rgb: "#FF0000" } } }
+        );
+    }
+
     it("writes the text of a cell that has no plain value", async () => {
-        const wb = await roundTrip(singleCellWorkbook({ p: { body: { dataStream: "Kit\r\n" } } }));
-        expect(wb.worksheets[0].getCell("A1").value).toBe("Kit");
+        const wb = await roundTrip(singleCellWorkbook({ p: { body: { dataStream: "Pen\r\n" } } }));
+        expect(wb.worksheets[0].getCell("A1").value).toBe("Pen");
+    });
+
+    it("writes an Excel hyperlink, whether or not the cell also has a plain value", async () => {
+        for (const extra of [{}, { v: "Pen", t: 1 }]) {
+            const wb = await roundTrip(linkedCell("https://example.com/pen", "Pen\r\n", 2, extra));
+            const cell = wb.worksheets[0].getCell("A1");
+            expect(cell.value).toEqual({ text: "Pen", hyperlink: "https://example.com/pen" });
+            expect(cell.hyperlink).toBe("https://example.com/pen");
+        }
+    });
+
+    it("gives a linked cell the built-in Hyperlink font, keeping the rest of its own style", async () => {
+        const plain = await roundTrip(linkedCell("https://example.com"));
+        expect(plain.worksheets[0].getCell("A1").font).toEqual({ color: { argb: "FF0563C1" }, underline: true });
+
+        const styled = await roundTrip(linkedCell("https://example.com", "Pen\r\n", 2, { s: "s1" }));
+        expect(styled.worksheets[0].getCell("A1").font).toEqual({
+            name: "Georgia",
+            bold: true,
+            color: { argb: "FF0563C1" },
+            underline: true
+        });
+    });
+
+    it("links the whole cell to the first target when the document has several", async () => {
+        const wb = await roundTrip(singleCellWorkbook({
+            p: {
+                body: {
+                    dataStream: "see supplier now\r\n",
+                    customRanges: [
+                        { startIndex: 4, endIndex: 11, properties: { url: "https://example.com/first" } },
+                        { startIndex: 13, endIndex: 15, properties: { url: "https://example.com/second" } }
+                    ]
+                }
+            }
+        }));
+
+        expect(wb.worksheets[0].getCell("A1").value).toEqual({
+            text: "see supplier now",
+            hyperlink: "https://example.com/first"
+        });
+    });
+
+    it("drops an unsafe target, keeping the text", async () => {
+        const wb = await roundTrip(linkedCell("javascript:alert(1)"));
+        const cell = wb.worksheets[0].getCell("A1");
+        expect(cell.value).toBe("Pen");
+        expect(cell.hyperlink).toBeUndefined();
+    });
+
+    it("keeps a linked numeric cell as a number so its format and formulas survive", async () => {
+        const wb = await roundTrip(linkedCell("https://example.com", "1000\r\n", 3, { v: 1000, t: 2 }));
+        expect(wb.worksheets[0].getCell("A1").value).toBe(1000);
     });
 });

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.spec.ts
@@ -837,3 +837,10 @@ function workbookWithSheetNames(names: string[]): string {
     });
     return JSON.stringify({ version: 1, workbook: { sheetOrder, styles: {}, sheets } });
 }
+
+describe("rich-text cells", () => {
+    it("writes the text of a cell that has no plain value", async () => {
+        const wb = await roundTrip(singleCellWorkbook({ p: { body: { dataStream: "Kit\r\n" } } }));
+        expect(wb.worksheets[0].getCell("A1").value).toBe("Kit");
+    });
+});

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -4,8 +4,8 @@
  * Unlike the HTML renderer, this is a near-lossless mapping: Univer's cell model mirrors
  * OOXML, so number formats pass through verbatim, the border-style enum maps almost 1:1 to
  * Excel's, and fonts/fills/alignment/merges map directly. Data-validation rules (dropdown lists,
- * numeric/date/text bounds) invert their import counterparts. The heavy lifting (zip + XML) is
- * delegated to `exceljs`.
+ * numeric/date/text bounds) invert their import counterparts, and a cell's hyperlink becomes an
+ * Excel hyperlink. The heavy lifting (zip + XML) is delegated to `exceljs`.
  *
  * The workbook type subset, sheet selection, and style resolution live in the shared
  * `workbook_model` reader; this module only owns the Univer→OOXML translation.
@@ -18,7 +18,7 @@ import "./exceljs_augmentation.js";
 import {
     BorderStyle,
     type DataValidationRule,
-    getCellDocumentText,
+    getCellDocumentSegments,
     getDataValidations,
     getFloatingDrawings,
     getVisibleSheets,
@@ -364,43 +364,65 @@ function applyRows(ws: ExcelJS.Worksheet, sheet: IWorksheetData): void {
     }
 }
 
+/**
+ * The font of Excel's built-in Hyperlink cell style. Excel stores a link's appearance in the cell
+ * when the link is inserted rather than deriving it on open, so a file written from outside Excel
+ * has to carry it: without this a linked cell is clickable but looks like plain text.
+ */
+const HYPERLINK_FONT: Partial<ExcelJS.Font> = { color: { argb: "FF0563C1" }, underline: true };
+
 function writeCell(target: ExcelJS.Cell, cell: ICellData | undefined, styles: Record<string, IStyleData | null>): void {
     if (!cell) return;
 
-    setCellValue(target, cell);
-
+    const isHyperlink = setCellValue(target, cell);
     const style = resolveCellStyle(cell.s, styles);
-    if (!style) return;
 
-    if (style.n?.pattern) target.numFmt = style.n.pattern;
+    if (style) {
+        if (style.n?.pattern) target.numFmt = style.n.pattern;
 
-    const font = buildFont(style);
-    if (font) target.font = font;
+        const font = buildFont(style);
+        if (font) target.font = font;
 
-    const fill = buildFill(style);
-    if (fill) target.fill = fill;
+        const fill = buildFill(style);
+        if (fill) target.fill = fill;
 
-    const alignment = buildAlignment(style);
-    if (alignment) target.alignment = alignment;
+        const alignment = buildAlignment(style);
+        if (alignment) target.alignment = alignment;
 
-    const border = buildBorder(style.bd);
-    if (border) target.border = border;
+        const border = buildBorder(style.bd);
+        if (border) target.border = border;
+    }
+
+    if (isHyperlink) target.font = { ...target.font, ...HYPERLINK_FONT };
 }
 
-function setCellValue(target: ExcelJS.Cell, cell: ICellData): void {
+/** Writes the cell's value, reporting whether it became an Excel hyperlink. */
+function setCellValue(target: ExcelJS.Cell, cell: ICellData): boolean {
     if (cell.f) {
         // Univer stores formulas with a leading "="; exceljs wants it stripped, plus the
         // cached result so the value shows without a recalc.
         target.value = { formula: cell.f.replace(/^=/, ""), result: cell.v ?? undefined } as ExcelJS.CellFormulaValue;
-        return;
+        return false;
     }
+
+    // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
+    const segments = getCellDocumentSegments(cell);
+    const text = segments.map((segment) => segment.text).join("");
+
+    // Excel holds at most one hyperlink per cell, so a document with several linked runs exports
+    // the first target over the whole cell. A number keeps its own value and format instead.
+    const url = isFiniteNumber(cell.v) ? undefined : segments.find((segment) => segment.url)?.url;
+    if (url) {
+        target.value = { text, hyperlink: url } as ExcelJS.CellHyperlinkValue;
+        return true;
+    }
+
     if (cell.v == null || cell.v === "") {
-        // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
-        const text = getCellDocumentText(cell);
         if (text) target.value = text;
-        return;
+        return false;
     }
     target.value = cell.v;
+    return false;
 }
 
 function buildFont(style: IStyleData): Partial<ExcelJS.Font> | null {

--- a/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_xlsx.ts
@@ -18,6 +18,7 @@ import "./exceljs_augmentation.js";
 import {
     BorderStyle,
     type DataValidationRule,
+    getCellDocumentText,
     getDataValidations,
     getFloatingDrawings,
     getVisibleSheets,
@@ -393,7 +394,12 @@ function setCellValue(target: ExcelJS.Cell, cell: ICellData): void {
         target.value = { formula: cell.f.replace(/^=/, ""), result: cell.v ?? undefined } as ExcelJS.CellFormulaValue;
         return;
     }
-    if (cell.v == null) return;
+    if (cell.v == null || cell.v === "") {
+        // A rich-text cell (a link, mixed formatting) can carry its text only in `p`.
+        const text = getCellDocumentText(cell);
+        if (text) target.value = text;
+        return;
+    }
     target.value = cell.v;
 }
 

--- a/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
@@ -108,7 +108,7 @@ describe("getDataValidations", () => {
 
 describe("getCellDocumentText", () => {
     it("reads the rich-text document, dropping the terminator and structural characters", () => {
-        expect(getCellDocumentText({ p: { body: { dataStream: "Kit\r\n" } } })).toBe("Kit");
+        expect(getCellDocumentText({ p: { body: { dataStream: "Pen\r\n" } } })).toBe("Pen");
         expect(getCellDocumentText({ p: { body: { dataStream: "first\rsecond\r\n" } } })).toBe("first\nsecond");
         expect(getCellDocumentText({ p: { body: { dataStream: "logo\b\r\n" } } })).toBe("logo");
     });
@@ -127,7 +127,7 @@ describe("getCellDocumentSegments", () => {
         const segments = getCellDocumentSegments({
             p: {
                 body: {
-                    dataStream: "see spy-shop now\r\n",
+                    dataStream: "see supplier now\r\n",
                     customRanges: [{ startIndex: 4, endIndex: 11, properties: { url: "https://example.com" } }]
                 }
             }
@@ -135,7 +135,7 @@ describe("getCellDocumentSegments", () => {
 
         expect(segments).toEqual([
             { text: "see " },
-            { text: "spy-shop", url: "https://example.com" },
+            { text: "supplier", url: "https://example.com" },
             { text: " now" }
         ]);
     });
@@ -144,10 +144,10 @@ describe("getCellDocumentSegments", () => {
         expect(getCellDocumentSegments({
             p: {
                 body: {
-                    dataStream: "Kit\r\n",
+                    dataStream: "Pen\r\n",
                     customRanges: [{ startIndex: 0, endIndex: 4, properties: { url: "https://example.com" } }]
                 }
             }
-        })).toEqual([{ text: "Kit", url: "https://example.com" }]);
+        })).toEqual([{ text: "Pen", url: "https://example.com" }]);
     });
 });

--- a/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    getCellDocumentText,
     getDataValidations,
     getFloatingDrawings,
     type IWorkbookData,
+    normalizeDataStream,
     SHEET_DATA_VALIDATION_RESOURCE,
     SHEET_DRAWING_RESOURCE
 } from "./workbook_model.js";
@@ -100,5 +102,21 @@ describe("getDataValidations", () => {
             workbookWithResource(SHEET_DATA_VALIDATION_RESOURCE, JSON.stringify({ sheet1: { uid: "v1" } })),
             "sheet1"
         )).toEqual([]);
+    });
+});
+
+describe("getCellDocumentText", () => {
+    it("reads the rich-text document, dropping the terminator and structural characters", () => {
+        expect(getCellDocumentText({ p: { body: { dataStream: "Kit\r\n" } } })).toBe("Kit");
+        expect(getCellDocumentText({ p: { body: { dataStream: "first\rsecond\r\n" } } })).toBe("first\nsecond");
+        expect(getCellDocumentText({ p: { body: { dataStream: "logo\b\r\n" } } })).toBe("logo");
+    });
+
+    it("returns an empty string when the cell carries no document text", () => {
+        expect(getCellDocumentText(undefined)).toBe("");
+        expect(getCellDocumentText({ v: "plain" })).toBe("");
+        expect(getCellDocumentText({ p: { drawings: {} } })).toBe("");
+        expect(getCellDocumentText({ p: { body: { dataStream: "\r\n" } } })).toBe("");
+        expect(normalizeDataStream(42)).toBe("");
     });
 });

--- a/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+    getCellDocumentSegments,
     getCellDocumentText,
     getDataValidations,
     getFloatingDrawings,
@@ -118,5 +119,35 @@ describe("getCellDocumentText", () => {
         expect(getCellDocumentText({ p: { drawings: {} } })).toBe("");
         expect(getCellDocumentText({ p: { body: { dataStream: "\r\n" } } })).toBe("");
         expect(normalizeDataStream(42)).toBe("");
+    });
+});
+
+describe("getCellDocumentSegments", () => {
+    it("cuts the document into plain and linked runs", () => {
+        const segments = getCellDocumentSegments({
+            p: {
+                body: {
+                    dataStream: "see spy-shop now\r\n",
+                    customRanges: [{ startIndex: 4, endIndex: 11, properties: { url: "https://example.com" } }]
+                }
+            }
+        });
+
+        expect(segments).toEqual([
+            { text: "see " },
+            { text: "spy-shop", url: "https://example.com" },
+            { text: " now" }
+        ]);
+    });
+
+    it("keeps the trailing terminator out of a run that ends the document", () => {
+        expect(getCellDocumentSegments({
+            p: {
+                body: {
+                    dataStream: "Kit\r\n",
+                    customRanges: [{ startIndex: 0, endIndex: 4, properties: { url: "https://example.com" } }]
+                }
+            }
+        })).toEqual([{ text: "Kit", url: "https://example.com" }]);
     });
 });

--- a/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.spec.ts
@@ -140,6 +140,21 @@ describe("getCellDocumentSegments", () => {
         ]);
     });
 
+    it("ignores a range whose offsets describe no span", () => {
+        const segmentsFor = (startIndex: number, endIndex: number) => getCellDocumentSegments({
+            p: {
+                body: {
+                    dataStream: "Pen\r\n",
+                    customRanges: [{ startIndex, endIndex, properties: { url: "https://example.com" } }]
+                }
+            }
+        });
+
+        // Reversed offsets, then a range starting past the end of the stream.
+        expect(segmentsFor(2, 0)).toEqual([{ text: "Pen" }]);
+        expect(segmentsFor(9, 12)).toEqual([{ text: "Pen" }]);
+    });
+
     it("keeps the trailing terminator out of a run that ends the document", () => {
         expect(getCellDocumentSegments({
             p: {

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -70,6 +70,10 @@ export interface ICellData {
 }
 
 export interface ICellDocumentData {
+    /** Univer's unit id for the cell document. */
+    id?: string;
+    /** Layout Univer recomputes from the cell's own style every time it renders the cell. */
+    documentStyle?: Record<string, unknown>;
     drawings?: Record<string, ISheetDrawing>;
     drawingsOrder?: string[];
     /** Text content, present when the cell holds rich text such as a link or mixed formatting. */
@@ -81,13 +85,19 @@ export interface ICellDocumentBody {
     dataStream?: string;
     /** Spans of `dataStream` carrying extra properties, hyperlinks among them. */
     customRanges?: ICellCustomRange[];
+    /** Formatting runs and the paragraph/section markers Univer lays the text out from. */
+    textRuns?: { ts: Record<string, unknown>; st: number; ed: number }[];
+    paragraphs?: { startIndex: number }[];
+    sectionBreaks?: { startIndex: number }[];
 }
 
 /** A span of a cell's document text. `startIndex` and `endIndex` are both inclusive. */
 export interface ICellCustomRange {
+    rangeId?: string;
+    rangeType?: CustomRangeType;
     startIndex?: number;
     endIndex?: number;
-    properties?: { url?: string };
+    properties?: { url?: string; refId?: string };
 }
 
 export interface ISheetDrawing {
@@ -195,6 +205,11 @@ export const enum CellValueType {
     NUMBER = 2,
     BOOLEAN = 3,
     FORCE_STRING = 4
+}
+
+/** Univer's kinds of `ICellCustomRange` (`CustomRangeType` in @univerjs/core). */
+export const enum CustomRangeType {
+    HYPERLINK = 0
 }
 
 // Alignment enums (from UniversJS).
@@ -320,6 +335,38 @@ export function getCellDocumentSegments(cell: ICellData | undefined): CellDocume
  */
 export function getCellDocumentText(cell: ICellData | undefined): string {
     return getCellDocumentSegments(cell).map((segment) => segment.text).join("");
+}
+
+/**
+ * Builds the rich-text document Univer stores for a hyperlinked cell: the text terminated by a
+ * paragraph and a section break, plus one custom range covering it. `rangeId` identifies the link
+ * inside the cell. Returns `null` when there is no text to link or the target is not safe to
+ * store, so the caller keeps the cell as plain text.
+ *
+ * `documentStyle` stays empty because Univer overwrites its margins, page size and render config
+ * from the cell's own style on every render.
+ */
+export function buildLinkedCellDocument(text: string, url: unknown, rangeId: string): ICellDocumentData | null {
+    const target = sanitizeLinkUrl(url);
+    if (!text || !target) return null;
+
+    return {
+        id: "d",
+        documentStyle: {},
+        body: {
+            dataStream: `${text}\r\n`,
+            textRuns: [{ ts: {}, st: 0, ed: text.length }],
+            paragraphs: [{ startIndex: text.length }],
+            sectionBreaks: [{ startIndex: text.length + 1 }],
+            customRanges: [{
+                rangeId,
+                rangeType: CustomRangeType.HYPERLINK,
+                startIndex: 0,
+                endIndex: text.length - 1,
+                properties: { url: target, refId: rangeId }
+            }]
+        }
+    };
 }
 
 /** Converts a whole `dataStream` to plain text, dropping the terminator it ends with. */

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -79,6 +79,15 @@ export interface ICellDocumentData {
 export interface ICellDocumentBody {
     /** Univer's flat text buffer, with structure encoded as control characters. */
     dataStream?: string;
+    /** Spans of `dataStream` carrying extra properties, hyperlinks among them. */
+    customRanges?: ICellCustomRange[];
+}
+
+/** A span of a cell's document text. `startIndex` and `endIndex` are both inclusive. */
+export interface ICellCustomRange {
+    startIndex?: number;
+    endIndex?: number;
+    properties?: { url?: string };
 }
 
 export interface ISheetDrawing {
@@ -270,27 +279,98 @@ export function resolveCellStyle(
     return s;
 }
 
+/** A run of a cell's document text, carrying the hyperlink it sits inside. */
+export interface CellDocumentSegment {
+    text: string;
+    url?: string;
+}
+
+/**
+ * Splits a cell's rich-text document into runs of plain and linked text. Univer stores a
+ * hyperlink as a `customRange` holding the target and the offsets it covers in `dataStream`,
+ * so the runs are cut on those offsets. Returns an empty array when the cell carries no
+ * document, which is the common case: Univer writes `p` only for a rich-text cell.
+ */
+export function getCellDocumentSegments(cell: ICellData | undefined): CellDocumentSegment[] {
+    const body = cell?.p?.body;
+    const stream = typeof body?.dataStream === "string" ? body.dataStream : "";
+    if (!stream) return [];
+
+    const segments: CellDocumentSegment[] = [];
+    let cursor = 0;
+    for (const link of linkRanges(body?.customRanges, stream.length)) {
+        if (link.start > cursor) {
+            segments.push({ text: stripDataStreamControls(stream.slice(cursor, link.start)) });
+        }
+        segments.push({ text: stripDataStreamControls(stream.slice(link.start, link.end + 1)), url: link.url });
+        cursor = link.end + 1;
+    }
+    if (cursor < stream.length) {
+        segments.push({ text: stripDataStreamControls(stream.slice(cursor)) });
+    }
+
+    return trimTrailingBreaks(segments);
+}
+
 /**
  * Returns the plain text of a cell Univer stored as a rich-text document. Univer writes `p`
  * without a matching `v` for some cells, such as a link typed into an empty cell, so an emitter
  * that reads only `v` renders them blank.
  */
 export function getCellDocumentText(cell: ICellData | undefined): string {
-    return normalizeDataStream(cell?.p?.body?.dataStream);
+    return getCellDocumentSegments(cell).map((segment) => segment.text).join("");
+}
+
+/** Converts a whole `dataStream` to plain text, dropping the terminator it ends with. */
+export function normalizeDataStream(dataStream: unknown): string {
+    if (typeof dataStream !== "string") return "";
+    return stripDataStreamControls(dataStream).replace(/\n+$/, "");
+}
+
+/** The hyperlink ranges to cut on, in document order, clamped to the stream and non-overlapping. */
+function linkRanges(customRanges: ICellCustomRange[] | undefined, length: number) {
+    const links: { start: number; end: number; url: string }[] = [];
+    for (const range of customRanges ?? []) {
+        const url = range?.properties?.url;
+        if (typeof url !== "string" || !url) continue;
+        if (!isFiniteNumber(range.startIndex) || !isFiniteNumber(range.endIndex)) continue;
+
+        const start = Math.max(0, Math.trunc(range.startIndex));
+        const end = Math.min(length - 1, Math.trunc(range.endIndex));
+        if (end >= start) links.push({ start, end, url });
+    }
+    links.sort((a, b) => a.start - b.start);
+
+    const ordered: typeof links = [];
+    let cursor = 0;
+    for (const link of links) {
+        if (link.start < cursor) continue;
+        ordered.push(link);
+        cursor = link.end + 1;
+    }
+    return ordered;
 }
 
 /**
- * Converts Univer's `dataStream` to plain text. A carriage return ends a paragraph and a line
- * feed ends a section, so both become newlines and the trailing terminator every stream carries
- * is dropped. The other C0 control characters are structural placeholders, the backspace
- * character standing in for an embedded drawing.
+ * Removes the structural placeholders Univer encodes as C0 control characters, the backspace
+ * character standing in for an embedded drawing, and turns its paragraph and section breaks
+ * into newlines.
  */
-export function normalizeDataStream(dataStream: unknown): string {
-    if (typeof dataStream !== "string") return "";
-    return dataStream
+function stripDataStreamControls(text: string): string {
+    return text
         .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "")
-        .replace(/\r\n|[\r\n]/g, "\n")
-        .replace(/\n+$/, "");
+        .replace(/\r\n|[\r\n]/g, "\n");
+}
+
+/** Drops the terminator every stream ends with, along with any run it leaves empty. */
+function trimTrailingBreaks(segments: CellDocumentSegment[]): CellDocumentSegment[] {
+    while (segments.length > 0) {
+        const last = segments[segments.length - 1];
+        last.text = last.text.replace(/\n+$/, "");
+        if (last.text) break;
+        segments.pop();
+    }
+    return segments;
 }
 
 export interface Bounds {

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -288,7 +288,8 @@ export interface CellDocumentSegment {
 /**
  * Splits a cell's rich-text document into runs of plain and linked text. Univer stores a
  * hyperlink as a `customRange` holding the target and the offsets it covers in `dataStream`,
- * so the runs are cut on those offsets. Returns an empty array when the cell carries no
+ * so the runs are cut on those offsets. A run keeps its `url` only when the target is safe to
+ * export, so an emitter can use it as-is. Returns an empty array when the cell carries no
  * document, which is the common case: Univer writes `p` only for a rich-text cell.
  */
 export function getCellDocumentSegments(cell: ICellData | undefined): CellDocumentSegment[] {
@@ -331,8 +332,8 @@ export function normalizeDataStream(dataStream: unknown): string {
 function linkRanges(customRanges: ICellCustomRange[] | undefined, length: number) {
     const links: { start: number; end: number; url: string }[] = [];
     for (const range of customRanges ?? []) {
-        const url = range?.properties?.url;
-        if (typeof url !== "string" || !url) continue;
+        const url = sanitizeLinkUrl(range?.properties?.url);
+        if (!url) continue;
         if (!isFiniteNumber(range.startIndex) || !isFiniteNumber(range.endIndex)) continue;
 
         const start = Math.max(0, Math.trunc(range.startIndex));
@@ -349,6 +350,17 @@ function linkRanges(customRanges: ICellCustomRange[] | undefined, length: number
         cursor = link.end + 1;
     }
     return ordered;
+}
+
+/**
+ * Validates a hyperlink target before it reaches an export. Accepts the absolute `http`, `https`
+ * and `mailto` URLs Univer's link dialog writes; anything else, `javascript:` among them, returns
+ * `null` so the run is exported as plain text.
+ */
+function sanitizeLinkUrl(url: unknown): string | null {
+    if (typeof url !== "string") return null;
+    const trimmed = url.trim();
+    return /^(?:https?:\/\/|mailto:)[^\u0000-\u0020\u007F]+$/i.test(trimmed) ? trimmed : null;
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -72,6 +72,13 @@ export interface ICellData {
 export interface ICellDocumentData {
     drawings?: Record<string, ISheetDrawing>;
     drawingsOrder?: string[];
+    /** Text content, present when the cell holds rich text such as a link or mixed formatting. */
+    body?: ICellDocumentBody;
+}
+
+export interface ICellDocumentBody {
+    /** Univer's flat text buffer, with structure encoded as control characters. */
+    dataStream?: string;
 }
 
 export interface ISheetDrawing {
@@ -261,6 +268,29 @@ export function resolveCellStyle(
     if (!s) return null;
     if (typeof s === "string") return styles[s] ?? null;
     return s;
+}
+
+/**
+ * Returns the plain text of a cell Univer stored as a rich-text document. Univer writes `p`
+ * without a matching `v` for some cells, such as a link typed into an empty cell, so an emitter
+ * that reads only `v` renders them blank.
+ */
+export function getCellDocumentText(cell: ICellData | undefined): string {
+    return normalizeDataStream(cell?.p?.body?.dataStream);
+}
+
+/**
+ * Converts Univer's `dataStream` to plain text. A carriage return ends a paragraph and a line
+ * feed ends a section, so both become newlines and the trailing terminator every stream carries
+ * is dropped. The other C0 control characters are structural placeholders, the backspace
+ * character standing in for an embedded drawing.
+ */
+export function normalizeDataStream(dataStream: unknown): string {
+    if (typeof dataStream !== "string") return "";
+    return dataStream
+        .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "")
+        .replace(/\r\n|[\r\n]/g, "\n")
+        .replace(/\n+$/, "");
 }
 
 export interface Bounds {


### PR DESCRIPTION
Spreadsheet notes now print, export and share the way they look in the editor. Cells that came out
blank in every export show their content again, hyperlinks survive into PDF, Excel and back, and the
layout keeps the alignment, rotation, borders and overflow behaviour of the original sheet instead of
falling back to the browser's table defaults.

## Cells that never appeared

* Render a cell whose text is stored only in its rich-text document, which Univer writes for some
  cells and which the HTML, XLSX and CSV emitters all skipped.
* Index those cells for full-text search, so a note can be found by text that only lives there.
* Read a cell's rich-text document once in the shared workbook model, so the HTML, XLSX, CSV and
  search paths cannot disagree about its text.

## Hyperlinks

* Render a cell's hyperlinks as anchors in the HTML export, one per linked run.
* Write a real Excel hyperlink for a linked cell in the XLSX export.
* Import an Excel hyperlink as the rich-text document Univer stores a link in, instead of keeping the
  display text and dropping the target.
* Keep a linked numeric cell numeric in the XLSX export, so its number format and the formulas
  referencing it survive.
* Restrict link targets to absolute http, https and mailto URLs inside the model, so no emitter can
  hand out an unsafe target and a rejected one renders as plain text.
* Carry Excel's built-in Hyperlink font on an exported linked cell, merged over the workbook's own
  font, since Excel stores a link's appearance rather than deriving it on open.
* Print a link in the cell's own text color with the underline as its only marker.

## Layout fidelity in the HTML export

* Clip a cell's text at its own edge when the neighbour it would spill over holds a value, instead of
  drawing one value on top of the other.
* Compose a merged range's border from the cells on its edges, so the range keeps the right and
  bottom lines Excel stores on its far members rather than on the anchor.
* Rotate a cell's text, mapping a quarter turn and stacked text to a vertical writing mode and any
  other angle to a transform, with the wrapper keeping the rotation off the cell's fill and borders.
* Align a cell by its value type when it sets no alignment: numbers to the right, booleans centered.
* Align a row's cells to the bottom by default, matching Excel rather than the HTML table default.
* Never spill a number or a boolean out of its cell, matching the editor.
* Print a sheet with the column widths and overflow behaviour of the editor, instead of rewrapping
  long values and growing the rows past their declared heights