### PR TITLE
fix(setup): don't trust a loopback location as a reachable address

### DIFF
--- a/apps/client/src/setup.spec.tsx
+++ b/apps/client/src/setup.spec.tsx
@@ -31,7 +31,7 @@ const serverMock = vi.hoisted(() => ({
 }));
 vi.mock("./services/server", () => ({ default: serverMock }));
 
-import { afterLanguage, initialState, openedAtRestore, renderState, SyncFailed, SyncFromServer, SyncInProgress } from "./setup";
+import { afterLanguage, getNetworkAddresses, initialState, openedAtRestore, renderState, SyncFailed, SyncFromServer, SyncInProgress } from "./setup";
 
 type Stats = { outstandingPullCount: number; totalPullCount: number | null; initialized: boolean; lastSyncError?: string | null };
 
@@ -476,6 +476,40 @@ describe("SyncFromServer", () => {
 
         const host = c.querySelector<HTMLInputElement>("input");
         expect(host?.value).toBe("");
+    });
+});
+
+describe("getNetworkAddresses, deciding whose word to trust for this device's address", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("trusts the page's own address when a plain browser reached it over the network", async () => {
+        vi.stubGlobal("location", { protocol: "http:", host: "192.168.1.20:8080", hostname: "192.168.1.20" });
+
+        expect(await getNetworkAddresses()).toEqual({ addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true });
+        expect(serverMock.get).not.toHaveBeenCalledWith("network-addresses");
+    });
+
+    it("distrusts its own loopback address and asks the server instead, as Pocket Trilium's webview would hit", async () => {
+        // Pocket Trilium runs a full Trilium server locally on the phone and shows it through a plain
+        // webview, no Electron API, but `location.hostname` is still 127.0.0.1 because the page never
+        // left the device. Trusting `location.host` here would hand the user back their own loopback
+        // address instead of one another device could actually reach.
+        vi.stubGlobal("location", { protocol: "http:", host: "127.0.0.1:8080", hostname: "127.0.0.1" });
+        mockRoutes({ "network-addresses": { addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true } });
+
+        expect(await getNetworkAddresses()).toEqual({ addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true });
+        expect(serverMock.get).toHaveBeenCalledWith("network-addresses");
+    });
+
+    it("still asks the server in Electron, whose location points at the internal protocol rather than a real listener", async () => {
+        vi.stubGlobal("electronApi", {});
+        vi.stubGlobal("location", { protocol: "trilium-app:", host: "", hostname: "" });
+        mockRoutes({ "network-addresses": { addresses: [], reachableOnNetwork: false } });
+
+        expect(await getNetworkAddresses()).toEqual({ addresses: [], reachableOnNetwork: false });
+        expect(serverMock.get).toHaveBeenCalledWith("network-addresses");
     });
 });
 

--- a/apps/client/src/setup.spec.tsx
+++ b/apps/client/src/setup.spec.tsx
@@ -491,12 +491,16 @@ describe("getNetworkAddresses, deciding whose word to trust for this device's ad
         expect(serverMock.get).not.toHaveBeenCalledWith("network-addresses");
     });
 
