### PR TITLE
Spreadsheet: improvements

### DIFF
--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -659,10 +659,14 @@ describe("renderSpreadsheetToHtml", () => {
         it("holds text to its own edge when the neighbour beside it holds a value", () => {
             expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "next", t: 1 } }), 0)).toEqual([0, 0]);
 
-            // Nothing in the way, so the stylesheets are left to spill the cell as the editor does.
+            // A cell that carries only formatting does not extend the grid, so there is no column
+            // beside these to run into.
             expect(room(row({ 0: { v: "a long label", t: 1 } }), 0)).toEqual([0, 0]);
-            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toEqual([0, 88]);
-            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toEqual([0, 88]);
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toEqual([0, 0]);
+
+            // With a column of content beyond it, the empty one between is room to run across.
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 2: { v: "next", t: 1 } }), 0)).toEqual([0, 88]);
         });
 
         it("gives the text the width of the empty cells it may run across", () => {
@@ -1930,6 +1934,59 @@ describe("renderSpreadsheetToHtml", () => {
 
         expect(html).toContain('<img class="spreadsheet-floating-image"');
         expect(html).not.toContain(`<span class="spreadsheet-floating-image"`);
+    });
+
+    it("bounds the grid by the cells that hold something, not the ones that only carry formatting", () => {
+        // A fill applied across whole rows leaves formatting far past the data. Rendering out to it
+        // would cost a cell per column for a band drawn as one rectangle.
+        const html = renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [],
+                        cellData: {
+                            "0": { "0": { v: "a", t: 1 }, "1": { v: "b", t: 1 }, "500": { s: { bg: { rgb: "#FFE699" } } } },
+                            "1": { "0": { v: "c", t: 1 }, "500": { s: { bg: { rgb: "#FFE699" } } } }
+                        },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        }));
+
+        expect((html.match(/<td/g) ?? []).length).toBe(4);
+        expect(html).toContain(`<col span="2" style="width:88px">`);
+    });
+
+    it("falls back to every cell for a sheet that is nothing but formatting", () => {
+        const html = renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [],
+                        cellData: { "0": { "0": { s: { bg: { rgb: "#FFE699" } } }, "1": { s: { bg: { rgb: "#FFE699" } } } } },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        }));
+
+        expect((html.match(/<td/g) ?? []).length).toBe(2);
+        expect(html).toContain("background-color:#FFE699");
     });
 
     it("renders a floating image absolutely positioned in a per-sheet wrapper", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -669,7 +669,7 @@ describe("renderSpreadsheetToHtml", () => {
             expect(room(row({ 0: { v: "a long label", t: 1 }, 2: { v: "next", t: 1 } }), 0)).toEqual([0, 88]);
         });
 
-        it("gives the text the width of the empty cells it may run across", () => {
+        it("gives the text the width of the empty cells it can run across", () => {
             const long = { v: "a long label", t: 1 };
             const widths = { 1: { w: 30 }, 2: { w: 50 } };
 
@@ -1398,7 +1398,7 @@ describe("renderSpreadsheetToHtml", () => {
         // Column 1 between A and C has no cell -> empty <td>.
         expect(html).toContain("<td></td>");
         expect(unboxed(html)).toContain("<td>C</td>");
-        // A may run across the empty column, so its text carries the room it has.
+        // A can run across the empty column, so its text carries the room it has.
         expect(html).toContain(`<td style="padding:0px 2px 2px 2px"><span style="display:block;overflow:hidden;max-height:22px;width:calc(100% + 88px);margin-right:-88px;line-height:normal">A</span></td>`);
     });
 
@@ -1966,6 +1966,36 @@ describe("renderSpreadsheetToHtml", () => {
 
         expect((html.match(/<td/g) ?? []).length).toBe(4);
         expect(html).toContain(`<col span="2" style="width:88px">`);
+    });
+
+    it("counts a border as structure the grid has to reach, but not a fill", () => {
+        const beyond = (style: unknown) => renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [],
+                        cellData: { "0": { "0": { v: "a", t: 1 } }, "1": { "3": { s: style } } },
+                        rowData: {},
+                        columnData: {}
+                    }
+                }
+            }
+        }));
+
+        // An empty bordered cell is a drawn box someone means to keep, so the grid reaches it.
+        const bordered = beyond({ bd: { t: { s: BorderStyle.THIN }, b: { s: BorderStyle.THIN } } });
+        expect((bordered.match(/<td/g) ?? []).length).toBe(8);
+        expect(bordered).toContain("border-top");
+
+        // A fill comes from colouring whole rows, so it does not carry the grid out to meet it.
+        expect((beyond({ bg: { rgb: "#FFE699" } }).match(/<td/g) ?? []).length).toBe(1);
+        expect((beyond({ bd: { t: { s: BorderStyle.NONE } } }).match(/<td/g) ?? []).length).toBe(1);
     });
 
     it("falls back to every cell for a sheet that is nothing but formatting", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1303,6 +1303,14 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain('<tr style="height:50px;vertical-align:bottom">');
     });
 
+    it("lays a cell out with the padding it states", () => {
+        const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", t: 1, s: { pd: { t: 3, r: 6, b: 5, l: 6 } } }));
+
+        expect(html).toContain(`<td style="padding:3px 6px 5px 6px">`);
+        // The box is measured against that padding rather than the default.
+        expect(html).toContain("max-height:16px");
+    });
+
     it("takes a self-sizing row's height from the height Univer measured for it", () => {
         const html = renderSpreadsheetToHtml(JSON.stringify({
             version: 1,
@@ -1929,6 +1937,16 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain(`<img style="position:absolute;left:-4px;top:-8px;width:110px;height:70px"`);
     });
 
+    it("treats a crop side the drawing leaves out as no inset", () => {
+        const html = renderSpreadsheetToHtml(workbookWithFloatingDrawings([{
+            ...urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 100, height: 50 }),
+            srcRect: { left: 4 }
+        }]));
+
+        // Only the left is cut, so the image grows by that alone and is pulled back by it.
+        expect(html).toContain(`<img style="position:absolute;left:-4px;top:0px;width:104px;height:50px"`);
+    });
+
     it("leaves a drawing whose crop takes nothing as a bare image", () => {
         const html = renderSpreadsheetToHtml(workbookWithFloatingDrawings([{
             ...urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 100, height: 50 }),
@@ -2322,6 +2340,20 @@ describe("renderSpreadsheetToHtml", () => {
             )
         );
         expect((html.match(/<tr/g) ?? []).length).toBe(1);
+    });
+
+    it("counts hidden and explicitly sized columns when extending the grid sideways", () => {
+        // The column axis has to read the same way as the row one: a hidden column takes none of
+        // the image's reach, and a column with a width of its own is counted at it.
+        const html = renderSpreadsheetToHtml(
+            workbookWithFloatingDrawings(
+                [urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 200, height: 10 })],
+                { columnData: { "0": { hd: 1 }, "1": { w: 100 }, "2": { w: 100 } } }
+            )
+        );
+        // Column 0 contributes nothing and columns 1-2 contribute 100px each, so the image ends on
+        // column 2 and the grid grows to three, of which the hidden one is not emitted.
+        expect(html).toContain(`<col span="2" style="width:100px">`);
     });
 
     it("counts hidden and explicitly sized tracks correctly when extending the grid", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1980,9 +1980,9 @@ describe("renderSpreadsheetToHtml", () => {
                 urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 200, height: 10 })
             ])
         );
