### PR TITLE
fix(desktop): adapt login item and clipboard APIs to Electron 44

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -51,7 +51,7 @@
     "@triliumnext/server": "workspace:*",
     "@types/electron-squirrel-startup": "1.0.2",
     "@types/pngjs": "6.0.5",
-    "electron": "43.4.1",
+    "electron": "44.0.0",
     "gifenc": "1.0.3",
     "node-mocks-http": "1.18.1",
     "pngjs": "7.0.0"

--- a/apps/desktop/src/services/auto_launch.spec.ts
+++ b/apps/desktop/src/services/auto_launch.spec.ts
@@ -9,7 +9,7 @@ const state = vi.hoisted(() => ({
     appName: "Trilium Notes",
     setLoginItemSettings: vi.fn(),
     setLoginItemThrows: false,
-    wasOpenedAsHidden: false,
+    wasOpenedAtLogin: false,
     ipcOn: new Map<string, Handler>(),
     mkdirSync: vi.fn(),
     writeFileSync: vi.fn(),
@@ -24,7 +24,7 @@ vi.mock("electron", () => ({
                 if (state.setLoginItemThrows) throw new Error("boom");
                 return state.setLoginItemSettings(...a);
             },
-            getLoginItemSettings: () => ({ wasOpenedAsHidden: state.wasOpenedAsHidden }),
+            getLoginItemSettings: () => ({ wasOpenedAtLogin: state.wasOpenedAtLogin }),
             getName: () => state.appName
         },
         ipcMain: {
@@ -77,7 +77,7 @@ beforeEach(() => {
     state.launchOnStartup = false;
     state.hideOnAutoStart = false;
     state.setLoginItemThrows = false;
-    state.wasOpenedAsHidden = false;
+    state.wasOpenedAtLogin = false;
     state.ipcOn.clear();
     delete process.env.APPIMAGE;
     delete process.env.XDG_CONFIG_HOME;
@@ -95,14 +95,14 @@ describe("auto_launch", () => {
         setPlatform("win32");
         state.launchOnStartup = true;
         applyLaunchOnStartup();
-        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true, openAsHidden: false, args: [] });
+        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true, args: [] });
     });
 
     it("disables the OS login item when the option is off", () => {
         setPlatform("darwin");
         state.launchOnStartup = false;
         applyLaunchOnStartup();
-        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false, openAsHidden: false, args: [] });
+        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false, args: [] });
     });
 
     it("tags the login item to start hidden when hide-on-auto-start is on", () => {
@@ -112,7 +112,6 @@ describe("auto_launch", () => {
         applyLaunchOnStartup();
         expect(state.setLoginItemSettings).toHaveBeenCalledWith({
             openAtLogin: true,
-            openAsHidden: true,
             args: [START_HIDDEN_FLAG]
         });
     });
@@ -122,7 +121,7 @@ describe("auto_launch", () => {
         state.launchOnStartup = false;
         state.hideOnAutoStart = true;
         applyLaunchOnStartup();
-        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false, openAsHidden: false, args: [] });
+        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false, args: [] });
     });
 
     it("writes a .desktop autostart file on Linux when enabled", () => {
@@ -208,11 +207,17 @@ describe("auto_launch", () => {
         }
     });
 
-    it("wasLaunchedHidden reflects wasOpenedAsHidden on macOS", () => {
+    it("wasLaunchedHidden combines wasOpenedAtLogin with hide-on-auto-start on macOS", () => {
         setPlatform("darwin");
-        state.wasOpenedAsHidden = true;
+        state.wasOpenedAtLogin = true;
+        state.hideOnAutoStart = true;
         expect(wasLaunchedHidden()).toBe(true);
-        state.wasOpenedAsHidden = false;
+
+        state.hideOnAutoStart = false;
+        expect(wasLaunchedHidden()).toBe(false);
+
+        state.wasOpenedAtLogin = false;
+        state.hideOnAutoStart = true;
         expect(wasLaunchedHidden()).toBe(false);
     });
 
@@ -225,6 +230,6 @@ describe("auto_launch", () => {
 
         state.launchOnStartup = true;
         handler?.();
-        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true, openAsHidden: false, args: [] });
+        expect(state.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true, args: [] });
     });
 });

--- a/apps/desktop/src/services/auto_launch.ts
+++ b/apps/desktop/src/services/auto_launch.ts
@@ -10,8 +10,8 @@ import path from "path";
 
 // We tag the autostart command so the app can tell, at launch, that it was started
 // by the OS at login (and should hide to the tray) rather than launched manually