-    it("distrusts its own loopback address and asks the server instead, as Pocket Trilium's webview would hit", async () => {
-        // Pocket Trilium runs a full Trilium server locally on the phone and shows it through a plain
-        // webview, no Electron API, but `location.hostname` is still 127.0.0.1 because the page never
-        // left the device. Trusting `location.host` here would hand the user back their own loopback
-        // address instead of one another device could actually reach.
+    it("distrusts its own loopback address and asks the server instead, as a webview on the same device would hit", async () => {
         vi.stubGlobal("location", { protocol: "http:", host: "127.0.0.1:8080", hostname: "127.0.0.1" });
+        mockRoutes({ "network-addresses": { addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true } });
+
+        expect(await getNetworkAddresses()).toEqual({ addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true });
+        expect(serverMock.get).toHaveBeenCalledWith("network-addresses");
+    });
+
+    it("distrusts a bracketed IPv6 loopback address the same way", async () => {
+        vi.stubGlobal("location", { protocol: "http:", host: "[::1]:8080", hostname: "[::1]" });
         mockRoutes({ "network-addresses": { addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true } });
 
         expect(await getNetworkAddresses()).toEqual({ addresses: [ "http://192.168.1.20:8080" ], reachableOnNetwork: true });

--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -875,22 +875,23 @@ export async function getNetworkAddresses(): Promise<NetworkAddressesResponse> {
         return { addresses: [`${location.protocol}//${location.host}`], reachableOnNetwork: true };
     }
 
-    // Either we're in Electron (Node's `os` module isn't available in the
-    // renderer, and the desktop renderer's `location` points at the internal
-    // `trilium-app://` protocol rather than the real HTTP listener), or the
-    // page itself was loaded over loopback, e.g. a mobile app's embedded
-    // webview talking to a server running locally on the same device, as with
-    // Pocket Trilium. Either way `location.host` isn't an address another
-    // device could use, so ask the server to enumerate its real network
-    // interfaces and build the reachable URLs (correct protocol and port
-    // included) instead.
+    // Either we're in Electron (`location` points at the internal `trilium-app://`
+    // protocol, not the real HTTP listener), or the page was loaded over loopback,
+    // e.g. a mobile app's embedded webview hitting a server running on the same
+    // device. Either way `location.host` isn't an address another device could
+    // use, so ask the server to enumerate its real network interfaces instead.
     return await server.get<NetworkAddressesResponse>("network-addresses");
 }
 
-/** Mirrors the loopback check the server applies to its own listen host in `isHostReachableOnNetwork`. */
+/**
+ * Mirrors the loopback check the server applies to its own listen host in
+ * `isHostReachableOnNetwork`, but on `location.hostname`, where a browser
+ * serializes an IPv6 address with its brackets intact (`[::1]`), unlike the
+ * server's raw, unbracketed config value.
+ */
 function isLoopbackHostname(hostname: string): boolean {
     const normalized = hostname.toLowerCase();
-    return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.");
+    return normalized === "localhost" || normalized === "::1" || normalized === "[::1]" || normalized.startsWith("127.");
 }
 
 async function allowLanAccessAndRestart() {

--- a/apps/client/src/setup.tsx
+++ b/apps/client/src/setup.tsx
@@ -868,20 +868,29 @@ function SetupOptionCard({ title, description, icon, onClick, disabled }: { titl
     );
 }
 
-async function getNetworkAddresses(): Promise<NetworkAddressesResponse> {
-    if (!isElectron()) {
+export async function getNetworkAddresses(): Promise<NetworkAddressesResponse> {
+    if (!isElectron() && !isLoopbackHostname(location.hostname)) {
         // The browser already reached this server over the network, so the
         // address it's using is reachable by definition.
         return { addresses: [`${location.protocol}//${location.host}`], reachableOnNetwork: true };
     }
 
-    // Node's `os` module isn't available in the renderer (node integration is
-    // disabled), and the desktop renderer's `location` points at the internal
-    // `trilium-app://` protocol rather than the real HTTP listener. So the
-    // server enumerates its interfaces and builds the reachable URLs (correct
-    // protocol and port included), and reports whether it's actually bound to a
-    // network-reachable interface.
+    // Either we're in Electron (Node's `os` module isn't available in the
+    // renderer, and the desktop renderer's `location` points at the internal
+    // `trilium-app://` protocol rather than the real HTTP listener), or the
+    // page itself was loaded over loopback, e.g. a mobile app's embedded
+    // webview talking to a server running locally on the same device, as with
+    // Pocket Trilium. Either way `location.host` isn't an address another
+    // device could use, so ask the server to enumerate its real network
+    // interfaces and build the reachable URLs (correct protocol and port
+    // included) instead.
     return await server.get<NetworkAddressesResponse>("network-addresses");
+}
+
+/** Mirrors the loopback check the server applies to its own listen host in `isHostReachableOnNetwork`. */
+function isLoopbackHostname(hostname: string): boolean {
+    const normalized = hostname.toLowerCase();
+    return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.");
 }
 
 async function allowLanAccessAndRestart() {


### PR DESCRIPTION
## What was broken

The setup wizard's "Connect a desktop app" screen (`SyncFromDesktop` in `apps/client/src/setup.tsx`) is supposed to show a reachable LAN address so a desktop instance can be pointed at this device. Instead, on any non-Electron client that loaded the page over loopback, it showed `127.0.0.1`, the device's own loopback address, which nothing else on the network can use.

The concrete trigger is [Pocket Trilium](https://github.com/Nriver/pocket-trilium), a third-party Android app that runs a full Trilium server locally on the phone and displays Trilium's own bundled web UI through a webview pointed at `http://127.0.0.1:<port>`. When a Pocket Trilium user opens the setup wizard, the address shown is useless, since it is the phone's own address, not one another device can reach.

Before:

![127.0.0.1 shown as the address](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-bug-loopback-address-and-column-overlap.jpeg)

## Why

`getNetworkAddresses()` had:

```ts
if (!isElectron()) {
    return { addresses: [`${location.protocol}//${location.host}`], reachableOnNetwork: true };
}
```

This assumed that any non-Electron client had reached the server over the network, so `location.host` must be reachable by other devices. That is true for a desktop browser hitting a hosted instance, but false when the page itself was loaded over loopback, on the same device, as with Pocket Trilium's webview. The Electron branch already handles this correctly by asking the server to enumerate its real interfaces via `GET /api/network-addresses` (`collectNetworkAddresses` in `apps/server/src/routes/api/system_info.ts`, which filters out internal and loopback interfaces). The webview case just needed to fall into that same path.

## The fix

Loopback hostnames now take the same server-enumeration path Electron already used:

```ts
if (!isElectron() && !isLoopbackHostname(location.hostname)) {
    return { addresses: [`${location.protocol}//${location.host}`], reachableOnNetwork: true };
}
```

`isLoopbackHostname` mirrors the same check the server already applies to its own listen host in `isHostReachableOnNetwork` (`localhost`, `::1`, and the full `127.0.0.0/8` range, not just `127.0.0.1`).

## Testing

- Added unit tests in `apps/client/src/setup.spec.tsx` covering all three branches of `getNetworkAddresses`: a plain network browser (trusts `location.host`), a loopback browser (asks the server), and Electron (asks the server).
- `pnpm client:test`, `pnpm server:test`, `pnpm typecheck`, and `pnpm dev:linter-check` all pass.
- Reproduced the bug on `main` first: opened `http://127.0.0.1:<port>/` in a plain desktop browser (not Electron), which is exactly the code path Pocket Trilium's webview takes, and confirmed it showed `127.0.0.1`.
- Applied the fix and confirmed it now shows the real LAN address instead.
- Regression checked the Electron loopback-only-binding flow, the case an earlier PR (#10222) built for: ran the desktop app fresh (no LAN access), confirmed the "This device can't be reached by other devices" banner and "Allow network access & restart" button still work, and that the address shown is correct after the restart.
- End to end: ran a second local Trilium instance, entered the address shown by the fixed wizard into that instance's Sync settings, and clicked "Test sync". Got back a real successful handshake: `{"success":true,"message":"Sync server handshake has been successful, sync has been started."}`.
- Confirmed on a real Android phone over Wi-Fi, using a plain browser (equivalent to Pocket Trilium's webview): the wizard now shows the phone's real LAN address.

After, on a real phone:

![Real LAN address shown on an Android phone](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-fix-confirmed-real-phone.jpeg)

After, in a desktop browser:

![Real LAN address shown in a desktop browser](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/after-fix-desktop-address.png)

## Scope note

This PR is the address fix only. There are two related CSS layout bugs on the same screen (a back button that overlaps scrolled content, and a two-column layout that does not collapse on narrow screens), which I am sending as a separate PR to keep each one focused on a single problem.

## AI assistance

The investigation and implementation were AI assisted. I reviewed the root cause against current `main` myself, wrote and ran the tests, and did all the manual verification described above myself, including the live browser reproduction, the Electron regression check, the two-instance sync handshake, and the real-phone confirmation. Happy to answer questions on any part of this.
