### PR TITLE
Preserve reverse proxy subpaths in share link generation

### DIFF
--- a/apps/client/src/services/share_link.spec.ts
+++ b/apps/client/src/services/share_link.spec.ts
@@ -7,6 +7,7 @@ describe("buildShareLink", () => {
 
     afterEach(() => {
         window.glob = originalGlob;
+        history.replaceState({}, "", "/");
     });
 
     function setGlob(patch: Record<string, unknown>) {
@@ -31,9 +32,32 @@ describe("buildShareLink", () => {
         expect(buildShareLink("abc123", null)).toBe("http://localhost:3000/share/abc123");
     });
 
+    it("keeps the browser deployment subpath with or without a trailing slash", () => {
+        setGlob({});
+
+        history.replaceState({}, "", "/trilium");
+        expect(buildShareLink("abc123", null)).toBe("http://localhost:3000/trilium/share/abc123");
+
+        history.replaceState({}, "", "/trilium/");
+        expect(buildShareLink("abc123", null)).toBe("http://localhost:3000/trilium/share/abc123");
+    });
+
     it("resolves an empty shareId (share root) to the /share/ base", () => {
         setGlob({ httpBaseUrl: "http://127.0.0.1:37742" });
         expect(buildShareLink("", undefined)).toBe("http://127.0.0.1:37742/share/");
+    });
+
+    it("keeps the subpath when the sync server is reverse-proxied below the domain root", () => {
+        setGlob({ httpBaseUrl: "http://127.0.0.1:37742" });
+        expect(buildShareLink("abc123", "https://notes.example.com/trilium")).toBe("https://notes.example.com/trilium/share/abc123");
+        expect(buildShareLink("abc123", "https://notes.example.com/trilium/")).toBe("https://notes.example.com/trilium/share/abc123");
+        expect(buildShareLink("abc123", "https://notes.example.com/trilium///")).toBe("https://notes.example.com/trilium/share/abc123");
+        expect(buildShareLink("abc123", "https://notes.example.com/a/b")).toBe("https://notes.example.com/a/b/share/abc123");
+    });
+
+    it("drops a query or fragment carried by the configured sync server address", () => {
+        setGlob({ httpBaseUrl: "http://127.0.0.1:37742" });
+        expect(buildShareLink("abc123", "https://notes.example.com/trilium?x=1#y")).toBe("https://notes.example.com/trilium/share/abc123");
     });
 
     it("percent-encodes a shareId carrying characters that are not path-safe", () => {

--- a/apps/client/src/services/share_link.spec.ts
+++ b/apps/client/src/services/share_link.spec.ts
@@ -49,15 +49,21 @@ describe("buildShareLink", () => {
 
     it("keeps the subpath when the sync server is reverse-proxied below the domain root", () => {
         setGlob({ httpBaseUrl: "http://127.0.0.1:37742" });
-        expect(buildShareLink("abc123", "https://notes.example.com/trilium")).toBe("https://notes.example.com/trilium/share/abc123");
-        expect(buildShareLink("abc123", "https://notes.example.com/trilium/")).toBe("https://notes.example.com/trilium/share/abc123");
-        expect(buildShareLink("abc123", "https://notes.example.com/trilium///")).toBe("https://notes.example.com/trilium/share/abc123");
-        expect(buildShareLink("abc123", "https://notes.example.com/a/b")).toBe("https://notes.example.com/a/b/share/abc123");
+
+        const subpath = "https://notes.example.com/trilium";
+        expect(buildShareLink("abc123", subpath)).toBe(`${subpath}/share/abc123`);
+        expect(buildShareLink("abc123", `${subpath}/`)).toBe(`${subpath}/share/abc123`);
+        expect(buildShareLink("abc123", `${subpath}///`)).toBe(`${subpath}/share/abc123`);
+
+        const nested = "https://notes.example.com/a/b";
+        expect(buildShareLink("abc123", nested)).toBe(`${nested}/share/abc123`);
     });
 
     it("drops a query or fragment carried by the configured sync server address", () => {
         setGlob({ httpBaseUrl: "http://127.0.0.1:37742" });
-        expect(buildShareLink("abc123", "https://notes.example.com/trilium?x=1#y")).toBe("https://notes.example.com/trilium/share/abc123");
+
+        const subpath = "https://notes.example.com/trilium";
+        expect(buildShareLink("abc123", `${subpath}?x=1#y`)).toBe(`${subpath}/share/abc123`);
     });
 
     it("percent-encodes a shareId carrying characters that are not path-safe", () => {

--- a/apps/client/src/services/share_link.ts
+++ b/apps/client/src/services/share_link.ts
@@ -13,12 +13,24 @@ export function buildShareLink(shareId: string, syncServerHost: string | null | 
     const encodedShareId = encodeURIComponent(shareId);
 
     if (syncServerHost) {
-        return new URL(`/share/${encodedShareId}`, syncServerHost).href;
+        return appendSharePath(syncServerHost, encodedShareId);
     }
 
     if (window.glob.httpBaseUrl) {
-        return new URL(`/share/${encodedShareId}`, window.glob.httpBaseUrl).href;
+        return appendSharePath(window.glob.httpBaseUrl, encodedShareId);
     }
 
-    return `${location.protocol}//${location.host}${location.pathname}share/${encodedShareId}`;
+    return appendSharePath(location.href, encodedShareId);
+}
+
+// `new URL("/share/x", base)` cannot stand in here: the leading slash makes the path absolute
+// and drops the base's own path, which an instance reverse-proxied under a subpath needs.
+function appendSharePath(base: string, encodedShareId: string): string {
+    const url = new URL(base);
+
+    url.search = "";
+    url.hash = "";
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/share/${encodedShareId}`;
+
+    return url.href;
 }


### PR DESCRIPTION
Fixes #8791, Fixes #10588
Related to #7078

## Problem

When the sync server uses a subpath (e.g., `https://domain.tld/notes`), desktop-generated share links drop it:

```
https://domain.tld/share/knvU8aJy4dJ7        # desktop (incorrect)
https://domain.tld/notes/share/knvU8aJy4dJ7  # expected (web client)
```

## Cause

Regressed in #7779 (`e937f1b6`). Replacing string concatenation with `new URL('/share/...', syncServerHost)` caused the leading slash to reset the URL path to root, discarding the subpath.

## Changes

- Added `appendSharePath()` to preserve subpaths, normalize trailing slashes, and strip queries/hashes.
- Routed both desktop and browser link generation through `appendSharePath()`. This also fixes a browser bug where missing trailing slashes caused malformed paths (e.g., `/notesshare/x`).

## Tests

Added tests in `share_link.spec.ts` covering:
- Sync server and browser-origin subpaths (with/without trailing slashes).
- Query and hash fragment stripping.

Existing root-domain cases are unchanged and still pass.

## Verification

- **Desktop:** Verified against a subpath reverse-proxy (v0.105.0); copied links retain the subpath and open correctly.
- **Browser:** Verified via unit tests across root and subpath setups.

## Notes

- Preserved tooltip behavior in `note_tree.ts` (`syncServerHost` remains `undefined`).
- No User Guide updates required.