-// (where it must show a window). macOS has no argv hook for login items, so it uses
-// the native openAsHidden flag and reports it back via wasOpenedAsHidden instead.
+// (where it must show a window). macOS has no argv hook for login items, so
+// wasLaunchedHidden() reads `wasOpenedAtLogin` from the login item there instead.
 export const START_HIDDEN_FLAG = "--start-hidden";
 
 /**
@@ -29,12 +29,11 @@ export function applyLaunchOnStartup() {
         if (process.platform === "linux") {
             applyLinuxAutostart(enabled, hidden);
         } else {
-            // macOS + Windows: handled natively by Electron. `openAsHidden` is the
-            // macOS mechanism; `args` is the Windows one. Each platform ignores the
-            // option that doesn't apply to it.
+            // macOS + Windows: handled natively by Electron. `args` is the Windows
+            // mechanism and macOS ignores it, so `hidden` reaches macOS through the
+            // `hideOnAutoStart` option that wasLaunchedHidden() reads at startup.
             electron.app.setLoginItemSettings({
                 openAtLogin: enabled,
-                openAsHidden: hidden,
                 args: hidden ? [START_HIDDEN_FLAG] : []
             });
         }
@@ -49,7 +48,9 @@ export function applyLaunchOnStartup() {
  */
 export function wasLaunchedHidden(): boolean {
     if (process.platform === "darwin") {
-        return electron.app.getLoginItemSettings().wasOpenedAsHidden;
+        // A macOS login item carries no arguments, so Electron reports only that the
+        // app was opened at login and `hideOnAutoStart` decides whether to hide it.
+        return electron.app.getLoginItemSettings().wasOpenedAtLogin && optionService.getOptionBool("hideOnAutoStart");
     }
     return process.argv.includes(START_HIDDEN_FLAG);
 }

--- a/apps/desktop/src/services/window.spec.ts
+++ b/apps/desktop/src/services/window.spec.ts
@@ -159,9 +159,14 @@ const fakeGlobalShortcut = {
 const fakeNativeImage = {
     createFromBuffer: vi.fn(() => {
         if (state.nativeImageThrow) throw new Error("bad buffer");
-        return { isEmpty: () => state.nativeImageEmpty };
+        return { isEmpty: () => state.nativeImageEmpty, toPNG: () => Buffer.from([137, 80, 78, 71]) };
     })
 };
+
+class FakeClipboardItem {
+    constructor(readonly items: Record<string, unknown>) {}
+}
+
 const fakeApp = {
     setUserTasks: vi.fn(),
     relaunch: vi.fn(),
@@ -175,7 +180,8 @@ const electronSurface = {
     shell: fakeShell,
     globalShortcut: fakeGlobalShortcut,
     nativeImage: fakeNativeImage,
-    clipboard: { writeImage: vi.fn() },
+    clipboard: { write: vi.fn((_items: FakeClipboardItem[]) => Promise.resolve()), readText: vi.fn(() => Promise.resolve("")) },
+    ClipboardItem: FakeClipboardItem,
     nativeTheme: { themeSource: "system" },
     BrowserWindow: fakeBrowserWindowClass,
     ipcMain: {
@@ -781,21 +787,25 @@ describe("window service", () => {
             expect(fakeApp.exit).toHaveBeenCalled();
         });
 
-        it("copy-image-to-clipboard writes a valid image", () => {
-            fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1, 2, 3]));
-            expect(electronSurface.clipboard.writeImage).toHaveBeenCalled();
+        it("copy-image-to-clipboard writes a PNG clipboard item", async () => {
+            await fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1, 2, 3]));
+            const [items] = electronSurface.clipboard.write.mock.calls[0] as [FakeClipboardItem[]];
+            expect(items[0]).toBeInstanceOf(FakeClipboardItem);
+            const blob = items[0].items["image/png"] as Blob;
+            expect(blob.type).toBe("image/png");
+            expect(blob.size).toBe(4);
         });
 
-        it("copy-image-to-clipboard logs when the image is empty", () => {
+        it("copy-image-to-clipboard logs when the image is empty", async () => {
             state.nativeImageEmpty = true;
-            fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1]));
+            await fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1]));
             expect(state.log.error).toHaveBeenCalledWith(expect.stringContaining("nativeImage is empty"));
-            expect(electronSurface.clipboard.writeImage).not.toHaveBeenCalled();
+            expect(electronSurface.clipboard.write).not.toHaveBeenCalled();
         });
 
-        it("copy-image-to-clipboard logs when conversion throws", () => {
+        it("copy-image-to-clipboard logs when conversion throws", async () => {
             state.nativeImageThrow = true;
-            fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1]));
+            await fireOn("copy-image-to-clipboard", makeEvent(), new Uint8Array([1]));
             expect(state.log.error).toHaveBeenCalledWith(expect.stringContaining("failed"));
         });
 

--- a/apps/desktop/src/services/window.ts
+++ b/apps/desktop/src/services/window.ts
@@ -500,14 +500,17 @@ export function setupWindowing() {
         electron.app.exit();
     });
 
