### PR TITLE
fix(client): stop dropping note title keystrokes after creating a note (closes #11244)

### DIFF
--- a/apps/client/src/services/focus.spec.ts
+++ b/apps/client/src/services/focus.spec.ts
@@ -1,11 +1,58 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import $ from "jquery";
 
-import { focusSavedElement, saveFocusedElement } from "./focus.js";
+import { focusSavedElement, isTitleFocusPending, markTitleFocusPending, saveFocusedElement } from "./focus.js";
 
 afterEach(() => {
     document.body.innerHTML = "";
     vi.restoreAllMocks();
+    vi.useRealTimers();
+});
+
+describe("pending title focus (#11244)", () => {
+    it("is not pending before anything marks it", () => {
+        expect(isTitleFocusPending()).toBe(false);
+        expect(isTitleFocusPending("ntx-1")).toBe(false);
+    });
+
+    it("is pending for the marked ntxId, for any ntxId query, but not for a different one", () => {
+        markTitleFocusPending("ntx-1");
+
+        expect(isTitleFocusPending("ntx-1")).toBe(true);
+        expect(isTitleFocusPending()).toBe(true);
+        expect(isTitleFocusPending("ntx-2")).toBe(false);
+    });
+
+    it("treats a null ntxId as its own identity, not as 'any'", () => {
+        markTitleFocusPending(null);
+
+        expect(isTitleFocusPending(null)).toBe(true);
+        expect(isTitleFocusPending("ntx-1")).toBe(false);
+        expect(isTitleFocusPending()).toBe(true);
+    });
+
+    it("expires after its protection window so it cannot suppress focus changes forever", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+
+        markTitleFocusPending("ntx-1");
+        expect(isTitleFocusPending("ntx-1")).toBe(true);
+
+        vi.setSystemTime(1499);
+        expect(isTitleFocusPending("ntx-1")).toBe(true);
+
+        vi.setSystemTime(1501);
+        expect(isTitleFocusPending("ntx-1")).toBe(false);
+        expect(isTitleFocusPending()).toBe(false);
+    });
+
+    it("a later mark supersedes an earlier one instead of accumulating", () => {
+        markTitleFocusPending("ntx-1");
+        markTitleFocusPending("ntx-2");
+
+        expect(isTitleFocusPending("ntx-1")).toBe(false);
+        expect(isTitleFocusPending("ntx-2")).toBe(true);
+    });
 });
 
 describe("focus service", () => {

--- a/apps/client/src/services/focus.spec.ts
+++ b/apps/client/src/services/focus.spec.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import $ from "jquery";
 
-import { focusSavedElement, isTitleFocusPending, markTitleFocusPending, saveFocusedElement } from "./focus.js";
+import {
+    focusSavedElement,
+    isTitleFocusPending,
+    markTitleFocusPending,
+    saveFocusedElement
+} from "./focus.js";
 
 afterEach(() => {
     document.body.innerHTML = "";

--- a/apps/client/src/services/focus.ts
+++ b/apps/client/src/services/focus.ts
@@ -1,18 +1,19 @@
 let $lastFocusedElement: JQuery<HTMLElement> | null;
 
-let pendingTitleFocusNtxId: string | null | undefined; // undefined = unset (distinct from a null ntxId)
+// undefined = unset, distinct from a null ntxId.
+let pendingTitleFocusNtxId: string | null | undefined;
 let pendingTitleFocusAt = 0;
 
 // Bounded so a request that never resolves can't suppress focus changes forever.
 const PENDING_TITLE_FOCUS_TIMEOUT_MS = 1500;
 
-/** Marks a new note's title as about to be focused, so other async focus handlers (see note_tree.ts #setActiveNode) can back off instead of racing it. See #11244. */
+/** Marks a new note's title as about to be focused, so other async focus handlers can back off. */
 export function markTitleFocusPending(ntxId: string | null) {
     pendingTitleFocusNtxId = ntxId;
     pendingTitleFocusAt = Date.now();
 }
 
-/** True if a title-focus request for `ntxId` (or any, if omitted) is still within its protection window. */
+/** True if a title-focus request for `ntxId` (or any, if omitted) is still pending. */
 export function isTitleFocusPending(ntxId?: string | null) {
     if (pendingTitleFocusNtxId === undefined) {
         return false;

--- a/apps/client/src/services/focus.ts
+++ b/apps/client/src/services/focus.ts
@@ -1,5 +1,31 @@
 let $lastFocusedElement: JQuery<HTMLElement> | null;
 
+let pendingTitleFocusNtxId: string | null | undefined; // undefined = unset (distinct from a null ntxId)
+let pendingTitleFocusAt = 0;
+
+// Bounded so a request that never resolves can't suppress focus changes forever.
+const PENDING_TITLE_FOCUS_TIMEOUT_MS = 1500;
+
+/** Marks a new note's title as about to be focused, so other async focus handlers (see note_tree.ts #setActiveNode) can back off instead of racing it. See #11244. */
+export function markTitleFocusPending(ntxId: string | null) {
+    pendingTitleFocusNtxId = ntxId;
+    pendingTitleFocusAt = Date.now();
+}
+
+/** True if a title-focus request for `ntxId` (or any, if omitted) is still within its protection window. */
+export function isTitleFocusPending(ntxId?: string | null) {
+    if (pendingTitleFocusNtxId === undefined) {
+        return false;
+    }
+
+    if (Date.now() - pendingTitleFocusAt > PENDING_TITLE_FOCUS_TIMEOUT_MS) {
+        pendingTitleFocusNtxId = undefined;
+        return false;
+    }
+
+    return ntxId === undefined || ntxId === pendingTitleFocusNtxId;
+}
+
 // perhaps there should be saved focused element per tab?
 export function saveFocusedElement() {
     $lastFocusedElement = $(":focus");

--- a/apps/client/src/services/note_create.ts
+++ b/apps/client/src/services/note_create.ts
@@ -7,6 +7,7 @@ import type FBranch from "../entities/fbranch.js";
 import type FNote from "../entities/fnote.js";
 import type { ChooseNoteTypeResponse } from "../widgets/dialogs/note_type_chooser.js";
 import branchService from "./branches.js";
+import { markTitleFocusPending } from "./focus.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import protectedSessionHolder from "./protected_session_holder.js";
@@ -112,6 +113,7 @@ async function createNote(parentNotePath: string | undefined, options: CreateNot
         });
 
         if (options.focus === "title") {
+            markTitleFocusPending(activeNoteContext.ntxId);
             appContext.triggerEvent("focusAndSelectTitle", { isNewNote: true, ntxId: activeNoteContext.ntxId });
         } else if (options.focus === "content") {
             appContext.triggerEvent("focusOnDetail", { ntxId: activeNoteContext.ntxId });

--- a/apps/client/src/widgets/note_tree.spec.ts
+++ b/apps/client/src/widgets/note_tree.spec.ts
@@ -62,14 +62,33 @@ describe("fancytree nodeKeydown patch (#11244)", () => {
             const tree: Fancytree.Fancytree = $tree.fancytree("getTree");
 
             // nodeKeydown()'s null-node fallback assumes tree.focusNode is populated the instant
-            // focusNode.setFocus() returns. Stub setFocus() as a no-op to violate that assumption
-            // directly, the same way a mid-flight DOM/tree update does in the real app.
-            vi.spyOn(tree, "getFirstChild").mockReturnValue({ setFocus: vi.fn() } as unknown as Fancytree.FancytreeNode);
+            // focusNode.setFocus() returns. Stub setFocus() as a no-op to violate that assumption.
+            const firstChild = { setFocus: vi.fn() } as unknown as Fancytree.FancytreeNode;
+            vi.spyOn(tree, "getFirstChild").mockReturnValue(firstChild);
             expect(tree.getActiveNode()).toBeNull();
             expect(tree.focusNode).toBeNull();
 
-            // Without the patch this threw "TypeError: Cannot read properties of null (reading 'debug')".
-            expect(() => tree.$container.trigger($.Event("keydown", { which: 65, key: "a" }))).not.toThrow();
+            const keydown = $.Event("keydown", { which: 65, key: "a" });
+            expect(() => tree.$container.trigger(keydown)).not.toThrow();
+        } finally {
+            $tree.remove();
+        }
+    });
+
+    it("still propagates an unrelated error from the same code path", () => {
+        const $tree = $("<div>").appendTo(document.body);
+
+        try {
+            $tree.fancytree({ keyboard: true, source: [{ title: "child", key: "child" }] });
+            const tree: Fancytree.Fancytree = $tree.fancytree("getTree");
+
+            vi.spyOn(tree, "getActiveNode").mockImplementation(() => {
+                throw new TypeError("unrelated failure");
+            });
+            expect(tree.focusNode).toBeNull();
+
+            const keydown = $.Event("keydown", { which: 65, key: "a" });
+            expect(() => tree.$container.trigger(keydown)).toThrow("unrelated failure");
         } finally {
             $tree.remove();
         }

--- a/apps/client/src/widgets/note_tree.spec.ts
+++ b/apps/client/src/widgets/note_tree.spec.ts
@@ -53,6 +53,29 @@ describe("fancytree scrollIntoView patch", () => {
     });
 });
 
+describe("fancytree nodeKeydown patch (#11244)", () => {
+    it("does not crash when node.setFocus() returns without updating tree.focusNode", () => {
+        const $tree = $("<div>").appendTo(document.body);
+
+        try {
+            $tree.fancytree({ keyboard: true, source: [{ title: "child", key: "child" }] });
+            const tree: Fancytree.Fancytree = $tree.fancytree("getTree");
+
+            // nodeKeydown()'s null-node fallback assumes tree.focusNode is populated the instant
+            // focusNode.setFocus() returns. Stub setFocus() as a no-op to violate that assumption
+            // directly, the same way a mid-flight DOM/tree update does in the real app.
+            vi.spyOn(tree, "getFirstChild").mockReturnValue({ setFocus: vi.fn() } as unknown as Fancytree.FancytreeNode);
+            expect(tree.getActiveNode()).toBeNull();
+            expect(tree.focusNode).toBeNull();
+
+            // Without the patch this threw "TypeError: Cannot read properties of null (reading 'debug')".
+            expect(() => tree.$container.trigger($.Event("keydown", { which: 65, key: "a" }))).not.toThrow();
+        } finally {
+            $tree.remove();
+        }
+    });
+});
+
 describe("NoteTreeWidget", () => {
     afterEach(() => {
         vi.restoreAllMocks();

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -2042,22 +2042,28 @@ patchScrollIntoViewCrash();
 
 type NodeKeydownFn = (this: Fancytree.Fancytree, ctx: Fancytree.EventData) => unknown;
 
-/**
- * jquery.fancytree's `nodeKeydown()` dereferences `this.focusNode` right after calling
- * `.setFocus()`, but that can still be null (DOM focus hasn't caught up yet), throwing
- * "Cannot read properties of null (reading 'debug')" and swallowing the keystroke. See #11244.
- */
+// jquery.fancytree's nodeKeydown() wrongly assumes this.focusNode is always populated
+// right after calling setFocus() on it. See #11244.
+const NULL_FOCUS_NODE_ERROR = /reading 'debug'/;
+
 function patchNodeKeydownCrash() {
     const { _FancytreeClass } = $.ui.fancytree as Fancytree.FancytreeStatic & {
         _FancytreeClass: { prototype: { nodeKeydown: NodeKeydownFn } };
     };
     const originalNodeKeydown = _FancytreeClass.prototype.nodeKeydown;
 
-    _FancytreeClass.prototype.nodeKeydown = function (this: Fancytree.Fancytree, ctx: Fancytree.EventData) {
+    _FancytreeClass.prototype.nodeKeydown = function (
+        this: Fancytree.Fancytree,
+        ctx: Fancytree.EventData
+    ) {
         try {
             return originalNodeKeydown.call(this, ctx);
         } catch (e) {
-            console.warn("Ignoring fancytree nodeKeydown crash", e);
+            if (e instanceof TypeError && NULL_FOCUS_NODE_ERROR.test(e.message)) {
+                console.warn("Ignoring fancytree nodeKeydown crash", e);
+                return;
+            }
+            throw e;
         }
     };
 }

--- a/apps/client/src/widgets/note_tree.ts
+++ b/apps/client/src/widgets/note_tree.ts
@@ -14,6 +14,7 @@ import type FNote from "../entities/fnote.js";
 import contextMenu from "../menus/context_menu.js";
 import type { TreeCommandNames } from "../menus/tree_context_menu.js";
 import branchService from "../services/branches.js";
+import { isTitleFocusPending } from "../services/focus.js";
 import froca from "../services/froca.js";
 import hoistedNoteService from "../services/hoisted_note.js";
 import { t } from "../services/i18n.js";
@@ -1530,12 +1531,16 @@ export default class NoteTreeWidget extends NoteContextAwareWidget {
             return;
         }
 
-        if (activeNodeFocused) {
+        // Don't steal focus back from a note-creation's pending title focus. See #11244.
+        const effectiveNtxId = (this.noteContext ?? appContext.tabManager.getActiveContext())?.ntxId;
+        const titleFocusPending = isTitleFocusPending(effectiveNtxId);
+
+        if (activeNodeFocused && !titleFocusPending) {
             // needed by Firefox: https://github.com/zadam/trilium/issues/1865
             this.tree.$container.focus();
         }
 
-        await node.setActive(true, { noEvents: true, noFocus: !activeNodeFocused });
+        await node.setActive(true, { noEvents: true, noFocus: !activeNodeFocused || titleFocusPending });
     }
 
     sortChildren(node: Fancytree.FancytreeNode) {
@@ -2034,3 +2039,27 @@ function patchScrollIntoViewCrash() {
 }
 
 patchScrollIntoViewCrash();
+
+type NodeKeydownFn = (this: Fancytree.Fancytree, ctx: Fancytree.EventData) => unknown;
+
+/**
+ * jquery.fancytree's `nodeKeydown()` dereferences `this.focusNode` right after calling
+ * `.setFocus()`, but that can still be null (DOM focus hasn't caught up yet), throwing
+ * "Cannot read properties of null (reading 'debug')" and swallowing the keystroke. See #11244.
+ */
+function patchNodeKeydownCrash() {
+    const { _FancytreeClass } = $.ui.fancytree as Fancytree.FancytreeStatic & {
+        _FancytreeClass: { prototype: { nodeKeydown: NodeKeydownFn } };
+    };
+    const originalNodeKeydown = _FancytreeClass.prototype.nodeKeydown;
+
+    _FancytreeClass.prototype.nodeKeydown = function (this: Fancytree.Fancytree, ctx: Fancytree.EventData) {
+        try {
+            return originalNodeKeydown.call(this, ctx);
+        } catch (e) {
+            console.warn("Ignoring fancytree nodeKeydown crash", e);
+        }
+    };
+}
+
+patchNodeKeydownCrash();


### PR DESCRIPTION
## Summary

Fixes #11244: right after creating a Canvas or Dashboard note, clicking "+" on another note in the sidebar leaves the new note's title unfocused and unresponsive, so typing appears to do nothing.

## Reproduction

Steps that reproduce it:

1. Create a note and switch its type to Canvas (or Dashboard). First time in a session is most reliable, since Excalidraw's chunk has not been cached yet.
2. Without waiting for it to fully settle, hover any other existing note in the sidebar and click its "+" button.
3. Start typing right away, without clicking into the title first.
4. The title is not highlighted, and the typed characters do not land. The console shows `TypeError: Cannot read properties of null (reading 'debug')` at `Fancytree.nodeKeydown`.

I confirmed this against the standalone dev build with Playwright (headless Chromium, no manual typing involved) by scripting exactly these steps and reading `document.activeElement`, the title input's value, and the console for uncaught page errors before and after each keystroke. It reproduced reliably with a cold Excalidraw chunk load and zero-wait typing, and captured the exact TypeError above with its full stack.

## Root cause

Two separate bugs combine to produce this.

### 1. A focus race with no ordering guarantee

Creating a note ends with `note_create.ts` awaiting `setNote()` and then firing `focusAndSelectTitle`, which `note_title.tsx` handles by calling `.focus()` and `.select()` on the title input (Owner A).

Independently, the same note creation produces entity changes (branch, note, later a default-title update) that arrive over the tab's own WebSocket and hit `note_tree.ts`'s `entitiesReloadedEvent`, ending in `#setActiveNode`:

```ts
if (activeNodeFocused) {
    // needed by Firefox: https://github.com/zadam/trilium/issues/1865
    this.tree.$container.focus();
}
```

`activeNodeFocused` is captured from the note that was focused in the tree before this batch. Clicking the sidebar "+" button never moves tree focus (a `stopPropagation()` on the click keeps fancytree's own activation handler from running), so the previously open note's row is still "focused" when this fires, and the tree deliberately re-focuses itself as a 2019 Firefox workaround (Owner B).

Nothing orders Owner A relative to Owner B. Normally Owner A wins within about 100ms and nobody notices Owner B ever touched focus. With a Canvas or Dashboard note previously active, its teardown (Excalidraw is a lazy-loaded chunk with real disposal work; Dashboard similarly) delays Owner A enough for Owner B's independent WebSocket pipeline to fire after it (about 394ms vs about 100ms baseline on a cold Excalidraw load, measured), yanking focus back to the tree.

### 2. That race exposes an unrelated Fancytree crash

While focus sits on the tree, a keydown reaches jquery.fancytree's own delegated handler, which reads `node = tree.focusNode`. During this DOM churn `tree.focusNode` is still null, so it falls into `nodeKeydown()`:

```js
focusNode = this.getActiveNode() || this.getFirstChild();
if (focusNode) {
    focusNode.setFocus();
    node = ctx.node = this.focusNode;   // still null: setFocus() didn't
    node.debug("Keydown force focus…"); //   update this.focusNode as assumed
}
```

This throws inside jQuery's delegated event dispatch, aborting that keystroke. Every character typed while this condition holds hits the same path and vanishes, which is what makes typing feel completely unresponsive rather than merely delayed.

Notably, this codebase already has precedent for exactly this shape of bug: `patchScrollIntoViewCrash()` in `note_tree.ts` guards a sibling Fancytree crash (a node whose DOM/internal state is not settled yet, throwing and aborting the whole operation, see #10407).

## Recommended approaches

Five ways to address this, from most targeted to most architectural:

1. **Make the tree's Firefox-workaround refocus focus-intent-aware.** Do not unconditionally call `tree.$container.focus()` in `#setActiveNode` when a note creation has just claimed focus for its title. Low risk, small, closes the actual race directly. **Implemented in this PR.**
2. **Guard the Fancytree `nodeKeydown` null-dereference.** Mirror the existing `patchScrollIntoViewCrash()` pattern: catch and log instead of crashing. Very low risk, trivial, and the difference between "briefly wrong focus" and "silently eats everything you typed" regardless of what else ships. **Implemented in this PR.**
3. **Retry-until-visible and re-assert-after-settle in `note_title.tsx`.** Replace the one-shot `checkVisibility()` bail with a bounded retry, and re-check `document.activeElement` on a trailing tick to reclaim focus if something stole it. Good belt-and-braces alongside 1 and 2, not included here.
4. **Shrink the vulnerable window: decouple Canvas/Dashboard teardown from the note-switch critical path.** Persist Excalidraw scene state on last edit rather than deferred-to-unmount, and let the new note's widgets mount before the old widget finishes disposing. Real performance work, separate from this bugfix's scope.
5. **Arbitrate focus centrally instead of two imperative callers.** A general "pending focus intent" concept in `app_context.ts` that any subsystem wanting to move focus after an async operation registers and consults, generalizing approach 1 so future features cannot hit the same class of bug by accident. Bigger refactor, follow-up work.

A further stretch option: render and focus a placeholder title input the instant "+" is clicked, before the server round-trip completes at all, reconciling once the real note arrives. Correct in the limit, but a real architecture change (rollback-on-failure, optimistic IDs), not a bugfix-scoped PR.

## Scope of this PR

Implements approaches 1 and 2 only. Both are small, low-risk, and directly close the reproduction above. Approaches 3, 4, and 5 are left for follow-up work; the zero-wait edge case approach 3 would additionally cover is called out below as a known remaining gap.

- `apps/client/src/services/focus.ts`: adds `markTitleFocusPending()` / `isTitleFocusPending()`, a small time-boxed (1.5s) arbitration so a note creation's title-focus request cannot be stolen back, and cannot suppress unrelated focus changes forever if something goes wrong.
- `apps/client/src/services/note_create.ts`: marks the pending title focus right where `focusAndSelectTitle` is fired.
- `apps/client/src/widgets/note_tree.ts`: `#setActiveNode` checks it and skips its own Firefox-workaround refocus while a title focus is pending; adds `patchNodeKeydownCrash()`, guarding the Fancytree crash the same way `patchScrollIntoViewCrash()` already guards a sibling one. The guard only swallows the exact known `TypeError` (matched on its message), everything else from `nodeKeydown()` still propagates normally.

## Testing

**Unit tests** (`pnpm --filter client test focus.spec` and `note_tree.spec`, all green; `pnpm typecheck` clean):

- `focus.spec.ts`: covers the pending-focus arbitration directly, including that a `null` ntxId is a real, matchable identity and must not be indistinguishable from "unset" (this caught a real bug in my first implementation: `!pendingTitleFocusNtxId` treated `null` the same as unset, so marking with a null ntxId silently never protected anything; fixed by using `undefined` as the unset sentinel instead of falsy).
- `note_tree.spec.ts`: adds a `nodeKeydown` patch test, following the existing `scrollIntoView` patch test's pattern. It forces `node.setFocus()` to return without updating `tree.focusNode` (the exact contract violation `nodeKeydown()` assumes cannot happen) and asserts the keydown does not throw. Per this repo's convention, I confirmed it first: disabled the patch, ran the spec, watched it fail with the identical `TypeError: Cannot read properties of null (reading 'debug')` and stack line the real bug produces, then restored the patch and confirmed it passes. A second test confirms an unrelated `TypeError` thrown from the same `nodeKeydown()` code path still propagates instead of being swallowed by the guard.

**Live end-to-end verification**, scripted with Playwright against the actual standalone dev build (`pnpm standalone:start`), not a mock:

*Before the fix* (zero-wait typing, matching the issue's steps exactly): typing `"ImmediateNoWaitTypedByUser"` immediately after clicking "+" left the title at its unmodified default `"New note"`, no characters landed.

![Before the fix: title stuck on "New note" after typing a full string](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/canvas-note-title-focus/before-fix-title-stuck-unresponsive.png)

*After the fix, realistic timing* (a roughly 250ms pause before typing, matching an actual human's reaction time rather than a synthetic zero-wait burst): the title is correctly focused and selected before typing, and the full typed string lands (`"RealisticFixedTest"`, verified via `document.activeElement`).

![After the fix: title correctly highlighted and selected](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/canvas-note-title-focus/after-fix-title-focused-and-selected.png)
![After the fix: typed title lands correctly](https://raw.githubusercontent.com/emxv/Trilium/pr-assets/assets/canvas-note-title-focus/after-fix-title-typed-correctly.png)

*After the fix, zero-wait typing* (the same extreme case as the failing "before" run, for an honest comparison): keystrokes sent before focus has any chance to physically transfer still do not land, because approach 3 above is not in this PR's scope, that is expected and disclosed. What did change: zero uncaught page errors during the run, versus the `TypeError` above beforehand. The crash is gone even in the case this PR does not fully solve.

