### PR TITLE
fix(deps): resolve @electron/node-gyp to vanilla node-gyp from npm

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@electron/node-gyp': npm:node-gyp@^11.2.0
   '@codemirror/view': 6.43.9
   '@codemirror/state': 6.7.1
   '@codemirror/language': 6.12.4
@@ -443,31 +444,31 @@ importers:
     devDependencies:
       '@electron-forge/cli':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
+        version: 7.11.2(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
       '@electron-forge/maker-deb':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/maker-dmg':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/maker-flatpak':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/maker-rpm':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/maker-squirrel':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/maker-zip':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/plugin-auto-unpack-natives':
         specifier: 7.11.2
-        version: 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(supports-color@10.2.2)
       '@electron-forge/plugin-fuses':
         specifier: 7.11.2
-        version: 7.11.2(@electron/fuses@2.1.3)(bluebird@3.7.2)(supports-color@10.2.2)
+        version: 7.11.2(@electron/fuses@2.1.3)(supports-color@10.2.2)
       '@electron/fuses':
         specifier: 2.1.3
         version: 2.1.3
@@ -2265,12 +2266,6 @@ packages:
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
     engines: {node: '>=22.12.0'}
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
-    version: 10.2.0-electron.1
-    engines: {node: '>=12.13.0'}
-    hasBin: true
-
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
     engines: {node: '>= 10.0.0'}
@@ -2805,9 +2800,6 @@ packages:
     peerDependencies:
       rrule: ^2.6.0
       temporal-polyfill: ^1.0.1
-
-  '@gar/promisify@1.1.3':
-    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
@@ -3518,14 +3510,13 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@npmcli/fs@2.1.2':
-    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  '@npmcli/agent@3.0.0':
+    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
-  '@npmcli/move-file@2.0.1':
-    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    deprecated: This functionality has been moved to @npmcli/fs
+  '@npmcli/fs@4.0.0':
+    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -4622,10 +4613,6 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
-
-  '@tootallnate/once@3.0.1':
-    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
-    engines: {node: '>= 10'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -5900,8 +5887,9 @@ packages:
     resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
     engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=18.0.0'}
 
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -5954,10 +5942,6 @@ packages:
   aes-js@3.1.2:
     resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -5965,14 +5949,6 @@ packages:
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   ai@7.0.79:
     resolution: {integrity: sha512-zZkSUq6MgmXjwIfML2wkPFeQ5Azk8kGEWkciAtE0NgnFy3slj4ljsw5LvigsCbYXxTSVr+6iCHBTPZafpx1P0w==}
@@ -6486,9 +6462,9 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  cacache@16.1.3:
-    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  cacache@19.0.1:
+    resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -6593,10 +6569,6 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -6617,10 +6589,6 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -8024,9 +7992,9 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   fs-temp@1.2.1:
     resolution: {integrity: sha512-okTwLB7/Qsq82G6iN5zZJFsOfZtx2/pqrA7Hk/9fvy+c+eJS9CvgGXT2uNxwnI14BDY9L/jQPkaBgSvlKfSW9w==}
@@ -8188,11 +8156,6 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@8.1.0:
-    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
-    engines: {node: '>=12'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
@@ -8438,10 +8401,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -8463,10 +8422,6 @@ packages:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
     engines: {node: '>=10.19.0'}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -8474,9 +8429,6 @@ packages:
   https-proxy-agent@9.1.0:
     resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
     engines: {node: '>= 20'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   i18next-fs-backend@2.6.7:
     resolution: {integrity: sha512-nN2TIycyR/d+OVuLm1ugPyOlMprqPRnQ7QktBgn44F3H8l7TeTH4ffHJ7nUsd4QVJfetWW7/VZ3s+4g7FoAZUA==}
@@ -8562,16 +8514,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
   index-array-by@1.4.2:
     resolution: {integrity: sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==}
     engines: {node: '>=12'}
-
-  infer-owner@1.0.4:
-    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -8703,9 +8648,6 @@ packages:
   is-interactive@2.0.0:
     resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
     engines: {node: '>=12'}
-
-  is-lambda@1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -8839,6 +8781,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   isexe@4.0.0:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
@@ -9327,6 +9273,9 @@ packages:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -9362,9 +9311,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  make-fetch-happen@10.2.1:
-    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  make-fetch-happen@14.0.3:
+    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   many-keys-map@3.0.3:
     resolution: {integrity: sha512-1DiZmDHPXMBgMRjeUtHy1q1VYmeJscHxhIAexX9z/zjRMP80+0ETuPfssi8z+kMY4DwUgsKuHqpjxgmeA9gBNA==}
@@ -9658,13 +9607,13 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass-collect@1.0.2:
-    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
-    engines: {node: '>= 8'}
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
-  minipass-fetch@2.1.2:
-    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  minipass-fetch@4.0.1:
+    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   minipass-flush@1.0.7:
     resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
@@ -9685,10 +9634,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -9821,6 +9766,11 @@ packages:
       encoding:
         optional: true
 
+  node-gyp@11.5.0:
+    resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
@@ -9846,9 +9796,9 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
-  nopt@6.0.0:
-    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   normalize-package-data@2.5.0:
@@ -10040,10 +9990,6 @@ packages:
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
-
-  p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
   p-map@7.0.4:
@@ -10347,9 +10293,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  proc-log@2.0.1:
-    resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  proc-log@5.0.0:
+    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -10361,14 +10307,6 @@ packages:
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
-
-  promise-inflight@1.0.1:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -10779,11 +10717,6 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rimraf@3.0.2:
-    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
@@ -11067,10 +11000,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socks-proxy-agent@7.0.0:
-    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
-    engines: {node: '>= 10'}
-
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -11137,9 +11066,9 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
-  ssri@9.0.1:
-    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  ssri@12.0.0:
+    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   stack-trace@1.0.0:
     resolution: {integrity: sha512-H6D7134xi6qONvh7ZHKgviXf+rd3vhGBSvebPZCaUkd8zvQ+7PtDw6CljPTe4cXWNf2IKZGNqw6VJXSb9IgBpA==}
@@ -11773,13 +11702,13 @@ packages:
     resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
     engines: {node: '>= 0.8.0'}
 
-  unique-filename@2.0.1:
-    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  unique-filename@4.0.0:
+    resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
-  unique-slug@3.0.0:
-    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+  unique-slug@5.0.0:
+    resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -12191,6 +12120,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   which@6.0.1:
@@ -13656,11 +13590,11 @@ snapshots:
 
   '@digitak/grubber@3.1.4': {}
 
-  '@electron-forge/cli@7.11.2(bluebird@3.7.2)(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
+  '@electron-forge/cli@7.11.2(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/core': 7.11.2(bluebird@3.7.2)(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
-      '@electron-forge/core-utils': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/core': 7.11.2(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
+      '@electron-forge/core-utils': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       '@electron/get': 3.1.0(supports-color@10.2.2)
       '@inquirer/prompts': 6.0.1
       '@listr2/prompt-adapter-inquirer': 2.0.22(@inquirer/prompts@6.0.1)
@@ -13676,7 +13610,6 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -13689,10 +13622,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/core-utils@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/core-utils@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron/rebuild': 3.7.2(supports-color@10.2.2)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
       debug: 4.4.3(supports-color@10.2.2)
@@ -13702,25 +13635,24 @@ snapshots:
       parse-author: 2.0.0
       semver: 7.8.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/core@7.11.2(bluebird@3.7.2)(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
+  '@electron-forge/core@7.11.2(csso@5.0.5)(encoding@0.1.13)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/core-utils': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/plugin-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/publisher-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-vite': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-vite-typescript': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-webpack': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-webpack-typescript': 7.11.2(bluebird@3.7.2)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
+      '@electron-forge/core-utils': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/plugin-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/publisher-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-vite': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-vite-typescript': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-webpack': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-webpack-typescript': 7.11.2(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)
       '@electron-forge/tracer': 7.11.2
       '@electron/get': 3.1.0(supports-color@10.2.2)
       '@electron/packager': 18.4.4(supports-color@10.2.2)
-      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron/rebuild': 3.7.2(supports-color@10.2.2)
       '@malept/cross-spawn-promise': 2.0.0
       '@vscode/sudo-prompt': 9.3.2
       chalk: 4.1.2
@@ -13746,7 +13678,6 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -13759,155 +13690,140 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/maker-base@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-base@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
       which: 2.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-deb@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-deb@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
     optionalDependencies:
       electron-installer-debian: 3.2.0(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-dmg@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-dmg@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     optionalDependencies:
       electron-installer-dmg: 5.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-flatpak@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-flatpak@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     optionalDependencies:
       '@malept/electron-installer-flatpak': 0.11.4(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-rpm@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-rpm@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
     optionalDependencies:
       electron-installer-redhat: 3.4.0(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-squirrel@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-squirrel@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     optionalDependencies:
       electron-winstaller: 5.4.0(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/maker-zip@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/maker-zip@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/maker-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/maker-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       cross-zip: 4.0.1
       fs-extra: 10.1.0
       got: 11.8.6
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/plugin-auto-unpack-natives@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/plugin-auto-unpack-natives@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/plugin-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/plugin-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/plugin-base@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/plugin-base@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/plugin-fuses@7.11.2(@electron/fuses@2.1.3)(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/plugin-fuses@7.11.2(@electron/fuses@2.1.3)(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/plugin-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/plugin-base': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       '@electron/fuses': 2.1.3
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/publisher-base@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/publisher-base@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/shared-types@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/shared-types@7.11.2(supports-color@10.2.2)':
     dependencies:
       '@electron-forge/tracer': 7.11.2
       '@electron/packager': 18.4.4(supports-color@10.2.2)
-      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron/rebuild': 3.7.2(supports-color@10.2.2)
       listr2: 7.0.2
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-base@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/template-base@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/core-utils': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/core-utils': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
       fs-extra: 10.1.0
       semver: 7.8.5
       username: 5.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-vite-typescript@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/template-vite-typescript@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-base': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-vite@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/template-vite@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-base': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
-  '@electron-forge/template-webpack-typescript@7.11.2(bluebird@3.7.2)(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
+  '@electron-forge/template-webpack-typescript@7.11.2(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-base': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
       typescript: 5.4.5
       webpack: 5.106.2(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.20)
@@ -13916,7 +13832,6 @@ snapshots:
       - '@swc/core'
       - '@swc/css'
       - '@swc/html'
-      - bluebird
       - clean-css
       - cssnano
       - csso
@@ -13928,13 +13843,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@electron-forge/template-webpack@7.11.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron-forge/template-webpack@7.11.2(supports-color@10.2.2)':
     dependencies:
-      '@electron-forge/shared-types': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
-      '@electron-forge/template-base': 7.11.2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron-forge/shared-types': 7.11.2(supports-color@10.2.2)
+      '@electron-forge/template-base': 7.11.2(supports-color@10.2.2)
       fs-extra: 10.1.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   '@electron-forge/tracer@7.11.2':
@@ -13976,22 +13890,6 @@ snapshots:
     optionalDependencies:
       undici: 7.28.0
     transitivePeerDependencies:
-      - supports-color
-
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2(bluebird@3.7.2)(supports-color@10.2.2)':
-    dependencies:
-      env-paths: 2.2.1
-      exponential-backoff: 3.1.3
-      glob: 8.1.0
-      graceful-fs: 4.2.11
-      make-fetch-happen: 10.2.1(bluebird@3.7.2)(supports-color@10.2.2)
-      nopt: 6.0.0
-      proc-log: 2.0.1
-      semver: 7.8.5
-      tar: 7.5.15
-      which: 2.0.2
-    transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   '@electron/notarize@2.5.0(supports-color@10.2.2)':
@@ -14039,9 +13937,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@3.7.2(bluebird@3.7.2)(supports-color@10.2.2)':
+  '@electron/rebuild@3.7.2(supports-color@10.2.2)':
     dependencies:
-      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2(bluebird@3.7.2)(supports-color@10.2.2)
+      '@electron/node-gyp': node-gyp@11.5.0(supports-color@10.2.2)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
       debug: 4.4.3(supports-color@10.2.2)
@@ -14056,7 +13954,6 @@ snapshots:
       tar: 7.5.15
       yargs: 17.7.3
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   '@electron/universal@2.0.3(supports-color@10.2.2)':
@@ -14533,8 +14430,6 @@ snapshots:
       '@fullcalendar/core': 7.0.2(@full-ui/headless-calendar@7.0.2(temporal-polyfill@1.0.4))(temporal-polyfill@1.0.4)
       rrule: 2.8.1
       temporal-polyfill: 1.0.4
-
-  '@gar/promisify@1.1.3': {}
 
   '@gerrit0/mini-shiki@3.23.0':
     dependencies:
@@ -15428,15 +15323,19 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/fs@2.1.2':
+  '@npmcli/agent@3.0.0(supports-color@10.2.2)':
     dependencies:
-      '@gar/promisify': 1.1.3
-      semver: 7.8.5
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      lru-cache: 10.4.3
+      socks-proxy-agent: 8.0.5(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
-  '@npmcli/move-file@2.0.1':
+  '@npmcli/fs@4.0.0':
     dependencies:
-      mkdirp: 1.0.4
-      rimraf: 3.0.2
+      semver: 7.8.5
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -16324,8 +16223,6 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
-
-  '@tootallnate/once@3.0.1': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -18587,7 +18484,7 @@ snapshots:
 
   '@zip.js/zip.js@2.8.26': {}
 
-  abbrev@1.1.1: {}
+  abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -18629,24 +18526,9 @@ snapshots:
 
   aes-js@3.1.2: {}
 
-  agent-base@6.0.2(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   agent-base@7.1.4: {}
 
   agent-base@9.0.0: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
 
   ai@7.0.79(zod@4.4.3):
     dependencies:
@@ -19228,28 +19110,20 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cacache@16.1.3(bluebird@3.7.2):
+  cacache@19.0.1:
     dependencies:
-      '@npmcli/fs': 2.1.2
-      '@npmcli/move-file': 2.0.1
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      glob: 8.1.0
-      infer-owner: 1.0.4
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
+      '@npmcli/fs': 4.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
       minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
-      mkdirp: 1.0.4
-      p-map: 4.0.0
-      promise-inflight: 1.0.1(bluebird@3.7.2)
-      rimraf: 3.0.2
-      ssri: 9.0.1
+      p-map: 7.0.4
+      ssri: 12.0.0
       tar: 7.5.15
-      unique-filename: 2.0.1
-    transitivePeerDependencies:
-      - bluebird
+      unique-filename: 4.0.0
 
   cacheable-lookup@5.0.4: {}
 
@@ -19386,8 +19260,6 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@2.0.0: {}
-
   chownr@3.0.0: {}
 
   chrome-trace-event@1.0.4: {}
@@ -19467,8 +19339,6 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
-
-  clean-stack@2.2.0: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -21167,9 +21037,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs-minipass@2.1.0:
+  fs-minipass@3.0.3:
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.1.3
 
   fs-temp@1.2.1:
     dependencies:
@@ -21358,14 +21228,6 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
-
-  glob@8.1.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 5.1.9
-      once: 1.4.0
 
   global-agent@3.0.0:
     dependencies:
@@ -21686,14 +21548,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0(supports-color@10.2.2):
-    dependencies:
-      '@tootallnate/once': 3.0.1
-      agent-base: 6.0.2(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -21742,13 +21596,6 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1(supports-color@10.2.2):
-    dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -21764,10 +21611,6 @@ snapshots:
     transitivePeerDependencies:
       - kerberos
       - supports-color
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   i18next-fs-backend@2.6.7: {}
 
@@ -21836,11 +21679,7 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  indent-string@4.0.0: {}
-
   index-array-by@1.4.2: {}
-
-  infer-owner@1.0.4: {}
 
   inflight@1.0.6:
     dependencies:
@@ -21955,8 +21794,6 @@ snapshots:
 
   is-interactive@2.0.0: {}
 
-  is-lambda@1.0.1: {}
-
   is-map@2.0.3: {}
 
   is-my-ip-valid@1.0.1:
@@ -22065,6 +21902,8 @@ snapshots:
   isbinaryfile@4.0.10: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   isexe@4.0.0: {}
 
@@ -22534,6 +22373,8 @@ snapshots:
 
   lowercase-keys@2.0.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
@@ -22569,26 +22410,20 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  make-fetch-happen@10.2.1(bluebird@3.7.2)(supports-color@10.2.2):
+  make-fetch-happen@14.0.3(supports-color@10.2.2):
     dependencies:
-      agentkeepalive: 4.6.0
-      cacache: 16.1.3(bluebird@3.7.2)
+      '@npmcli/agent': 3.0.0(supports-color@10.2.2)
+      cacache: 19.0.1
       http-cache-semantics: 4.2.0
-      http-proxy-agent: 5.0.0(supports-color@10.2.2)
-      https-proxy-agent: 5.0.1(supports-color@10.2.2)
-      is-lambda: 1.0.1
-      lru-cache: 7.18.3
-      minipass: 3.3.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 2.1.2
+      minipass: 7.1.3
+      minipass-fetch: 4.0.1
       minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
-      negotiator: 0.6.4
+      negotiator: 1.0.0
+      proc-log: 5.0.0
       promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0(supports-color@10.2.2)
-      ssri: 9.0.1
+      ssri: 12.0.0
     transitivePeerDependencies:
-      - bluebird
       - supports-color
 
   many-keys-map@3.0.3: {}
@@ -23066,15 +22901,15 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass-collect@1.0.2:
+  minipass-collect@2.0.1:
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.1.3
 
-  minipass-fetch@2.1.2:
+  minipass-fetch@4.0.1:
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.1.3
       minipass-sized: 1.0.3
-      minizlib: 2.1.2
+      minizlib: 3.1.0
     optionalDependencies:
       encoding: 0.1.13
 
@@ -23095,11 +22930,6 @@ snapshots:
       yallist: 4.0.0
 
   minipass@7.1.3: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
 
   minizlib@3.1.0:
     dependencies:
@@ -23223,6 +23053,21 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
+  node-gyp@11.5.0(supports-color@10.2.2):
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 14.0.3(supports-color@10.2.2)
+      nopt: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.8.5
+      tar: 7.5.15
+      tinyglobby: 0.2.17
+      which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   node-html-parser@6.1.13:
     dependencies:
       css-select: 5.2.2
@@ -23252,9 +23097,9 @@ snapshots:
 
   node-releases@2.0.50: {}
 
-  nopt@6.0.0:
+  nopt@8.1.0:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 3.0.1
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -23460,10 +23305,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  p-map@4.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
 
   p-map@7.0.4: {}
 
@@ -23750,17 +23591,13 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  proc-log@2.0.1: {}
+  proc-log@5.0.0: {}
 
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
 
   progress@2.0.3: {}
-
-  promise-inflight@1.0.1(bluebird@3.7.2):
-    optionalDependencies:
-      bluebird: 3.7.2
 
   promise-retry@2.0.1:
     dependencies:
@@ -24263,10 +24100,6 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rimraf@3.0.2:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
@@ -24657,14 +24490,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@7.0.0(supports-color@10.2.2):
-    dependencies:
-      agent-base: 6.0.2(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
   socks-proxy-agent@8.0.5(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
@@ -24727,9 +24552,9 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
-  ssri@9.0.1:
+  ssri@12.0.0:
     dependencies:
-      minipass: 3.3.6
+      minipass: 7.1.3
 
   stack-trace@1.0.0: {}
 
@@ -25466,11 +25291,11 @@ snapshots:
     dependencies:
       qs: 6.15.2
 
-  unique-filename@2.0.1:
+  unique-filename@4.0.0:
     dependencies:
-      unique-slug: 3.0.0
+      unique-slug: 5.0.0
 
-  unique-slug@3.0.0:
+  unique-slug@5.0.0:
     dependencies:
       imurmurhash: 0.1.4
 
@@ -25951,6 +25776,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.5
 
   which@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,6 @@ packages:
 
 nodeLinker: hoisted
 
-# pnpm v11 enabled this by default; @electron/rebuild pulls @electron/node-gyp via git.
-blockExoticSubdeps: false
-
 # pnpm v11 introduced a 1-day default release age; keep at 0 so Renovate-driven
 # updates and regular installs aren't stalled.
 minimumReleaseAge: 0
@@ -15,6 +12,12 @@ minimumReleaseAge: 0
 pmOnFail: ignore
 
 overrides:
+  # @electron/rebuild 3.7.x (via electron-forge 7) pins @electron/node-gyp to a GitHub
+  # tarball, which fails wherever only registry.npmjs.org is reachable and trips pnpm's
+  # blockExoticSubdeps default. Vanilla node-gyp >= 11.2 carries the fork's fixes, and
+  # rebuild's one import of it is API-compatible -- rebuild 4.0.1 made the identical
+  # swap (electron/rebuild#1185); electron-forge 7 still pins rebuild 3.7.x.
+  "@electron/node-gyp": "npm:node-gyp@^11.2.0"
   # CodeMirror 6 is a swarm of packages that peer-depend on a shared runtime
   # (view/state/language/...) and rely on single-instance object identity for
   # facets to work. A partial bump leaves two copies in the tree, which breaks


### PR DESCRIPTION
electron-forge 7 pulls @electron/rebuild 3.7.x, which pins
@electron/node-gyp to a GitHub commit tarball on codeload.github.com.
That single non-registry source fails pnpm install with
ERR_PNPM_FETCH_403 in any environment where only registry.npmjs.org is
reachable (restricted CI, sandboxed agents such as Claude Code cloud),
and it is the sole reason blockExoticSubdeps had to be disabled.

Alias the fork to vanilla node-gyp instead. This mirrors what upstream
shipped in @electron/rebuild 4.0.1 (electron/rebuild#1185, "return to
node-gyp"): node-gyp >= 11.2 carries the fork's Python 3.12 / macOS
Sequoia fixes, and rebuild's one import of it (module-type/node-gyp/
worker.js) uses the unchanged programmatic API - the 4.0.0 -> 4.0.1 diff
is exactly that dependency swap and nothing else. electron-forge still
pins rebuild ^3.7.0 in its latest release, so the override applies the
same swap until forge 8 lands, and can be dropped then.

With no git-hosted subdependency left, the blockExoticSubdeps
workaround is removed and pnpm's default protection passes again.

Validated: pnpm install completes with the lockfile containing only
registry.npmjs.org sources; @electron/rebuild 3.7.2 loads and drives
the aliased node-gyp 11.5.0; a forced better-sqlite3 rebuild through it
(configure, full SQLite amalgamation compile, link) succeeds.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017BAF6qDX4DsZfHwd5QaZEk