-    electron.ipcMain.on("copy-image-to-clipboard", (_event, buffer: Uint8Array) => {
+    electron.ipcMain.on("copy-image-to-clipboard", async (_event, buffer: Uint8Array) => {
         try {
             const image = electron.nativeImage.createFromBuffer(Buffer.from(buffer));
             if (image.isEmpty()) {
                 getLog().error("copy-image-to-clipboard: nativeImage is empty, unsupported format?");
                 return;
             }
-            electron.clipboard.writeImage(image);
+            // `clipboard.write()` takes MIME-typed payloads, and PNG is the format every
+            // platform clipboard accepts, so the decoded image is re-encoded to PNG.
+            const png = new Uint8Array(image.toPNG());
+            await electron.clipboard.write([new electron.ClipboardItem({ "image/png": new Blob([png], { type: "image/png" }) })]);
         } catch (e) {
             getLog().error(`copy-image-to-clipboard failed: ${coreUtils.safeExtractMessageAndStackFromError(e)}`);
         }

--- a/apps/edit-docs/package.json
+++ b/apps/edit-docs/package.json
@@ -12,7 +12,7 @@
     "@triliumnext/core": "workspace:*",
     "@triliumnext/commons": "workspace:*",
     "@triliumnext/desktop": "workspace:*",
-    "electron": "43.4.1"
+    "electron": "44.0.0"
   },
   "scripts": {
     "build": "tsx scripts/build.ts",

--- a/apps/website/src/translations/en/translation.json
+++ b/apps/website/src/translations/en/translation.json
@@ -252,7 +252,7 @@
   "download_helper_desktop_macos": {
     "title_x64": "macOS for Intel",
     "title_arm64": "macOS for Apple Silicon",
-    "description_x64": "For Intel-based Macs running macOS Monterey or later.",
+    "description_x64": "For Intel-based Macs running macOS Ventura or later.",
     "description_arm64": "For Apple Silicon Macs such as those with M1 and M2 chips.",
     "quick_start": "To install via Homebrew:",
     "download_dmg": "Download Installer (.dmg)",

--- a/docs/User Guide/User Guide/Installation & Setup/Desktop Installation/System Requirements.md
+++ b/docs/User Guide/User Guide/Installation & Setup/Desktop Installation/System Requirements.md
@@ -8,5 +8,5 @@ The desktop version of Trilium supports all three main operating systems:
     *   Most modern distributions are supported, including NixOS.
     *   ARM is supported in `aarch64` (no ARM v7 support).
 *   macOS
-    *   Minimum supported operating system: macOS Monterey
+    *   Minimum supported operating system: macOS Ventura
     *   Both Intel and Apple Silicon devices are supported.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,8 +487,8 @@ importers:
         specifier: 6.0.5
         version: 6.0.5
       electron:
-        specifier: 43.4.1
-        version: 43.4.1(supports-color@10.2.2)
+        specifier: 44.0.0
+        version: 44.0.0(supports-color@10.2.2)
       gifenc:
         specifier: 1.0.3
         version: 1.0.3
@@ -549,8 +549,8 @@ importers:
         specifier: workspace:*
         version: link:../desktop
       electron:
-        specifier: 43.4.1
-        version: 43.4.1(supports-color@10.2.2)
+        specifier: 44.0.0
+        version: 44.0.0(supports-color@10.2.2)
 
   apps/icon-pack-builder:
     devDependencies:
@@ -7452,8 +7452,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.1:
-    resolution: {integrity: sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==}
+  electron@44.0.0:
+    resolution: {integrity: sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -20382,7 +20382,7 @@ snapshots:
       - supports-color
     optional: true
 
-  electron@43.4.1(supports-color@10.2.2):
+  electron@44.0.0(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.3
       '@electron/get': 5.0.0(supports-color@10.2.2)


### PR DESCRIPTION
Bumps electron 43.4.1 -> 44.0.0 and repairs the three `pnpm typecheck`
errors the bump surfaces in apps/desktop.

Login items: Electron 44 removed `openAsHidden` from
`app.setLoginItemSettings()` and `wasOpenedAsHidden` from
`app.getLoginItemSettings()`, since both only worked on macOS 12 and
below. `wasLaunchedHidden()` now combines the remaining
`wasOpenedAtLogin` with the stored `hideOnAutoStart` option, so macOS
keeps the feature: the app opens normally and hides its own window,
matching what Windows and Linux already do through --start-hidden.

Clipboard: the module is now modelled on the W3C Clipboard API, so
`writeImage()` is gone and `write()` takes MIME-typed payloads and
returns a promise. The copy-image-to-clipboard handler re-encodes the
decoded image to PNG and writes it as a `ClipboardItem`. `toPNG()`
returns `Buffer<ArrayBufferLike>`, which is not a valid `BlobPart`,
hence the `Uint8Array` view.

Electron 44 also drops macOS 12, so the User Guide system requirements
and the website download blurb move from Monterey to Ventura.

Verified with electron 44.0.0 installed: `pnpm typecheck` is clean and
`pnpm --filter desktop test` passes 492 tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WkCLU8T5ENHbhMaL2zdEuW