### PR TITLE
Restore autocomplete for multi-value promoted labels

### DIFF
--- a/apps/client/src/services/attributes.spec.ts
+++ b/apps/client/src/services/attributes.spec.ts
@@ -4,7 +4,17 @@ import { buildNote } from "../test/easy-froca";
 import { allViewTypes } from "../widgets/collections/interface";
 import { getPresentationThemes } from "../widgets/collections/presentation/themes";
 import { MEDIA_PLAY_MODES } from "../widgets/type_widgets/file/media_play_mode";
-import attributeService, { getBuiltinLabelSelectOptions, getBuiltinLabelValueType, isBuiltinAttribute, removeOwnedAttributesByNameOrType, setAttribute, setBooleanWithInheritance, setLabel, setRelation } from "./attributes";
+import attributeService, {
+    getBuiltinLabelSelectOptions,
+    getBuiltinLabelValueType,
+    isBuiltinAttribute,
+    PartialWriteError,
+    removeOwnedAttributesByNameOrType,
+    setAttribute,
+    setBooleanWithInheritance,
+    setLabel,
+    setRelation
+} from "./attributes";
 import froca from "./froca";
 import server from "./server.js";
 
@@ -250,6 +260,74 @@ describe("setLabelValues", () => {
             { attributeId: undefined, type: "label", name: "tags", value: "c" },
             undefined
         );
+    });
+
+    it("reports the confirmed state when a write fails partway", async () => {
+        const note = noteHolding("a");
+        vi.mocked(server.put)
+            .mockResolvedValueOnce({ attributeId: "attr-b" })
+            .mockRejectedValueOnce(new Error("write refused"));
+
+        let error: unknown;
+        try {
+            await attributeService.setLabelValues(note, "tags", [ "a", "b", "c" ]);
+        } catch (e: unknown) {
+            error = e;
+        }
+
+        // The first PUT ("b") succeeds and the second ("c") fails; the error carries the
+        // confirmed state, so the caller keeps diffing against it instead of the set it asked for.
+        expect(error).toBeInstanceOf(PartialWriteError);
+        const partial = error as PartialWriteError;
+        expect(partial.confirmed).toEqual([
+            expect.objectContaining({ attributeId: "attr-0", value: "a" }),
+            { attributeId: "attr-b", value: "b" }
+        ]);
+        expect(partial.message).toBe("write refused");
+    });
+
+    it("reports the confirmed state when a removal fails partway", async () => {
+        const note = noteHolding("a", "b", "c");
+        vi.mocked(server.remove)
+            .mockResolvedValueOnce(undefined)
+            .mockRejectedValueOnce(new Error("remove refused"));
+
+        let error: unknown;
+        try {
+            await attributeService.setLabelValues(note, "tags", [ "a" ]);
+        } catch (e: unknown) {
+            error = e;
+        }
+
+        // The first DELETE ("b") succeeds and the second ("c") fails, so "c" is still held.
+        expect(error).toBeInstanceOf(PartialWriteError);
+        expect((error as PartialWriteError).confirmed).toEqual([
+            expect.objectContaining({ attributeId: "attr-0", value: "a" }),
+            expect.objectContaining({ attributeId: "attr-2", value: "c" })
+        ]);
+    });
+
+    it("reports a duplicated value when the trim fails after a rename", async () => {
+        const note = noteHolding("a", "b", "c");
+        // Writing [a, c] renames "b"'s attribute to "c" first, then trims the original "c".
+        vi.mocked(server.put).mockResolvedValueOnce({ attributeId: "attr-1" });
+        vi.mocked(server.remove).mockRejectedValueOnce(new Error("remove refused"));
+
+        let error: unknown;
+        try {
+            await attributeService.setLabelValues(note, "tags", [ "a", "c" ]);
+        } catch (e: unknown) {
+            error = e;
+        }
+
+        // The rename succeeded and the trim did not, so the note holds "c" twice. Reported as it
+        // is: a later write that drops "c" removes both copies.
+        expect(error).toBeInstanceOf(PartialWriteError);
+        expect((error as PartialWriteError).confirmed).toEqual([
+            expect.objectContaining({ attributeId: "attr-0", value: "a" }),
+            { attributeId: "attr-1", value: "c" },
+            expect.objectContaining({ attributeId: "attr-2", value: "c" })
+        ]);
     });
 
     it("removes the labels the set no longer fills, emptying included", async () => {

--- a/apps/client/src/services/attributes.spec.ts
+++ b/apps/client/src/services/attributes.spec.ts
@@ -230,6 +230,28 @@ describe("setLabelValues", () => {
         );
     });
 
+    it("reuses returned state before the note cache reloads", async () => {
+        const note = noteHolding("a");
+        vi.mocked(server.put).mockResolvedValueOnce({ attributeId: "attr-new" });
+
+        const current = await attributeService.setLabelValues(note, "tags", [ "a", "b" ]);
+        vi.mocked(server.put).mockClear();
+        await attributeService.setLabelValues(
+            note,
+            "tags",
+            [ "a", "b", "c" ],
+            undefined,
+            current
+        );
+
+        expect(server.put).toHaveBeenCalledOnce();
+        expect(server.put).toHaveBeenCalledWith(
+            `notes/${note.noteId}/attribute`,
+            { attributeId: undefined, type: "label", name: "tags", value: "c" },
+            undefined
+        );
+    });
+
     it("removes the labels the set no longer fills, emptying included", async () => {
         const note = noteHolding("a", "b", "c");
 

--- a/apps/client/src/services/attributes.ts
+++ b/apps/client/src/services/attributes.ts
@@ -109,6 +109,11 @@ function removeOwnedRelationByName(note: FNote, relationName: string) {
     return false;
 }
 
+export interface AttributeValueState {
+    attributeId?: string;
+    value: string;
+}
+
 /**
  * Sets the labels of one name on a note to exactly `values`, for a field holding a set of them.
  *
@@ -116,9 +121,17 @@ function removeOwnedRelationByName(note: FNote, relationName: string) {
  * the ones after it rather than deleting and recreating the lot — which keeps their positions, and
  * with them the order the set reads in. Only owned labels are touched: an inherited one belongs to
  * the note it is written on.
+ *
+ * `current` carries returned state across serialized calls that run before the note cache reloads.
  */
-export async function setLabelValues(note: FNote, name: string, values: string[], componentId?: string) {
-    await setAttributeValues(note, "label", name, values, componentId);
+export async function setLabelValues(
+    note: FNote,
+    name: string,
+    values: string[],
+    componentId?: string,
+    current?: readonly AttributeValueState[]
+) {
+    return await setAttributeValues(note, "label", name, values, componentId, current);
 }
 
 /**
@@ -129,25 +142,43 @@ export async function setRelationValues(note: FNote, name: string, values: strin
     await setAttributeValues(note, "relation", name, values, componentId);
 }
 
-async function setAttributeValues(note: FNote, type: "label" | "relation", name: string, values: string[], componentId?: string) {
-    const existing = type === "label" ? note.getOwnedLabels(name) : note.getOwnedRelations(name);
+async function setAttributeValues(
+    note: FNote,
+    type: "label" | "relation",
+    name: string,
+    values: string[],
+    componentId?: string,
+    current?: readonly AttributeValueState[]
+) {
+    const existing = current
+        ?? (type === "label" ? note.getOwnedLabels(name) : note.getOwnedRelations(name));
+    const updated: AttributeValueState[] = [];
 
     for (const [ index, value ] of values.entries()) {
         const attributeId = existing[index]?.attributeId;
         if (existing[index]?.value === value) {
+            updated.push(existing[index]);
             continue;
         }
-        await server.put(
+        const response = await server.put<{ attributeId?: string }>(
             `notes/${note.noteId}/attribute`,
             { attributeId, type, name, value },
             componentId
         );
+        updated.push({ attributeId: response?.attributeId ?? attributeId, value });
     }
 
     // Whatever the new set did not fill is no longer held.
     for (const spare of existing.slice(values.length)) {
-        await server.remove(`notes/${note.noteId}/attributes/${spare.attributeId}`, componentId);
+        if (spare.attributeId) {
+            await server.remove(
+                `notes/${note.noteId}/attributes/${spare.attributeId}`,
+                componentId
+            );
+        }
     }
+
+    return updated;
 }
 
 /**

--- a/apps/client/src/services/attributes.ts
+++ b/apps/client/src/services/attributes.ts
@@ -115,6 +115,26 @@ export interface AttributeValueState {
 }
 
 /**
+ * Thrown when an exact-set write fails. `confirmed` is the state the responses confirmed before
+ * the failed request, so the caller can keep diffing against it instead of a set the server no
+ * longer matches. A failed response does not reveal whether the server applied that request.
+ * `cause` is the error that stopped the write.
+ *
+ * `confirmed` can hold the same value twice: renaming an attribute succeeds and trimming the old
+ * holder of the value then fails. A later write that removes the duplicated value removes every
+ * copy.
+ */
+export class PartialWriteError extends Error {
+    constructor(
+        readonly confirmed: readonly AttributeValueState[],
+        override readonly cause: unknown
+    ) {
+        super(cause instanceof Error ? cause.message : String(cause));
+        this.name = "PartialWriteError";
+    }
+}
+
+/**
  * Sets the labels of one name on a note to exactly `values`, for a field holding a set of them.
  *
  * The labels already there are reused in order, so taking a value out of the middle of a set renames
@@ -123,6 +143,8 @@ export interface AttributeValueState {
  * the note it is written on.
  *
  * `current` carries returned state across serialized calls that run before the note cache reloads.
+ *
+ * Rejects with {@link PartialWriteError} when a request fails partway, carrying what was confirmed.
  */
 export async function setLabelValues(
     note: FNote,
@@ -152,33 +174,40 @@ async function setAttributeValues(
 ) {
     const existing = current
         ?? (type === "label" ? note.getOwnedLabels(name) : note.getOwnedRelations(name));
-    const updated: AttributeValueState[] = [];
+    // Updated after every response, so a write that fails partway can report what was confirmed.
+    const confirmed: AttributeValueState[] = [ ...existing ];
 
-    for (const [ index, value ] of values.entries()) {
-        const attributeId = existing[index]?.attributeId;
-        if (existing[index]?.value === value) {
-            updated.push(existing[index]);
-            continue;
-        }
-        const response = await server.put<{ attributeId?: string }>(
-            `notes/${note.noteId}/attribute`,
-            { attributeId, type, name, value },
-            componentId
-        );
-        updated.push({ attributeId: response?.attributeId ?? attributeId, value });
-    }
-
-    // Whatever the new set did not fill is no longer held.
-    for (const spare of existing.slice(values.length)) {
-        if (spare.attributeId) {
-            await server.remove(
-                `notes/${note.noteId}/attributes/${spare.attributeId}`,
+    try {
+        for (const [ index, value ] of values.entries()) {
+            const attributeId = existing[index]?.attributeId;
+            if (existing[index]?.value === value) {
+                continue;
+            }
+            const response = await server.put<{ attributeId?: string }>(
+                `notes/${note.noteId}/attribute`,
+                { attributeId, type, name, value },
                 componentId
             );
+            confirmed[index] = { attributeId: response?.attributeId ?? attributeId, value };
         }
+
+        // Whatever the new set did not fill is no longer held. The next spare sits at
+        // `values.length` after every splice, the ones before it being gone already.
+        while (confirmed.length > values.length) {
+            const spare = confirmed[values.length];
+            if (spare.attributeId) {
+                await server.remove(
+                    `notes/${note.noteId}/attributes/${spare.attributeId}`,
+                    componentId
+                );
+            }
+            confirmed.splice(values.length, 1);
+        }
+    } catch (e: unknown) {
+        throw new PartialWriteError(confirmed, e);
     }
 
-    return updated;
+    return confirmed;
 }
 
 /**

--- a/apps/client/src/widgets/PromotedAttributes.spec.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.spec.tsx
@@ -226,54 +226,70 @@ describe("PromotedAttributesContent", () => {
         expect(multiInput.current?.values).toEqual([ "alpha", "beta" ]);
     });
 
-    it("keeps quick multi-label commits in order and shows their latest set immediately", async () => {
-        const note = buildNote({ title: "Task", "#label:tags": "promoted,multi,text", "#tags": "alpha" });
+    it("keeps quick multi-label commits in order and shows a set once it is written", async () => {
+        const note = buildNote({
+            title: "Task",
+            "#label:tags": "promoted,multi,text",
+            "#tags": "alpha"
+        });
         let finishFirstWrite: (response: { attributeId: string }) => void = () => {};
         serverPutMock.mockReturnValueOnce(new Promise((resolve) => {
             finishFirstWrite = resolve;
         }));
         mount(note);
 
+        const commit = multiInput.current?.onCommit as (values: string[]) => Promise<void>;
         let firstCommit: Promise<void> | undefined;
         await act(async () => {
-            firstCommit = (multiInput.current?.onCommit as (values: string[]) => Promise<void>)([ "alpha", "beta" ]);
+            firstCommit = commit([ "alpha", "beta" ]);
             await Promise.resolve();
         });
-        expect(multiInput.current?.values).toEqual([ "alpha", "beta" ]);
+        // `values` remains unchanged until `setLabelValues()` resolves.
+        expect(multiInput.current?.values).toEqual([ "alpha" ]);
         expect(serverPutMock).toHaveBeenCalledOnce();
 
         let secondCommit: Promise<void> | undefined;
         await act(async () => {
-            secondCommit = (multiInput.current?.onCommit as (values: string[]) => Promise<void>)([ "alpha", "beta", "gamma" ]);
+            secondCommit = commit([ "alpha", "beta", "gamma" ]);
             await Promise.resolve();
         });
-        expect(multiInput.current?.values).toEqual([ "alpha", "beta", "gamma" ]);
+        // `commitQueue` does not start the second request before the first request resolves.
         expect(serverPutMock).toHaveBeenCalledOnce();
 
         await act(async () => {
             finishFirstWrite({ attributeId: "beta-id" });
             await Promise.all([ firstCommit, secondCommit ]);
         });
+        expect(serverPutMock).toHaveBeenCalledTimes(2);
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta", "gamma" ]);
     });
 
-    it("lets a failed write settle rather than stranding the edits queued behind it", async () => {
-        const note = buildNote({ title: "Task", "#label:tags": "promoted,multi,text", "#tags": "alpha" });
+    it("rebases edits queued after a failed multi-label write", async () => {
+        const note = buildNote({
+            title: "Task",
+            "#label:tags": "promoted,multi,text",
+            "#tags": "alpha"
+        });
         serverPutMock.mockRejectedValueOnce(new Error("write refused"));
         mount(note);
 
         const commit = multiInput.current?.onCommit as (values: string[]) => Promise<void>;
         let failed: Promise<void> | undefined;
+        let following: Promise<void> | undefined;
         await act(async () => {
             failed = commit([ "alpha", "beta" ]);
-            await failed.catch(() => {});
+            following = commit([ "alpha", "beta", "gamma" ]);
+            await Promise.allSettled([ failed, following ]);
         });
         await expect(failed).rejects.toThrow("write refused");
-
-        serverPutMock.mockClear();
-        await act(async () => {
-            await commit([ "alpha", "beta", "gamma" ]);
-        });
-        expect(serverPutMock).toHaveBeenCalled();
+        await expect(following).resolves.toBeUndefined();
+        expect(serverPutMock).toHaveBeenCalledTimes(2);
+        expect(serverPutMock).toHaveBeenLastCalledWith(
+            `notes/${note.noteId}/attribute`,
+            { attributeId: undefined, type: "label", name: "tags", value: "gamma" },
+            "cid"
+        );
+        expect(multiInput.current?.values).toEqual([ "alpha", "gamma" ]);
     });
 
     it("adds a select option to the definition itself, the field offering it from then on", async () => {

--- a/apps/client/src/widgets/PromotedAttributes.spec.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.spec.tsx
@@ -292,6 +292,38 @@ describe("PromotedAttributesContent", () => {
         expect(multiInput.current?.values).toEqual([ "alpha", "gamma" ]);
     });
 
+    it("preserves a value when its removal fails before a queued addition", async () => {
+        const note = buildNote({
+            title: "Task",
+            "#label:tags": "promoted,multi,text",
+            "#tags": "alpha"
+        });
+        hold(note, "label", "tags", "beta");
+        serverRemoveMock.mockRejectedValueOnce(new Error("remove refused"));
+        mount(note);
+
+        const commit = multiInput.current?.onCommit as (values: string[]) => Promise<void>;
+        let failedRemoval: Promise<void> | undefined;
+        let following: Promise<void> | undefined;
+        await act(async () => {
+            failedRemoval = commit([ "alpha" ]);
+            following = commit([ "alpha", "cherry" ]);
+            await Promise.allSettled([ failedRemoval, following ]);
+        });
+        await expect(failedRemoval).rejects.toThrow("remove refused");
+        await expect(following).resolves.toBeUndefined();
+
+        // `setLabelValues()` reuses `acceptedAttributes.current`, so the queued edit writes only
+        // "cherry" — "beta" matches the accepted state and is skipped.
+        expect(serverPutMock).toHaveBeenCalledOnce();
+        expect(serverPutMock).toHaveBeenCalledWith(
+            `notes/${note.noteId}/attribute`,
+            { attributeId: undefined, type: "label", name: "tags", value: "cherry" },
+            "cid"
+        );
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta", "cherry" ]);
+    });
+
     it("adds a select option to the definition itself, the field offering it from then on", async () => {
         const note = buildNote({ title: "Task", "#label:status": "promoted,multi,select,options=Todo;Done" });
         mount(note);
@@ -689,6 +721,18 @@ describe("PromotedAttributesContent rendering", () => {
         expect(serverGetMock).toHaveBeenCalledWith("attribute-values/fresh");
         const suggestFresh = multiInput.current?.source as (query: string) => Promise<string[]>;
         expect(await suggestFresh("")).toEqual([]);
+    });
+
+    it("offers nothing when the suggestion request fails", async () => {
+        serverGetMock.mockRejectedValueOnce(new Error("offline"));
+        await renderCells(note, [ buildCell(note, {
+            name: "tags",
+            definition: { labelType: "text", multiplicity: "multi" },
+            values: []
+        }) ]);
+
+        const suggest = multiInput.current?.source as (query: string) => Promise<string[]>;
+        expect(await suggest("")).toEqual([]);
     });
 
     it("keeps a multi text field's suggestion source attached while its values load", async () => {

--- a/apps/client/src/widgets/PromotedAttributes.spec.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.spec.tsx
@@ -226,6 +226,56 @@ describe("PromotedAttributesContent", () => {
         expect(multiInput.current?.values).toEqual([ "alpha", "beta" ]);
     });
 
+    it("keeps quick multi-label commits in order and shows their latest set immediately", async () => {
+        const note = buildNote({ title: "Task", "#label:tags": "promoted,multi,text", "#tags": "alpha" });
+        let finishFirstWrite: (response: { attributeId: string }) => void = () => {};
+        serverPutMock.mockReturnValueOnce(new Promise((resolve) => {
+            finishFirstWrite = resolve;
+        }));
+        mount(note);
+
+        let firstCommit: Promise<void> | undefined;
+        await act(async () => {
+            firstCommit = (multiInput.current?.onCommit as (values: string[]) => Promise<void>)([ "alpha", "beta" ]);
+            await Promise.resolve();
+        });
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta" ]);
+        expect(serverPutMock).toHaveBeenCalledOnce();
+
+        let secondCommit: Promise<void> | undefined;
+        await act(async () => {
+            secondCommit = (multiInput.current?.onCommit as (values: string[]) => Promise<void>)([ "alpha", "beta", "gamma" ]);
+            await Promise.resolve();
+        });
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta", "gamma" ]);
+        expect(serverPutMock).toHaveBeenCalledOnce();
+
+        await act(async () => {
+            finishFirstWrite({ attributeId: "beta-id" });
+            await Promise.all([ firstCommit, secondCommit ]);
+        });
+    });
+
+    it("lets a failed write settle rather than stranding the edits queued behind it", async () => {
+        const note = buildNote({ title: "Task", "#label:tags": "promoted,multi,text", "#tags": "alpha" });
+        serverPutMock.mockRejectedValueOnce(new Error("write refused"));
+        mount(note);
+
+        const commit = multiInput.current?.onCommit as (values: string[]) => Promise<void>;
+        let failed: Promise<void> | undefined;
+        await act(async () => {
+            failed = commit([ "alpha", "beta" ]);
+            await failed.catch(() => {});
+        });
+        await expect(failed).rejects.toThrow("write refused");
+
+        serverPutMock.mockClear();
+        await act(async () => {
+            await commit([ "alpha", "beta", "gamma" ]);
+        });
+        expect(serverPutMock).toHaveBeenCalled();
+    });
+
     it("adds a select option to the definition itself, the field offering it from then on", async () => {
         const note = buildNote({ title: "Task", "#label:status": "promoted,multi,select,options=Todo;Done" });
         mount(note);
@@ -592,6 +642,58 @@ describe("PromotedAttributesContent rendering", () => {
         await renderCells(note, [ buildCell(note, { name: "fresh", definition: { labelType: "text" }, uniqueId: "fresh" }) ]);
         expect(autocompleteMock).not.toHaveBeenCalled();
     });
+
+    it("hands a field holding several values the names already entered under its own", async () => {
+        serverGetMock.mockResolvedValueOnce([ "Game", "RPG" ]);
+        await renderCells(note, [ buildCell(note, {
+            name: "tags",
+            definition: { labelType: "text", multiplicity: "multi" },
+            values: [ "Game" ]
+        }) ]);
+        expect(serverGetMock).toHaveBeenCalledWith("attribute-values/tags");
+
+        const suggest = multiInput.current?.source as (query: string) => Promise<string[]>;
+        expect(await suggest("")).toEqual([ "Game", "RPG" ]);
+        expect(await suggest(" ga ")).toEqual([ "Game" ]);
+
+        await renderCells(note, [ buildCell(note, {
+            name: "due",
+            definition: { labelType: "date", multiplicity: "multi" },
+            values: [],
+            uniqueId: "due"
+        }) ]);
+        expect(multiInput.current?.source).toBeUndefined();
+
+        await renderCells(note, [ buildCell(note, {
+            name: "fresh",
+            definition: { labelType: "text", multiplicity: "multi" },
+            values: [],
+            uniqueId: "fresh"
+        }) ]);
+        expect(serverGetMock).toHaveBeenCalledWith("attribute-values/fresh");
+        const suggestFresh = multiInput.current?.source as (query: string) => Promise<string[]>;
+        expect(await suggestFresh("")).toEqual([]);
+    });
+
+    it("keeps a multi text field's suggestion source attached while its values load", async () => {
+        let finishLoading: (values: string[]) => void = () => {};
+        serverGetMock.mockReturnValueOnce(new Promise<string[]>((resolve) => {
+            finishLoading = resolve;
+        }));
+
+        await renderCells(note, [ buildCell(note, {
+            name: "tags",
+            definition: { labelType: "text", multiplicity: "multi" },
+            values: []
+        }) ]);
+
+        const loadingSource = multiInput.current?.source as (query: string) => Promise<string[]>;
+        expect(await loadingSource("")).toEqual([]);
+
+        await act(async () => finishLoading([ "Game", "RPG" ]));
+        const loadedSource = multiInput.current?.source as (query: string) => Promise<string[]>;
+        expect(await loadedSource("rp")).toEqual([ "RPG" ]);
+    });
 });
 
 describe("usePromotedAttributeData", () => {
@@ -694,7 +796,8 @@ function buildCell(note: FNote, {
     value = "",
     definition = {},
     attributeId = "valueAttrId",
-    uniqueId = "cell-1"
+    uniqueId = "cell-1",
+    values
 }: {
     name?: string;
     type?: "label" | "relation";
@@ -702,6 +805,7 @@ function buildCell(note: FNote, {
     definition?: DefinitionObject;
     attributeId?: string;
     uniqueId?: string;
+    values?: string[];
 } = {}): CellLike {
     const definitionAttr = new FAttribute(froca, {
         noteId: note.noteId,
@@ -721,7 +825,8 @@ function buildCell(note: FNote, {
         definitionAttr,
         definition: { isPromoted: true, ...definition },
         valueAttr: { attributeId, type, name, value, noteId: note.noteId },
-        valueName: name
+        valueName: name,
+        ...(values && { values })
     };
 }
 

--- a/apps/client/src/widgets/PromotedAttributes.spec.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.spec.tsx
@@ -324,6 +324,44 @@ describe("PromotedAttributesContent", () => {
         expect(multiInput.current?.values).toEqual([ "alpha", "beta", "cherry" ]);
     });
 
+    it("tracks and shows what was confirmed when a write fails partway", async () => {
+        const note = buildNote({
+            title: "Task",
+            "#label:tags": "promoted,multi,text",
+            "#tags": "alpha"
+        });
+        // Writing [alpha, beta, cherry]: the first PUT ("beta") succeeds, the second fails.
+        serverPutMock
+            .mockResolvedValueOnce({ attributeId: "beta-id" })
+            .mockRejectedValueOnce(new Error("write refused"));
+        mount(note);
+
+        const commit = multiInput.current?.onCommit as (values: string[]) => Promise<void>;
+        let failed: Promise<void> | undefined;
+        await act(async () => {
+            failed = commit([ "alpha", "beta", "cherry" ]);
+            await failed.catch(() => {});
+        });
+        await expect(failed).rejects.toThrow("write refused");
+
+        // The chips show what the note now actually holds, not the set that was asked for.
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta" ]);
+
+        // The next edit diffs against that state: "beta" is not written a second time, and the
+        // spare beyond the new set — none here — leaves nothing stranded on the server.
+        serverPutMock.mockClear();
+        await act(async () => {
+            await commit([ "alpha", "beta", "date" ]);
+        });
+        expect(serverPutMock).toHaveBeenCalledOnce();
+        expect(serverPutMock).toHaveBeenCalledWith(
+            `notes/${note.noteId}/attribute`,
+            { attributeId: undefined, type: "label", name: "tags", value: "date" },
+            "cid"
+        );
+        expect(multiInput.current?.values).toEqual([ "alpha", "beta", "date" ]);
+    });
+
     it("adds a select option to the definition itself, the field offering it from then on", async () => {
         const note = buildNote({ title: "Task", "#label:status": "promoted,multi,select,options=Todo;Done" });
         mount(note);

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -1,9 +1,9 @@
 import "./PromotedAttributes.css";
 
-import { DefinitionObject, extractAttributeDefinitionTypeAndName, UpdateAttributeResponse } from "@triliumnext/commons";
+import { DefinitionObject, extractAttributeDefinitionTypeAndName, LabelType, UpdateAttributeResponse } from "@triliumnext/commons";
 import clsx from "clsx";
 import { ComponentChild, TargetedEvent } from "preact";
-import { Dispatch, StateUpdater, useCallback, useEffect, useState } from "preact/hooks";
+import { Dispatch, StateUpdater, useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
 
 import NoteContext from "../components/note_context";
 import FAttribute from "../entities/fattribute";
@@ -294,13 +294,19 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
     const { valueName, definition, definitionAttr, values, uniqueId } = cell;
     const labelType = definition.labelType ?? "text";
     const createOption = useCreateSelectOption(definitionAttr, componentId, setCells);
+    const suggestValues = useAttributeValueSuggestions(valueName, labelType);
+    // Serialize writes so quick successive selections cannot finish out of order.
+    const commitQueue = useRef(Promise.resolve());
 
-    const commit = useCallback(async (edited: string[]) => {
-        await attributes.setLabelValues(note, valueName, edited, componentId);
+    const commit = useCallback((edited: string[]) => {
         // The grid ignores reloads it is itself the source of (see usePromotedAttributeData), so the
-        // set it shows is patched in place, as updateAttribute does for a single value — otherwise
-        // the chips would not follow the value just taken.
+        // set it shows is patched in place, as updateAttribute does for a single value.
         setCells(prev => prev?.map(c => c.uniqueId === uniqueId ? { ...c, values: edited } : c));
+
+        const write = commitQueue.current.then(() => attributes.setLabelValues(note, valueName, edited, componentId));
+        // Continue processing queued edits after a failed write.
+        commitQueue.current = write.catch(() => {});
+        return write;
     }, [ note, valueName, componentId, uniqueId, setCells ]);
 
     return (
@@ -310,6 +316,7 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
                 values={values ?? []}
                 options={definition.selectOptions}
                 onCreateOption={labelType === "select" ? createOption : undefined}
+                source={suggestValues}
                 inputId={inputId}
                 tabIndex={200 + definitionAttr.position}
                 onCommit={commit}
@@ -376,6 +383,35 @@ function MultiRelationInput({ inputId, note, cell, componentId, setCells }: Cell
             />
         </div>
     );
+}
+
+function useAttributeValueSuggestions(name: string, labelType: LabelType) {
+    const [ known, setKnown ] = useState<{ name: string; values: string[] }>();
+
+    useEffect(() => {
+        if (labelType !== "text" || !name) {
+            setKnown(undefined);
+            return;
+        }
+
+        let active = true;
+        server.get<string[]>(`attribute-values/${encodeURIComponent(name)}`).then((values) => {
+            if (active) {
+                setKnown({ name, values });
+            }
+        });
+        return () => {
+            active = false;
+        };
+    }, [ name, labelType ]);
+
+    return useMemo(() => labelType === "text" && name
+        ? async (query: string) => {
+            const term = query.trim().toLowerCase();
+            const values = known?.name === name ? known.values : [];
+            return values.filter((value) => value.toLowerCase().includes(term));
+        }
+        : undefined, [ known, labelType, name ]);
 }
 
 function useTextLabelAutocomplete(inputId: string, valueAttr: Attribute, definition: DefinitionObject, onChangeListener: OnChangeListener) {

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -22,7 +22,7 @@ import NoteContext from "../components/note_context";
 import FAttribute from "../entities/fattribute";
 import FNote from "../entities/fnote";
 import { Attribute } from "../services/attribute_parser";
-import attributes, { type AttributeValueState } from "../services/attributes";
+import attributes, { type AttributeValueState, PartialWriteError } from "../services/attributes";
 import { t } from "../services/i18n";
 import server from "../services/server";
 import { randomString } from "../services/utils";
@@ -310,7 +310,8 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
     const suggestValues = useAttributeValueSuggestions(valueName, labelType);
     const commitQueue = useRef<Promise<void>>(Promise.resolve());
     const acceptedValues = useRef(values ?? []);
-    const acceptedAttributes = useRef<AttributeValueState[]>(note.getOwnedLabels(valueName));
+    const acceptedAttributes =
+        useRef<readonly AttributeValueState[]>(note.getOwnedLabels(valueName));
     const desiredValues = useRef(values ?? []);
     const lastValuesProp = useRef(values);
     const pendingCommits = useRef(0);
@@ -338,19 +339,39 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
                 }
             }
 
-            acceptedAttributes.current = await attributes.setLabelValues(
-                note,
-                valueName,
-                accepted,
-                componentId,
-                acceptedAttributes.current
-            );
-            acceptedValues.current = accepted;
-            // `usePromotedAttributeData()` ignores reloads from `componentId`, so update the cell
-            // only after `setLabelValues()` succeeds.
-            setCells(prev => prev?.map(c =>
-                c.uniqueId === uniqueId ? { ...c, values: accepted } : c));
+            let confirmed: readonly AttributeValueState[];
+            try {
+                confirmed = await attributes.setLabelValues(
+                    note,
+                    valueName,
+                    accepted,
+                    componentId,
+                    acceptedAttributes.current
+                );
+            } catch (e: unknown) {
+                // A write that failed partway did change the note. Track and show what the
+                // responses confirmed, so later diffs run against it — otherwise a value the note
+                // kept could never be removed here, and re-adding one it wrote would duplicate it.
+                if (e instanceof PartialWriteError) {
+                    applyConfirmedState(e.confirmed);
+                }
+                throw e;
+            }
+            applyConfirmedState(confirmed);
         });
+
+        function applyConfirmedState(confirmed: readonly AttributeValueState[]) {
+            acceptedAttributes.current = confirmed;
+            acceptedValues.current = confirmed.map((attr) => attr.value);
+            // The patch below echoes back as the `values` prop. Acknowledging it here keeps the
+            // reset above for genuinely external updates — re-reading froca on an own echo would
+            // replace `confirmed`, whose attribute ids froca only carries after the next sync.
+            lastValuesProp.current = acceptedValues.current;
+            // `usePromotedAttributeData()` ignores reloads from `componentId`, so patch the cell
+            // here — with what was confirmed, which on a partial failure is not what was asked.
+            setCells(prev => prev?.map(c =>
+                c.uniqueId === uniqueId ? { ...c, values: acceptedValues.current } : c));
+        }
         const settled = write.finally(() => {
             pendingCommits.current--;
             if (pendingCommits.current === 0) {

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -357,8 +357,10 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
                 desiredValues.current = acceptedValues.current;
             }
         });
-        // A rejection does not block the next queued edit. `ValuesInput` observes `write` itself.
+        // A rejected `write` does not block the queue. The next edit starts from `acceptedValues`,
+        // so failed additions are not retried and failed removals stay in the accepted set.
         commitQueue.current = settled.catch(() => {});
+        // The un-caught `write`, so the caller can observe a rejection the queue never re-raises.
         return write;
     }, [ note, valueName, componentId, uniqueId, setCells ]);
 
@@ -452,6 +454,8 @@ function useAttributeValueSuggestions(name: string, labelType: LabelType) {
             if (active) {
                 setKnown({ name, values });
             }
+        }).catch(() => {
+            // Suggestions are optional, so ignore a failed `server.get()` request.
         });
         return () => {
             active = false;

--- a/apps/client/src/widgets/PromotedAttributes.tsx
+++ b/apps/client/src/widgets/PromotedAttributes.tsx
@@ -1,15 +1,28 @@
 import "./PromotedAttributes.css";
 
-import { DefinitionObject, extractAttributeDefinitionTypeAndName, LabelType, UpdateAttributeResponse } from "@triliumnext/commons";
+import {
+    DefinitionObject,
+    extractAttributeDefinitionTypeAndName,
+    LabelType,
+    UpdateAttributeResponse
+} from "@triliumnext/commons";
 import clsx from "clsx";
 import { ComponentChild, TargetedEvent } from "preact";
-import { Dispatch, StateUpdater, useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import {
+    Dispatch,
+    StateUpdater,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
+} from "preact/hooks";
 
 import NoteContext from "../components/note_context";
 import FAttribute from "../entities/fattribute";
 import FNote from "../entities/fnote";
 import { Attribute } from "../services/attribute_parser";
-import attributes from "../services/attributes";
+import attributes, { type AttributeValueState } from "../services/attributes";
 import { t } from "../services/i18n";
 import server from "../services/server";
 import { randomString } from "../services/utils";
@@ -295,17 +308,57 @@ function MultiLabelInput({ inputId, note, cell, componentId, setCells }: CellPro
     const labelType = definition.labelType ?? "text";
     const createOption = useCreateSelectOption(definitionAttr, componentId, setCells);
     const suggestValues = useAttributeValueSuggestions(valueName, labelType);
-    // Serialize writes so quick successive selections cannot finish out of order.
-    const commitQueue = useRef(Promise.resolve());
+    const commitQueue = useRef<Promise<void>>(Promise.resolve());
+    const acceptedValues = useRef(values ?? []);
+    const acceptedAttributes = useRef<AttributeValueState[]>(note.getOwnedLabels(valueName));
+    const desiredValues = useRef(values ?? []);
+    const lastValuesProp = useRef(values);
+    const pendingCommits = useRef(0);
+    if (lastValuesProp.current !== values && pendingCommits.current === 0) {
+        lastValuesProp.current = values;
+        acceptedValues.current = values ?? [];
+        acceptedAttributes.current = note.getOwnedLabels(valueName);
+        desiredValues.current = values ?? [];
+    }
 
     const commit = useCallback((edited: string[]) => {
-        // The grid ignores reloads it is itself the source of (see usePromotedAttributeData), so the
-        // set it shows is patched in place, as updateAttribute does for a single value.
-        setCells(prev => prev?.map(c => c.uniqueId === uniqueId ? { ...c, values: edited } : c));
+        const previousDesired = desiredValues.current;
+        const previousSet = new Set(previousDesired);
+        const editedSet = new Set(edited);
+        const added = edited.filter((value) => !previousSet.has(value));
+        const removed = new Set(previousDesired.filter((value) => !editedSet.has(value)));
+        desiredValues.current = edited;
+        pendingCommits.current++;
 
-        const write = commitQueue.current.then(() => attributes.setLabelValues(note, valueName, edited, componentId));
-        // Continue processing queued edits after a failed write.
-        commitQueue.current = write.catch(() => {});
+        const write = commitQueue.current.then(async () => {
+            const accepted = acceptedValues.current.filter((value) => !removed.has(value));
+            for (const value of added) {
+                if (!accepted.includes(value)) {
+                    accepted.push(value);
+                }
+            }
+
+            acceptedAttributes.current = await attributes.setLabelValues(
+                note,
+                valueName,
+                accepted,
+                componentId,
+                acceptedAttributes.current
+            );
+            acceptedValues.current = accepted;
+            // `usePromotedAttributeData()` ignores reloads from `componentId`, so update the cell
+            // only after `setLabelValues()` succeeds.
+            setCells(prev => prev?.map(c =>
+                c.uniqueId === uniqueId ? { ...c, values: accepted } : c));
+        });
+        const settled = write.finally(() => {
+            pendingCommits.current--;
+            if (pendingCommits.current === 0) {
+                desiredValues.current = acceptedValues.current;
+            }
+        });
+        // A rejection does not block the next queued edit. `ValuesInput` observes `write` itself.
+        commitQueue.current = settled.catch(() => {});
         return write;
     }, [ note, valueName, componentId, uniqueId, setCells ]);
 

--- a/apps/client/src/widgets/attribute_widgets/multi_value_input.tsx
+++ b/apps/client/src/widgets/attribute_widgets/multi_value_input.tsx
@@ -19,6 +19,8 @@ interface MultiValueInputProps {
      * them. Left out, the field picks from the options as they stand.
      */
     onCreateOption?(option: string): void | Promise<void>;
+    /** Provides suggestions for free-form values. */
+    source?(query: string): Promise<string[]>;
     /** Set onto the box, so that a host's own label points at the field. */
     inputId?: string;
     /** Set onto the box, for a host placing its fields in a tab order of its own. */
@@ -37,7 +39,7 @@ interface MultiValueInputProps {
  * Shared by the promoted-attribute grid and the table's own cells, so that the same definition is
  * edited the same way wherever the note is opened.
  */
-export default function MultiValueInput({ labelType, values, onCommit, options, onCreateOption, inputId, tabIndex, disabled }: MultiValueInputProps) {
+export default function MultiValueInput({ labelType, values, onCommit, options, onCreateOption, source, inputId, tabIndex, disabled }: MultiValueInputProps) {
     if (labelType === "select" || labelType === "boolean") {
         return (
             <SelectValuesInput
@@ -60,6 +62,7 @@ export default function MultiValueInput({ labelType, values, onCommit, options, 
             labelType={labelType}
             values={values}
             placeholder={t("promoted_attributes.values_placeholder")}
+            source={source}
             inputId={inputId}
             tabIndex={tabIndex}
             disabled={disabled}

--- a/apps/client/src/widgets/attribute_widgets/multi_value_input.tsx
+++ b/apps/client/src/widgets/attribute_widgets/multi_value_input.tsx
@@ -11,7 +11,7 @@ interface MultiValueInputProps {
     /** The values held, in the order they are shown. */
     values: readonly string[];
     /** Receives the values as they now stand, whenever one is taken or dropped. */
-    onCommit(values: string[]): void;
+    onCommit(values: string[]): void | Promise<void>;
     /** The options a `select` holds, from the definition that declared it. Ignored by other types. */
     options?: readonly string[];
     /**
@@ -39,7 +39,17 @@ interface MultiValueInputProps {
  * Shared by the promoted-attribute grid and the table's own cells, so that the same definition is
  * edited the same way wherever the note is opened.
  */
-export default function MultiValueInput({ labelType, values, onCommit, options, onCreateOption, source, inputId, tabIndex, disabled }: MultiValueInputProps) {
+export default function MultiValueInput({
+    labelType,
+    values,
+    onCommit,
+    options,
+    onCreateOption,
+    source,
+    inputId,
+    tabIndex,
+    disabled
+}: MultiValueInputProps) {
     if (labelType === "select" || labelType === "boolean") {
         return (
             <SelectValuesInput

--- a/apps/client/src/widgets/attribute_widgets/select_input.spec.tsx
+++ b/apps/client/src/widgets/attribute_widgets/select_input.spec.tsx
@@ -88,6 +88,123 @@ describe("SelectValuesInput", () => {
         expect(input?.value).toBe("");
     });
 
+    it("builds a second quick pick on the first, before the host has rendered it", async () => {
+        const finish: Array<() => void> = [];
+        const onCommit = vi.fn(() => new Promise<void>((resolve) => finish.push(resolve)));
+        await mount({ options, values: [], onCommit });
+
+        const input = container.querySelector("input");
+        await act(async () => input?.focus());
+        const first = await settleDropdown();
+        await act(async () => (first[0] as HTMLElement | undefined)?.click());
+        expect(onCommit).toHaveBeenCalledWith([ "Todo" ]);
+
+        // The host has not rendered the commit back as `values`. The refreshed list already leaves
+        // the taken value out, and the next pick builds on it instead of the stale prop.
+        const second = await settleDropdown();
+        expect(second.map((item) => item.textContent)).toEqual([ "In progress", "Done" ]);
+        await act(async () => (second[0] as HTMLElement | undefined)?.click());
+        expect(onCommit).toHaveBeenLastCalledWith([ "Todo", "In progress" ]);
+
+        await act(async () => {
+            for (const resolve of finish) {
+                resolve();
+            }
+        });
+    });
+
+    it("restores the accepted values after an async commit fails", async () => {
+        let rejectFirst: (error: Error) => void = () => {};
+        const onCommit = vi.fn()
+            .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => {
+                rejectFirst = reject;
+            }))
+            .mockResolvedValue(undefined);
+        await mount({ options, values: [], onCommit });
+
+        const input = container.querySelector("input");
+        await act(async () => input?.focus());
+        const first = await settleDropdown();
+        await act(async () => (first[0] as HTMLElement | undefined)?.click());
+        expect(onCommit).toHaveBeenCalledWith([ "Todo" ]);
+        await act(async () => rejectFirst(new Error("write refused")));
+
+        // The failed pick is not built upon: the edits follow the prop again, so the next pick
+        // starts from the set the host accepted.
+        const second = await settleDropdown();
+        await act(async () => (second[1] as HTMLElement | undefined)?.click());
+        expect(onCommit).toHaveBeenLastCalledWith([ "In progress" ]);
+    });
+
+    it("offers a failed pick again, even on a list that already refreshed without it", async () => {
+        let rejectFirst: (error: Error) => void = () => {};
+        const onCommit = vi.fn(() => new Promise<void>((_resolve, reject) => {
+            rejectFirst = reject;
+        }));
+        await mount({ options, values: [], onCommit });
+
+        const input = container.querySelector("input");
+        await act(async () => input?.focus());
+        const first = await settleDropdown();
+        await act(async () => (first[0] as HTMLElement | undefined)?.click());
+
+        // The list has already refreshed without the pick when the write fails...
+        expect((await settleDropdown()).map((item) => item.textContent))
+            .toEqual([ "In progress", "Done" ]);
+        await act(async () => rejectFirst(new Error("write refused")));
+
+        // ...so the failure itself has to put the value back on offer.
+        expect((await settleDropdown()).map((item) => item.textContent))
+            .toEqual([ "Todo", "In progress", "Done" ]);
+    });
+
+    it("takes a value only once, however quickly it is picked", async () => {
+        // Between a pick and the list refreshing, the old entries still take clicks.
+        const finish: Array<() => void> = [];
+        const onCommit = vi.fn(() => new Promise<void>((resolve) => finish.push(resolve)));
+        await mount({ options, values: [], onCommit });
+
+        const input = container.querySelector("input");
+        await act(async () => input?.focus());
+        const items = await settleDropdown();
+        await act(async () => {
+            (items[0] as HTMLElement | undefined)?.click();
+            (items[0] as HTMLElement | undefined)?.click();
+        });
+
+        expect(onCommit).toHaveBeenCalledOnce();
+        expect(onCommit).toHaveBeenCalledWith([ "Todo" ]);
+        await act(async () => {
+            for (const resolve of finish) {
+                resolve();
+            }
+        });
+    });
+
+    it("observes an async commit result", async () => {
+        // The test environment swallows unhandled rejections silently, so ownership is asserted
+        // structurally: the field must assimilate what `onCommit` returns, which a fire-and-forget
+        // call would never touch. A rejecting host (the promoted-attribute grid) otherwise leaks
+        // every failed write as an unhandled rejection.
+        let subscribed = 0;
+        const write = {
+            then() {
+                subscribed++;
+                return Promise.resolve();
+            }
+        };
+        const onCommit = vi.fn(() => write as unknown as Promise<void>);
+        await mount({ options, values: [], onCommit });
+
+        const input = container.querySelector("input");
+        await act(async () => input?.focus());
+        const items = await settleDropdown();
+        await act(async () => (items[0] as HTMLElement | undefined)?.click());
+
+        expect(onCommit).toHaveBeenCalledWith([ "Todo" ]);
+        expect(subscribed).toBeGreaterThan(0);
+    });
+
     it("drops the last chip on backspace in an empty box, and leaves a filled one alone", async () => {
         const onCommit = vi.fn();
         await mount({ options, values: [ "Todo", "Done" ], onCommit });

--- a/apps/client/src/widgets/attribute_widgets/select_input.tsx
+++ b/apps/client/src/widgets/attribute_widgets/select_input.tsx
@@ -117,7 +117,7 @@ interface SelectValuesInputProps {
     /** The values held, in the order they are shown. */
     values: readonly string[];
     /** Receives the values as they now stand, whenever one is taken or dropped. */
-    onCommit(values: string[]): void;
+    onCommit(values: string[]): void | Promise<void>;
     /**
      * Adds an option to the definition, for the entry offered on text naming none of them. Left out,
      * the field picks from the options as they stand.
@@ -146,30 +146,74 @@ interface SelectValuesInputProps {
  */
 export function SelectValuesInput({ options, values, onCommit, onCreateOption, renderValue, inputId, tabIndex, placeholder, disabled }: SelectValuesInputProps) {
     const [ filter, setFilter ] = useState("");
+    // Counts local edits. The list refetches when its `source` changes identity, which `values`
+    // alone no longer drives: an edit reaches the prop only once the host accepts it.
+    const [ editRound, setEditRound ] = useState(0);
+    // Tracks edits until they come back as `values`, so a pick made before the host re-renders
+    // builds on the pick before it rather than on the stale prop. The chips still render from
+    // `values`, which is the set the host has accepted.
+    const editedValues = useRef(values);
+    const latestValuesProp = useRef(values);
+    const pendingCommits = useRef(0);
+    if (latestValuesProp.current !== values) {
+        latestValuesProp.current = values;
+        if (pendingCommits.current === 0) {
+            editedValues.current = values;
+        }
+    }
 
     // Taken values leave the list: what is held is shown as a chip, so offering it again would only
-    // invite a duplicate the field cannot show apart from the first.
+    // invite a duplicate the field cannot show apart from the first. Excluded by the edits, not the
+    // prop: `keepOpenOnPick` leaves the list open, so a value just taken must leave it at once.
     const source = useCallback(async (query: string) => selectEntriesFor({
         options,
         filter: query,
-        exclude: values,
+        exclude: editedValues.current,
         canCreate: !!onCreateOption
-    }), [ options, values, onCreateOption ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `values` is read through editedValues
+    }), [ options, values, editRound, onCreateOption ]);
 
     function take(value: string) {
         setFilter("");
-        onCommit([ ...values, value ]);
+        if (editedValues.current.includes(value)) {
+            return;
+        }
+        commit([ ...editedValues.current, value ]);
     }
 
     function drop(value: string) {
-        onCommit(values.filter((held) => held !== value));
+        commit(editedValues.current.filter((held) => held !== value));
+    }
+
+    function commit(edited: string[]) {
+        editedValues.current = edited;
+        setEditRound((round) => round + 1);
+        const result = onCommit(edited);
+        if (!result) {
+            return;
+        }
+
+        // An async host reports a failed write itself; here its settling only says when the edits
+        // may follow the prop again — and gives a rejection its owner.
+        pendingCommits.current++;
+        void Promise.resolve(result).then(settleCommit, settleCommit);
+    }
+
+    function settleCommit() {
+        pendingCommits.current--;
+        if (pendingCommits.current === 0) {
+            editedValues.current = latestValuesProp.current;
+            // The edits changed without a commit, so the refetch is asked for here: a failure has
+            // put a value back on offer, and a list already refreshed would keep hiding it.
+            setEditRound((round) => round + 1);
+        }
     }
 
     function handleKeyDown(e: TargetedKeyboardEvent<HTMLInputElement>) {
         // Backspace on an empty box drops the last chip, the box having nothing of its own to erase.
-        if (e.key === "Backspace" && !e.currentTarget.value && values.length) {
+        if (e.key === "Backspace" && !e.currentTarget.value && editedValues.current.length) {
             e.preventDefault();
-            drop(values[values.length - 1]);
+            drop(editedValues.current[editedValues.current.length - 1]);
         }
     }
 

--- a/apps/client/src/widgets/attribute_widgets/values_input.spec.tsx
+++ b/apps/client/src/widgets/attribute_widgets/values_input.spec.tsx
@@ -33,7 +33,10 @@ describe("ValuesInput", () => {
 
     async function press(input: HTMLInputElement | null, key: string) {
         await act(async () => {
-            input?.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+            input?.dispatchEvent(new KeyboardEvent(
+                "keydown",
+                { key, bubbles: true, cancelable: true }
+            ));
         });
     }
 
@@ -86,6 +89,46 @@ describe("ValuesInput", () => {
         await press(input, "Enter");
         expect(onCommit).not.toHaveBeenCalled();
         expect(input?.value).toBe("");
+    });
+
+    it("keeps newer edits while an earlier async commit updates values", async () => {
+        const finish: Array<() => void> = [];
+        const onCommit = vi.fn(() => new Promise<void>((resolve) => finish.push(resolve)));
+        let input = await mount({ labelType: "text", values: [ "one" ], onCommit });
+
+        await typeInto(input, "two");
+        await press(input, "Enter");
+        await typeInto(input, "three");
+        await press(input, "Enter");
+
+        input = await mount({ labelType: "text", values: [ "one", "two" ], onCommit });
+        await typeInto(input, "four");
+        await press(input, "Enter");
+
+        expect(onCommit).toHaveBeenLastCalledWith([ "one", "two", "three", "four" ]);
+        await act(async () => {
+            for (const resolve of finish) {
+                resolve();
+            }
+        });
+    });
+
+    it("restores accepted values after an async commit fails", async () => {
+        let rejectFirst: (error: Error) => void = () => {};
+        const onCommit = vi.fn()
+            .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => {
+                rejectFirst = reject;
+            }))
+            .mockResolvedValue(undefined);
+        const input = await mount({ labelType: "text", values: [ "one" ], onCommit });
+
+        await typeInto(input, "two");
+        await press(input, "Enter");
+        await act(async () => rejectFirst(new Error("write refused")));
+        await typeInto(input, "three");
+        await press(input, "Enter");
+
+        expect(onCommit).toHaveBeenLastCalledWith([ "one", "three" ]);
     });
 
     it("asks for a date rather than taking it as the field reports one", async () => {
@@ -207,12 +250,18 @@ describe("ValuesInput", () => {
         };
 
         it("offers them on focus, minus the ones the field already holds", async () => {
-            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit: vi.fn(), source });
+            const input = await mount({
+                labelType: "text",
+                values: [ "Game" ],
+                onCommit: vi.fn(),
+                source
+            });
 
             expect(container.querySelector(".tn-chip")?.closest(".values-input")).not.toBeNull();
 
             await act(async () => input?.focus());
-            expect((await settleDropdown()).map((item) => item.textContent)).toEqual([ "RPG", "\u4e09\u570b" ]);
+            expect((await settleDropdown()).map((item) => item.textContent))
+                .toEqual([ "RPG", "\u4e09\u570b" ]);
         });
 
         it("takes a picked entry as a chip, and stays open for the next", async () => {
@@ -248,7 +297,8 @@ describe("ValuesInput", () => {
             const input = await mount({ labelType: "text", values: [], onCommit, source });
 
             await typeInto(input, "\u4e09");
-            expect((await settleDropdown()).map((item) => item.textContent)).toEqual([ "\u4e09\u570b" ]);
+            expect((await settleDropdown()).map((item) => item.textContent))
+                .toEqual([ "\u4e09\u570b" ]);
             await press(input, "Enter");
             expect(onCommit).toHaveBeenCalledWith([ "\u4e09" ]);
 
@@ -261,7 +311,7 @@ describe("ValuesInput", () => {
             expect(onCommit).toHaveBeenCalledWith([ "\u4e09", "\u4e09\u570b" ]);
         });
 
-        it("keeps the button within the field the list hangs from, and its press taking", async () => {
+        it("keeps the add button inside the autocomplete field", async () => {
             const onCommit = vi.fn();
             const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source });
 
@@ -269,7 +319,8 @@ describe("ValuesInput", () => {
             const field = container.querySelector(".form-autocomplete-field.values-input");
             const add = container.querySelector<HTMLElement>(".values-input-add");
             expect(add?.closest(".form-autocomplete-field")).toBe(field);
-            expect(container.querySelector(".tn-chip")?.closest(".form-autocomplete-field")).toBe(field);
+            expect(container.querySelector(".tn-chip")?.closest(".form-autocomplete-field"))
+                .toBe(field);
 
             await act(async () => add?.click());
             expect(onCommit).toHaveBeenCalledWith([ "Game", "RPG" ]);
@@ -277,7 +328,12 @@ describe("ValuesInput", () => {
 
         it("keeps the keys and the leaving the field answers for itself", async () => {
             const onCommit = vi.fn();
-            const input = await mount({ labelType: "text", values: [ "Game", "RPG" ], onCommit, source });
+            const input = await mount({
+                labelType: "text",
+                values: [ "Game", "RPG" ],
+                onCommit,
+                source
+            });
 
             await press(input, "Backspace");
             expect(onCommit).toHaveBeenCalledWith([ "Game" ]);
@@ -292,7 +348,13 @@ describe("ValuesInput", () => {
 
         it("commits nothing while disabled, the list included", async () => {
             const onCommit = vi.fn();
-            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source, disabled: true });
+            const input = await mount({
+                labelType: "text",
+                values: [ "Game" ],
+                onCommit,
+                source,
+                disabled: true
+            });
 
             await act(async () => input?.focus());
             expect(await settleDropdown()).toEqual([]);
@@ -307,7 +369,12 @@ describe("ValuesInput", () => {
         });
 
         it("keeps the box plain where the value is picked through a widget", async () => {
-            const input = await mount({ labelType: "color", values: [], onCommit: vi.fn(), source });
+            const input = await mount({
+                labelType: "color",
+                values: [],
+                onCommit: vi.fn(),
+                source
+            });
 
             await act(async () => input?.focus());
             expect(await settleDropdown()).toEqual([]);

--- a/apps/client/src/widgets/attribute_widgets/values_input.spec.tsx
+++ b/apps/client/src/widgets/attribute_widgets/values_input.spec.tsx
@@ -33,8 +33,15 @@ describe("ValuesInput", () => {
 
     async function press(input: HTMLInputElement | null, key: string) {
         await act(async () => {
-            input?.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+            input?.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
         });
+    }
+
+    async function settleDropdown() {
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+        });
+        return [ ...document.querySelectorAll<HTMLElement>(".form-autocomplete-dropdown li") ];
     }
 
     it("commits nothing while disabled, whatever reaches it", async () => {
@@ -191,6 +198,121 @@ describe("ValuesInput", () => {
             }
         };
     }
+
+    describe("offering the values entered elsewhere", () => {
+        const known = [ "Game", "RPG", "\u4e09\u570b" ];
+        const source = async (query: string) => {
+            const term = query.trim().toLowerCase();
+            return known.filter((value) => value.toLowerCase().includes(term));
+        };
+
+        it("offers them on focus, minus the ones the field already holds", async () => {
+            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit: vi.fn(), source });
+
+            expect(container.querySelector(".tn-chip")?.closest(".values-input")).not.toBeNull();
+
+            await act(async () => input?.focus());
+            expect((await settleDropdown()).map((item) => item.textContent)).toEqual([ "RPG", "\u4e09\u570b" ]);
+        });
+
+        it("takes a picked entry as a chip, and stays open for the next", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source });
+
+            await act(async () => input?.focus());
+            const items = await settleDropdown();
+            await act(async () => items[1]?.click());
+
+            expect(onCommit).toHaveBeenCalledWith([ "Game", "\u4e09\u570b" ]);
+            expect(document.querySelector(".form-autocomplete-dropdown")).not.toBeNull();
+
+            await act(async () => items[0]?.click());
+            expect(onCommit).toHaveBeenLastCalledWith([ "Game", "\u4e09\u570b", "RPG" ]);
+        });
+
+        it("stops offering a value it has taken, before the host has said so", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source });
+
+            await act(async () => input?.focus());
+            const items = await settleDropdown();
+            await act(async () => items[0]?.click());
+            expect(onCommit).toHaveBeenCalledWith([ "Game", "RPG" ]);
+
+            await typeInto(input, "rp");
+            expect(await settleDropdown()).toEqual([]);
+        });
+
+        it("leaves Enter meaning what was typed until an entry is stepped onto", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [], onCommit, source });
+
+            await typeInto(input, "\u4e09");
+            expect((await settleDropdown()).map((item) => item.textContent)).toEqual([ "\u4e09\u570b" ]);
+            await press(input, "Enter");
+            expect(onCommit).toHaveBeenCalledWith([ "\u4e09" ]);
+
+            onCommit.mockClear();
+            await typeInto(input, "\u4e09");
+            await settleDropdown();
+            await press(input, "ArrowDown");
+            await press(input, "Enter");
+            expect(onCommit).toHaveBeenCalledTimes(1);
+            expect(onCommit).toHaveBeenCalledWith([ "\u4e09", "\u4e09\u570b" ]);
+        });
+
+        it("keeps the button within the field the list hangs from, and its press taking", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source });
+
+            await typeInto(input, "RPG");
+            const field = container.querySelector(".form-autocomplete-field.values-input");
+            const add = container.querySelector<HTMLElement>(".values-input-add");
+            expect(add?.closest(".form-autocomplete-field")).toBe(field);
+            expect(container.querySelector(".tn-chip")?.closest(".form-autocomplete-field")).toBe(field);
+
+            await act(async () => add?.click());
+            expect(onCommit).toHaveBeenCalledWith([ "Game", "RPG" ]);
+        });
+
+        it("keeps the keys and the leaving the field answers for itself", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [ "Game", "RPG" ], onCommit, source });
+
+            await press(input, "Backspace");
+            expect(onCommit).toHaveBeenCalledWith([ "Game" ]);
+
+            onCommit.mockClear();
+            await typeInto(input, "\u4e09\u570b | Game");
+            await act(async () => {
+                input?.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+            });
+            expect(onCommit).toHaveBeenCalledWith([ "Game", "\u4e09\u570b | Game" ]);
+        });
+
+        it("commits nothing while disabled, the list included", async () => {
+            const onCommit = vi.fn();
+            const input = await mount({ labelType: "text", values: [ "Game" ], onCommit, source, disabled: true });
+
+            await act(async () => input?.focus());
+            expect(await settleDropdown()).toEqual([]);
+
+            await typeInto(input, "RPG");
+            await press(input, "Enter");
+            await press(input, "Backspace");
+            await act(async () => {
+                input?.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+            });
+            expect(onCommit).not.toHaveBeenCalled();
+        });
+
+        it("keeps the box plain where the value is picked through a widget", async () => {
+            const input = await mount({ labelType: "color", values: [], onCommit: vi.fn(), source });
+
+            await act(async () => input?.focus());
+            expect(await settleDropdown()).toEqual([]);
+        });
+    });
 
     it("drops the last chip on backspace in an empty box, and leaves a filled one alone", async () => {
         const onCommit = vi.fn();

--- a/apps/client/src/widgets/attribute_widgets/values_input.tsx
+++ b/apps/client/src/widgets/attribute_widgets/values_input.tsx
@@ -19,7 +19,7 @@ interface ValuesInputProps {
     /** The values held, in the order they are shown. */
     values: readonly string[];
     /** Receives the values as they now stand, whenever one is taken or dropped. */
-    onCommit(values: string[]): void;
+    onCommit(values: string[]): void | Promise<void>;
     /** What removing a chip means, in the host's own words. Left out, a chip holds "a value". */
     removeButtonText?: string;
     /** What taking the box's content means, in the host's own words. Left out, it adds "a value". */
@@ -43,16 +43,30 @@ interface ValuesInputProps {
  * rather than quietly dropped. A value already held is not taken a second time: the chips are a set,
  * and two alike could not be told apart.
  */
-export default function ValuesInput({ labelType, values, onCommit, removeButtonText, addButtonText, source, inputId, tabIndex, placeholder, disabled }: ValuesInputProps) {
+export default function ValuesInput({
+    labelType,
+    values,
+    onCommit,
+    removeButtonText,
+    addButtonText,
+    source,
+    inputId,
+    tabIndex,
+    placeholder,
+    disabled
+}: ValuesInputProps) {
     const [ draft, setDraft ] = useState("");
     const inputRef = useRef<HTMLInputElement>(null);
-    // Keep local edits until the host reflects them in props. Only what the field does reads
-    // from here; what it shows stays the host's, so the chips are the set actually saved.
+    // `editedValues` accumulates edits before `values` updates. Pending commits keep newer edits
+    // from being replaced by an intermediate `values` update.
     const editedValues = useRef(values);
-    const lastValuesProp = useRef(values);
-    if (lastValuesProp.current !== values) {
-        lastValuesProp.current = values;
-        editedValues.current = values;
+    const latestValuesProp = useRef(values);
+    const pendingCommits = useRef(0);
+    if (latestValuesProp.current !== values) {
+        latestValuesProp.current = values;
+        if (pendingCommits.current === 0) {
+            editedValues.current = values;
+        }
     }
     const isColor = labelType === "color";
     // Every widget but the colour dialog has to be asked for its value, having no plain way of
@@ -64,11 +78,12 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
     const showAdd = needsAsking || (!isColor && draft.trim().length > 0);
     const suggests = !!source && !PICKED_TYPES.has(labelType);
 
-    // Filtered against the edits, not the prop: with the list open across picks, a value just
-    // taken would otherwise be offered again, on an entry that `take` then refuses.
+    // `keepOpenOnPick` keeps the list open, so filter `editedValues` to prevent duplicate `take()`
+    // calls before `values` updates.
     const suggest = useCallback(
-        async (query: string) => (await source?.(query) ?? []).filter((value) => !editedValues.current.includes(value)),
-        // eslint-disable-next-line react-hooks/exhaustive-deps -- `values` is read through the ref above
+        async (query: string) => (await source?.(query) ?? [])
+            .filter((value) => !editedValues.current.includes(value)),
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- read through editedValues
         [ source, values ]);
 
     // A colour picker holds its own value and is never told one: it is set at birth and only read
@@ -112,7 +127,7 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
 
         const edited = [ ...current, trimmed ];
         editedValues.current = edited;
-        onCommit(edited);
+        commit(edited);
     }
 
     function drop(value: string) {
@@ -120,11 +135,28 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
 
         const edited = editedValues.current.filter((held) => held !== value);
         editedValues.current = edited;
-        onCommit(edited);
+        commit(edited);
+    }
+
+    function commit(edited: string[]) {
+        const result = onCommit(edited);
+        if (!result) {
+            return;
+        }
+
+        pendingCommits.current++;
+        void result.then(settleCommit, settleCommit);
+    }
+
+    function settleCommit() {
+        pendingCommits.current--;
+        if (pendingCommits.current === 0) {
+            editedValues.current = latestValuesProp.current;
+        }
     }
 
     function handleKeyDown(e: TargetedKeyboardEvent<HTMLInputElement>) {
-        // Enter already spent on a picked suggestion; the text it was picked out of is not a value.
+        // FormAutocomplete consumed Enter to take a suggestion, so do not also commit the draft.
         if (e.defaultPrevented) {
             return;
         }
@@ -165,10 +197,7 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
             icon="bx bx-plus"
             text={addButtonText ?? t("promoted_attributes.add_value")}
             disabled={disabled}
-            // The value is read from the field rather than from the draft: leaving the field
-            // to press this takes it already, and the draft is empty by the time this runs.
-            // For a typed box that leaving is also the whole of the press — the take empties
-            // the box and the button goes with it, before the click lands on anything.
+            // `onBlur` can clear `draft` before the click, so read the current input value.
             onClick={() => take(inputRef.current?.value ?? "")}
         />
     );
@@ -224,7 +253,7 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
                         tabIndex={tabIndex}
                         type={LABEL_MAPPINGS[labelType] ?? "text"}
                         currentValue={draft}
-                        // Only while the field is empty: beside chips it would read as one of them.
+                        // Existing chips make the empty-field placeholder unnecessary.
                         placeholder={values.length ? undefined : placeholder}
                         disabled={disabled}
                         onChange={setDraft}

--- a/apps/client/src/widgets/attribute_widgets/values_input.tsx
+++ b/apps/client/src/widgets/attribute_widgets/values_input.tsx
@@ -3,11 +3,12 @@ import "./values_input.css";
 import { type LabelType } from "@triliumnext/commons";
 import clsx from "clsx";
 import type { ComponentChildren, TargetedKeyboardEvent } from "preact";
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import { t } from "../../services/i18n";
 import ActionButton from "../react/ActionButton";
 import Chip from "../react/Chip";
+import FormAutocomplete from "../react/FormAutocomplete";
 import FormTextBox from "../react/FormTextBox";
 import { ColorSwatch } from "./label_value_display";
 import { DEFAULT_COLOR, LABEL_MAPPINGS } from "./label_value_input";
@@ -23,6 +24,8 @@ interface ValuesInputProps {
     removeButtonText?: string;
     /** What taking the box's content means, in the host's own words. Left out, it adds "a value". */
     addButtonText?: string;
+    /** Provides suggestions for values entered under the same name. */
+    source?(query: string): Promise<string[]>;
     /** Set onto the box, so that a host's own label points at the field. */
     inputId?: string;
     /** Set onto the box, for a host placing its fields in a tab order of its own. */
@@ -40,9 +43,17 @@ interface ValuesInputProps {
  * rather than quietly dropped. A value already held is not taken a second time: the chips are a set,
  * and two alike could not be told apart.
  */
-export default function ValuesInput({ labelType, values, onCommit, removeButtonText, addButtonText, inputId, tabIndex, placeholder, disabled }: ValuesInputProps) {
+export default function ValuesInput({ labelType, values, onCommit, removeButtonText, addButtonText, source, inputId, tabIndex, placeholder, disabled }: ValuesInputProps) {
     const [ draft, setDraft ] = useState("");
     const inputRef = useRef<HTMLInputElement>(null);
+    // Keep local edits until the host reflects them in props. Only what the field does reads
+    // from here; what it shows stays the host's, so the chips are the set actually saved.
+    const editedValues = useRef(values);
+    const lastValuesProp = useRef(values);
+    if (lastValuesProp.current !== values) {
+        lastValuesProp.current = values;
+        editedValues.current = values;
+    }
     const isColor = labelType === "color";
     // Every widget but the colour dialog has to be asked for its value, having no plain way of
     // saying it is done with.
@@ -51,6 +62,14 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
     // to take, the same button offers the confirming where it can be seen. Not before: empty, it
     // would have nothing to add, and sit there asking to be explained.
     const showAdd = needsAsking || (!isColor && draft.trim().length > 0);
+    const suggests = !!source && !PICKED_TYPES.has(labelType);
+
+    // Filtered against the edits, not the prop: with the list open across picks, a value just
+    // taken would otherwise be offered again, on an entry that `take` then refuses.
+    const suggest = useCallback(
+        async (query: string) => (await source?.(query) ?? []).filter((value) => !editedValues.current.includes(value)),
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- `values` is read through the ref above
+        [ source, values ]);
 
     // A colour picker holds its own value and is never told one: it is set at birth and only read
     // from after that. Anything written into it can reach a dialog that is still open — it reports
@@ -88,100 +107,133 @@ export default function ValuesInput({ labelType, values, onCommit, removeButtonT
     function take(value: string) {
         const trimmed = value.trim();
         setDraft("");
-        if (disabled || !trimmed || values.includes(trimmed)) return;
-        onCommit([ ...values, trimmed ]);
+        const current = editedValues.current;
+        if (disabled || !trimmed || current.includes(trimmed)) return;
+
+        const edited = [ ...current, trimmed ];
+        editedValues.current = edited;
+        onCommit(edited);
     }
 
     function drop(value: string) {
         if (disabled) return;
-        onCommit(values.filter((held) => held !== value));
+
+        const edited = editedValues.current.filter((held) => held !== value);
+        editedValues.current = edited;
+        onCommit(edited);
     }
 
     function handleKeyDown(e: TargetedKeyboardEvent<HTMLInputElement>) {
+        // Enter already spent on a picked suggestion; the text it was picked out of is not a value.
+        if (e.defaultPrevented) {
+            return;
+        }
+
         if (e.key === "Enter") {
             // Consumed, so that it does not also reach whatever the field sits in — a table cell
             // takes Enter as "done here", which would end the edit at the first value.
             e.preventDefault();
             e.stopPropagation();
             take(e.currentTarget.value);
-        } else if (e.key === "Backspace" && !e.currentTarget.value && values.length) {
+        } else if (e.key === "Backspace" && !e.currentTarget.value && editedValues.current.length) {
             // Backspace on an empty box drops the last chip, the box having nothing of its own to
             // erase. With something typed it is the box's own, as anywhere else.
             e.preventDefault();
-            drop(values[values.length - 1]);
+            drop(editedValues.current[editedValues.current.length - 1]);
         }
+    }
+
+    const chips = values.map((value) => (
+        <Chip
+            key={value}
+            removeButtonText={removeButtonText ?? t("promoted_attributes.remove_value")}
+            disabled={disabled}
+            onRemove={() => drop(value)}
+        >
+            {/* A colour reads as its swatch even while being edited, `#3d5a80` naming
+                nothing to the eye. A swatch rather than the chip's own ground, as the
+                read-only chips wear it: this chip also holds the button removing it,
+                which no ground a user may pick can be trusted to keep visible. */}
+            <span>{isColor ? <ColorSwatch color={value} /> : value}</span>
+        </Chip>
+    ));
+
+    const addButton = showAdd && (
+        <ActionButton
+            key="add"
+            className="values-input-add"
+            icon="bx bx-plus"
+            text={addButtonText ?? t("promoted_attributes.add_value")}
+            disabled={disabled}
+            // The value is read from the field rather than from the draft: leaving the field
+            // to press this takes it already, and the draft is empty by the time this runs.
+            // For a typed box that leaving is also the whole of the press — the take empties
+            // the box and the button goes with it, before the click lands on anything.
+            onClick={() => take(inputRef.current?.value ?? "")}
+        />
+    );
+
+    if (suggests) {
+        return (
+            <FormAutocomplete
+                inputRef={inputRef}
+                id={inputId}
+                tabIndex={tabIndex}
+                type={LABEL_MAPPINGS[labelType] ?? "text"}
+                fieldClassName="values-input"
+                currentValue={draft}
+                placeholder={values.length ? undefined : placeholder}
+                disabled={disabled}
+                openOnFocus
+                keepOpenOnPick
+                source={suggest}
+                leading={chips}
+                trailing={addButton}
+                onChange={setDraft}
+                onPick={take}
+                onBlur={take}
+                onKeyDown={handleKeyDown}
+            />
+        );
     }
 
     return (
         // Values and the box they are entered in share the one wrapping line, the box after them,
         // however they are entered — a widget of the browser's own only dresses the box differently.
         <div className={clsx("tn-field values-input", PICKED_TYPES.has(labelType) && "widget-entry")}>
-            {values.map((value) => (
-                <Chip
-                    key={value}
-                    removeButtonText={removeButtonText ?? t("promoted_attributes.remove_value")}
-                    disabled={disabled}
-                    onRemove={() => drop(value)}
-                >
-                    {/* A colour reads as its swatch even while being edited, `#3d5a80` naming
-                        nothing to the eye. A swatch rather than the chip's own ground, as the
-                        read-only chips wear it: this chip also holds the button removing it,
-                        which no ground a user may pick can be trusted to keep visible. */}
-                    <span>{isColor ? <ColorSwatch color={value} /> : value}</span>
-                </Chip>
-            ))}
+            {chips}
             {/* The box and the button that asks for what it holds are one thing on the page, so they
                 are wrapped as one: whatever wraps or is ordered, they go together, and the button
-                never ends up on a line without the box it belongs to.
-
-                Keyed, as the chips before them are: a field of keyed and unkeyed siblings together is
-                matched up by position as it grows, so taking a second value would rebuild the box
-                rather than keep it — losing the focus in it, and with it the widget it had open. */}
+                never ends up on a line without the box it belongs to. */}
             <Entry grouped={PICKED_TYPES.has(labelType)}>
-            {isColor ? (
-                <input
-                    key="field"
-                    ref={inputRef}
-                    id={inputId}
-                    tabIndex={tabIndex}
-                    className="form-control"
-                    type="color"
-                    disabled={disabled}
-                />
-            ) : (
-                <FormTextBox
-                    key="field"
-                    inputRef={inputRef}
-                    id={inputId}
-                    tabIndex={tabIndex}
-                    type={LABEL_MAPPINGS[labelType] ?? "text"}
-                    currentValue={draft}
-                    // Only while the field is empty: beside chips it would read as one of them.
-                    placeholder={values.length ? undefined : placeholder}
-                    disabled={disabled}
-                    onChange={setDraft}
-                    onBlur={take}
-                    onKeyDown={handleKeyDown}
-                />
-            )}
+                {isColor ? (
+                    <input
+                        key="field"
+                        ref={inputRef}
+                        id={inputId}
+                        tabIndex={tabIndex}
+                        className="form-control"
+                        type="color"
+                        disabled={disabled}
+                    />
+                ) : (
+                    <FormTextBox
+                        key="field"
+                        inputRef={inputRef}
+                        id={inputId}
+                        tabIndex={tabIndex}
+                        type={LABEL_MAPPINGS[labelType] ?? "text"}
+                        currentValue={draft}
+                        // Only while the field is empty: beside chips it would read as one of them.
+                        placeholder={values.length ? undefined : placeholder}
+                        disabled={disabled}
+                        onChange={setDraft}
+                        onBlur={take}
+                        onKeyDown={handleKeyDown}
+                    />
+                )}
 
-            {/* A widget says nothing useful about when it is done — a date reports a change per part
-                of it — so a field entered through one is asked rather than watched. Enter does as
-                much for the keyboard; this is the same thing where it can be seen. */}
-            {showAdd && (
-                <ActionButton
-                    key="add"
-                    className="values-input-add"
-                    icon="bx bx-plus"
-                    text={addButtonText ?? t("promoted_attributes.add_value")}
-                    disabled={disabled}
-                    // The value is read from the field rather than from the draft: leaving the field
-                    // to press this takes it already, and the draft is empty by the time this runs.
-                    // For a typed box that leaving is also the whole of the press — the take empties
-                    // the box and the button goes with it, before the click lands on anything.
-                    onClick={() => take(inputRef.current?.value ?? "")}
-                />
-            )}
+                {addButton}
             </Entry>
         </div>
     );

--- a/apps/client/src/widgets/react/FormAutocomplete.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.tsx
@@ -1,5 +1,6 @@
 import "./FormAutocomplete.css";
 
+import clsx from "clsx";
 import type { ComponentChildren, TargetedKeyboardEvent } from "preact";
 import { createPortal, type CSSProperties } from "preact/compat";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
@@ -66,6 +67,10 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
      * the whole field instead of only the stretch of it left over for typing.
      */
     leading?: ComponentChildren;
+    /** Rendered inside the field after the input. */
+    trailing?: ComponentChildren;
+    /** Additional class name for the field wrapper. */
+    fieldClassName?: string;
     /**
      * Marks an entry as a heading over the ones below it rather than a choice of its own: it takes no
      * click, is stepped over on the way through the list, and is never what Enter takes.
@@ -94,7 +99,7 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
  * The dropdown is portalled to the body and positioned over everything else, so it is not clipped
  * by scrolling ancestors. Selecting a suggestion reports it through `onChange`, exactly like typing.
  */
-export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, openOnEnter, onPick, keepOpenOnPick, renderItem, leading, autoActivate, isHeading, dropdownMinWidth, inputRef, onFocus, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
+export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, openOnEnter, onPick, keepOpenOnPick, renderItem, leading, trailing, fieldClassName, autoActivate, isHeading, dropdownMinWidth, inputRef, onFocus, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
     const ownInputRef = useRef<HTMLInputElement>(null);
     const inputEl = inputRef ?? ownInputRef;
     const fieldRef = useRef<HTMLDivElement>(null);
@@ -267,8 +272,8 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
 
     return (
         <>
-            {leading !== undefined
-                ? <div ref={fieldRef} className="tn-field form-autocomplete-field">{leading}{field}</div>
+            {leading !== undefined || trailing !== undefined
+                ? <div ref={fieldRef} className={clsx("tn-field form-autocomplete-field", fieldClassName)}>{leading}{field}{trailing}</div>
                 : field}
 
             {isOpen && items.length > 0 && position && createPortal(

--- a/apps/client/src/widgets/react/FormAutocomplete.tsx
+++ b/apps/client/src/widgets/react/FormAutocomplete.tsx
@@ -99,7 +99,27 @@ interface FormAutocompleteProps extends Omit<FormTextBoxProps, "onChange"> {
  * The dropdown is portalled to the body and positioned over everything else, so it is not clipped
  * by scrolling ancestors. Selecting a suggestion reports it through `onChange`, exactly like typing.
  */
-export default function FormAutocomplete({ currentValue, onChange, source, openOnFocus, openOnEnter, onPick, keepOpenOnPick, renderItem, leading, trailing, fieldClassName, autoActivate, isHeading, dropdownMinWidth, inputRef, onFocus, onBlur, onKeyDown, ...restProps }: FormAutocompleteProps) {
+export default function FormAutocomplete({
+    currentValue,
+    onChange,
+    source,
+    openOnFocus,
+    openOnEnter,
+    onPick,
+    keepOpenOnPick,
+    renderItem,
+    leading,
+    trailing,
+    fieldClassName,
+    autoActivate,
+    isHeading,
+    dropdownMinWidth,
+    inputRef,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    ...restProps
+}: FormAutocompleteProps) {
     const ownInputRef = useRef<HTMLInputElement>(null);
     const inputEl = inputRef ?? ownInputRef;
     const fieldRef = useRef<HTMLDivElement>(null);
@@ -273,7 +293,12 @@ export default function FormAutocomplete({ currentValue, onChange, source, openO
     return (
         <>
             {leading !== undefined || trailing !== undefined
-                ? <div ref={fieldRef} className={clsx("tn-field form-autocomplete-field", fieldClassName)}>{leading}{field}{trailing}</div>
+                ? <div
+                    ref={fieldRef}
+                    className={clsx("tn-field form-autocomplete-field", fieldClassName)}
+                >
+                    {leading}{field}{trailing}
+                </div>
                 : field}
 
             {isOpen && items.length > 0 && position && createPortal(


### PR DESCRIPTION
Related to #4124, #10664

## Problem

A promoted label with `multi` lost value autocomplete in v0.105.0. Single-value labels still have it:

```
#label:tags=promoted,single,text   # focus → the values already used under "tags"
#label:tags=promoted,multi,text    # focus → nothing, type it out from memory
```

For free-form values such as tags, users must retype each name. 
A typo creates a separate value.

## Cause

This regressed in #10758 (`51ff4673`). 
The multi-value field became one chip input based on the table cell editor, which had no autocomplete. `useTextLabelAutocomplete` still worked only for single-value fields, and the tests covered only that case.

## Changes

- `ValuesInput` accepts an optional `source`. Given one, it renders the existing `FormAutocomplete`; without one the field is unchanged. Chips are shown as `leading` and the confirm button as `trailing`.
- `PromotedAttributes` supplies that source for `text` labels, backed by `attribute-values/<name>`. It fetches once and filters locally, like the single-value field.
- `FormAutocomplete` now supports `trailing` and `fieldClassName`, matching `leading`.
- There is no `autoActivate`. Enter keeps the typed text unless the arrow keys select a suggestion first. New values work as before.
- Fixed two race conditions: a fast second pick no longer drops the first, and an older write response can no longer restore an earlier value set.
- `setLabelValues` passes through the written attribute state across calls to prevent queued writes from re-reading the note cache and duplicating values.

## Tests

Added 12 tests.

- `values_input.spec.tsx` — list contents, picking, Enter, backspace, blur, disabled state, and widget types that keep the plain input.
- `PromotedAttributes.spec.tsx` — field props, source loading, commit order, and failed writes.

## Verification

- **Desktop (Windows):** manually tested on a v0.105.0 build with this change. Focus opens the list, typing filters it, Enter keeps a new value, and arrow-down + Enter selects a suggestion.
- **Browser:** not manually tested. Same client code, covered by the unit tests.
- **Unit:** `pnpm --filter client test` passes.

https://github.com/user-attachments/assets/375c7135-4046-472f-81eb-f3f9336b1d32

## Notes

- No changes for `select`, flags, relations, or browser widgets (colour, date, time).
- The source is attached from the first render and returns nothing until the values load, so a slow response never replaces the input while the user is typing.
- No new dependency. No User Guide changes.
- #8972 migrates the legacy jQuery autocomplete, including `useTextLabelAutocomplete` in this file. This change does not affect that path; the new hook feeds the Preact `FormAutocomplete` instead. That PR does not touch the other files changed here.