-        // Default 88px columns: the image right edge at 200px reaches column 2, so 3 columns emit.
-        const colCount = (html.match(/<col /g) ?? []).length;
-        expect(colCount).toBe(3);
+        // Default 88px columns: the image right edge at 200px reaches column 2, so 3 columns emit,
+        // as one `col` spanning them since they share a width.
+        expect(html).toContain(`<col span="3" style="width:88px">`);
     });
 
     it("does not shrink the grid when a floating image fits within the data bounds", () => {
@@ -2214,8 +2214,8 @@ describe("renderSpreadsheetToHtml", () => {
     it("renders leading empty columns so the grid starts at the sheet origin", () => {
         // Data only at column 2 -> columns 0 and 1 must still be emitted.
         const html = renderSpreadsheetToHtml(cellAtWorkbook(0, 2));
-        const colCount = (html.match(/<col /g) ?? []).length;
-        expect(colCount).toBe(3);
+        // Three columns of the same width, so one `col` spans them.
+        expect(html).toContain(`<col span="3" style="width:88px">`);
     });
 
     it("extends bounds to cover a merge range that exceeds the cell data", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1968,6 +1968,36 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain(`<col span="2" style="width:88px">`);
     });
 
+    it("lets a merged banner widen the grid unless it was applied to entire rows", () => {
+        const banner = (endColumn: number, columnCount: number) => renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [{ startRow: 0, endRow: 0, startColumn: 0, endColumn }],
+                        cellData: { "0": { "0": { v: "Banner", t: 1 } }, "1": { "0": { v: "a", t: 1 }, "3": { v: "d", t: 1 } } },
+                        rowData: {},
+                        columnData: {},
+                        rowCount: 1000,
+                        columnCount
+                    }
+                }
+            }
+        }));
+
+        // Merged by hand: the sheet declares only the columns it uses, so the banner keeps its span.
+        expect(banner(25, 26)).toContain(`colspan="26"`);
+
+        // Applied to entire rows: the sheet declares every column Excel has, and the banner is
+        // clamped into the content rather than carrying the grid out to meet it.
+        expect(banner(16383, 16384)).toContain(`colspan="4"`);
+    });
+
     it("counts a border as structure the grid has to reach, but not a fill", () => {
         const beyond = (style: unknown) => renderSpreadsheetToHtml(JSON.stringify({
             version: 1,

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -690,10 +690,13 @@ describe("renderSpreadsheetToHtml", () => {
 
             const centered = { t: 1, s: { ht: HorizontalAlign.CENTER } };
             expect(room(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...centered } }), 1)).toEqual([0, 0]);
-            expect(room(row({ 1: { v: "x", ...centered } }), 1)).toEqual([88, 0]);
+            // Nothing to its right, so the room on its left is given up to keep it centred.
+            expect(room(row({ 1: { v: "x", ...centered } }), 1)).toEqual([0, 0]);
 
-            // Stopped on the right, with the empty column on its left still open to it.
-            expect(room(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toEqual([88, 0]);
+            // Centred text is given the same room on both sides, so the middle of the text stays on
+            // the middle of the cell: stopped on the right, it gives up the room on its left too.
+            expect(room(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toEqual([0, 0]);
+            expect(room(row({ 1: { v: "x", ...centered }, 3: { v: "after", t: 1 } }), 1)).toEqual([88, 88]);
         });
 
         it("keeps turned text in its own cell rather than running it into a neighbour", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1908,6 +1908,30 @@ describe("renderSpreadsheetToHtml", () => {
 
     // #region Floating images (SHEET_DRAWING_PLUGIN resource)
 
+    it("shows a cropped drawing through its box, with the whole image held inside", () => {
+        const cropped = {
+            ...urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 10, top: 20, width: 100, height: 50 }),
+            srcRect: { left: 4, top: 8, right: 6, bottom: 12 }
+        };
+        const html = renderSpreadsheetToHtml(workbookWithFloatingDrawings([cropped]));
+
+        // The box stays the drawing's own size and clips; the image inside grows by the insets and
+        // is pulled back by them, so the visible window is the part the editor shows.
+        expect(html).toContain(`<span class="spreadsheet-floating-image" style="position:absolute;left:10px;top:20px;`
+            + `width:100px;height:50px;display:block;overflow:hidden">`);
+        expect(html).toContain(`<img style="position:absolute;left:-4px;top:-8px;width:110px;height:70px"`);
+    });
+
+    it("leaves a drawing whose crop takes nothing as a bare image", () => {
+        const html = renderSpreadsheetToHtml(workbookWithFloatingDrawings([{
+            ...urlDrawing("img1", "api/attachments/cgN4jEBCA1Kn/image/image.png", { left: 0, top: 0, width: 100, height: 50 }),
+            srcRect: { left: 0, top: 0, right: 0, bottom: 0 }
+        }]));
+
+        expect(html).toContain('<img class="spreadsheet-floating-image"');
+        expect(html).not.toContain(`<span class="spreadsheet-floating-image"`);
+    });
+
     it("renders a floating image absolutely positioned in a per-sheet wrapper", () => {
         const html = renderSpreadsheetToHtml(
             workbookWithFloatingDrawings([

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -585,7 +585,7 @@ describe("renderSpreadsheetToHtml", () => {
         }
 
         // An untouched cell keeps the box that only caps it, so its own alignment still places it.
-        expect(rotated(0)).toContain(`<span style="display:block;overflow:hidden;max-height:22px">`);
+        expect(rotated(0)).toContain(`<span style="display:block;overflow:hidden;max-height:22px;line-height:normal">`);
     });
 
     it("leaves a cell unwrapped when it has no rotation to apply", () => {
@@ -1396,7 +1396,7 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("<td></td>");
         expect(unboxed(html)).toContain("<td>C</td>");
         // A may run across the empty column, so its text carries the room it has.
-        expect(html).toContain(`<td style="padding:0px 2px 2px 2px"><span style="display:block;overflow:hidden;max-height:22px;width:calc(100% + 88px);margin-right:-88px">A</span></td>`);
+        expect(html).toContain(`<td style="padding:0px 2px 2px 2px"><span style="display:block;overflow:hidden;max-height:22px;width:calc(100% + 88px);margin-right:-88px;line-height:normal">A</span></td>`);
     });
 
     it("renders numeric cell values", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -581,52 +581,76 @@ describe("renderSpreadsheetToHtml", () => {
             return grid({ "0": cells }, extra);
         }
 
-        /** Whether the workbook's cell at `column` clips its text. The render always starts at A1. */
-        function clips(json: string, column: number): boolean {
-            const cells = renderSpreadsheetToHtml(json).match(/<td[^>]*>/g) ?? [];
-            return (cells[column] ?? "").includes("overflow:hidden");
+        /**
+         * The px of room the workbook's cell at `column` is given on each side, `[0, 0]` when it is
+         * held to its own edges, and `null` when nothing bounds it. The render always starts at A1.
+         */
+        function room(json: string, column: number): [number, number] | null {
+            const cells = renderSpreadsheetToHtml(json).match(/<td[^>]*>(?:<span style="[^"]*">)?/g) ?? [];
+            const cell = cells[column] ?? "";
+            if (!cell.includes("width:calc")) return cell.includes("overflow:hidden") ? [0, 0] : null;
+
+            const before = /margin-left:-([\d.]+)px/.exec(cell)?.[1] ?? "0";
+            const after = /margin-right:-([\d.]+)px/.exec(cell)?.[1] ?? "0";
+            return [Number(before), Number(after)];
         }
 
-        it("clips text only when the neighbour it would spill over holds a value", () => {
-            const occupied = row({ 0: { v: "a long label", t: 1 }, 1: { v: "next", t: 1 } });
-            expect(clips(occupied, 0)).toBe(true);
+        it("holds text to its own edge when the neighbour beside it holds a value", () => {
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "next", t: 1 } }), 0)).toEqual([0, 0]);
 
-            // An empty neighbour, or one carrying only a style, is spilled over as in the editor.
-            expect(clips(row({ 0: { v: "a long label", t: 1 } }), 0)).toBe(false);
-            expect(clips(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toBe(false);
-            expect(clips(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toBe(false);
+            // Nothing in the way, so the stylesheets are left to spill the cell as the editor does.
+            expect(room(row({ 0: { v: "a long label", t: 1 } }), 0)).toBeNull();
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toBeNull();
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toBeNull();
+        });
+
+        it("gives the text the width of the empty cells it may run across", () => {
+            const long = { v: "a long label", t: 1 };
+            const widths = { 1: { w: 30 }, 2: { w: 50 } };
+
+            // Two empty columns, then a value: the text runs over both and is cut before the value.
+            expect(room(row({ 0: long, 3: { v: "next", t: 1 } }, { columnData: widths }), 0)).toEqual([0, 80]);
+
+            // A hidden column between them contributes nothing, since none of it reaches the page.
+            expect(room(
+                row({ 0: long, 3: { v: "next", t: 1 } }, { columnData: { ...widths, 2: { w: 50, hd: 1 } } }),
+                0
+            )).toEqual([0, 30]);
         });
 
         it("follows the alignment to decide which side the text spills towards", () => {
             const rightAligned = { t: 1, s: { ht: HorizontalAlign.RIGHT } };
-            expect(clips(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...rightAligned } }), 1)).toBe(true);
-            expect(clips(row({ 1: { v: "x", ...rightAligned }, 2: { v: "after", t: 1 } }), 1)).toBe(false);
+            expect(room(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...rightAligned } }), 1)).toEqual([0, 0]);
+            expect(room(row({ 1: { v: "x", ...rightAligned }, 2: { v: "after", t: 1 } }), 1)).toBeNull();
 
             const centered = { t: 1, s: { ht: HorizontalAlign.CENTER } };
-            expect(clips(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...centered } }), 1)).toBe(true);
-            expect(clips(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toBe(true);
-            expect(clips(row({ 1: { v: "x", ...centered } }), 1)).toBe(false);
+            expect(room(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...centered } }), 1)).toEqual([0, 0]);
+            expect(room(row({ 1: { v: "x", ...centered } }), 1)).toBeNull();
+
+            // Stopped on the right, with the empty column on its left still open to it.
+            expect(room(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toEqual([88, 0]);
         });
 
-        it("never spills a number, and never clips a wrapped or empty cell", () => {
-            expect(clips(row({ 0: { v: 42, t: 2 } }), 0)).toBe(true);
-            expect(clips(row({ 0: { v: true, t: 3 } }), 0)).toBe(true);
+        it("never spills a number, a boolean or a clipped cell, and never bounds a wrapped one", () => {
+            expect(room(row({ 0: { v: 42, t: 2 } }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: { v: true, t: 3 } }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.CLIP } } }), 0)).toEqual([0, 0]);
 
-            expect(clips(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
-            expect(clips(row({ 0: { s: { bl: 1 } }, 1: { v: "next", t: 1 } }), 0)).toBe(false);
+            expect(room(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toBeNull();
+            expect(room(row({ 0: { s: { bl: 1 } }, 1: { v: "next", t: 1 } }), 0)).toBeNull();
         });
 
         it("judges adjacency on the rendered row rather than the cell matrix", () => {
             const long = { v: "a long label", t: 1 };
 
             // A hidden column reaches nobody, so the cell steps over it in both directions.
-            expect(clips(row({ 0: long, 1: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBe(false);
-            expect(clips(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBe(true);
+            expect(room(row({ 0: long, 1: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBeNull();
+            expect(room(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toEqual([0, 0]);
 
             // A merged cell starts looking past the last column its own range covers.
             const merged = [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 }];
-            expect(clips(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { mergeData: merged }), 0)).toBe(true);
-            expect(clips(row({ 0: long, 1: {} }, { mergeData: merged }), 0)).toBe(false);
+            expect(room(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { mergeData: merged }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: long, 1: {} }, { mergeData: merged }), 0)).toBeNull();
         });
 
         it("reads a column a merge spans into as holding that range's content", () => {
@@ -644,7 +668,7 @@ describe("renderSpreadsheetToHtml", () => {
                 0: { v: "a long label", t: 1 },
                 1: { p: { body: { dataStream: "linked\r\n" } } }
             });
-            expect(clips(html, 0)).toBe(true);
+            expect(room(html, 0)).toEqual([0, 0]);
         });
     });
 
@@ -1267,9 +1291,10 @@ describe("renderSpreadsheetToHtml", () => {
         });
         const html = renderSpreadsheetToHtml(input);
         // Column 1 between A and C has no cell -> empty <td>.
-        expect(html).toContain("<td>A</td>");
         expect(html).toContain("<td></td>");
         expect(html).toContain("<td>C</td>");
+        // A may run across the empty column, so its text carries the room it has.
+        expect(html).toContain(`<td><span style="display:inline-block;width:calc(100% + 88px);overflow:hidden;margin-right:-88px">A</span></td>`);
     });
 
     it("renders numeric cell values", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSpreadsheetToHtml } from "./render_to_html.js";
-import { BorderStyle, HorizontalAlign, WrapStrategy } from "./workbook_model.js";
+import { BorderStyle, HorizontalAlign, VerticalAlign, WrapStrategy } from "./workbook_model.js";
 
 /**
  * The markup with the box model stripped: each cell's sizing box and the padding it is measured
@@ -524,19 +524,68 @@ describe("renderSpreadsheetToHtml", () => {
         const rotated = (tr: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s: { tr } }));
 
         // A quarter turn either way becomes a vertical writing mode, so the row can grow to fit it.
-        expect(rotated({ a: 90 })).toContain(
-            `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl;transform:rotate(180deg)">Days left</span>`);
+        // Univer measures the angle the way CSS turns, so -90 lifts the text and reads upwards.
         expect(rotated({ a: -90 })).toContain(
+            `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl;transform:rotate(180deg)">Days left</span>`);
+        expect(rotated({ a: 90 })).toContain(
             `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl">Days left</span>`);
 
         // Stacked text reads downwards with upright characters.
         expect(rotated({ v: 1 })).toContain(
             `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl;text-orientation:upright">Days left</span>`);
 
-        // Any other angle turns the glyphs; CSS rotates clockwise, so the sign flips.
+        // Any other angle turns the glyphs about a bottom corner of the cell, shifted by the line
+        // height the turn would otherwise swing past that corner: lifting text from the bottom
+        // left, dropping text from the bottom right.
+        expect(rotated({ a: -45 })).toContain(
+            `transform:translateX(calc(1lh * 0.707)) rotate(-45deg);transform-origin:left bottom">Days left</span>`);
         expect(rotated({ a: 45 })).toContain(
-            `<span style="display:inline-block;vertical-align:top;transform:rotate(-45deg)">Days left</span>`);
-        expect(rotated({ a: -30.5 })).toContain(`transform:rotate(30.5deg)`);
+            `transform:translateX(calc(1lh * -0.707)) rotate(45deg);transform-origin:right bottom">Days left</span>`);
+        expect(rotated({ a: -30.5 })).toContain(`transform:translateX(calc(1lh * 0.508)) rotate(-30.5deg)`);
+    });
+
+    it("anchors turned text to the cell edge the string meets", () => {
+        const tilted = (s: Record<string, unknown>) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s }));
+
+        // Against the bottom, lifting text meets the edge with its start, dropping text with its end.
+        expect(tilted({ tr: { a: -45 } })).toContain("align-items:flex-end;justify-content:flex-start");
+        expect(tilted({ tr: { a: 45 } })).toContain("align-items:flex-end;justify-content:flex-end");
+
+        // Against the top the ends swap over; a middle-aligned cell keeps the bottom's sides.
+        expect(tilted({ tr: { a: -45 }, vt: VerticalAlign.TOP })).toContain("align-items:flex-start;justify-content:flex-end");
+        expect(tilted({ tr: { a: 45 }, vt: VerticalAlign.TOP })).toContain("align-items:flex-start;justify-content:flex-start");
+        expect(tilted({ tr: { a: 45 }, vt: VerticalAlign.MIDDLE })).toContain("align-items:center;justify-content:flex-end");
+
+        // A cell that states its own alignment keeps it.
+        expect(tilted({ tr: { a: 45 }, ht: HorizontalAlign.CENTER })).toContain("justify-content:center");
+    });
+
+    it("turns text about the cell edge it hangs from", () => {
+        const tilted = (a: number, vt?: number) =>
+            renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s: { tr: { a }, vt } }));
+
+        expect(tilted(-45)).toContain(`translateX(calc(1lh * 0.707)) rotate(-45deg);transform-origin:left bottom`);
+        expect(tilted(45)).toContain(`translateX(calc(1lh * -0.707)) rotate(45deg);transform-origin:right bottom`);
+
+        expect(tilted(-45, VerticalAlign.TOP)).toContain(`translateX(calc(1lh * -0.707)) rotate(-45deg);transform-origin:right top`);
+        expect(tilted(45, VerticalAlign.TOP)).toContain(`translateX(calc(1lh * 0.707)) rotate(45deg);transform-origin:left top`);
+
+        // Turning about the centre needs no correction and leaves the shape centred in the cell.
+        expect(tilted(45, VerticalAlign.MIDDLE)).toContain(`transform:rotate(45deg)">Days left</span>`);
+    });
+
+    it("holds turned text inside its own cell", () => {
+        const rotated = (a: number) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s: { tr: { a } } }));
+
+        // Every turn sits in a box that fills the cell, so the cell is what cuts an overrun. A box
+        // only as tall as the text would clip a band across the turn instead.
+        for (const angle of [45, -45, 90, -90]) {
+            expect(rotated(angle), `${angle} degrees`).toContain(`<span style="display:flex;overflow:hidden`);
+            expect(rotated(angle), `${angle} degrees`).toContain("height:22px");
+        }
+
+        // An untouched cell keeps the box that only caps it, so its own alignment still places it.
+        expect(rotated(0)).toContain(`<span style="display:block;overflow:hidden;max-height:22px">`);
     });
 
     it("leaves a cell unwrapped when it has no rotation to apply", () => {
@@ -641,6 +690,12 @@ describe("renderSpreadsheetToHtml", () => {
 
             // Stopped on the right, with the empty column on its left still open to it.
             expect(room(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toEqual([88, 0]);
+        });
+
+        it("keeps turned text in its own cell rather than running it into a neighbour", () => {
+            const turned = { v: "a long label", t: 1, s: { tr: { a: 45 } } };
+            expect(room(row({ 0: turned }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: turned, 1: {} }), 0)).toEqual([0, 0]);
         });
 
         it("never spills a number, a boolean or a clipped cell, and never bounds a wrapped one", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -2028,6 +2028,36 @@ describe("renderSpreadsheetToHtml", () => {
         expect(tall(1048575, 1000)).toContain(`rowspan="2"`);
     });
 
+    it("gives up half an edge to a bordered neighbour when sizing a cell's box", () => {
+        // Under border-collapse the wider of two facing borders wins the shared edge, so a cell with
+        // none of its own still loses half of its neighbour's. A cell that fills its row exactly,
+        // which a turned one does, is a border's half too tall without this.
+        const html = renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [],
+                        rowData: { "0": { h: 40 }, "1": { h: 24 } },
+                        columnData: {},
+                        cellData: {
+                            "0": { "0": { v: "turned", t: 1, s: { tr: { a: 90 } } } },
+                            "1": { "0": { v: "bordered", t: 1, s: { bd: { t: { s: BorderStyle.MEDIUM } } } } }
+                        }
+                    }
+                }
+            }
+        }));
+
+        // 40 less the 2px of padding, less half of the neighbour's 2px border.
+        expect(html).toContain("height:37px");
+    });
+
     it("counts a border as structure the grid has to reach, but not a fill", () => {
         const beyond = (style: unknown) => renderSpreadsheetToHtml(JSON.stringify({
             version: 1,

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -1998,6 +1998,36 @@ describe("renderSpreadsheetToHtml", () => {
         expect(banner(16383, 16384)).toContain(`colspan="4"`);
     });
 
+    it("lets a tall merge widen the grid unless it was applied to entire columns", () => {
+        const tall = (endRow: number, rowCount: number) => renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [{ startRow: 0, endRow, startColumn: 0, endColumn: 0 }],
+                        cellData: { "0": { "0": { v: "Side", t: 1 }, "1": { v: "a", t: 1 } }, "1": { "1": { v: "b", t: 1 } } },
+                        rowData: {},
+                        columnData: {},
+                        rowCount,
+                        columnCount: 20
+                    }
+                }
+            }
+        }));
+
+        // Merged by hand down a sheet shorter than the rows one starts with: the span is kept.
+        expect(tall(49, 50)).toContain(`rowspan="50"`);
+
+        // Applied to entire columns, so it covers at least those rows and is clamped to the content.
+        expect(tall(999, 1000)).toContain(`rowspan="2"`);
+        expect(tall(1048575, 1000)).toContain(`rowspan="2"`);
+    });
+
     it("counts a border as structure the grid has to reach, but not a fill", () => {
         const beyond = (style: unknown) => renderSpreadsheetToHtml(JSON.stringify({
             version: 1,

--- a/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.spec.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import { renderSpreadsheetToHtml } from "./render_to_html.js";
 import { BorderStyle, HorizontalAlign, WrapStrategy } from "./workbook_model.js";
 
+/**
+ * The markup with the box model stripped: each cell's sizing box and the padding it is measured
+ * against, leaving the content and the cell's own theming.
+ */
+function unboxed(html: string): string {
+    return html
+        .replace(/<td([^>]*)><span style="display:block;overflow:hidden[^"]*">([\s\S]*?)<\/span><\/td>/g, "<td$1>$2</td>")
+        .replace(/padding:[^;"]*;?/g, "")
+        .replace(/;"/g, '"')
+        .replace(/ style=""/g, "");
+}
+
 describe("renderSpreadsheetToHtml", () => {
     it("renders a basic spreadsheet with values and styles", () => {
         const input = JSON.stringify({
@@ -513,22 +525,22 @@ describe("renderSpreadsheetToHtml", () => {
 
         // A quarter turn either way becomes a vertical writing mode, so the row can grow to fit it.
         expect(rotated({ a: 90 })).toContain(
-            `<span style="display:inline-block;writing-mode:vertical-rl;transform:rotate(180deg)">Days left</span>`);
+            `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl;transform:rotate(180deg)">Days left</span>`);
         expect(rotated({ a: -90 })).toContain(
-            `<span style="display:inline-block;writing-mode:vertical-rl">Days left</span>`);
+            `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl">Days left</span>`);
 
         // Stacked text reads downwards with upright characters.
         expect(rotated({ v: 1 })).toContain(
-            `<span style="display:inline-block;writing-mode:vertical-rl;text-orientation:upright">Days left</span>`);
+            `<span style="display:inline-block;vertical-align:top;writing-mode:vertical-rl;text-orientation:upright">Days left</span>`);
 
         // Any other angle turns the glyphs; CSS rotates clockwise, so the sign flips.
         expect(rotated({ a: 45 })).toContain(
-            `<span style="display:inline-block;transform:rotate(-45deg)">Days left</span>`);
+            `<span style="display:inline-block;vertical-align:top;transform:rotate(-45deg)">Days left</span>`);
         expect(rotated({ a: -30.5 })).toContain(`transform:rotate(30.5deg)`);
     });
 
     it("leaves a cell unwrapped when it has no rotation to apply", () => {
-        const plain = (s: unknown) => renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s }));
+        const plain = (s: unknown) => unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: "Days left", t: 1, s })));
 
         expect(plain({})).toContain("<td>Days left</td>");
         expect(plain({ tr: { a: 0, v: 0 } })).toContain("<td>Days left</td>");
@@ -549,7 +561,7 @@ describe("renderSpreadsheetToHtml", () => {
             }
         }));
 
-        expect(html).toContain(`Days left</span><img class="spreadsheet-cell-image"`);
+        expect(html).toContain(`Days left</span></span><img class="spreadsheet-cell-image"`);
     });
 
     describe("overflow into neighbouring cells", () => {
@@ -599,9 +611,9 @@ describe("renderSpreadsheetToHtml", () => {
             expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "next", t: 1 } }), 0)).toEqual([0, 0]);
 
             // Nothing in the way, so the stylesheets are left to spill the cell as the editor does.
-            expect(room(row({ 0: { v: "a long label", t: 1 } }), 0)).toBeNull();
-            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toBeNull();
-            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toBeNull();
+            expect(room(row({ 0: { v: "a long label", t: 1 } }), 0)).toEqual([0, 0]);
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { s: { bl: 1 } } }), 0)).toEqual([0, 88]);
+            expect(room(row({ 0: { v: "a long label", t: 1 }, 1: { v: "", t: 1 } }), 0)).toEqual([0, 88]);
         });
 
         it("gives the text the width of the empty cells it may run across", () => {
@@ -621,11 +633,11 @@ describe("renderSpreadsheetToHtml", () => {
         it("follows the alignment to decide which side the text spills towards", () => {
             const rightAligned = { t: 1, s: { ht: HorizontalAlign.RIGHT } };
             expect(room(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...rightAligned } }), 1)).toEqual([0, 0]);
-            expect(room(row({ 1: { v: "x", ...rightAligned }, 2: { v: "after", t: 1 } }), 1)).toBeNull();
+            expect(room(row({ 1: { v: "x", ...rightAligned }, 2: { v: "after", t: 1 } }), 1)).toEqual([88, 0]);
 
             const centered = { t: 1, s: { ht: HorizontalAlign.CENTER } };
             expect(room(row({ 0: { v: "before", t: 1 }, 1: { v: "x", ...centered } }), 1)).toEqual([0, 0]);
-            expect(room(row({ 1: { v: "x", ...centered } }), 1)).toBeNull();
+            expect(room(row({ 1: { v: "x", ...centered } }), 1)).toEqual([88, 0]);
 
             // Stopped on the right, with the empty column on its left still open to it.
             expect(room(row({ 1: { v: "x", ...centered }, 2: { v: "after", t: 1 } }), 1)).toEqual([88, 0]);
@@ -636,7 +648,7 @@ describe("renderSpreadsheetToHtml", () => {
             expect(room(row({ 0: { v: true, t: 3 } }), 0)).toEqual([0, 0]);
             expect(room(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.CLIP } } }), 0)).toEqual([0, 0]);
 
-            expect(room(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toBeNull();
+            expect(room(row({ 0: { v: "a long label", t: 1, s: { tb: WrapStrategy.WRAP } }, 1: { v: "next", t: 1 } }), 0)).toEqual([0, 0]);
             expect(room(row({ 0: { s: { bl: 1 } }, 1: { v: "next", t: 1 } }), 0)).toBeNull();
         });
 
@@ -644,13 +656,13 @@ describe("renderSpreadsheetToHtml", () => {
             const long = { v: "a long label", t: 1 };
 
             // A hidden column reaches nobody, so the cell steps over it in both directions.
-            expect(room(row({ 0: long, 1: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toBeNull();
+            expect(room(row({ 0: long, 1: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toEqual([0, 0]);
             expect(room(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { columnData: { 1: { hd: 1 } } }), 0)).toEqual([0, 0]);
 
             // A merged cell starts looking past the last column its own range covers.
             const merged = [{ startRow: 0, endRow: 0, startColumn: 0, endColumn: 1 }];
             expect(room(row({ 0: long, 1: {}, 2: { v: "next", t: 1 } }, { mergeData: merged }), 0)).toEqual([0, 0]);
-            expect(room(row({ 0: long, 1: {} }, { mergeData: merged }), 0)).toBeNull();
+            expect(room(row({ 0: long, 1: {} }, { mergeData: merged }), 0)).toEqual([0, 0]);
         });
 
         it("reads a column a merge spans into as holding that range's content", () => {
@@ -660,7 +672,7 @@ describe("renderSpreadsheetToHtml", () => {
                 { mergeData: [{ startRow: 0, endRow: 1, startColumn: 0, endColumn: 0 }] }
             ));
 
-            expect(html.split("</tr>")[1]).toContain(`<td style="text-align:right;overflow:hidden">x</td>`);
+            expect(unboxed(html).split("</tr>")[1]).toContain(`<td style="text-align:right">x</td>`);
         });
 
         it("counts a cell whose text lives only in its rich-text document as occupied", () => {
@@ -887,7 +899,7 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(input);
         expect(html).toContain("noStyle");
         // Missing style id resolves to null -> no inline style attribute.
-        expect(html).toContain("<td>noStyle</td>");
+        expect(unboxed(html)).toContain("<td>noStyle</td>");
     });
 
     it("renders bold, italic and underline inline styles", () => {
@@ -953,7 +965,7 @@ describe("renderSpreadsheetToHtml", () => {
     it("omits text-align for an unknown horizontal alignment", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", s: { ht: 9 } }));
         expect(html).not.toContain("text-align");
-        expect(html).toContain("<td>x</td>");
+        expect(unboxed(html)).toContain("<td>x</td>");
     });
 
     it("wraps a cell whose style enables the wrap strategy", () => {
@@ -1009,7 +1021,7 @@ describe("renderSpreadsheetToHtml", () => {
     it("omits vertical-align for an unknown vertical alignment", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", s: { vt: 9 } }));
         // The cell contributes none, so it falls back to the row's.
-        expect(html).toContain("<td>x</td>");
+        expect(unboxed(html)).toContain("<td>x</td>");
         expect(html).toContain(`<tr style="height:24px;vertical-align:bottom">`);
     });
 
@@ -1017,10 +1029,10 @@ describe("renderSpreadsheetToHtml", () => {
         // Univer leaves a cell at the bottom of its row unless it sets `vt`, unlike HTML.
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x" }));
         expect(html).toContain(`<tr style="height:24px;vertical-align:bottom">`);
-        expect(html).toContain("<td>x</td>");
+        expect(unboxed(html)).toContain("<td>x</td>");
 
         const middle = renderSpreadsheetToHtml(singleCellWorkbook({ v: "x", s: { vt: 2 } }));
-        expect(middle).toContain(`<td style="vertical-align:middle">x</td>`);
+        expect(unboxed(middle)).toContain(`<td style="vertical-align:middle">x</td>`);
     });
 
     it("renders borders on all four sides with the correct Univer widths and styles", () => {
@@ -1165,8 +1177,8 @@ describe("renderSpreadsheetToHtml", () => {
         expect(html).toContain("color:#ff0000");
         expect(html).toContain("byId");
         // null style id and empty style object -> no styling of their own.
-        expect(html).toContain(`<td style="overflow:hidden">nulled</td>`);
-        expect(html).toContain("<td>emptyStyle</td>");
+        expect(unboxed(html)).toContain("<td>nulled</td>");
+        expect(unboxed(html)).toContain("<td>emptyStyle</td>");
     });
 
     it("skips hidden rows and hidden columns", () => {
@@ -1227,6 +1239,37 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(input);
         expect(html).toContain('<col style="width:200px">');
         expect(html).toContain('<tr style="height:50px;vertical-align:bottom">');
+    });
+
+    it("takes a self-sizing row's height from the height Univer measured for it", () => {
+        const html = renderSpreadsheetToHtml(JSON.stringify({
+            version: 1,
+            workbook: {
+                sheetOrder: ["s1"],
+                styles: {},
+                sheets: {
+                    s1: {
+                        id: "s1",
+                        name: "Sheet1",
+                        hidden: 0,
+                        mergeData: [],
+                        cellData: { "0": { "0": { v: "a" } }, "1": { "0": { v: "b" } }, "2": { "0": { v: "c" } }, "3": { "0": { v: "d" } } },
+                        rowData: {
+                            // Measured with no `ia`, and measured while explicitly self-sizing.
+                            "0": { ah: 34 },
+                            "1": { ah: 40, h: 20, ia: 1 },
+                            // Sized by hand, so the measurement is ignored even when both are there.
+                            "2": { ah: 24, h: 99, ia: 0 },
+                            "3": { h: 55, ia: 0 }
+                        },
+                        columnData: {}
+                    }
+                }
+            }
+        }));
+
+        const heights = [...html.matchAll(/<tr style="height:([\d.]+)px/g)].map((match) => Number(match[1]));
+        expect(heights).toEqual([34, 40, 99, 55]);
     });
 
     it("falls back to default column width and row height when absent", () => {
@@ -1292,29 +1335,29 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(input);
         // Column 1 between A and C has no cell -> empty <td>.
         expect(html).toContain("<td></td>");
-        expect(html).toContain("<td>C</td>");
+        expect(unboxed(html)).toContain("<td>C</td>");
         // A may run across the empty column, so its text carries the room it has.
-        expect(html).toContain(`<td><span style="display:inline-block;width:calc(100% + 88px);overflow:hidden;margin-right:-88px">A</span></td>`);
+        expect(html).toContain(`<td style="padding:0px 2px 2px 2px"><span style="display:block;overflow:hidden;max-height:22px;width:calc(100% + 88px);margin-right:-88px">A</span></td>`);
     });
 
     it("renders numeric cell values", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }));
-        expect(html).toContain(">42</td>");
+        expect(unboxed(html)).toContain(">42</td>");
     });
 
     it("aligns a cell by its value type when it sets no alignment of its own", () => {
         // Univer right-aligns numbers and centers booleans; text keeps the table default.
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 }))).toContain(`<td style="text-align:right;overflow:hidden">`);
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: true, t: 3 }))).toContain(`<td style="text-align:center;overflow:hidden">`);
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: "A", t: 1 }))).toContain("<td>A</td>");
+        expect(unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2 })))).toContain(`<td style="text-align:right">`);
+        expect(unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: true, t: 3 })))).toContain(`<td style="text-align:center">`);
+        expect(unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: "A", t: 1 })))).toContain("<td>A</td>");
 
         // A number formatted and styled by the workbook still gets the fallback alignment.
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { bl: 1 } })))
-            .toContain(`<td style="text-align:right;font-weight:bold;overflow:hidden">`);
+        expect(unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { bl: 1 } }))))
+            .toContain(`<td style="text-align:right;font-weight:bold">`);
 
         // An explicit alignment wins over the fallback.
