### PR TITLE
fix(setup): stop the back button overlapping content and collapse the two-column layout on narrow screens

### DIFF
--- a/apps/client/src/setup.css
+++ b/apps/client/src/setup.css
@@ -141,10 +141,30 @@ body.setup {
             overflow: auto;
 
             >.back-button {
-                position: absolute;
+                /* `.page` is the element that scrolls (`overflow: auto` above), not
+                   `.setup-container`, so `absolute` positioned this against the
+                   non-scrolling outer container and left it pinned on screen while
+                   the content scrolled underneath it. `sticky` keeps it reserved in
+                   normal flow, pushing later content below it instead of under it,
+                   while still sticking to the top of the scrollable area on scroll,
+                   the same technique `.page > footer` below already uses to stick to
+                   the bottom. */
+                position: sticky;
                 top: calc(1em + env(safe-area-inset-top));
                 inset-inline-start: 1em;
+                align-self: flex-start;
+                z-index: 1;
                 color: var(--muted-text-color);
+                /* Sticking means later content scrolls up underneath this button, the same as
+                   `.page > footer` below sticking to the bottom. Without a background of its own
+                   that content would show through and read as overlapping text; give it the same
+                   fill footer uses, dropped the same way in the effects theme where the card
+                   itself has none to match. */
+                background: var(--main-background-color);
+
+                body.background-effects & {
+                    background: transparent;
+                }
 
                 body.desktop & {
                     inset-inline-start: 2em;
@@ -411,8 +431,23 @@ body.setup .bx-spin {
 .page.sync-from-desktop {
     .card-columns {
         display: flex;
-        flex-direction: row;
+        flex-direction: column;
         gap: 1.5rem;
+
+        @media (min-width: 700px) {
+            flex-direction: row;
+
+            /* `.tn-card` opts into `container-type: inline-size` (Card.css) so its own contents
+               can be laid out by the room the card is given rather than by the viewport, but
+               that same size containment zeroes its intrinsic width contribution as a flex item.
+               `.ip-addresses` has an explicit min-width to fall back on; this, the instructions
+               card, does not, so uncontained it collapsed to 0 width and rendered on top of
+               `.ip-addresses` instead of beside it. Giving it a flex-basis of its own fixes that
+               regardless of its own (zeroed) content size. */
+            > :first-child {
+                flex: 1;
+            }
+        }
     }
 
     .sync-from-desktop-waiting {

--- a/apps/client/src/setup.css
+++ b/apps/client/src/setup.css
@@ -141,25 +141,16 @@ body.setup {
             overflow: auto;
 
             >.back-button {
-                /* `.page` is the element that scrolls (`overflow: auto` above), not
-                   `.setup-container`, so `absolute` positioned this against the
-                   non-scrolling outer container and left it pinned on screen while
-                   the content scrolled underneath it. `sticky` keeps it reserved in
-                   normal flow, pushing later content below it instead of under it,
-                   while still sticking to the top of the scrollable area on scroll,
-                   the same technique `.page > footer` below already uses to stick to
-                   the bottom. */
+                /* `.page` scrolls (not `.setup-container`), so sticky is required here, not
+                   absolute, to stay in flow and follow the scroll. */
                 position: sticky;
                 top: calc(1em + env(safe-area-inset-top));
                 inset-inline-start: 1em;
                 align-self: flex-start;
                 z-index: 1;
                 color: var(--muted-text-color);
-                /* Sticking means later content scrolls up underneath this button, the same as
-                   `.page > footer` below sticking to the bottom. Without a background of its own
-                   that content would show through and read as overlapping text; give it the same
-                   fill footer uses, dropped the same way in the effects theme where the card
-                   itself has none to match. */
+                /* Sticky content still scrolls in underneath; an opaque fill stops it showing
+                   through, same technique `.page > footer` below already uses. */
                 background: var(--main-background-color);
 
                 body.background-effects & {
@@ -437,13 +428,8 @@ body.setup .bx-spin {
         @media (min-width: 700px) {
             flex-direction: row;
 
-            /* `.tn-card` opts into `container-type: inline-size` (Card.css) so its own contents
-               can be laid out by the room the card is given rather than by the viewport, but
-               that same size containment zeroes its intrinsic width contribution as a flex item.
-               `.ip-addresses` has an explicit min-width to fall back on; this, the instructions
-               card, does not, so uncontained it collapsed to 0 width and rendered on top of
-               `.ip-addresses` instead of beside it. Giving it a flex-basis of its own fixes that
-               regardless of its own (zeroed) content size. */
+            /* `container-type: inline-size` on `.tn-card` (Card.css) zeroes a flex item's
+               own width contribution; give this card an explicit share of the row. */
             > :first-child {
                 flex: 1;
             }

--- a/apps/client/src/translations/en/entry.json
+++ b/apps/client/src/translations/en/entry.json
@@ -59,7 +59,7 @@
     "sync-from-desktop-step1": "Open your desktop instance of Trilium Notes.",
     "sync-from-desktop-step2": "From the Trilium Menu, click Options.",
     "sync-from-desktop-step3": "Click on Sync category in the note tree.",
-    "sync-from-desktop-step4": "Change server instance address to point to one of the addresses on the right and click Save.",
+    "sync-from-desktop-step4": "Change server instance address to point to one of the addresses on the right (or below, on a narrow screen) and click Save.",
     "sync-from-desktop-step5": "Click the \"Test sync\" button to verify connection is successful.",
     "sync-from-desktop-warning": "Make sure both devices are on the same network.",
     "sync-from-desktop-waiting": "Waiting for connection...",


### PR DESCRIPTION
## What was broken

Two related layout bugs on the same setup wizard screen as #11262 (`SyncFromDesktop` in `apps/client/src/setup.tsx`), both most visible on narrow screens such as Pocket Trilium's webview:

**1. The back button overlaps scrolled content.**

`.back-button` was `position: absolute`, but its positioning context was the outer, non-scrolling `.setup-container`, while its actual parent `.page` scrolls internally (`overflow: auto`). As the user scrolled the long instructions, the button stayed pinned at a fixed screen position instead of scrolling with the content, so whatever text scrolled underneath it visually merged with it.

**2. The two-column layout collides instead of collapsing on narrow screens.**

`.card-columns` was hardcoded `flex-direction: row` with no responsive breakpoint, so on a phone-width viewport the instructions card and the addresses card were forced into a row with no room for either.

Before:

![Back button overlapping scrolled text](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-bug-back-button-overlap-1.jpeg)
![Back button overlapping scrolled text, further down](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-bug-back-button-overlap-2.jpeg)
![Back button overlapping text near the top](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-bug-back-button-overlap-3.jpeg)
![Column headings colliding on a narrow screen](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-bug-loopback-address-and-column-overlap.jpeg)

## The fix

**Back button:** switched to `position: sticky`, the same technique `.page > footer` already uses to stick to the bottom of this same scroll container. `sticky` keeps the button reserved in normal flow, pushing later content below it instead of under it, while still sticking to the top of the scrollable area as the user scrolls. Sticking still means later content scrolls up underneath the button, though, and unlike footer it had no background of its own, so that content kept showing through and reading as overlapping text. Gave it the same `var(--main-background-color)` fill footer uses, dropped the same way in the `background-effects` theme where the card itself has none to match.

**Column layout:** added the 700px breakpoint this file already uses elsewhere for the same desktop and mobile split, so `.card-columns` stacks vertically below that width instead of forcing a row.

**A third, previously undocumented bug found while testing the above:** the breakpoint alone was not enough to stop the two cards colliding, even above 700px. `.tn-card` (`Card.css`) opts every card into `container-type: inline-size` for its own internal container queries, and that same size containment zeroes a card's intrinsic width contribution as a flex item. `.ip-addresses` has an explicit `min-width` to fall back on; the instructions card does not, so uncontained it collapsed to 0 width and rendered on top of `.ip-addresses` instead of beside it, in row mode at any width. This predates this PR, present since the two-column layout was first introduced (commit 8eb45e2 in this file's history), and is not specific to the responsive breakpoint added here. Gave the instructions card a flex-basis of its own so it holds its share of the row regardless of its own (zeroed) content size.

**A fourth issue, also found while testing:** step 4's instructions said to use "one of the addresses on the right," which was only ever true in the two-column layout. Now that narrow screens correctly get their own single-column layout instead of a collision, the address card sits below the instructions rather than beside them, so the copy needed to say both.

## Testing

- `pnpm typecheck` passes.
- `pnpm client:stylelint` shows no new violations from this diff (checked line by line against the pre-existing repo-wide backlog of logical-property warnings, none of which fall inside the ranges this PR touches).
- `pnpm client:test` passes.
- Verified live against a running dev server (headless Chromium via Playwright, not just reasoning about the CSS): at 900px width the two columns now sit cleanly side by side with no overlap, including the width-collapse bug; at 390px width the layout stacks into a single column with no collision, and the back button keeps a legible, opaque background while scrolling instead of the previous garbled overlap.
- Confirmed on a real Android phone over Wi-Fi: single stacked column, no back-button overlap while scrolling.

After, on a real phone:

![Real phone confirming the layout fix](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/setup-wizard-fix-confirmed-real-phone.jpeg)

After, at phone width, unscrolled:

![Single column, no collision](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/after-fix-mobile-top.png)

After, at phone width, scrolled:

![Back button stays legible while scrolling](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/after-fix-mobile-scrolled.png)

After, at desktop width:

![Two columns side by side, no collision](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/setup-wizard-fix/after-fix-desktop-address.png)

## Scope note

This is the layout half of the fix from #11262, split out per the contributing guide's request for small, focused PRs covering one problem each. The two issues found while testing (the card-width collapse and the step 4 copy) are included here rather than as separate PRs, since both are direct consequences of correctly fixing the same `.card-columns` layout this PR already touches, and shipping the breakpoint fix without them would leave the exact same collision this PR claims to fix, just moved to a different viewport width or left inaccurate in the instructions.

## AI assistance

The investigation and implementation were AI assisted. I reviewed the root causes myself, including the two additional issues found only by actually testing the fix in a live browser rather than just reading the CSS, and did all the manual verification described above myself. Happy to answer questions on any part of this.