-        expect(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { ht: HorizontalAlign.LEFT } })))
-            .toContain(`<td style="text-align:left;overflow:hidden">`);
+        expect(unboxed(renderSpreadsheetToHtml(singleCellWorkbook({ v: 42, t: 2, s: { ht: HorizontalAlign.LEFT } }))))
+            .toContain(`<td style="text-align:left">`);
     });
 
     it("emits colspan only for a purely horizontal merge", () => {
@@ -1373,7 +1416,7 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(
             singleCellWorkbook({ v: 1234.5, t: 2, s: { n: { pattern: "#,##0.00" } } })
         );
-        expect(html).toContain(">1,234.50</td>");
+        expect(unboxed(html)).toContain(">1,234.50</td>");
         expect(html).not.toContain("1234.5<");
     });
 
@@ -1473,7 +1516,7 @@ describe("renderSpreadsheetToHtml", () => {
         const html = renderSpreadsheetToHtml(
             singleCellWorkbook({ v: "n/a", t: 1, s: { n: { pattern: "#,##0.00" } } })
         );
-        expect(html).toContain("<td>n/a</td>");
+        expect(unboxed(html)).toContain("<td>n/a</td>");
     });
 
     it("falls back to the raw value for an invalid pattern instead of throwing", () => {
@@ -1487,7 +1530,7 @@ describe("renderSpreadsheetToHtml", () => {
 
     it("renders an unformatted number when no pattern is set", () => {
         const html = renderSpreadsheetToHtml(singleCellWorkbook({ v: 1234.5, t: 2 }));
-        expect(html).toContain(">1234.5</td>");
+        expect(unboxed(html)).toContain(">1234.5</td>");
     });
 
     it("marks the table with show-gridlines when the sheet has gridlines enabled", () => {

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -640,6 +640,13 @@ function cellShownAt(col: number, neighbours: RowNeighbours): ICellData | undefi
 }
 
 /**
+ * A cell's text is laid out on the font's own leading, as the editor lays it out. The page around it
+ * sets a line height for prose, which is taller than a spreadsheet row expects and pushes the text
+ * out of the bottom of a box measured from the row.
+ */
+const CELL_LINE_HEIGHT = "line-height:normal";
+
+/**
  * Wraps a cell's text in the box that fixes its size. An HTML row grows to whatever it holds, while
  * a spreadsheet row is exactly as tall as it says and clips what does not fit, so without this the
  * grid drifts from the geometry the sheet declares and every absolutely placed image drifts with
@@ -656,6 +663,7 @@ function cellBox(html: string, bound: SpillBound | null, height: number): string
         if (bound.before) parts.push(`margin-left:${px(-bound.before)}px`);
         if (bound.after) parts.push(`margin-right:${px(-bound.after)}px`);
     }
+    parts.push(CELL_LINE_HEIGHT);
     return `<span style="${parts.join(";")}">${html}</span>`;
 }
 
@@ -693,6 +701,7 @@ function turnedBox(html: string, height: number, style: IStyleData | null): stri
         `justify-content:${turnedJustify(style)}`
     ];
     if (height > 0) parts.push(`height:${px(height)}px`);
+    parts.push(CELL_LINE_HEIGHT);
     return `<span style="${parts.join(";")}">${html}</span>`;
 }
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -757,19 +757,26 @@ function cellPadding(style: IStyleData | null): Required<IPaddingData> {
 }
 
 /**
- * The merges that say something about how far a sheet reaches. One spanning the whole width or
- * height of the grid was applied to entire rows or columns, which is a formatting gesture rather
- * than a statement that the sheet runs to the last column Excel has, so it is left out and clamped
- * into the content instead.
+ * The merges that say something about how far a sheet reaches. One applied to entire rows or columns
+ * is a formatting gesture rather than a statement that the sheet runs that far, so it is left out
+ * and clamped into the content instead.
+ *
+ * Across, that gesture is recognised by the sheet declaring every column Excel has: a banner merged
+ * by hand stops well short of that, and keeps widening the grid as any other merge does. Down, the
+ * same test is not available, because a sheet's row count is capped at the rows it uses rather than
+ * carried over from the file, so a merge reaching the last declared row is taken as the gesture.
  */
 function boundingMerges(mergeData: IRange[], sheet: IWorksheetData): IRange[] {
-    const lastColumn = (sheet.columnCount ?? 0) - 1;
+    const columnCount = sheet.columnCount ?? 0;
     const lastRow = (sheet.rowCount ?? 0) - 1;
 
     return mergeData.filter((range) =>
-        !(lastColumn > 0 && range.startColumn === 0 && range.endColumn >= lastColumn)
+        !(columnCount >= EXCEL_COLUMN_COUNT && range.startColumn === 0 && range.endColumn >= columnCount - 1)
         && !(lastRow > 0 && range.startRow === 0 && range.endRow >= lastRow));
 }
+
+/** The columns an Excel sheet has, which only a sheet formatted across all of them declares. */
+const EXCEL_COLUMN_COUNT = 16384;
 
 /**
  * Whether a cell holds something the grid has to reach, which is what it is bounded by. A formula

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -15,6 +15,8 @@ import { format as formatNumfmt, formatColor as formatNumfmtColor } from "numfmt
 import {
     BorderStyle,
     type CellDocumentSegment,
+    DEFAULT_CELL_PADDING,
+    type IPaddingData,
     type CellMatrix,
     CellValueType,
     computeBounds,
@@ -29,6 +31,7 @@ import {
     type IColumnData,
     isFiniteNumber,
     type IRange,
+    type IRowData,
     type ISheetDrawing,
     type IStyleData,
     type ITextRotation,
@@ -213,29 +216,49 @@ function extendBoundsForImages(sheet: IWorksheetData, maxRow: number, maxCol: nu
     }
     if (bottomPx <= 0 && rightPx <= 0) return { maxRow, maxCol };
 
+    const defaultHeight = sheet.defaultRowHeight ?? 24;
+    const defaultWidth = sheet.defaultColumnWidth ?? 88;
     return {
-        maxRow: Math.max(maxRow, trackIndexAtPx(bottomPx, sheet.defaultRowHeight ?? 24, sheet.rowCount, (i) => sheet.rowData?.[i])),
-        maxCol: Math.max(maxCol, trackIndexAtPx(rightPx, sheet.defaultColumnWidth ?? 88, sheet.columnCount, (i) => sheet.columnData?.[i]))
+        maxRow: Math.max(maxRow, trackIndexAtPx(bottomPx, sheet.rowCount, (i) => {
+            const meta = sheet.rowData?.[i];
+            return meta?.hd ? 0 : rowHeight(meta, defaultHeight);
+        })),
+        maxCol: Math.max(maxCol, trackIndexAtPx(rightPx, sheet.columnCount, (i) => {
+            const meta = sheet.columnData?.[i];
+            return meta?.hd ? 0 : (isFiniteNumber(meta?.w) ? meta.w : defaultWidth);
+        }))
     };
 }
 
 /**
- * Returns the 0-based index of the last row/column needed to reach `targetPx` from the sheet
- * origin, walking the per-track sizes (`h`/`w`, hidden tracks contributing 0) and falling back to
- * `defaultSize`. Bounded by `count` (or a large cap) so a zero/degenerate size can't loop forever.
+ * A row's rendered height. Univer keeps the height it measured for a self-sizing row in `ah` and
+ * uses that unless the row was sized by hand (`ia === 0`), where `h` wins (`getRowHeight` in
+ * `@univerjs/core`). Reading only `h` leaves a self-sizing row at the sheet default, which shortens
+ * the grid and pulls the floating images, placed in the editor's coordinates, out of line with it.
  */
-function trackIndexAtPx(targetPx: number, defaultSize: number, count: number | undefined, meta: (index: number) => { hd?: number; h?: number; w?: number } | undefined): number {
-    if (targetPx <= 0 || defaultSize <= 0) return 0;
+function rowHeight(meta: IRowData | undefined, defaultHeight: number): number {
+    const measured = meta?.ah;
+    if ((meta?.ia == null || meta.ia === 1) && isFiniteNumber(measured)) return measured;
+
+    const height = meta?.h;
+    return isFiniteNumber(height) ? height : defaultHeight;
+}
+
+/**
+ * Returns the 0-based index of the last row/column needed to reach `targetPx` from the sheet
+ * origin, walking the per-track sizes. Bounded by `count` (or a large cap) so a degenerate size
+ * can't loop forever, and an axis whose tracks all measure zero extends by nothing at all.
+ */
+function trackIndexAtPx(targetPx: number, count: number | undefined, size: (index: number) => number): number {
+    if (targetPx <= 0) return 0;
     const cap = isFiniteNumber(count) && count > 0 ? count : 100000;
     let cumulative = 0;
     let index = 0;
     while (cumulative < targetPx && index < cap) {
-        const track = meta(index);
-        const size = track?.h ?? track?.w;
-        cumulative += track?.hd ? 0 : (isFiniteNumber(size) ? size : defaultSize);
+        cumulative += size(index);
         index++;
     }
-    return index - 1;
+    return cumulative > 0 ? index - 1 : 0;
 }
 
 // #endregion
@@ -280,12 +303,16 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
     lines.push("</colgroup>");
 
     const defaultHeight = sheet.defaultRowHeight ?? 24;
+    const heights: number[] = [];
+    for (let row = minRow; row <= maxRow; row++) {
+        heights[row] = rowData[row]?.hd ? 0 : rowHeight(rowData[row], defaultHeight);
+    }
 
     for (let row = minRow; row <= maxRow; row++) {
         const rowMeta = rowData[row];
         if (rowMeta?.hd) continue;
 
-        const height = isFiniteNumber(rowMeta?.h) ? rowMeta.h : defaultHeight;
+        const height = heights[row];
         // Univer leaves a cell at the bottom of its row unless it sets `vt`, while HTML centres it.
         // The row carries that default because a `td` inherits `vertical-align`, so a cell that
         // sets its own still wins.
@@ -302,10 +329,15 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
             const cell = cellData[row]?.[col];
             const cellStyle = mergeAwareStyle(resolveCellStyle(cell?.s, styles), mergeInfo, row, col, cellData, styles);
             const bound = spillBound(cell, cellStyle, col, mergeInfo, neighbours);
+            const padding = cellPadding(cellStyle);
+            const boxHeight = spannedHeight(heights, row, mergeInfo?.endRow ?? row)
+                - padding.t - padding.b - collapsedBorderHeight(cellStyle);
             const declarations = [buildCssText(cellStyle, cell)];
-            if (bound && !bound.before && !bound.after) declarations.push("overflow:hidden");
+            if (hasContent(cell)) {
+                declarations.push(`padding:${px(padding.t)}px ${px(padding.r)}px ${px(padding.b)}px ${px(padding.l)}px`);
+            }
             const cssText = declarations.filter(Boolean).join(";");
-            const value = spill(rotate(formatCellValue(cell, cellStyle), cellStyle?.tr), bound)
+            const value = cellBox(rotate(formatCellValue(cell, cellStyle), cellStyle?.tr), bound, boxHeight)
                 + (cell ? renderCellImages(cell) : "");
 
             const attrs: string[] = [];
@@ -510,8 +542,9 @@ interface SpillBound {
  * The room a cell's text has before it reaches a cell that shows something. A spreadsheet runs text
  * across the empty cells beside it and cuts it at the first occupied one, and keeps a number, a
  * boolean or a cell set to CLIP inside its own edges (the overflow check in
- * `@univerjs/engine-render`, and `WrapStrategy` in `@univerjs/core`). Returns `null` when nothing
- * stops the text, which is what the stylesheets already do by letting a cell spill.
+ * `@univerjs/engine-render`, and `WrapStrategy` in `@univerjs/core`). Text that nothing stops is
+ * given the room to the edge of the sheet, since the box that carries it clips both axes at once
+ * and so always needs a width. Returns `null` only when there is nothing to bound.
  */
 function spillBound(
     cell: ICellData | undefined,
@@ -534,7 +567,6 @@ function spillBound(
         ? null
         : spillRoom(merge?.endColumn ?? col, 1, neighbours);
 
-    if (!before?.stopped && !after?.stopped) return null;
     return { before: before?.width ?? 0, after: after?.width ?? 0 };
 }
 
@@ -566,17 +598,53 @@ function cellShownAt(col: number, neighbours: RowNeighbours): ICellData | undefi
 }
 
 /**
- * Widens a cell's text box by the room it has on either side and clips it there, so the text runs
- * across the empty cells beside it and stops at the one holding a value. The negative margins
- * cancel the extra width, leaving the table's own geometry untouched.
+ * Wraps a cell's text in the box that fixes its size. An HTML row grows to whatever it holds, while
+ * a spreadsheet row is exactly as tall as it says and clips what does not fit, so without this the
+ * grid drifts from the geometry the sheet declares and every absolutely placed image drifts with
+ * it. The box also carries the room the text has to run sideways, widened by it and clipped there,
+ * with the negative margins cancelling the extra width so the table's own layout is untouched.
  */
-function spill(html: string, bound: SpillBound | null): string {
-    if (!html || !bound || (!bound.before && !bound.after)) return html;
+function cellBox(html: string, bound: SpillBound | null, height: number): string {
+    if (!html) return html;
 
-    const parts = ["display:inline-block", `width:calc(100% + ${px(bound.before + bound.after)}px)`, "overflow:hidden"];
-    if (bound.before) parts.push(`margin-left:${px(-bound.before)}px`);
-    if (bound.after) parts.push(`margin-right:${px(-bound.after)}px`);
+    const parts = ["display:block", "overflow:hidden"];
+    if (height > 0) parts.push(`max-height:${px(height)}px`);
+    if (bound && (bound.before || bound.after)) {
+        parts.push(`width:calc(100% + ${px(bound.before + bound.after)}px)`);
+        if (bound.before) parts.push(`margin-left:${px(-bound.before)}px`);
+        if (bound.after) parts.push(`margin-right:${px(-bound.after)}px`);
+    }
     return `<span style="${parts.join(";")}">${html}</span>`;
+}
+
+/** The height a cell covers, summing the rows a `rowspan` reaches across. */
+function spannedHeight(heights: number[], from: number, to: number): number {
+    let total = 0;
+    for (let row = from; row <= to; row++) total += heights[row] ?? 0;
+    return total;
+}
+
+/**
+ * The height a cell's own borders take from its row. Under `border-collapse` a border is shared
+ * with the cell across it, so each side keeps half, and the sheet's row heights count the gridline
+ * as drawn inside the row rather than added to it.
+ */
+function collapsedBorderHeight(style: IStyleData | null): number {
+    const half = (border: IBorderStyleData | null | undefined) =>
+        (!border || border.s === BorderStyle.NONE ? 0 : Number.parseFloat(borderStyleToWidth(border.s)) / 2);
+    return half(style?.bd?.t) + half(style?.bd?.b);
+}
+
+/** The padding a cell is laid out with, which the box has to leave room for inside the row. */
+function cellPadding(style: IStyleData | null): Required<IPaddingData> {
+    const padding = style?.pd;
+    const side = (value: number | undefined, fallback: number) => (isFiniteNumber(value) ? value : fallback);
+    return {
+        t: side(padding?.t, DEFAULT_CELL_PADDING.t),
+        r: side(padding?.r, DEFAULT_CELL_PADDING.r),
+        b: side(padding?.b, DEFAULT_CELL_PADDING.b),
+        l: side(padding?.l, DEFAULT_CELL_PADDING.l)
+    };
 }
 
 /** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */
@@ -730,15 +798,19 @@ function rotate(html: string, rotation: ITextRotation | null | undefined): strin
  * counter-clockwise and CSS turns clockwise, so the sign flips.
  */
 function rotationCss(rotation: ITextRotation | null | undefined): string | null {
+    // `vertical-align` keeps the turned text off the line box's baseline, whose descender gap
+    // would otherwise add height the row has to absorb.
+    const ROTATED = "display:inline-block;vertical-align:top";
+
     if (!rotation) return null;
     // Stacked text: upright characters reading downwards.
-    if (rotation.v) return "display:inline-block;writing-mode:vertical-rl;text-orientation:upright";
+    if (rotation.v) return `${ROTATED};writing-mode:vertical-rl;text-orientation:upright`;
 
     const angle = isFiniteNumber(rotation.a) ? rotation.a : 0;
     if (angle === 0) return null;
-    if (angle === 90) return "display:inline-block;writing-mode:vertical-rl;transform:rotate(180deg)";
-    if (angle === -90) return "display:inline-block;writing-mode:vertical-rl";
-    return `display:inline-block;transform:rotate(${px(-angle)}deg)`;
+    if (angle === 90) return `${ROTATED};writing-mode:vertical-rl;transform:rotate(180deg)`;
+    if (angle === -90) return `${ROTATED};writing-mode:vertical-rl`;
+    return `${ROTATED};transform:rotate(${px(-angle)}deg)`;
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -301,7 +301,7 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
     // cover any floating image that reaches past the data, so the grid encloses it as the editor does.
     // A merge widens it as before, except one applied to entire rows or columns, which would
     // pull the sheet back out to the far edge of the grid.
-    const bounds = computeBounds(cellData, boundingMerges(mergeData, sheet), holdsSomething)
+    const bounds = computeBounds(cellData, boundingMerges(mergeData, sheet), (cell) => holdsSomething(cell, styles))
         ?? computeBounds(cellData, mergeData);
     const { maxRow, maxCol } = extendBoundsForImages(sheet, bounds?.maxRow ?? -1, bounds?.maxCol ?? -1, images);
     if (maxRow < 0 || maxCol < 0) {
@@ -571,7 +571,7 @@ interface RowNeighbours {
     defaultWidth: number;
 }
 
-/** How far a cell's text may run past its own edges, in px on each side. */
+/** How far a cell's text can run past its own edges, in px on each side. */
 interface SpillBound {
     before: number;
     after: number;
@@ -772,11 +772,17 @@ function boundingMerges(mergeData: IRange[], sheet: IWorksheetData): IRange[] {
 }
 
 /**
- * Whether a cell holds something of its own, which is what the rendered grid is bounded by. A
- * formula counts even when its result is blank, since the cell is part of the sheet's data.
+ * Whether a cell holds something the grid has to reach, which is what it is bounded by. A formula
+ * counts even when its result is blank, since the cell is part of the sheet's data, and so does a
+ * border: an empty bordered cell is a drawn box, a form or a table outline someone means to keep.
+ * A fill does not, because it comes from colouring whole rows, which would carry the grid out to
+ * the far edge for a band nobody reads.
  */
-function holdsSomething(cell: ICellData): boolean {
-    return Boolean(cell.f) || hasContent(cell);
+function holdsSomething(cell: ICellData, styles: Record<string, IStyleData | null>): boolean {
+    if (cell.f || hasContent(cell)) return true;
+
+    const borders = resolveCellStyle(cell.s, styles)?.bd;
+    return Boolean(borders && (borders.t?.s || borders.r?.s || borders.b?.s || borders.l?.s));
 }
 
 /** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -609,6 +609,14 @@ function spillBound(
         ? null
         : spillRoom(merge?.endColumn ?? col, 1, neighbours);
 
+    // Centred text has to stay centred on its own cell, so the room it is given is the same on
+    // both sides: growing one side further would carry the middle of the text away from the
+    // middle of the cell, which is where the editor keeps it.
+    if (align === HorizontalAlign.CENTER) {
+        const room = Math.min(before?.width ?? 0, after?.width ?? 0);
+        return { before: room, after: room };
+    }
+
     return { before: before?.width ?? 0, after: after?.width ?? 0 };
 }
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -291,7 +291,7 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
         // sets its own still wins.
         lines.push(`<tr style="height:${height}px;vertical-align:bottom">`);
 
-        const neighbours: RowNeighbours = { row, minCol, maxCol, cellData, columnData, mergeMap };
+        const neighbours: RowNeighbours = { row, minCol, maxCol, cellData, columnData, mergeMap, defaultWidth };
 
         for (let col = minCol; col <= maxCol; col++) {
             if (columnData[col]?.hd) continue;
@@ -301,10 +301,11 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
 
             const cell = cellData[row]?.[col];
             const cellStyle = mergeAwareStyle(resolveCellStyle(cell?.s, styles), mergeInfo, row, col, cellData, styles);
+            const bound = spillBound(cell, cellStyle, col, mergeInfo, neighbours);
             const declarations = [buildCssText(cellStyle, cell)];
-            if (clipsOverflow(cell, cellStyle, col, mergeInfo, neighbours)) declarations.push("overflow:hidden");
+            if (bound && !bound.before && !bound.after) declarations.push("overflow:hidden");
             const cssText = declarations.filter(Boolean).join(";");
-            const value = rotate(formatCellValue(cell, cellStyle), cellStyle?.tr)
+            const value = spill(rotate(formatCellValue(cell, cellStyle), cellStyle?.tr), bound)
                 + (cell ? renderCellImages(cell) : "");
 
             const attrs: string[] = [];
@@ -496,52 +497,86 @@ interface RowNeighbours {
     cellData: CellMatrix;
     columnData: Record<number, IColumnData>;
     mergeMap: Map<string, MergeInfo>;
+    defaultWidth: number;
+}
+
+/** How far a cell's text may run past its own edges, in px on each side. */
+interface SpillBound {
+    before: number;
+    after: number;
 }
 
 /**
- * Whether a cell has to clip its text at its own edge. A spreadsheet spills text into a
- * neighbouring cell only while that neighbour is empty, and never spills a number or a boolean
- * (the overflow check in `@univerjs/engine-render`). The stylesheets let every cell spill, so
- * without this a long value is drawn over the value beside it. The spill direction follows the
- * alignment, and a wrapped cell never spills to begin with.
+ * The room a cell's text has before it reaches a cell that shows something. A spreadsheet runs text
+ * across the empty cells beside it and cuts it at the first occupied one, and keeps a number, a
+ * boolean or a cell set to CLIP inside its own edges (the overflow check in
+ * `@univerjs/engine-render`, and `WrapStrategy` in `@univerjs/core`). Returns `null` when nothing
+ * stops the text, which is what the stylesheets already do by letting a cell spill.
  */
-function clipsOverflow(
+function spillBound(
     cell: ICellData | undefined,
     style: IStyleData | null,
     col: number,
     merge: MergeOrigin | undefined,
     neighbours: RowNeighbours
-): boolean {
-    if (!hasContent(cell) || style?.tb === WrapStrategy.WRAP) return false;
-    if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN) return true;
-
-    // Rightwards, a merged cell starts looking past the last column its own range covers.
-    const before = () => neighbourHasContent(col, -1, neighbours);
-    const after = () => neighbourHasContent(merge?.endColumn ?? col, 1, neighbours);
-    switch (style?.ht) {
-        case HorizontalAlign.RIGHT: return before();
-        case HorizontalAlign.CENTER: return before() || after();
-        default: return after();
+): SpillBound | null {
+    if (!hasContent(cell) || style?.tb === WrapStrategy.WRAP) return null;
+    if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN || style?.tb === WrapStrategy.CLIP) {
+        return { before: 0, after: 0 };
     }
+
+    // Text runs the way its alignment points; rightwards a merged cell starts past its own range.
+    const align = style?.ht;
+    const before = align === HorizontalAlign.RIGHT || align === HorizontalAlign.CENTER
+        ? spillRoom(col, -1, neighbours)
+        : null;
+    const after = align === HorizontalAlign.RIGHT
+        ? null
+        : spillRoom(merge?.endColumn ?? col, 1, neighbours);
+
+    if (!before?.stopped && !after?.stopped) return null;
+    return { before: before?.width ?? 0, after: after?.width ?? 0 };
 }
 
 /**
- * Whether the cell rendered beside `from` shows anything. Adjacency follows the rendered row, not
- * the cell matrix: hidden columns are stepped over because nothing of them reaches the page, and a
- * column a merge covers reports that range's anchor, whose text is what fills the space there.
+ * The rendered width beside `from`, and whether a cell showing something is what ended it. The walk
+ * follows the rendered row: a hidden column takes up no width because nothing of it reaches the
+ * page, and a column a merge covers shows that range's anchor.
  */
-function neighbourHasContent(from: number, step: -1 | 1, neighbours: RowNeighbours): boolean {
-    const { row, minCol, maxCol, cellData, columnData, mergeMap } = neighbours;
+function spillRoom(from: number, step: -1 | 1, neighbours: RowNeighbours): { width: number; stopped: boolean } {
+    const { minCol, maxCol, columnData, defaultWidth } = neighbours;
 
+    let width = 0;
     for (let col = from + step; col >= minCol && col <= maxCol; col += step) {
         if (columnData[col]?.hd) continue;
+        if (hasContent(cellShownAt(col, neighbours))) return { width, stopped: true };
 
-        const info = mergeMap.get(cellKey(row, col));
-        return hasContent(info?.kind === "member"
-            ? cellData[info.anchorRow]?.[info.anchorColumn]
-            : cellData[row]?.[col]);
+        const columnWidth = columnData[col]?.w;
+        width += isFiniteNumber(columnWidth) ? columnWidth : defaultWidth;
     }
-    return false;
+    return { width, stopped: false };
+}
+
+/** The cell filling `col` in this row: a column a merge covers shows the range's anchor. */
+function cellShownAt(col: number, neighbours: RowNeighbours): ICellData | undefined {
+    const { row, cellData, mergeMap } = neighbours;
+
+    const info = mergeMap.get(cellKey(row, col));
+    return info?.kind === "member" ? cellData[info.anchorRow]?.[info.anchorColumn] : cellData[row]?.[col];
+}
+
+/**
+ * Widens a cell's text box by the room it has on either side and clips it there, so the text runs
+ * across the empty cells beside it and stops at the one holding a value. The negative margins
+ * cancel the extra width, leaving the table's own geometry untouched.
+ */
+function spill(html: string, bound: SpillBound | null): string {
+    if (!html || !bound || (!bound.before && !bound.after)) return html;
+
+    const parts = ["display:inline-block", `width:calc(100% + ${px(bound.before + bound.after)}px)`, "overflow:hidden"];
+    if (bound.before) parts.push(`margin-left:${px(-bound.before)}px`);
+    if (bound.after) parts.push(`margin-right:${px(-bound.after)}px`);
+    return `<span style="${parts.join(";")}">${html}</span>`;
 }
 
 /** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -368,7 +368,8 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
             const bound = spillBound(cell, cellStyle, col, mergeInfo, neighbours);
             const padding = cellPadding(cellStyle);
             const boxHeight = spannedHeight(heights, row, mergeInfo?.endRow ?? row)
-                - padding.t - padding.b - collapsedBorderHeight(cellStyle);
+                - padding.t - padding.b
+                - collapsedBorderHeight(cellStyle, row, mergeInfo?.endRow ?? row, col, rowData, cellData, styles);
             const declarations = [buildCssText(cellStyle, cell)];
             if (hasContent(cell)) {
                 declarations.push(`padding:${px(padding.t)}px ${px(padding.r)}px ${px(padding.b)}px ${px(padding.l)}px`);
@@ -734,14 +735,35 @@ function spannedHeight(heights: number[], from: number, to: number): number {
 }
 
 /**
- * The height a cell's own borders take from its row. Under `border-collapse` a border is shared
- * with the cell across it, so each side keeps half, and the sheet's row heights count the gridline
- * as drawn inside the row rather than added to it.
+ * The height a cell's borders take from its row. Under `border-collapse` an edge is shared with the
+ * cell across it and the wider of the two borders wins, so a cell with none of its own still gives
+ * up half an edge to a bordered neighbour. Reading only the cell's own borders leaves a cell that
+ * fills its row exactly, which a turned one does, a border's half taller than the row it sits in.
  */
-function collapsedBorderHeight(style: IStyleData | null): number {
-    const half = (border: IBorderStyleData | null | undefined) =>
-        (!border || border.s === BorderStyle.NONE ? 0 : Number.parseFloat(borderStyleToWidth(border.s)) / 2);
-    return half(style?.bd?.t) + half(style?.bd?.b);
+function collapsedBorderHeight(
+    style: IStyleData | null,
+    row: number,
+    endRow: number,
+    col: number,
+    rowData: Record<number, IRowData>,
+    cellData: CellMatrix,
+    styles: Record<string, IStyleData | null>
+): number {
+    const width = (border: IBorderStyleData | null | undefined) =>
+        (!border || border.s === BorderStyle.NONE ? 0 : Number.parseFloat(borderStyleToWidth(border.s)));
+
+    const above = resolveCellStyle(cellData[renderedRow(row, -1, rowData)]?.[col]?.s, styles);
+    const below = resolveCellStyle(cellData[renderedRow(endRow, 1, rowData)]?.[col]?.s, styles);
+
+    return (Math.max(width(style?.bd?.t), width(above?.bd?.b))
+        + Math.max(width(style?.bd?.b), width(below?.bd?.t))) / 2;
+}
+
+/** The row an edge is shared with: the nearest one that is drawn, since a hidden row draws nothing. */
+function renderedRow(from: number, step: -1 | 1, rowData: Record<number, IRowData>): number {
+    let row = from + step;
+    while (row >= 0 && rowData[row]?.hd) row += step;
+    return row;
 }
 
 /** The padding a cell is laid out with, which the box has to leave room for inside the row. */

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -325,8 +325,11 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
     lines.push(buildTableTag(sheet, totalWidth));
 
     lines.push("<colgroup>");
-    for (const width of colWidths) {
-        lines.push(`<col style="width:${px(width)}px">`);
+    for (let index = 0; index < colWidths.length;) {
+        let span = 1;
+        while (index + span < colWidths.length && colWidths[index + span] === colWidths[index]) span++;
+        lines.push(`<col${span > 1 ? ` span="${span}"` : ""} style="width:${px(colWidths[index])}px">`);
+        index += span;
     }
     lines.push("</colgroup>");
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -602,23 +602,20 @@ function spillBound(
     }
 
     // Text runs the way its alignment points; rightwards a merged cell starts past its own range.
-    const align = style?.ht;
-    const before = align === HorizontalAlign.RIGHT || align === HorizontalAlign.CENTER
-        ? spillRoom(col, -1, neighbours)
-        : null;
-    const after = align === HorizontalAlign.RIGHT
-        ? null
-        : spillRoom(merge?.endColumn ?? col, 1, neighbours);
+    const leftwards = () => spillRoom(col, -1, neighbours).width;
+    const rightwards = () => spillRoom(merge?.endColumn ?? col, 1, neighbours).width;
 
     // Centred text has to stay centred on its own cell, so the room it is given is the same on
     // both sides: growing one side further would carry the middle of the text away from the
     // middle of the cell, which is where the editor keeps it.
-    if (align === HorizontalAlign.CENTER) {
-        const room = Math.min(before?.width ?? 0, after?.width ?? 0);
+    if (style?.ht === HorizontalAlign.CENTER) {
+        const room = Math.min(leftwards(), rightwards());
         return { before: room, after: room };
     }
 
-    return { before: before?.width ?? 0, after: after?.width ?? 0 };
+    return style?.ht === HorizontalAlign.RIGHT
+        ? { before: leftwards(), after: 0 }
+        : { before: 0, after: rightwards() };
 }
 
 /**
@@ -688,10 +685,8 @@ function isTurned(rotation: ITextRotation | null | undefined): boolean {
  * the cell's own alignments already place.
  */
 function rotatesByTransform(rotation: ITextRotation | null | undefined): boolean {
-    if (!rotation || rotation.v) return false;
-
-    const angle = isFiniteNumber(rotation.a) ? rotation.a : 0;
-    return angle !== 0 && angle !== 90 && angle !== -90;
+    if (!rotation || rotation.v || !isFiniteNumber(rotation.a)) return false;
+    return rotation.a !== 0 && rotation.a !== 90 && rotation.a !== -90;
 }
 
 /**
@@ -730,7 +725,7 @@ function turnedJustify(style: IStyleData | null): string {
 /** The height a cell covers, summing the rows a `rowspan` reaches across. */
 function spannedHeight(heights: number[], from: number, to: number): number {
     let total = 0;
-    for (let row = from; row <= to; row++) total += heights[row] ?? 0;
+    for (let row = from; row <= to; row++) total += heights[row];
     return total;
 }
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -32,6 +32,7 @@ import {
     isFiniteNumber,
     type IRange,
     type IRowData,
+    type ISourceRect,
     type ISheetDrawing,
     type IStyleData,
     type ITextRotation,
@@ -87,6 +88,8 @@ interface PlacedImage {
     height: number;
     /** CSS `transform` value for rotation/flip, or "" when the image is upright and unflipped. */
     transform: string;
+    /** How far the image runs past each edge of the box, when only part of it is shown. */
+    crop: Required<ISourceRect> | null;
 }
 
 /**
@@ -110,10 +113,20 @@ function placeFloatingImages(sheet: IWorksheetData, drawings: ISheetDrawing[]): 
             top: toFinite(drawing.transform.top) - headerHeight,
             width: toFinite(drawing.transform.width),
             height: toFinite(drawing.transform.height),
-            transform: cssTransform(drawing.transform)
+            transform: cssTransform(drawing.transform),
+            crop: cropInsets(drawing.srcRect)
         });
     }
     return placed;
+}
+
+/** A drawing's crop insets, or `null` when the whole image is shown. */
+function cropInsets(srcRect: ISourceRect | null | undefined): Required<ISourceRect> | null {
+    if (!srcRect) return null;
+
+    const side = (value: number | undefined) => (isFiniteNumber(value) ? value : 0);
+    const insets = { left: side(srcRect.left), top: side(srcRect.top), right: side(srcRect.right), bottom: side(srcRect.bottom) };
+    return insets.left || insets.top || insets.right || insets.bottom ? insets : null;
 }
 
 /**
@@ -146,8 +159,23 @@ function wrapWithFloatingImages(tableHtml: string, images: PlacedImage[]): strin
     for (const image of images) {
         maxBottom = Math.max(maxBottom, image.top + image.height);
         const transform = image.transform ? `;transform:${image.transform}` : "";
+        const box = `position:absolute;left:${px(image.left)}px;top:${px(image.top)}px`
+            + `;width:${px(image.width)}px;height:${px(image.height)}px${transform}`;
+        const src = escapeHtml(image.src);
+
+        if (!image.crop) {
+            tags.push(`<img class="spreadsheet-floating-image" style="${box}" src="${src}" alt="">`);
+            continue;
+        }
+
+        // A cropped drawing keeps the box as its window and holds the whole image inside it,
+        // enlarged by the insets and pulled back by them, which is how the editor draws it.
+        const { left, top, right, bottom } = image.crop;
         tags.push(
-            `<img class="spreadsheet-floating-image" style="position:absolute;left:${px(image.left)}px;top:${px(image.top)}px;width:${px(image.width)}px;height:${px(image.height)}px${transform}" src="${escapeHtml(image.src)}" alt="">`
+            `<span class="spreadsheet-floating-image" style="${box};display:block;overflow:hidden">`
+            + `<img style="position:absolute;left:${px(-left)}px;top:${px(-top)}px`
+            + `;width:${px(image.width + left + right)}px;height:${px(image.height + top + bottom)}px" src="${src}" alt="">`
+            + `</span>`
         );
     }
 

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -764,7 +764,8 @@ function cellPadding(style: IStyleData | null): Required<IPaddingData> {
  * Across, that gesture is recognised by the sheet declaring every column Excel has: a banner merged
  * by hand stops well short of that, and keeps widening the grid as any other merge does. Down, the
  * same test is not available, because a sheet's row count is capped at the rows it uses rather than
- * carried over from the file, so a merge reaching the last declared row is taken as the gesture.
+ * carried over from the file. So a merge is taken as the gesture there when it reaches the last
+ * declared row *and* covers at least the rows every sheet starts with, which no one merges by hand.
  */
 function boundingMerges(mergeData: IRange[], sheet: IWorksheetData): IRange[] {
     const columnCount = sheet.columnCount ?? 0;
@@ -772,8 +773,11 @@ function boundingMerges(mergeData: IRange[], sheet: IWorksheetData): IRange[] {
 
     return mergeData.filter((range) =>
         !(columnCount >= EXCEL_COLUMN_COUNT && range.startColumn === 0 && range.endColumn >= columnCount - 1)
-        && !(lastRow > 0 && range.startRow === 0 && range.endRow >= lastRow));
+        && !(range.startRow === 0 && range.endRow >= lastRow && range.endRow - range.startRow + 1 >= DEFAULT_ROW_COUNT));
 }
+
+/** The rows a sheet starts with, which both importers floor at and the editor creates. */
+const DEFAULT_ROW_COUNT = 1000;
 
 /** The columns an Excel sheet has, which only a sheet formatted across all of them declares. */
 const EXCEL_COLUMN_COUNT = 16384;

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -337,8 +337,10 @@ function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | 
                 declarations.push(`padding:${px(padding.t)}px ${px(padding.r)}px ${px(padding.b)}px ${px(padding.l)}px`);
             }
             const cssText = declarations.filter(Boolean).join(";");
-            const value = cellBox(rotate(formatCellValue(cell, cellStyle), cellStyle?.tr), bound, boxHeight)
-                + (cell ? renderCellImages(cell) : "");
+            const text = rotate(formatCellValue(cell, cellStyle), cellStyle);
+            const value = (isTurned(cellStyle?.tr)
+                ? turnedBox(text, boxHeight, cellStyle)
+                : cellBox(text, bound, boxHeight)) + (cell ? renderCellImages(cell) : "");
 
             const attrs: string[] = [];
             // Cells with a background fill carry `has-fill` so the stylesheet can suppress
@@ -554,7 +556,10 @@ function spillBound(
     neighbours: RowNeighbours
 ): SpillBound | null {
     if (!hasContent(cell) || style?.tb === WrapStrategy.WRAP) return null;
-    if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN || style?.tb === WrapStrategy.CLIP) {
+
+    // Turned text stays in its own cell, as do a number, a boolean and a cell set to CLIP.
+    if (cell?.t === CellValueType.NUMBER || cell?.t === CellValueType.BOOLEAN
+        || style?.tb === WrapStrategy.CLIP || isTurned(style?.tr)) {
         return { before: 0, after: 0 };
     }
 
@@ -615,6 +620,56 @@ function cellBox(html: string, bound: SpillBound | null, height: number): string
         if (bound.after) parts.push(`margin-right:${px(-bound.after)}px`);
     }
     return `<span style="${parts.join(";")}">${html}</span>`;
+}
+
+/** Whether a cell's text is turned at all, in any of the ways Univer can turn it. */
+function isTurned(rotation: ITextRotation | null | undefined): boolean {
+    if (!rotation) return false;
+    return Boolean(rotation.v) || (isFiniteNumber(rotation.a) && rotation.a !== 0);
+}
+
+/**
+ * Whether a rotation is painted by a transform rather than laid out, which is every angle other
+ * than a quarter turn. Only those hang from a cell edge; a quarter turn is a writing mode, which
+ * the cell's own alignments already place.
+ */
+function rotatesByTransform(rotation: ITextRotation | null | undefined): boolean {
+    if (!rotation || rotation.v) return false;
+
+    const angle = isFiniteNumber(rotation.a) ? rotation.a : 0;
+    return angle !== 0 && angle !== 90 && angle !== -90;
+}
+
+/**
+ * The box a turned cell's text sits in. It fills the cell rather than hugging the text, so what it
+ * clips is the cell itself: a box only as tall as the text's own line would cut a band across the
+ * turn and drop everything above and below it. Filling the cell takes the placement away from the
+ * cell's alignments, so the box carries them itself.
+ */
+function turnedBox(html: string, height: number, style: IStyleData | null): string {
+    if (!html) return html;
+
+    const parts = [
+        "display:flex",
+        "overflow:hidden",
+        `align-items:${turnedAlign(style?.vt)}`,
+        `justify-content:${turnedJustify(style)}`
+    ];
+    if (height > 0) parts.push(`height:${px(height)}px`);
+    return `<span style="${parts.join(";")}">${html}</span>`;
+}
+
+/** Where a turned cell puts its text down the cell, following the cell's vertical alignment. */
+function turnedAlign(verticalAlign: number | null | undefined): string {
+    if (verticalAlign === VerticalAlign.MIDDLE) return "center";
+    return verticalAlign === VerticalAlign.TOP ? "flex-start" : "flex-end";
+}
+
+/** Where it puts it across the cell: the cell's own alignment when it states one, else the side the turn is anchored to. */
+function turnedJustify(style: IStyleData | null): string {
+    const align = style?.ht ?? (tiltAnchor(style) === "right" ? HorizontalAlign.RIGHT : HorizontalAlign.LEFT);
+    if (align === HorizontalAlign.CENTER) return "center";
+    return align === HorizontalAlign.RIGHT ? "flex-end" : "flex-start";
 }
 
 /** The height a cell covers, summing the rows a `rowspan` reaches across. */
@@ -784,20 +839,21 @@ function formatCellValue(cell: ICellData | undefined, style: IStyleData | null):
  * the `td` itself, which would take the background and borders with it, and images anchored in the
  * cell stay upright as they do in the editor.
  */
-function rotate(html: string, rotation: ITextRotation | null | undefined): string {
+function rotate(html: string, style: IStyleData | null): string {
     if (!html) return html;
 
-    const css = rotationCss(rotation);
+    const css = rotationCss(style?.tr, style?.vt);
     return css ? `<span style="${css}">${html}</span>` : html;
 }
 
 /**
- * The CSS for Univer's text rotation. A quarter turn and stacked text become a vertical writing
- * mode, which gives the text a real vertical box the row grows to fit; any other angle falls back
- * to a transform, which turns the glyphs without reserving room for them. Excel measures the angle
- * counter-clockwise and CSS turns clockwise, so the sign flips.
+ * The CSS for Univer's text rotation. Univer measures the angle the way CSS turns, clockwise from
+ * the horizontal, so a negative angle lifts the text and a positive one drops it. A quarter turn
+ * and stacked text become a vertical writing mode, which gives the text a real vertical box the row
+ * grows to fit; any other angle falls back to a transform, which turns the glyphs without reserving
+ * room for them.
  */
-function rotationCss(rotation: ITextRotation | null | undefined): string | null {
+function rotationCss(rotation: ITextRotation | null | undefined, verticalAlign: number | null | undefined): string | null {
     // `vertical-align` keeps the turned text off the line box's baseline, whose descender gap
     // would otherwise add height the row has to absorb.
     const ROTATED = "display:inline-block;vertical-align:top";
@@ -808,9 +864,35 @@ function rotationCss(rotation: ITextRotation | null | undefined): string | null 
 
     const angle = isFiniteNumber(rotation.a) ? rotation.a : 0;
     if (angle === 0) return null;
-    if (angle === 90) return `${ROTATED};writing-mode:vertical-rl;transform:rotate(180deg)`;
-    if (angle === -90) return `${ROTATED};writing-mode:vertical-rl`;
-    return `${ROTATED};transform:rotate(${px(-angle)}deg)`;
+    if (angle === -90) return `${ROTATED};writing-mode:vertical-rl;transform:rotate(180deg)`;
+    if (angle === 90) return `${ROTATED};writing-mode:vertical-rl`;
+
+    // A middle-aligned cell turns its text about the centre, which leaves the shape centred.
+    if (verticalAlign === VerticalAlign.MIDDLE) return `${ROTATED};transform:rotate(${px(angle)}deg)`;
+
+    // Otherwise the text hangs from the cell edge it is aligned to, turning about the end of the
+    // string that meets it: lifting text meets the bottom with its start and the top with its end.
+    // Turning about that corner swings the text's own line height past it, so the shift takes that
+    // back; `lh` is the line height itself, which keeps the correction right at any font size.
+    const swing = Math.round(Math.sin(Math.abs(angle) * (Math.PI / 180)) * 1000) / 1000;
+    const fromTop = verticalAlign === VerticalAlign.TOP;
+    const lifts = angle < 0;
+    const origin = `${lifts === fromTop ? "right" : "left"} ${fromTop ? "top" : "bottom"}`;
+    return `${ROTATED};transform:translateX(calc(1lh * ${lifts === fromTop ? -swing : swing})) rotate(${px(angle)}deg)`
+        + `;transform-origin:${origin}`;
+}
+
+/**
+ * The side of its cell turned text is anchored to, or `null` when the cell has no turned text. The
+ * string meets the cell edge it is aligned to with one of its ends, and which end that is flips
+ * between an alignment to the top and one to the bottom or the middle.
+ */
+function tiltAnchor(style: IStyleData | null): "left" | "right" | null {
+    const rotation = style?.tr;
+    if (!rotatesByTransform(rotation) || !isFiniteNumber(rotation?.a)) return null;
+
+    const lifts = rotation.a < 0;
+    return lifts === (style?.vt === VerticalAlign.TOP) ? "right" : "left";
 }
 
 /**

--- a/packages/commons/src/lib/spreadsheet/render_to_html.ts
+++ b/packages/commons/src/lib/spreadsheet/render_to_html.ts
@@ -294,9 +294,15 @@ function trackIndexAtPx(targetPx: number, count: number | undefined, size: (inde
 function renderSheet(sheet: IWorksheetData, styles: Record<string, IStyleData | null>, images: PlacedImage[]): string {
     const { cellData, mergeData = [], columnData = {}, rowData = {} } = sheet;
 
-    // Determine the actual bounds (only cells with data), then extend them to cover any floating
-    // images that reach past the data so the grid encloses them like the editor does.
-    const bounds = computeBounds(cellData, mergeData);
+    // A sheet often carries formatting far past its data: a fill applied to whole rows leaves tens
+    // of thousands of empty cells, each of which would become a `td` the browser has to lay out for
+    // a band it draws as one rectangle. The grid is bounded by the cells that hold something, and
+    // falls back to every cell for a sheet that is nothing but formatting. Then it is extended to
+    // cover any floating image that reaches past the data, so the grid encloses it as the editor does.
+    // A merge widens it as before, except one applied to entire rows or columns, which would
+    // pull the sheet back out to the far edge of the grid.
+    const bounds = computeBounds(cellData, boundingMerges(mergeData, sheet), holdsSomething)
+        ?? computeBounds(cellData, mergeData);
     const { maxRow, maxCol } = extendBoundsForImages(sheet, bounds?.maxRow ?? -1, bounds?.maxCol ?? -1, images);
     if (maxRow < 0 || maxCol < 0) {
         return "<p>Empty sheet.</p>";
@@ -731,6 +737,29 @@ function cellPadding(style: IStyleData | null): Required<IPaddingData> {
         b: side(padding?.b, DEFAULT_CELL_PADDING.b),
         l: side(padding?.l, DEFAULT_CELL_PADDING.l)
     };
+}
+
+/**
+ * The merges that say something about how far a sheet reaches. One spanning the whole width or
+ * height of the grid was applied to entire rows or columns, which is a formatting gesture rather
+ * than a statement that the sheet runs to the last column Excel has, so it is left out and clamped
+ * into the content instead.
+ */
+function boundingMerges(mergeData: IRange[], sheet: IWorksheetData): IRange[] {
+    const lastColumn = (sheet.columnCount ?? 0) - 1;
+    const lastRow = (sheet.rowCount ?? 0) - 1;
+
+    return mergeData.filter((range) =>
+        !(lastColumn > 0 && range.startColumn === 0 && range.endColumn >= lastColumn)
+        && !(lastRow > 0 && range.startRow === 0 && range.endRow >= lastRow));
+}
+
+/**
+ * Whether a cell holds something of its own, which is what the rendered grid is bounded by. A
+ * formula counts even when its result is blank, since the cell is part of the sheet's data.
+ */
+function holdsSomething(cell: ICellData): boolean {
+    return Boolean(cell.f) || hasContent(cell);
 }
 
 /** Whether a cell shows anything. A cell carrying only a style is empty, as it is in the editor. */

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -149,7 +149,19 @@ export interface IStyleData {
     tr?: ITextRotation | null;
     bd?: IBorderData | null;
     n?: INumberFormat | null;
+    pd?: IPaddingData | null;
 }
+
+/** Cell padding in px. Univer leaves out the sides it does not set; see `DEFAULT_CELL_PADDING`. */
+export interface IPaddingData {
+    t?: number;
+    r?: number;
+    b?: number;
+    l?: number;
+}
+
+/** The padding Univer lays a cell out with when its style names none. */
+export const DEFAULT_CELL_PADDING = { t: 0, r: 2, b: 2, l: 2 };
 
 export interface INumberFormat {
     pattern?: string | null;
@@ -190,6 +202,10 @@ export interface IRange {
 export interface IRowData {
     h?: number;
     hd?: number;
+    /** Height Univer measured for a row that sizes itself to its content. */
+    ah?: number;
+    /** Whether the row sizes itself to its content. Absent counts as yes. */
+    ia?: number;
 }
 
 export interface IColumnData {

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -107,6 +107,19 @@ export interface ISheetDrawing {
     transform?: IDrawingTransform | null;
     /** Cell-anchored extent (top-left/bottom-right), used by the XLSX emitter's two-cell anchor. */
     sheetTransform?: ISheetDrawingAnchor | null;
+    /** How much of the image is cropped away, in px of the drawing's own box on each side. */
+    srcRect?: ISourceRect | null;
+}
+
+/**
+ * A drawing's crop. Univer draws the whole image enlarged by these insets and offset by them, with
+ * the drawing's box as the window onto it, so each value is how far past that edge the image runs.
+ */
+export interface ISourceRect {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
 }
 
 export interface ISheetDrawingAnchor {

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -474,10 +474,15 @@ export interface Bounds {
 }
 
 /**
- * Computes the inclusive bounding rectangle of all populated cells, extended to cover
- * any merged ranges. Returns `null` when there are no cells and no merges (empty sheet).
+ * Computes the inclusive bounding rectangle of all populated cells, extended to cover any merged
+ * ranges. Returns `null` when there are no cells and no merges (empty sheet). Pass `counts` to
+ * bound the rectangle by a subset of the cells, such as only the ones holding something.
  */
-export function computeBounds(cellData: CellMatrix, mergeData: IRange[] = []): Bounds | null {
+export function computeBounds(
+    cellData: CellMatrix,
+    mergeData: IRange[] = [],
+    counts?: (cell: ICellData) => boolean
+): Bounds | null {
     let minRow = Infinity;
     let maxRow = -Infinity;
     let minCol = Infinity;
@@ -488,6 +493,8 @@ export function computeBounds(cellData: CellMatrix, mergeData: IRange[] = []): B
         const cols = cellData[row];
         for (const colStr of Object.keys(cols)) {
             const col = Number(colStr);
+            if (counts && !counts(cols[col])) continue;
+
             if (minRow > row) minRow = row;
             if (maxRow < row) maxRow = row;
             if (minCol > col) minCol = col;

--- a/packages/commons/src/lib/spreadsheet/workbook_model.ts
+++ b/packages/commons/src/lib/spreadsheet/workbook_model.ts
@@ -225,7 +225,12 @@ export const enum VerticalAlign {
     BOTTOM = 3
 }
 
+// Wrap strategies (from UniversJS). OVERFLOW runs long text across the empty cells beside it,
+// CLIP cuts it at the cell edge, and WRAP breaks it inside the cell.
 export const enum WrapStrategy {
+    UNSPECIFIED = 0,
+    OVERFLOW = 1,
+    CLIP = 2,
     WRAP = 3
 }
 

--- a/packages/trilium-e2e/src/note_types/spreadsheet.spec.ts
+++ b/packages/trilium-e2e/src/note_types/spreadsheet.spec.ts
@@ -28,7 +28,8 @@ const WORKBOOK = {
                     "0": { ah: 30 },
                     "1": { h: 40 },
                     "2": { h: 24 },
-                    "3": { h: 24 }
+                    "3": { h: 24 },
+                    "4": { h: 60 }
                 },
                 columnData: { "0": { w: 90 }, "1": { w: 90 } },
                 cellData: {
@@ -39,6 +40,11 @@ const WORKBOOK = {
                     "1": {
                         "0": { v: "turned a quarter turn", t: 1, s: { tr: { a: 90 } } },
                         "1": { v: "stacked", t: 1, s: { tr: { a: 0, v: 1 } } }
+                    },
+                    // A transform paints outside its layout box but must not move the row.
+                    "4": {
+                        "0": { v: "tilted up", t: 1, s: { tr: { a: 45 } } },
+                        "1": { v: "tilted down", t: 1, s: { tr: { a: -45 } } }
                     },
                     "2": {
                         "0": { v: "bordered", t: 1, s: { bd: { t: { s: 1 }, b: { s: 1 } } } },
@@ -74,7 +80,7 @@ test("prints the grid at the row heights the sheet declares", async ({ page, con
             }));
         });
 
-        expect(rows.length).toBe(4);
+        expect(rows.length).toBe(5);
 
         let expectedTop = 0;
         for (const [index, row] of rows.entries()) {

--- a/packages/trilium-e2e/src/note_types/spreadsheet.spec.ts
+++ b/packages/trilium-e2e/src/note_types/spreadsheet.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+
+import App from "../support/app";
+
+/**
+ * A sheet whose every row would outgrow the height it declares if the renderer let it: text that
+ * wraps, text turned a quarter turn, and cells carrying borders. The printed grid has to stay at
+ * the declared heights, because a floating image is placed in those coordinates and drifts away
+ * from the cells as soon as they do not hold.
+ */
+const WORKBOOK = {
+    version: 1,
+    workbook: {
+        sheetOrder: ["s1"],
+        styles: {},
+        sheets: {
+            s1: {
+                id: "s1",
+                name: "Sheet1",
+                hidden: 0,
+                // Gridlines are drawn by the stylesheets, not the emitter, and their width differs
+                // between print and the share view, so they are left off to keep this about the
+                // geometry the emitter itself states.
+                showGridlines: 0,
+                mergeData: [],
+                rowData: {
+                    // A row Univer measured for itself, which is stored as `ah` rather than `h`.
+                    "0": { ah: 30 },
+                    "1": { h: 40 },
+                    "2": { h: 24 },
+                    "3": { h: 24 }
+                },
+                columnData: { "0": { w: 90 }, "1": { w: 90 } },
+                cellData: {
+                    "0": {
+                        "0": { v: "wraps onto several lines when it is allowed to", t: 1, s: { tb: 3 } },
+                        "1": { v: "plain", t: 1 }
+                    },
+                    "1": {
+                        "0": { v: "turned a quarter turn", t: 1, s: { tr: { a: 90 } } },
+                        "1": { v: "stacked", t: 1, s: { tr: { a: 0, v: 1 } } }
+                    },
+                    "2": {
+                        "0": { v: "bordered", t: 1, s: { bd: { t: { s: 1 }, b: { s: 1 } } } },
+                        "1": { v: 42, t: 2, s: { bd: { t: { s: 8 }, b: { s: 8 } } } }
+                    },
+                    "3": {
+                        "0": { v: "a long single line that runs past its own column", t: 1 },
+                        "1": { v: "stops it", t: 1 }
+                    }
+                }
+            }
+        }
+    }
+};
+
+test("prints the grid at the row heights the sheet declares", async ({ page, context }) => {
+    const app = new App(page, context);
+    await app.goto();
+
+    const noteId = await createSpreadsheet(app, JSON.stringify(WORKBOOK));
+
+    try {
+        await app.goto({ url: `/?print=#root/${noteId}` });
+        await page.waitForSelector(".spreadsheet-table");
+
+        const rows = await page.evaluate(() => {
+            const table = document.querySelector(".spreadsheet-table");
+            const base = table?.getBoundingClientRect().top ?? 0;
+            return [...(table?.querySelectorAll("tr") ?? [])].map((row) => ({
+                declared: Number.parseFloat((row as HTMLElement).style.height),
+                top: row.getBoundingClientRect().top - base,
+                rendered: row.getBoundingClientRect().height
+            }));
+        });
+
+        expect(rows.length).toBe(4);
+
+        let expectedTop = 0;
+        for (const [index, row] of rows.entries()) {
+            expect(row.rendered, `row ${index} keeps the height it declares`).toBeCloseTo(row.declared, 0);
+            expect(row.top, `row ${index} starts where the rows above it end`).toBeCloseTo(expectedTop, 0);
+            expectedTop += row.declared;
+        }
+    } finally {
+        await deleteNote(app, noteId);
+    }
+});
+
+/**
+ * Creates a spreadsheet note under the root and returns its id. The request goes from inside the
+ * page so standalone's service worker routes it to the SQLite worker, as `setOption` does.
+ */
+async function createSpreadsheet(app: App, content: string): Promise<string> {
+    const result = await app.page.evaluate(async (body) => {
+        const csrfToken = (window as any).glob.csrfToken;
+        const response = await fetch("/api/notes/root/children?target=into", {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-csrf-token": csrfToken },
+            body: JSON.stringify({
+                title: "Spreadsheet geometry fixture",
+                type: "spreadsheet",
+                mime: "application/json",
+                content: body
+            })
+        });
+        if (!response.ok) return { ok: false, status: response.status, noteId: "" };
+        const created = await response.json();
+        return { ok: true, status: response.status, noteId: created.note.noteId as string };
+    }, content);
+
+    expect(result.ok, `creating the fixture note failed (status=${result.status})`).toBe(true);
+    return result.noteId;
+}
+
+async function deleteNote(app: App, noteId: string): Promise<void> {
+    await app.page.evaluate(async (id) => {
+        const csrfToken = (window as any).glob.csrfToken;
+        await fetch(`/api/notes/${id}`, { method: "DELETE", headers: { "x-csrf-token": csrfToken } });
+    }, noteId);
+}


### PR DESCRIPTION
Printing, exporting or sharing a spreadsheet now produces a page that matches what the editor shows.
Rows keep the height they were given, text sits where the editor puts it and stops where the editor
stops it, rotated text points the right way and stays inside its cell, and a cropped image shows the
part that was kept. Sheets that carry formatting far beyond their data, which is what happens when
whole rows are coloured in Excel, no longer take a minute to open.

## Grid geometry

* Bound the rendered grid by the cells that hold something, so formatting carried past the data no
  longer stretches the sheet out to the far edge of the grid.
* Exclude a merge applied to entire rows or columns from widening the grid, since it says nothing
  about how far the sheet reaches.
* Take a self-sizing row's height from the height Univer measured for it (`ah`) rather than leaving
  it at the sheet default, which shortened the grid and pulled the floating images out of line.
* Give every cell a box sized from its row, so a row renders the height it declares instead of
  growing to whatever it holds.
* Emit the cell padding from the workbook's own `pd`, and size the box against it and against the
  cell's share of a collapsed border.
* Lay a cell's text out on the font's own leading instead of the surrounding page's prose line
  height, which was taller than the row and cut the descenders off.
* Collapse consecutive equal column widths into a single `col` element with a `span`.
* Add a Playwright check that each row renders the height it declares and starts where the rows
  above it end.

## Text overflow

* Cut a cell's text at the first occupied cell in the direction its alignment points, measured
  across the rendered row rather than the cell matrix, so hidden columns and merged ranges count as
  what they display.
* Give centred text the same room on both sides, so the middle of the text stays on the middle of
  its cell.
* Keep a number, a boolean and a cell set to CLIP inside its own edges.
* Keep turned text inside its own cell instead of letting it run into a neighbour.

## Rotated text

* Follow the workbook's own sign convention, so a negative angle lifts the text and a positive one
  drops it, for quarter turns as well as tilts.
* Anchor turned text to the cell edge its vertical alignment hangs it from, correcting for the line
  height that turning about that corner would otherwise swing past it.
* Render a quarter turn and stacked text as a vertical writing mode, and any other angle as a
  transform that leaves the row's layout untouched.
* Clip turned text at the cell, in a box that fills the cell rather than one that hugs the text's
  own line.

## Images

* Show a cropped drawing through its box, holding the whole image inside it at the crop's insets,
  which is how the editor draws it.
