### PR TITLE
Board: a new touch-friendly drag and drop mechanism and other UI improvements

### DIFF
--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -631,11 +631,18 @@ describe("BoardApi card operations", () => {
             note: created, branch: { branchId: "createdBranch" }
         } as never);
 
+        // The column goes in with the note. A write of its own would refresh the whole board a
+        // second time, which is what adding a card costs on a board of any size.
         await api.createNewItem("Done", "Created");
-        expect(put).toHaveBeenCalledWith(
-            "notes/" + created.noteId + "/set-attribute",
-            expect.objectContaining({ name: "status", value: "Done" }),
-            undefined);
+        expect(note_create.createNote).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                title: "Created",
+                attributes: [ expect.objectContaining({
+                    type: "label", name: "status", value: "Done"
+                }) ]
+            }));
+        expect(put).not.toHaveBeenCalled();
 
         // The board has already drawn the card, so a failure here is logged rather than thrown.
         const logged = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -95,18 +95,24 @@ export default class BoardApi {
     private sentToColumnEnd = new Map<string, string>();
     statusAttribute: string;
 
+    /** The config as the board last handed it over, against which a fresh one is recognised. */
+    private viewConfigSource: BoardViewData | undefined;
+    private viewConfig: BoardViewData;
+
     constructor(
         private byColumn: ColumnMap | undefined,
         public columns: string[],
         private parentNote: FNote,
         statusAttribute: string,
-        private viewConfig: BoardViewData,
+        viewConfig: BoardViewData | undefined,
         private saveConfig: (newConfig: BoardViewData) => void,
         private setBranchIdToEdit: (branchId: string | undefined) => void,
         private pending: PendingColumnWrites =
             { renames: new Map(), claims: new Map(), inFlight: 0 },
         private statusDefinition?: BoardStatusDefinition
     ) {
+        this.viewConfigSource = viewConfig;
+        this.viewConfig = viewConfig ?? {};
         this.isRelationMode = statusAttribute.startsWith("~");
 
         if (statusAttribute.startsWith("~") || statusAttribute.startsWith("#")) {
@@ -115,21 +121,70 @@ export default class BoardApi {
         this.statusAttribute = statusAttribute;
     };
 
+    /**
+     * Points the api at the board as it now stands.
+     *
+     * A refresh calls this instead of building a new api, so that the object every card holds keeps
+     * its identity and a move redraws only the cards whose position changed. What the api works out
+     * for itself, such as {@link sentToColumnEnd}, is kept.
+     */
+    update(
+        byColumn: ColumnMap | undefined,
+        columns: string[],
+        parentNote: FNote,
+        statusAttribute: string,
+        viewConfig: BoardViewData | undefined,
+        saveConfig: (newConfig: BoardViewData) => void,
+        setBranchIdToEdit: (branchId: string | undefined) => void,
+        statusDefinition?: BoardStatusDefinition
+    ) {
+        this.byColumn = byColumn;
+        this.columns = columns;
+        this.parentNote = parentNote;
+        // Only a config the board has actually replaced, since `storeColumns` moves this one ahead
+        // of what the board holds and an unrelated render must not take that back.
+        if (viewConfig !== this.viewConfigSource) {
+            this.viewConfigSource = viewConfig;
+            this.viewConfig = viewConfig ?? {};
+        }
+        this.saveConfig = saveConfig;
+        this.setBranchIdToEdit = setBranchIdToEdit;
+        this.statusDefinition = statusDefinition;
+        this.isRelationMode = statusAttribute.startsWith("~");
+        this.statusAttribute = statusAttribute.replace(/^[~#]/, "");
+    }
+
     async createNewItem(column: string, title: string) {
         try {
-            // Create a new note as a child of the parent note
-            const { note: newNote, branch: newBranch } = await note_create.createNote(this.parentNote.noteId, {
+            await note_create.createNote(this.parentNote.noteId, {
                 activate: false,
                 title,
-                isProtected: this.parentNote.isProtected
+                isProtected: this.parentNote.isProtected,
+                attributes: this.groupingFor(column)
             });
-
-            if (newNote && newBranch) {
-                await this.changeColumn(newNote.noteId, column);
-            }
         } catch (error) {
             console.error("Failed to create new item:", error);
         }
+    }
+
+    /**
+     * What a new card carries so that it lands in the column it was added to.
+     *
+     * Written with the note rather than after it: a write of its own is a second round trip and a
+     * second refresh, which on a large board is most of what adding a card costs. The inbox is the
+     * column held by having no value at all, so it carries nothing.
+     */
+    private groupingFor(column: string) {
+        if (column === INBOX_COLUMN) {
+            return [];
+        }
+
+        return [ {
+            type: this.isRelationMode ? "relation" as const : "label" as const,
+            name: this.statusAttribute,
+            value: column,
+            isInheritable: false
+        } ];
     }
 
     /**
@@ -682,15 +737,14 @@ export default class BoardApi {
             activate: false,
             targetBranchId: relativeToBranchId,
             target: direction,
-            title: t("board_view.new-item")
+            title: t("board_view.new-item"),
+            attributes: this.groupingFor(column)
         });
 
         if (!note || !branch) {
             throw new Error("Failed to create note");
         }
 
-        const { noteId } = note;
-        await this.changeColumn(noteId, column);
         this.startEditing(branch.branchId);
 
         return note;

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -156,12 +156,14 @@ export default class BoardApi {
 
     async createNewItem(column: string, title: string) {
         try {
-            await note_create.createNote(this.parentNote.noteId, {
+            const { note } = await note_create.createNote(this.parentNote.noteId, {
                 activate: false,
                 title,
                 isProtected: this.parentNote.isProtected,
                 attributes: this.groupingFor(column)
             });
+
+            return note?.noteId;
         } catch (error) {
             console.error("Failed to create new item:", error);
         }

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -1,0 +1,657 @@
+import { render } from "preact";
+import { useRef } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type BoardDragCallbacks, type DropPosition, useBoardDrag } from "./board_drag";
+
+describe("useBoardDrag, carrying a card", () => {
+    let container: HTMLElement | undefined;
+    let board: HTMLElement;
+    let calls: {
+        start: unknown[],
+        move: { position: unknown | null, inside: boolean }[],
+        end: { card: unknown, position: unknown }[],
+        columnStart: { column: string, index: number, size: unknown }[],
+        columnMove: (number | null)[],
+        columnEnd: { from: number, to: number | null }[]
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        calls = {
+            start: [], move: [], end: [], columnStart: [], columnMove: [], columnEnd: []
+        };
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    it("takes hold once the mouse has moved, and not before", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        expect(calls.start).toHaveLength(0);
+
+        // Within the threshold: still a click, not a drag.
+        move(52, 60);
+        expect(calls.start).toHaveLength(0);
+
+        move(70, 60);
+        expect(calls.start)
+            .toEqual([ { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 } ]);
+    });
+
+    it("carries a copy under the pointer without redrawing the board", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 50, 60);
+        move(90, 90);
+        act(() => { vi.advanceTimersByTime(20); });
+
+        // Shrunk as it is carried, written with the movement so neither can overwrite the other.
+        expect(preview()?.style.transform).toBe("translate3d(40px, 30px, 0) scale(0.9)");
+        // The card itself is left where it stands, and is not the thing being moved.
+        expect(element.style.transform).toBe("");
+    });
+
+    /**
+     * The copy stands inside the board, so the board's own styling reaches it, and is placed
+     * against the window, which the column's scrolling cannot cut off.
+     */
+    it("lifts the copy out of the column and hides the card behind it", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 50, 60);
+        move(90, 90);
+
+        const copy = preview();
+        // In the layer, not among the board's own children, which Preact places.
+        expect(copy?.parentElement).toBe(layer());
+        expect(copy?.className).toContain("board-note");
+        expect(copy?.style.width).toBe("100px");
+        expect(copy?.style.left).toBe("0px");
+        // Only one card answers to the id, so nothing looking one up finds the copy.
+        expect(copy?.getAttribute("data-note-id")).toBeNull();
+        // What the card offers is left behind with it.
+        expect(copy?.querySelector(".edit-icon")).toBeNull();
+        expect(element.querySelector(".edit-icon")).not.toBeNull();
+        expect(element.style.display).toBe("none");
+    });
+
+    it("puts the card back and takes the copy away once the gesture is over", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 50, 60);
+        move(90, 90);
+        release(90, 90);
+
+        expect(preview()).toBeNull();
+        expect(element.style.display).toBe("");
+    });
+
+    it("reports where the card would land, and only when that changes", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        // Taken 20 below its own top edge, so its top stands at 80 on the page, which is 40 into
+        // the card area: past the first card's middle at 25 and above the second's at 85.
+        move(120, 100);
+        act(() => { vi.advanceTimersByTime(20); });
+        expect(calls.move.at(-1)?.position).toEqual({ column: "To Do", index: 1 });
+
+        // Still over the same place: nothing is reported again.
+        const reported = calls.move.length;
+        move(122, 102);
+        act(() => { vi.advanceTimersByTime(20); });
+        expect(calls.move).toHaveLength(reported);
+
+        // Over the second column, below its only card's middle.
+        move(320, 200);
+        act(() => { vi.advanceTimersByTime(20); });
+        expect(calls.move.at(-1)?.position).toEqual({ column: "Doing", index: 1 });
+    });
+
+    /**
+     * The columns run 0 to 100 and 200 to 300, so 100 to 200 is between them and is answered for by
+     * the nearer of the two without the card standing on either. Only resting on one opens a
+     * collapsed column, which is why the two are told apart.
+     */
+    it("says whether the card stands on the column or merely nearest to it", () => {
+        setup();
+        const reported = () => calls.move.at(-1);
+
+        press(card("n1"), 50, 60);
+
+        // Between them, nearer the second.
+        move(170, 100);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(reported()).toMatchObject({ position: { column: "Doing" }, inside: false });
+
+        // Past the last column, which still answers for it so the card has somewhere to go.
+        move(320, 100);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(reported()).toMatchObject({ position: { column: "Doing" }, inside: false });
+
+        // Standing on it at last, once it has rested there.
+        move(250, 100);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(reported()).toMatchObject({ position: { column: "Doing" }, inside: true });
+    });
+
+    /** Crossing a column on the way somewhere else leaves it as it was found. */
+    it("counts a rest on the column, not a passage over it", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        move(250, 100);
+        act(() => { vi.advanceTimersByTime(200); });
+        expect(calls.move.at(-1)).toMatchObject({ inside: false });
+
+        // Off again before the rest was long enough, so the column it crossed was never stood on.
+        // Where it came to rest instead is its own affair, and does count.
+        move(50, 100);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(calls.move.filter(call =>
+            call.inside && (call.position as DropPosition | null)?.column === "Doing")).toEqual([]);
+        expect(calls.move.at(-1)).toMatchObject({ position: { column: "To Do" }, inside: true });
+    });
+
+    /** The empty space below a collapsed column's heading is not the column. */
+    it("does not count the space below a column that is shorter than the board", () => {
+        setup();
+        // A strip, as a collapsed column is drawn: only as tall as its heading.
+        const strip = board.querySelectorAll<HTMLElement>(".board-column")[1];
+        strip.getBoundingClientRect = () => ({
+            left: 200, top: 0, width: 100, height: 80, right: 300, bottom: 80
+        }) as DOMRect;
+
+        press(card("n1"), 50, 60);
+        // Held over it, but below where it ends: still the column it would land in, not stood on.
+        move(250, 300);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(calls.move.at(-1)).toMatchObject({ position: { column: "Doing" }, inside: false });
+
+        // Brought up onto the heading itself.
+        move(250, 60);
+        act(() => { vi.advanceTimersByTime(600); });
+        expect(calls.move.at(-1)).toMatchObject({ inside: true });
+    });
+
+    /**
+     * The reader takes hold of a card wherever they press, and it is the card's own top edge the
+     * gap opens at. Held low in a tall card, the pointer is well below where the card's top sits.
+     */
+    it("places the card by its top edge, not by where it was taken hold of", () => {
+        setup();
+
+        // Taken by its very bottom, so its top stands 48 above the pointer from here on.
+        press(card("n1"), 50, 88);
+        move(50, 150);
+        act(() => { vi.advanceTimersByTime(20); });
+        const heldLow = calls.move.at(-1)?.position;
+
+        release(50, 150);
+        calls.move.length = 0;
+
+        // Taken by its very top: the same pointer place leaves its top far lower down.
+        press(card("n1"), 50, 42);
+        move(50, 150);
+        act(() => { vi.advanceTimersByTime(20); });
+
+        // One pointer place, two grips, and the card lands where the card is rather than where the
+        // pointer is: taken by its foot it sits a place higher than taken by its head.
+        expect(heldLow).toEqual({ column: "To Do", index: 1 });
+        expect(calls.move.at(-1)?.position).toEqual({ column: "To Do", index: 2 });
+    });
+
+    /** Held at the board's edge, the board walks along under what is carried. */
+    it("walks the board along while a card is held at its edge", () => {
+        setup();
+        // The board runs to 500 on screen and holds twice that.
+        Object.defineProperty(board, "clientWidth", { value: 500, configurable: true });
+        Object.defineProperty(board, "scrollWidth", { value: 1000, configurable: true });
+        board.scrollLeft = 100;
+
+        press(card("n1"), 50, 60);
+        move(490, 100);
+        act(() => { vi.advanceTimersByTime(200); });
+
+        expect(board.scrollLeft).toBeGreaterThan(100);
+    });
+
+    it("stops walking it once the gesture is over", () => {
+        setup();
+        Object.defineProperty(board, "clientWidth", { value: 500, configurable: true });
+        Object.defineProperty(board, "scrollWidth", { value: 1000, configurable: true });
+        board.scrollLeft = 100;
+
+        press(card("n1"), 50, 60);
+        move(490, 100);
+        act(() => { vi.advanceTimersByTime(100); });
+        release(490, 100);
+
+        const reached = board.scrollLeft;
+        act(() => { vi.advanceTimersByTime(500); });
+        expect(board.scrollLeft).toBe(reached);
+    });
+
+    it("hands the last place it reported to the drop", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        move(320, 200);
+        act(() => { vi.advanceTimersByTime(20); });
+        release(320, 200);
+
+        expect(calls.end).toEqual([ {
+            card: { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 },
+            position: { column: "Doing", index: 1 }
+        } ]);
+    });
+
+    /** A finger resting is a drag; a finger moving off is the column being scrolled. */
+    it("waits for a finger to rest before carrying anything", () => {
+        setup();
+
+        press(card("n1"), 100, 100, "touch");
+        expect(calls.start).toHaveLength(0);
+
+        act(() => { vi.advanceTimersByTime(399); });
+        expect(calls.start).toHaveLength(0);
+
+        act(() => { vi.advanceTimersByTime(2); });
+        expect(calls.start).toHaveLength(1);
+    });
+
+    it("lets a finger that moves off scroll instead of carrying the card", () => {
+        setup();
+
+        press(card("n1"), 100, 100, "touch");
+        move(100, 140);
+        act(() => { vi.advanceTimersByTime(1000); });
+
+        expect(calls.start).toHaveLength(0);
+        expect(calls.end).toHaveLength(0);
+    });
+
+    /** The same press carries the card, so the menu it would otherwise open is left out. */
+    /** A press that never became a drag is a click, and the click has to reach what was pressed. */
+    it("takes the pointer only once something is being carried", () => {
+        setup();
+        const captured: number[] = [];
+        board.setPointerCapture = (id: number) => { captured.push(id); };
+
+        press(card("n1"), 50, 60);
+        expect(captured).toEqual([]);
+
+        move(90, 90);
+        expect(captured).toEqual([ 1 ]);
+    });
+
+    /** A tap asks for the menu, the long press being how a finger picks a card up instead. */
+    it("asks a card for its menu when it is tapped", () => {
+        setup();
+        const element = card("n1");
+        const menus: string[] = [];
+        element.addEventListener("contextmenu", () => menus.push("card"));
+
+        press(element, 50, 60, "touch");
+        release(50, 62, "touch");
+
+        expect(menus).toEqual([ "card" ]);
+    });
+
+    /** The heading answers for a column's menu, the column itself holding no handler. */
+    it("asks a column's heading for its menu when it is tapped", () => {
+        setup();
+        const heading = board.querySelector<HTMLElement>(".board-column h3");
+        if (!heading) throw new Error("expected a heading");
+        const menus: string[] = [];
+        heading.addEventListener("contextmenu", () => menus.push("heading"));
+
+        press(heading, 10, 10, "touch");
+        release(11, 11, "touch");
+
+        expect(menus).toEqual([ "heading" ]);
+    });
+
+    it("leaves the click a tap also lands unanswered", () => {
+        setup();
+        const element = card("n1");
+        const clicks: boolean[] = [];
+        board.addEventListener("click", (event) => clicks.push(event.defaultPrevented));
+
+        press(element, 50, 60, "touch");
+        release(50, 62, "touch");
+        act(() => {
+            element.dispatchEvent(new Event("click", { bubbles: true, cancelable: true }));
+        });
+
+        expect(clicks).toEqual([]);
+    });
+
+    /**
+     * A browser follows a tap with mouse events for pages that know nothing of touch. They land on
+     * the menu the tap just opened, right under the finger, and the first of them takes it back off
+     * again. They are made from `touchend`, so that is where they are refused.
+     */
+    it("refuses the mouse events a browser would make from a tap", () => {
+        setup();
+
+        press(card("n1"), 50, 60, "touch");
+        release(50, 62, "touch");
+
+        const followed = new Event("touchend", { bubbles: true, cancelable: true });
+        act(() => { document.dispatchEvent(followed); });
+        expect(followed.defaultPrevented).toBe(true);
+
+        // Once only: the next touch of the reader's own is theirs to have.
+        const later = new Event("touchend", { bubbles: true, cancelable: true });
+        act(() => { document.dispatchEvent(later); });
+        expect(later.defaultPrevented).toBe(false);
+    });
+
+    /** A press that became a drag is not a tap, and its `touchend` is the browser's to answer. */
+    it("leaves the touch that carried a card alone", () => {
+        setup();
+
+        press(card("n1"), 50, 60, "touch");
+        act(() => { vi.advanceTimersByTime(500); });
+        move(250, 100);
+        release(250, 100, "touch");
+
+        const followed = new Event("touchend", { bubbles: true, cancelable: true });
+        act(() => { document.dispatchEvent(followed); });
+        expect(followed.defaultPrevented).toBe(false);
+    });
+
+    it("leaves a mouse click alone, which is not a tap", () => {
+        setup();
+        const element = card("n1");
+        const menus: string[] = [];
+        element.addEventListener("contextmenu", () => menus.push("card"));
+
+        press(element, 50, 60);
+        release(50, 60);
+
+        expect(menus).toEqual([]);
+    });
+
+    it("keeps a finger's press from opening the menu as well", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 100, 100, "touch");
+        const swallowed = new Event("contextmenu", { bubbles: true, cancelable: true });
+        act(() => { element.dispatchEvent(swallowed); });
+        expect(swallowed.defaultPrevented).toBe(true);
+    });
+
+    it("leaves a right click's menu alone", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 50, 60);
+        const allowed = new Event("contextmenu", { bubbles: true, cancelable: true });
+        act(() => { element.dispatchEvent(allowed); });
+        expect(allowed.defaultPrevented).toBe(false);
+    });
+
+    /** A column heading's menu is the only way to reach what it offers on a touch screen. */
+    it("leaves a press away from a card with its menu", () => {
+        setup();
+        const heading = board.querySelector<HTMLElement>(".board-column");
+        if (!heading) throw new Error("expected a column");
+
+        press(heading, 50, 60, "touch");
+        const allowed = new Event("contextmenu", { bubbles: true, cancelable: true });
+        act(() => { heading.dispatchEvent(allowed); });
+        expect(allowed.defaultPrevented).toBe(false);
+    });
+
+    it("calls the gesture off on Escape, with nowhere to land", () => {
+        setup();
+        const element = card("n1");
+
+        press(element, 50, 60);
+        move(320, 200);
+        act(() => { vi.advanceTimersByTime(20); });
+
+        act(() => {
+            document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        });
+
+        expect(calls.end).toEqual([ {
+            card: { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 },
+            position: null
+        } ]);
+        expect(element.style.transform).toBe("");
+    });
+
+    it("calls the gesture off when the pointer is taken away", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        move(320, 200);
+        act(() => { vi.advanceTimersByTime(20); });
+        act(() => { board.dispatchEvent(pointer("pointercancel", 320, 200, "mouse")); });
+
+        expect(calls.end.at(-1)).toMatchObject({ position: null });
+    });
+
+    it("says nothing at all for a press that never became a drag", () => {
+        setup();
+
+        press(card("n1"), 50, 60);
+        release(100, 100);
+
+        expect(calls.start).toHaveLength(0);
+        expect(calls.end).toHaveLength(0);
+    });
+
+    /** The card's own controls keep their press: an editor is not a handle. */
+    it("leaves a press on something the card offers alone", () => {
+        setup();
+        const element = card("n1");
+        const button = document.createElement("button");
+        element.appendChild(button);
+
+        press(button, 50, 60);
+        move(200, 100);
+
+        expect(calls.start).toHaveLength(0);
+    });
+
+    it("offers nothing while it is switched off", () => {
+        setup({ disabled: true });
+
+        press(card("n1"), 50, 60);
+        move(200, 100);
+
+        expect(calls.start).toHaveLength(0);
+    });
+
+    describe("carrying a column", () => {
+        it("takes hold of it by its heading, and says what it measures", () => {
+            setup();
+
+            press(heading(0), 10, 10);
+            move(120, 10);
+
+            expect(calls.columnStart)
+                .toEqual([ { column: "To Do", index: 0, size: { width: 100, height: 400 } } ]);
+            // Nothing was taken for a card, the press having landed on the heading.
+            expect(calls.start).toHaveLength(0);
+        });
+
+        it("cuts the copy it carries to a set height", () => {
+            setup();
+            const column = board.querySelector<HTMLElement>(".board-column");
+
+            press(heading(0), 10, 10);
+            move(120, 10);
+
+            const copy = board.querySelector<HTMLElement>(".board-column.board-drag-preview");
+            expect(copy?.style.height).toBe("150px");
+            expect(copy?.style.width).toBe("100px");
+            expect(column?.style.display).toBe("none");
+        });
+
+        it("reports the place it would take, counting the columns as they stand", () => {
+            setup();
+
+            press(heading(0), 10, 10);
+            // The column's middle stands 40 right of the pointer, and short of the second
+            // column's own middle at 250.
+            move(200, 10);
+            act(() => { vi.advanceTimersByTime(20); });
+            expect(calls.columnMove.at(-1)).toBe(1);
+
+            move(280, 10);
+            act(() => { vi.advanceTimersByTime(20); });
+            expect(calls.columnMove.at(-1)).toBe(2);
+
+            release(280, 10);
+            expect(calls.columnEnd).toEqual([ { from: 0, to: 2 } ]);
+        });
+
+        it("hands back nothing for a gesture called off", () => {
+            setup();
+
+            press(heading(0), 10, 10);
+            move(280, 10);
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+            });
+
+            expect(calls.columnEnd).toEqual([ { from: 0, to: null } ]);
+            expect(board.querySelector(".board-drag-preview")).toBeNull();
+        });
+
+        function heading(index: number) {
+            const element = [ ...board.querySelectorAll<HTMLElement>(".board-column h3") ][index];
+            if (!element) throw new Error(`no heading ${index}`);
+            return element;
+        }
+    });
+
+    /**
+     * Two 100px columns, 200 apart, each card 50 tall. The first holds two cards, the second one.
+     * happy-dom lays nothing out, so every box is declared.
+     */
+    function setup({ disabled = false } = {}) {
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        const callbacks: BoardDragCallbacks = {
+            onCardStart: (card) => calls.start.push(card),
+            onCardMove: (position, inside) => calls.move.push({ position, inside }),
+            onCardEnd: (card, position) => calls.end.push({ card, position }),
+            onColumnStart: (column, index, size) => calls.columnStart.push({ column, index, size }),
+            onColumnMove: (index) => calls.columnMove.push(index),
+            onColumnEnd: (from, to) => calls.columnEnd.push({ from, to })
+        };
+
+        function Harness() {
+            const ref = useRef<HTMLDivElement>(null);
+            useBoardDrag(ref, callbacks, disabled);
+            return <div ref={ref} className="board-view-container" />;
+        }
+
+        act(() => { render(<Harness />, mountPoint); });
+        board = mountPoint.firstElementChild as HTMLElement;
+        board.appendChild(Object.assign(document.createElement("div"), {
+            className: "board-drag-layer"
+        }));
+        place(board, 0, 0, 500, 400);
+        // Writable: the board walks itself along while something is held at its edge.
+        Object.defineProperty(board, "scrollLeft", { value: 0, configurable: true, writable: true });
+
+        for (const [ index, cards ] of [ [ "n1", "n2" ], [ "n3" ] ].entries()) {
+            const column = document.createElement("div");
+            column.className = "board-column";
+            column.dataset.column = [ "To Do", "Doing" ][index];
+            board.appendChild(column);
+            place(column, index * 200, 0, 100, 400);
+
+            const heading = document.createElement("h3");
+            column.appendChild(heading);
+            place(heading, index * 200, 0, 100, 40);
+
+            const area = document.createElement("div");
+            area.className = "board-column-content";
+            column.appendChild(area);
+            place(area, index * 200, 40, 100, 360);
+            Object.defineProperty(area, "scrollTop", {
+                value: 0, configurable: true, writable: true
+            });
+
+            for (const [ position, noteId ] of cards.entries()) {
+                const note = document.createElement("div");
+                note.className = "board-note";
+                note.dataset.noteId = noteId;
+                note.appendChild(Object.assign(document.createElement("span"), {
+                    className: "edit-icon"
+                }));
+                area.appendChild(note);
+                place(note, index * 200, 40 + position * 60, 100, 50);
+            }
+        }
+
+        // Attached from an effect, which Preact defers past the render.
+        act(() => { vi.advanceTimersByTime(20); });
+    }
+
+    function preview() {
+        return board.querySelector<HTMLElement>(".board-drag-preview");
+    }
+
+    function layer() {
+        return board.querySelector<HTMLElement>(".board-drag-layer");
+    }
+
+    function card(noteId: string) {
+        const element = board.querySelector<HTMLElement>(`.board-note[data-note-id="${noteId}"]`);
+        if (!element) throw new Error(`no card ${noteId}`);
+        return element;
+    }
+
+    function place(element: HTMLElement, left: number, top: number, width: number, height: number) {
+        element.getBoundingClientRect = () => ({
+            left, top, width, height, right: left + width, bottom: top + height
+        }) as DOMRect;
+    }
+
+    function pointer(type: string, clientX: number, clientY: number, pointerType: string) {
+        const event = new Event(type, { bubbles: true, cancelable: true });
+        for (const [ name, value ] of Object.entries({
+            clientX, clientY, pointerId: 1, button: 0, pointerType
+        })) {
+            Object.defineProperty(event, name, { value, configurable: true });
+        }
+        return event;
+    }
+
+    function press(target: HTMLElement, x: number, y: number, pointerType = "mouse") {
+        act(() => { target.dispatchEvent(pointer("pointerdown", x, y, pointerType)); });
+    }
+
+    function move(x: number, y: number, pointerType = "mouse") {
+        act(() => { board.dispatchEvent(pointer("pointermove", x, y, pointerType)); });
+    }
+
+    function release(x: number, y: number, pointerType = "mouse") {
+        act(() => { board.dispatchEvent(pointer("pointerup", x, y, pointerType)); });
+    }
+});

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -502,7 +502,8 @@ describe("useBoardDrag, carrying a card", () => {
             move(120, 10);
 
             const copy = board.querySelector<HTMLElement>(".board-column.board-drag-preview");
-            expect(copy?.style.height).toBe("150px");
+            expect(copy?.style.maxHeight).toBe("150px");
+            expect(copy?.style.height).toBe("");
             expect(copy?.style.width).toBe("100px");
             expect(column?.style.display).toBe("none");
         });

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -508,6 +508,23 @@ describe("useBoardDrag, carrying a card", () => {
             expect(column?.style.display).toBe("none");
         });
 
+        it("carries the tint of the column a card came from, and none where there is none", () => {
+            setup();
+
+            press(card("n1"), 10, 10);
+            move(60, 10);
+            const tinted = board.querySelector<HTMLElement>(".board-note.board-drag-preview");
+            expect(tinted?.classList.contains("column-tinted")).toBe(true);
+            expect(tinted?.style.getPropertyValue("--board-column-custom-hue")).toBe("210");
+            release(60, 10);
+
+            press(card("n3"), 210, 10);
+            move(260, 10);
+            const plain = board.querySelector<HTMLElement>(".board-note.board-drag-preview");
+            expect(plain?.classList.contains("column-tinted")).toBe(false);
+            release(260, 10);
+        });
+
         it("reports the place it would take, counting the columns as they stand", () => {
             setup();
 
@@ -583,6 +600,11 @@ describe("useBoardDrag, carrying a card", () => {
             const column = document.createElement("div");
             column.className = "board-column";
             column.dataset.column = [ "To Do", "Doing" ][index];
+            // The first column is tinted, the second is not, so a copy can be checked against both.
+            if (index === 0) {
+                column.classList.add("with-hue");
+                column.style.setProperty("--board-column-custom-hue", "210");
+            }
             board.appendChild(column);
             place(column, index * 200, 0, 100, 400);
 

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -103,19 +103,20 @@ describe("useBoardDrag, carrying a card", () => {
         setup();
 
         press(card("n1"), 50, 60);
-        // Taken 20 below its own top edge, so its top stands at 80 on the page, which is 40 into
-        // the card area: past the first card's middle at 25 and above the second's at 85.
-        move(120, 100);
+        // Taken 20 below its own top edge, so its top stands at 100 on the page, which is 60 into
+        // the card area: below the card that is left standing there once this one is picked up, so
+        // it goes after it rather than before it.
+        move(120, 120);
         act(() => { vi.advanceTimersByTime(20); });
-        expect(calls.move.at(-1)?.position).toEqual({ column: "To Do", index: 1 });
+        expect(calls.move.at(-1)?.position).toEqual({ column: "To Do", index: 2 });
 
         // Still over the same place: nothing is reported again.
         const reported = calls.move.length;
-        move(122, 102);
+        move(122, 122);
         act(() => { vi.advanceTimersByTime(20); });
         expect(calls.move).toHaveLength(reported);
 
-        // Over the second column, below its only card's middle.
+        // Over the second column, below its only card.
         move(320, 200);
         act(() => { vi.advanceTimersByTime(20); });
         expect(calls.move.at(-1)?.position).toEqual({ column: "Doing", index: 1 });
@@ -196,7 +197,7 @@ describe("useBoardDrag, carrying a card", () => {
 
         // Taken by its very bottom, so its top stands 48 above the pointer from here on.
         press(card("n1"), 50, 88);
-        move(50, 150);
+        move(50, 120);
         act(() => { vi.advanceTimersByTime(20); });
         const heldLow = calls.move.at(-1)?.position;
 
@@ -205,7 +206,7 @@ describe("useBoardDrag, carrying a card", () => {
 
         // Taken by its very top: the same pointer place leaves its top far lower down.
         press(card("n1"), 50, 42);
-        move(50, 150);
+        move(50, 120);
         act(() => { vi.advanceTimersByTime(20); });
 
         // One pointer place, two grips, and the card lands where the card is rather than where the

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -493,6 +493,15 @@ function lift(held: Gesture, container: HTMLElement) {
     preview.querySelector(".edit-icon")?.remove();
     preview.querySelector(".board-new-item")?.remove();
 
+    // The copy is carried in the drag layer rather than in the column it came from, where the rule
+    // that tints a card no longer reaches it, so the column's hue is put on the copy itself.
+    const hue = held.element.closest<HTMLElement>(".board-column.with-hue")
+        ?.style.getPropertyValue("--board-column-custom-hue");
+    if (held.kind === "card" && hue) {
+        preview.classList.add("column-tinted");
+        preview.style.setProperty("--board-column-custom-hue", hue);
+    }
+
     for (const [ property, value ] of Object.entries({
         left: `${rect.left}px`,
         top: `${rect.top}px`,

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -2,7 +2,9 @@ import { RefObject } from "preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import { useTrackedElement } from "../../react/hooks";
-import { cardInsertionIndex, columnAt, columnCovers, columnInsertionIndex } from "./drag_geometry";
+import {
+    type CardBox, cardInsertionIndex, columnAt, columnCovers, columnInsertionIndex
+} from "./drag_geometry";
 import { type BoardMeasurement, measureBoard, toAreaY, toBoardX } from "./drag_measure";
 import { createEdgeScroller, type ScrollTarget } from "./edge_scroll";
 
@@ -215,7 +217,9 @@ export function useBoardDrag(
             const position = column
                 ? {
                     column: column.value,
-                    index: area ? cardInsertionIndex(column.cards, toAreaY(area, topY)) : 0
+                    index: area
+                        ? placeIn(column.cards, toAreaY(area, topY), held.card, column.value)
+                        : 0
                 }
                 : null;
             // Standing on the column itself, which for a collapsed one is its heading alone: the
@@ -416,12 +420,54 @@ export function useBoardDrag(
      */
     const remeasure = useCallback(() => {
         const held = gesture.current;
-        if (held?.active && container) {
-            held.measurement = measureBoard(container);
+        if (!held?.active || !container) {
+            return;
         }
+
+        const measurement = measureBoard(container);
+        // Each column keeps the cards it was measured with. The board now holds the gap where the
+        // card was, which stands every card below it one place lower, so reading them again would
+        // take the drag's own doing for a move of its own and the places would creep away from the
+        // card with every one it passes.
+        for (const column of measurement.columns) {
+            const before = held.measurement?.columns.find(({ value }) => value === column.value);
+            if (before) {
+                column.cards = before.cards;
+            }
+        }
+
+        held.measurement = measurement;
     }, [ container ]);
 
     return { isDragging, remeasure };
+}
+
+/**
+ * The place a carried card would take in a column, counting that column as the board holds it.
+ *
+ * The cards were measured with the carried one among them, and it leaves the flow the moment it is
+ * picked up, so the column is read here as it is drawn: without that card, and with everything
+ * below it standing where the card's own place used to be. Its height is its own, so the cards
+ * below move by that and not by a card's worth, which is what a column of mixed heights turns on.
+ * The answer is then counted back into the list the board holds, which is what a move names.
+ */
+function placeIn(cards: CardBox[], y: number, card: DraggedCard, column: string): number {
+    const carried = cards[card.index];
+    if (column !== card.fromColumn || !carried) {
+        return cardInsertionIndex(cards, y);
+    }
+
+    const below = cards[card.index + 1];
+    const vacated = below ? below.top - carried.top : carried.height;
+    const drawn = cards
+        .filter((_, index) => index !== card.index)
+        .map((other, index) => index < card.index
+            ? other
+            : { top: other.top - vacated, height: other.height });
+
+    const index = cardInsertionIndex(drawn, y);
+
+    return index >= card.index ? index + 1 : index;
 }
 
 /** Asks an element for its menu the way a right click does, at the place the tap landed. */

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -150,7 +150,20 @@ export function useBoardDrag(
             // Held from here on, so the gesture keeps the pointer wherever it goes. Taken at the
             // press instead, it would carry the click away from what was pressed.
             container.setPointerCapture?.(held.pointerId);
+
+            // Taking the card out of the flow shortens its column, and a column scrolled near its
+            // foot is clamped to the new end before the gap standing in for the card has been
+            // drawn. Put back on the next frame, by which time it has.
+            const area = held.element.closest<HTMLElement>(".board-column-content");
+            const keptScroll = area?.scrollTop;
             const lifted = lift(held, container);
+            if (area && keptScroll !== undefined) {
+                requestAnimationFrame(() => {
+                    if (area.scrollTop < keptScroll) {
+                        area.scrollTop = keptScroll;
+                    }
+                });
+            }
             held.preview = lifted.preview;
             held.grab = lifted.grab;
             container.classList.add("board-dragging");

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -1,0 +1,553 @@
+import { RefObject } from "preact";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+
+import { useTrackedElement } from "../../react/hooks";
+import { cardInsertionIndex, columnAt, columnCovers, columnInsertionIndex } from "./drag_geometry";
+import { type BoardMeasurement, measureBoard, toAreaY, toBoardX } from "./drag_measure";
+import { createEdgeScroller, type ScrollTarget } from "./edge_scroll";
+
+/** How far a pointer travels before a press with a button held is taken for a drag. */
+const MOUSE_THRESHOLD = 4;
+
+/** How long a finger rests before its press is taken for a drag. */
+const TOUCH_DELAY_MS = 400;
+
+/** How far a finger may stray in that time and still be resting rather than scrolling. */
+const TOUCH_TOLERANCE = 8;
+
+/** How much a carried card shrinks. Written with the movement, a class could not add to it. */
+const DRAG_SCALE = 0.9;
+
+/** How tall a carried column stands, whatever it holds, so it can be seen past. */
+const COLUMN_DRAG_HEIGHT = 150;
+
+/** How long a card rests on a column's heading before it counts as standing there. */
+const DWELL_MS = 500;
+
+/** How long the mouse events a browser makes from a tap can take to arrive. */
+const COMPATIBILITY_WINDOW_MS = 700;
+
+/** Which card is being carried, named the way the board's own moves are. */
+export interface DraggedCard {
+    noteId: string;
+    fromColumn: string;
+    index: number;
+    /** How tall it stands, so the gap held open for it is the size it will fill. */
+    height: number;
+}
+
+/** Where the card would land. */
+export interface DropPosition {
+    column: string;
+    index: number;
+}
+
+export interface BoardDragCallbacks {
+    /** A card has been taken hold of, and is now being carried. */
+    onCardStart(card: DraggedCard): void;
+    /**
+     * Where the card would land has changed, or it is over nowhere it could land.
+     *
+     * @param inside whether the card has come to rest on the column itself, rather than merely
+     * being nearest to it or passing over it. A column claims the gap beside it so that a card held
+     * there still has somewhere to go, and a collapsed one claims the empty space below its
+     * heading; neither is reason enough to open it, and nor is crossing the heading on the way
+     * somewhere else.
+     */
+    onCardMove(position: DropPosition | null, inside: boolean): void;
+    /**
+     * The gesture is over. A position means let go somewhere; nothing means it was called off, by
+     * Escape or by the pointer being taken away.
+     */
+    onCardEnd(card: DraggedCard, position: DropPosition | null): void;
+    /**
+     * A column has been taken hold of by its heading.
+     *
+     * @param size what it measures, so the gap held open for it is the size it will land in.
+     */
+    onColumnStart(column: string, index: number, size: { width: number, height: number }): void;
+    /** Which place among the columns it would take, counting them as they stand. */
+    onColumnMove(index: number | null): void;
+    /** As {@link onCardEnd}, for a column: a place means let go, nothing means called off. */
+    onColumnEnd(from: number, to: number | null): void;
+}
+
+/**
+ * Carries a card or a column around the board under the pointer.
+ *
+ * A mouse takes hold as soon as it moves with a button down; a finger has to rest first, so that a
+ * swipe still scrolls the column it started in. Everything the gesture needs is measured when it
+ * starts, so a move reads two rectangles rather than one for every card on the board.
+ *
+ * What is carried is a copy, placed against the window: a card is carried past the edges of the
+ * column holding it, which scrolls, and would be cut off at them.
+ *
+ * @param containerRef the board's scrolling container.
+ * @param callbacks what to do as the gesture opens, moves and closes.
+ * @param disabled whether to leave presses alone.
+ */
+export function useBoardDrag(
+    containerRef: RefObject<HTMLElement>,
+    callbacks: BoardDragCallbacks,
+    disabled = false
+) {
+    const [ isDragging, setDragging ] = useState(false);
+    // Held in a ref rather than in state: every move reads them, and none of them draw anything.
+    const gesture = useRef<Gesture | null>(null);
+    const latest = useRef(callbacks);
+    latest.current = callbacks;
+    // The board draws its container only once the notes have loaded, and filling a ref triggers no
+    // render, so an effect reading the ref alone would never hear it arrive.
+    const container = useTrackedElement(containerRef);
+
+    useEffect(() => {
+        if (!container || disabled) return;
+
+        // Walks the board along, and the column's cards up and down, while what is carried is held
+        // near an edge. Each frame that moves anything reads the point again, since what is under
+        // the pointer has changed without the pointer itself moving.
+        const scroller = createEdgeScroller({
+            onScroll: () => {
+                const held = gesture.current;
+                if (held?.active) {
+                    resolve(held);
+                }
+            }
+        });
+
+        const close = (cancelled: boolean) => {
+            const held = gesture.current;
+            gesture.current = null;
+            if (!held) return;
+
+            window.clearTimeout(held.timer);
+            window.clearTimeout(held.dwell);
+            scroller.stop();
+            container.classList.remove("board-dragging");
+            held.preview?.remove();
+            held.element.style.display = "";
+            if (held.frame !== undefined) {
+                cancelAnimationFrame(held.frame);
+            }
+            if (!held.active) return;
+
+            setDragging(false);
+            if (held.kind === "card") {
+                latest.current.onCardEnd(held.card, cancelled ? null : held.position);
+            } else {
+                latest.current.onColumnEnd(held.index, cancelled ? null : held.target);
+            }
+        };
+
+        const activate = () => {
+            const held = gesture.current;
+            if (!held || held.active) return;
+
+            held.active = true;
+            // Measured before what is carried is taken out of the flow, so the places it can land
+            // are the ones the board is showing.
+            held.measurement = measureBoard(container);
+            // Held from here on, so the gesture keeps the pointer wherever it goes. Taken at the
+            // press instead, it would carry the click away from what was pressed.
+            container.setPointerCapture?.(held.pointerId);
+            const lifted = lift(held, container);
+            held.preview = lifted.preview;
+            held.grab = lifted.grab;
+            container.classList.add("board-dragging");
+            setDragging(true);
+
+            if (held.kind === "card") {
+                latest.current.onCardStart(held.card);
+            } else {
+                latest.current.onColumnStart(held.column, held.index, lifted.size);
+            }
+            resolve(held);
+        };
+
+        const resolve = (held: Gesture) => {
+            const measurement = held.measurement;
+            const grab = held.grab;
+            if (!measurement || !grab) return;
+
+            // Read from what is being carried, not from the pointer: the reader took hold of it
+            // wherever they happened to press, and it is the card they are placing. Across, its
+            // middle says which column it is over; down, its top edge says which place it takes,
+            // that being the edge the gap opens at. Scrolling still follows the pointer, which is
+            // what the reader steers with.
+            const middleX = held.lastX - grab.x + grab.width / 2;
+            const topY = held.lastY - grab.y;
+
+            const x = toBoardX(container, middleX);
+            if (held.kind === "column") {
+                scroller.update([ { element: container, axis: "x" } ], held.lastX, held.lastY);
+                const target = columnInsertionIndex(measurement.columns, x);
+                if (target !== held.target) {
+                    held.target = target;
+                    latest.current.onColumnMove(target);
+                }
+                return;
+            }
+
+            const column = columnAt(measurement.columns, x);
+            const area = column && measurement.areas.get(column.value);
+            const edges: ScrollTarget[] = [ { element: container, axis: "x" } ];
+            if (area) {
+                edges.push({ element: area, axis: "y" });
+            }
+            scroller.update(edges, held.lastX, held.lastY);
+
+
+            // A collapsed column draws no card area and holds no cards on screen, so a card carried
+            // over it goes to the front of whatever it holds.
+            const position = column
+                ? {
+                    column: column.value,
+                    index: area ? cardInsertionIndex(column.cards, toAreaY(area, topY)) : 0
+                }
+                : null;
+            // Standing on the column itself, which for a collapsed one is its heading alone: the
+            // empty space under it belongs to no column the reader can see.
+            const on = column && columnCovers(column, x, topY) ? column.value : undefined;
+            if (on !== held.on) {
+                window.clearTimeout(held.dwell);
+                held.on = on;
+                held.inside = false;
+                if (on) {
+                    // Rested on rather than crossed: a card carried over a heading on its way
+                    // somewhere else leaves the column as it found it.
+                    held.dwell = window.setTimeout(() => {
+                        held.inside = true;
+                        report(held);
+                    }, DWELL_MS);
+                }
+            }
+
+            report(held, position);
+        };
+
+        /** Says where the card would land, and whether it has come to rest on that column. */
+        const report = (held: Gesture, next?: DropPosition | null) => {
+            if (held.kind !== "card") return;
+
+            const position = next === undefined ? held.position : next;
+            if (position?.column !== held.position?.column
+                    || position?.index !== held.position?.index
+                    || held.inside !== held.reported) {
+                held.position = position;
+                held.reported = held.inside;
+                latest.current.onCardMove(position, held.inside);
+            }
+        };
+
+        const onPointerDown = (event: PointerEvent) => {
+            if (event.button !== 0 || gesture.current) return;
+
+            const target = event.target as HTMLElement | null;
+            // Anything the card or the heading offers in its own right keeps its press.
+            if (!target || target.closest("input, textarea, button, a")) return;
+
+            const started = startCard(target) ?? startColumn(target, container);
+            if (!started) return;
+
+            gesture.current = {
+                ...started,
+                pointerId: event.pointerId,
+                startX: event.clientX,
+                startY: event.clientY,
+                lastX: event.clientX,
+                lastY: event.clientY,
+                touch: event.pointerType !== "mouse",
+                active: false,
+                preview: undefined,
+                measurement: undefined,
+                frame: undefined,
+                timer: 0
+            };
+
+            if (gesture.current.touch) {
+                gesture.current.timer = window.setTimeout(activate, TOUCH_DELAY_MS);
+            }
+        };
+
+        const onPointerMove = (event: PointerEvent) => {
+            const held = gesture.current;
+            if (!held || event.pointerId !== held.pointerId) return;
+
+            held.lastX = event.clientX;
+            held.lastY = event.clientY;
+
+            if (!held.active) {
+                const travelled = Math.hypot(event.clientX - held.startX, event.clientY - held.startY);
+                if (held.touch) {
+                    // Straying this far before the press has ripened means the finger is scrolling.
+                    if (travelled > TOUCH_TOLERANCE) close(true);
+                    return;
+                }
+
+                if (travelled <= MOUSE_THRESHOLD) return;
+                // Carried on into the move below, so what is picked up takes its place under the
+                // pointer on the move that picked it up rather than on the one after.
+                activate();
+            }
+
+            // Written in a frame of its own, and only the transform: a move that redrew the board
+            // would redraw every card on it.
+            if (held.frame === undefined) {
+                held.frame = requestAnimationFrame(() => {
+                    held.frame = undefined;
+                    if (!gesture.current || !held.preview) return;
+
+                    const dx = held.lastX - held.startX;
+                    const dy = held.lastY - held.startY;
+                    const scale = held.kind === "card" ? ` scale(${DRAG_SCALE})` : "";
+                    held.preview.style.transform = `translate3d(${dx}px, ${dy}px, 0)${scale}`;
+                    resolve(held);
+                });
+            }
+        };
+
+        const onPointerUp = (event: PointerEvent) => {
+            const held = gesture.current;
+            if (!held || event.pointerId !== held.pointerId) return;
+
+            // A tap is a press that never became a drag: it asks for the menu, the long press that
+            // would have opened one being how a finger picks a card up instead.
+            const tapped = held.touch && !held.active && event.type === "pointerup"
+                && Math.hypot(event.clientX - held.startX, event.clientY - held.startY)
+                    <= TOUCH_TOLERANCE;
+            const target = held.menuTarget;
+
+            close(event.type === "pointercancel");
+
+            if (tapped) {
+                // The browser follows a tap with mouse events for pages that know nothing of touch,
+                // and they land on the menu this is about to open, right under the finger: the
+                // first of them takes the menu straight back off again. Refused at `touchend`,
+                // which is what the browser makes them from, and which has yet to be sent.
+                justTapped = true;
+                // The click is left out as well, for a browser that sends one regardless. Given up
+                // after a moment so a later click of the reader's own is never the one taken.
+                container.addEventListener("click", swallow, { capture: true, once: true });
+                window.setTimeout(
+                    () => container.removeEventListener("click", swallow, { capture: true }),
+                    COMPATIBILITY_WINDOW_MS);
+                askForMenu(target, event.clientX, event.clientY);
+            }
+        };
+
+        /** Set between a tap and the `touchend` the browser would make mouse events from. */
+        let justTapped = false;
+
+        const onTouchEnd = (event: TouchEvent) => {
+            if (justTapped) {
+                justTapped = false;
+                event.preventDefault();
+            }
+        };
+
+        const swallow = (event: Event) => {
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape" && gesture.current?.active) {
+                close(true);
+            }
+        };
+
+        // A long press is how a finger picks something up, so the menu the same press would
+        // otherwise open is left out. Taken while the event is on its way down, the card's own
+        // handler standing between this and the menu.
+        const onContextMenu = (event: MouseEvent) => {
+            if (gesture.current?.touch) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
+        };
+
+        // Non-passive, and at the document: the page decides whether a touch scrolls from the first
+        // move it sees, so refusing it has to happen there rather than once the board hears of it.
+        const onTouchMove = (event: TouchEvent) => {
+            if (gesture.current?.active) {
+                event.preventDefault();
+            }
+        };
+
+        container.addEventListener("contextmenu", onContextMenu, { capture: true });
+        container.addEventListener("pointerdown", onPointerDown);
+        container.addEventListener("pointermove", onPointerMove);
+        container.addEventListener("pointerup", onPointerUp);
+        container.addEventListener("pointercancel", onPointerUp);
+        document.addEventListener("keydown", onKeyDown);
+        document.addEventListener("touchmove", onTouchMove, { passive: false });
+        document.addEventListener("touchend", onTouchEnd, { passive: false });
+
+        return () => {
+            close(true);
+            container.removeEventListener("contextmenu", onContextMenu, { capture: true });
+            container.removeEventListener("pointerdown", onPointerDown);
+            container.removeEventListener("pointermove", onPointerMove);
+            container.removeEventListener("pointerup", onPointerUp);
+            container.removeEventListener("pointercancel", onPointerUp);
+            document.removeEventListener("keydown", onKeyDown);
+            document.removeEventListener("touchmove", onTouchMove);
+            document.removeEventListener("touchend", onTouchEnd);
+            container.removeEventListener("click", swallow, { capture: true });
+        };
+    }, [ container, disabled ]);
+
+    /**
+     * Measures the board again, for a drag the board has redrawn under: a collapsed column opened
+     * to take the card moves every column after it.
+     */
+    const remeasure = useCallback(() => {
+        const held = gesture.current;
+        if (held?.active && container) {
+            held.measurement = measureBoard(container);
+        }
+    }, [ container ]);
+
+    return { isDragging, remeasure };
+}
+
+/** Asks an element for its menu the way a right click does, at the place the tap landed. */
+function askForMenu(element: HTMLElement, clientX: number, clientY: number) {
+    element.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, clientX, clientY }));
+}
+
+/** What a press on a card starts, or nothing where the press was not on one. */
+function startCard(target: HTMLElement): CardSubject | null {
+    const element = target.closest<HTMLElement>(".board-note");
+    const columnElement = element?.closest<HTMLElement>(".board-column");
+    const noteId = element?.dataset.noteId;
+    if (!element || !columnElement || !noteId) return null;
+
+    const cards = [ ...columnElement.querySelectorAll(".board-note") ];
+    return {
+        kind: "card",
+        element,
+        menuTarget: element,
+        card: {
+            noteId,
+            fromColumn: columnElement.dataset.column ?? "",
+            index: cards.indexOf(element),
+            height: element.getBoundingClientRect().height
+        },
+        position: null,
+        inside: false,
+        reported: false
+    };
+}
+
+/**
+ * What a press on a column heading starts. The heading is the handle, as it was when the browser
+ * carried the column; a press anywhere else in the column belongs to what stands there.
+ */
+function startColumn(target: HTMLElement, container: HTMLElement): ColumnSubject | null {
+    const heading = target.closest<HTMLElement>(".board-column h3");
+    const element = heading?.closest<HTMLElement>(".board-column");
+    if (!heading || !element || heading.classList.contains("editing")) return null;
+
+    const columns = [ ...container.querySelectorAll(".board-column") ];
+    return {
+        kind: "column",
+        element,
+        menuTarget: heading,
+        column: element.dataset.column ?? "",
+        index: columns.indexOf(element),
+        target: null
+    };
+}
+
+/**
+ * Takes a copy of what is being carried out of the board's flow and hands it back.
+ *
+ * The copy is positioned against the window, which no ancestor's overflow can clip, and stands
+ * inside the board so that the board's own styling still reaches it. A column is cut to a set
+ * height, so that a tall one does not cover the board it is being placed on.
+ */
+function lift(held: Gesture, container: HTMLElement) {
+    const rect = held.element.getBoundingClientRect();
+    const preview = held.element.cloneNode(true) as HTMLElement;
+
+    preview.classList.add("board-drag-preview");
+    preview.removeAttribute("data-note-id");
+    preview.removeAttribute("data-column");
+    // A copy can be used for nothing, and the copy stands outside the column its controls are
+    // styled from, so what it offers is taken out rather than left showing.
+    preview.querySelector(".edit-icon")?.remove();
+
+    for (const [ property, value ] of Object.entries({
+        left: `${rect.left}px`,
+        top: `${rect.top}px`,
+        width: `${rect.width}px`,
+        height: held.kind === "column" ? `${COLUMN_DRAG_HEIGHT}px` : `${rect.height}px`
+    })) {
+        preview.style.setProperty(property, value);
+    }
+
+    // Into the layer rather than the board itself: the board's children are Preact's to place, and
+    // a node put among them by hand is one it has to reckon with when it next draws.
+    (container.querySelector(".board-drag-layer") ?? container).appendChild(preview);
+    held.element.style.display = "none";
+    return {
+        preview,
+        size: { width: rect.width, height: rect.height },
+        // Where inside it the reader took hold, so the middle can be found from the pointer.
+        grab: {
+            x: held.startX - rect.left,
+            y: held.startY - rect.top,
+            width: rect.width,
+            height: rect.height
+        }
+    };
+}
+
+interface CardSubject {
+    kind: "card";
+    element: HTMLElement;
+    /** What a tap asks for the menu, which for a column is its heading rather than the column. */
+    menuTarget: HTMLElement;
+    card: DraggedCard;
+    position: DropPosition | null;
+    /** The column the card stands on, if any, which resting there opens. */
+    on?: string;
+    /** Whether it has rested there long enough to count. */
+    inside: boolean;
+    /** What was last said about that, so nothing is said twice. */
+    reported: boolean;
+}
+
+interface ColumnSubject {
+    kind: "column";
+    element: HTMLElement;
+    menuTarget: HTMLElement;
+    column: string;
+    /** Where it stands among the columns, counting them as they are drawn. */
+    index: number;
+    /** The place it would take, as last reported. */
+    target: number | null;
+}
+
+/** One press, from the moment it lands until it is let go or called off. */
+type Gesture = (CardSubject | ColumnSubject) & {
+    pointerId: number;
+    startX: number;
+    startY: number;
+    lastX: number;
+    lastY: number;
+    /** Whether the press has to ripen before it carries anything. */
+    touch: boolean;
+    /** Whether it has, and something is being carried. */
+    active: boolean;
+    /** The copy that follows the pointer, what it stands for staying where it is. */
+    preview?: HTMLElement;
+    /** Where the press landed inside it, and how big it is, for finding its middle. */
+    grab?: { x: number, y: number, width: number, height: number };
+    measurement?: BoardMeasurement;
+    frame?: number;
+    timer: number;
+    /** Counts down the rest on a column's heading, which is what opens a collapsed one. */
+    dwell?: number;
+};

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -18,8 +18,8 @@ const TOUCH_TOLERANCE = 8;
 /** How much a carried card shrinks. Written with the movement, a class could not add to it. */
 const DRAG_SCALE = 0.9;
 
-/** How tall a carried column stands, whatever it holds, so it can be seen past. */
-const COLUMN_DRAG_HEIGHT = 150;
+/** How tall a carried column is allowed to stand, so a full one can be seen past. */
+const COLUMN_DRAG_MAX_HEIGHT = 150;
 
 /** How long a card rests on a column's heading before it counts as standing there. */
 const DWELL_MS = 500;
@@ -477,8 +477,9 @@ function startColumn(target: HTMLElement, container: HTMLElement): ColumnSubject
  * Takes a copy of what is being carried out of the board's flow and hands it back.
  *
  * The copy is positioned against the window, which no ancestor's overflow can clip, and stands
- * inside the board so that the board's own styling still reaches it. A column is cut to a set
- * height, so that a tall one does not cover the board it is being placed on.
+ * inside the board so that the board's own styling still reaches it. A column is capped rather than
+ * given a height, so that a tall one does not cover the board it is being placed on while a short
+ * one still stands as tall as it is.
  */
 function lift(held: Gesture, container: HTMLElement) {
     const rect = held.element.getBoundingClientRect();
@@ -490,12 +491,15 @@ function lift(held: Gesture, container: HTMLElement) {
     // A copy can be used for nothing, and the copy stands outside the column its controls are
     // styled from, so what it offers is taken out rather than left showing.
     preview.querySelector(".edit-icon")?.remove();
+    preview.querySelector(".board-new-item")?.remove();
 
     for (const [ property, value ] of Object.entries({
         left: `${rect.left}px`,
         top: `${rect.top}px`,
         width: `${rect.width}px`,
-        height: held.kind === "column" ? `${COLUMN_DRAG_HEIGHT}px` : `${rect.height}px`
+        ...(held.kind === "column"
+            ? { "max-height": `${COLUMN_DRAG_MAX_HEIGHT}px` }
+            : { height: `${rect.height}px` })
     })) {
         preview.style.setProperty(property, value);
     }

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import appContext from "../../../components/app_context";
 import Component from "../../../components/component";
 import contextMenu from "../../../menus/context_menu";
+import cssClassManager from "../../../services/css_class_manager";
 import FAttribute from "../../../entities/fattribute";
 import froca from "../../../services/froca";
 import LoadResults from "../../../services/load_results";
@@ -83,6 +84,22 @@ describe("Board card", () => {
         expect(columnsOf(container)).toContain("Done");
         expect(draws.get(first)).toBe(before);
         expect(draws.get(second)).toBeGreaterThan(before ?? 0);
+    });
+
+    /**
+     * The board does not redraw a card for a colour, and a card whose props have not changed is
+     * skipped by the memo around it, so the card has to hear about the label itself.
+     */
+    it("follows its note's colour", async () => {
+        const { component, first, second } = await renderBoard();
+        const coloured = cssClassManager.createClassForColor("#ff0000");
+
+        expect(cardClasses(first)).not.toContain(coloured);
+
+        await addLabel(component, first, "color", "#ff0000");
+
+        expect(cardClasses(first)).toContain(coloured);
+        expect(cardClasses(second)).not.toContain(coloured);
     });
 
     it("follows its note's icon, which the quick edit popup sets as a label", async () => {

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -129,25 +129,6 @@ describe("Board card", () => {
         expect(openInPopup).not.toHaveBeenCalled();
     });
 
-    it("carries its own id and column in the clipboard when a drag starts", async () => {
-        const { first } = await renderBoard();
-        const clipboard: Record<string, string> = {};
-        const dataTransfer = {
-            effectAllowed: "",
-            setData: (type: string, value: string) => { clipboard[type] = value; }
-        };
-
-        await act(async () => { fireDrag(card(first), "dragstart", dataTransfer); });
-
-        expect(JSON.parse(clipboard["trilium/board-card"]))
-            .toMatchObject({ noteId: first, fromColumn: "To Do", index: 0 });
-        expect(dataTransfer.effectAllowed).toBe("move");
-
-        // Dropping it anywhere clears the drag, which is what un-hides the card.
-        await act(async () => { fireDrag(card(first), "dragend", dataTransfer); });
-        expect(card(first).className).not.toContain("dragging");
-    });
-
     it("offers the card menu on a right click", async () => {
         const { first } = await renderBoard();
         const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -25,12 +25,24 @@ vi.mock("../../../menus/link_context_menu", () => ({
     default: { getItems: () => [], handleLinkContextMenuItem: () => {} }
 }));
 
+/** Counts how often each card has drawn, which is what the memo boundary around it decides. */
+const draws = vi.hoisted(() => new Map<string, number>());
+vi.mock("../../attribute_widgets/UserAttributesList", () => ({
+    default: ({ note }: { note: { noteId: string } }) => {
+        draws.set(note.noteId, (draws.get(note.noteId) ?? 0) + 1);
+        return null;
+    }
+}));
+
 describe("Board card", () => {
     let container: HTMLElement | undefined;
     /** froca is module-level, so ids are kept distinct rather than reset between tests. */
     let idSeed = 0;
 
-    beforeEach(() => vi.restoreAllMocks());
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        draws.clear();
+    });
 
     afterEach(() => {
         if (container) {
@@ -52,6 +64,25 @@ describe("Board card", () => {
 
         expect(cardClasses(first)).toContain("archived");
         expect(cardClasses(second)).not.toContain("archived");
+    });
+
+    /**
+     * A board holds hundreds of cards, so a refresh that redrew all of them would make one card's
+     * move cost the whole board. The api is what this rests on: rebuilt per refresh, as it once was,
+     * it is a new prop on every card and no card can be skipped.
+     */
+    it("leaves the cards a refresh did not change undrawn", async () => {
+        const { component, first, second } = await renderBoard();
+        const before = draws.get(first);
+        expect(before).toBeGreaterThan(0);
+
+        // The last card takes a column of its own, so the first one keeps both its column and its
+        // place in it while the board rebuilds its data.
+        await changeStatus(component, second, "Done");
+
+        expect(columnsOf(container)).toContain("Done");
+        expect(draws.get(first)).toBe(before);
+        expect(draws.get(second)).toBeGreaterThan(before ?? 0);
     });
 
     it("follows its note's icon, which the quick edit popup sets as a label", async () => {
@@ -195,6 +226,35 @@ describe("Board card", () => {
         await settle();
 
         return { note, component, first, second };
+    }
+
+    /** Moves a card to another column the way an edit made anywhere else reaches the board. */
+    async function changeStatus(component: Component, noteId: string, value: string) {
+        const attribute = (noteAttributeCache.attributes[noteId] ?? [])
+            .find(candidate => candidate.name === "status");
+        if (!attribute) throw new Error(`no status label on ${noteId}`);
+        attribute.value = value;
+
+        const entity = {
+            attributeId: attribute.attributeId, noteId, type: "label", name: "status", value,
+            isDeleted: false
+        };
+        const loadResults = new LoadResults([ {
+            entityName: "attributes", entityId: attribute.attributeId, entity, hash: "",
+            isSynced: true, isErased: false
+        } ]);
+        loadResults.addAttribute(attribute.attributeId, "someOtherComponent");
+
+        await act(async () => {
+            await component.handleEvent("entitiesReloaded", { loadResults });
+        });
+        await settle();
+    }
+
+    /** The columns the board is showing, in the order it draws them. */
+    function columnsOf(root: HTMLElement | undefined) {
+        return [ ...root?.querySelectorAll(".board-column") ?? [] ]
+            .map(column => column.getAttribute("data-column"));
     }
 
     /** Adds a label to a note already in froca and announces it the way a websocket message would. */

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -59,6 +59,9 @@ function Card({
     const editorRef = useRef<HTMLInputElement>(null);
     const cardRef = useRef<HTMLDivElement>(null);
     const [ isArchived ] = useNoteLabelBoolean(note, "archived");
+    // The card stays the one just made until another is, so what has already been shown is
+    // remembered here rather than played again by every redraw of the column.
+    const [ isRevealed, setIsRevealed ] = useState(false);
     const [ title, setTitle ] = useState(note.title);
     // Tracks the `iconClass` label, which an attribute change carries and the note row never does.
     const icon = useNoteIcon(note);
@@ -141,7 +144,12 @@ function Card({
     return (
         <div
             ref={cardRef}
-            className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""} ${isNew ? "appearing" : ""}`}
+            className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""} ${isNew && !isRevealed ? "appearing" : ""}`}
+            onAnimationEnd={(e) => {
+                if (e.animationName === "board-card-appear") {
+                    setIsRevealed(true);
+                }
+            }}
             data-note-id={note.noteId}
             onContextMenu={handleContextMenu}
             onClick={!isEditing ? handleOpen : undefined}

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -20,9 +20,11 @@ function Card({
     index,
     statusAttribute,
     isNew,
+    focusOnArrival,
     isDragging,
     isEditing,
-    onFocusCard
+    onFocusCard,
+    onCreated
 }: {
     api: BoardApi,
     note: FNote,
@@ -34,8 +36,10 @@ function Card({
      * one identity for the life of the board, which a `memo` comparison cannot see through.
      */
     statusAttribute: string,
-    /** Whether this is the card the new-item editor has just made, which is revealed on arrival. */
+    /** Whether this is the card just made, which is revealed on arrival. */
     isNew: boolean,
+    /** Whether the card just made is also left focused, which an insert's is and the footer's is not. */
+    focusOnArrival: boolean,
     isDragging: boolean,
     /**
      * Passed down rather than derived here from the drag state's `branchIdToEdit`, so that a card
@@ -43,7 +47,9 @@ function Card({
      */
     isEditing: boolean,
     /** Puts focus back on this card once a change of column has drawn it under another one. */
-    onFocusCard: (noteId: string) => void
+    onFocusCard: (noteId: string) => void,
+    /** Names the card inserted next to this one, which the column reveals as it draws it. */
+    onCreated: (noteId: string | undefined) => void
 }) {
     const { setBranchIdToEdit } = useContext(BoardActionsContext);
     const colorClass = note.getColorClass() || '';
@@ -64,8 +70,8 @@ function Card({
     });
 
     const handleContextMenu = useCallback((e: ContextMenuEvent) => {
-        openNoteContextMenu(api, e, note, branch.branchId, column, onFocusCard);
-    }, [ api, note, branch, column, onFocusCard ]);
+        openNoteContextMenu(api, e, note, branch.branchId, column, onFocusCard, onCreated);
+    }, [ api, note, branch, column, onFocusCard, onCreated ]);
 
     const handleOpen = useCallback((e: MouseEvent) => {
         // A double click is one gesture, and its second click would open the note over itself: the
@@ -85,30 +91,46 @@ function Card({
             // Enter adds a card the way it adds a row in a spreadsheet, and Space is what opens
             // one. Shift adds it above instead of below.
             e.preventDefault();
-            api.insertRowAtPosition(column, branch.branchId, e.shiftKey ? "before" : "after");
+            api.insertRowAtPosition(column, branch.branchId, e.shiftKey ? "before" : "after")
+                .then(created => onCreated(created?.noteId));
         } else if (e.key === "F2") {
             setBranchIdToEdit(branch.branchId);
         }
-    }, [ api, column, branch, setBranchIdToEdit ]);
+    }, [ api, column, branch, setBranchIdToEdit, onCreated ]);
 
     useEffect(() => {
         editorRef.current?.focus();
     }, [ isEditing ]);
 
+    // An insert opens the new card's title editor, which holds focus while a title is typed. The
+    // card takes it from there, so that the arrow keys carry on from where the reader is.
+    useEffect(() => {
+        if (focusOnArrival && !isEditing) {
+            cardRef.current?.focus();
+        }
+    }, [ focusOnArrival, isEditing ]);
+
     useEffect(() => {
         setTitle(note.title);
     }, [ note ]);
 
-    // A card is added at the end of its column, which on a full column is below the fold. The
-    // column is taken to its end rather than the card into view, so the card lands clear of the
-    // fade the scrolling body draws over its bottom edge.
+    // A new card can be below the fold on a full column. One at the end takes the column to its
+    // end, so it lands clear of the fade the scrolling body draws over its bottom edge; one
+    // inserted between others is only brought into view.
     useLayoutEffect(() => {
         if (!isNew) {
             return;
         }
 
-        const content = cardRef.current?.closest(".board-column-content");
-        if (content) {
+        const card = cardRef.current;
+        const content = card?.closest(".board-column-content");
+        if (!card || !content) {
+            return;
+        }
+
+        if (card.nextElementSibling) {
+            card.scrollIntoView?.({ block: "nearest" });
+        } else {
             content.scrollTop = content.scrollHeight;
         }
     }, [ isNew ]);
@@ -138,6 +160,7 @@ function Card({
                 </>
             ) : (
                 <TitleEditor
+                    returnFocusTo={cardRef}
                     currentValue={note.title}
                     save={newTitle => {
                         api.renameCard(note.noteId, newTitle);

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -10,7 +10,9 @@ import { ContextMenuEvent } from "../../../menus/context_menu";
 import { openNoteContextMenu } from "./context_menu";
 import { t } from "../../../services/i18n";
 import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
-import { useNoteIcon, useNoteLabelBoolean, useTriliumEvent } from "../../react/hooks";
+import {
+    useNoteColorClass, useNoteIcon, useNoteLabelBoolean, useTriliumEvent
+} from "../../react/hooks";
 
 function Card({
     api,
@@ -52,7 +54,8 @@ function Card({
     onCreated: (noteId: string | undefined) => void
 }) {
     const { setBranchIdToEdit } = useContext(BoardActionsContext);
-    const colorClass = note.getColorClass() || '';
+    // Tracks the `color` label, which the board does not redraw a card for.
+    const colorClass = useNoteColorClass(note) || "";
     const editorRef = useRef<HTMLInputElement>(null);
     const cardRef = useRef<HTMLDivElement>(null);
     const [ isArchived ] = useNoteLabelBoolean(note, "archived");

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -16,6 +16,7 @@ function Card({
     branch,
     column,
     index,
+    statusAttribute,
     isDragging,
     isEditing,
     onFocusCard
@@ -25,6 +26,11 @@ function Card({
     branch: FBranch,
     column: string,
     index: number,
+    /**
+     * The label the board groups by, so that a card is not left reading it off `api`. The api keeps
+     * one identity for the life of the board, which a `memo` comparison cannot see through.
+     */
+    statusAttribute: string,
     isDragging: boolean,
     /**
      * Passed down rather than derived here from the drag state's `branchIdToEdit`, so that a card
@@ -107,7 +113,7 @@ function Card({
                         title={t("board_view.edit-note-title")}
                         onClick={handleEdit}
                     />
-                    <UserAttributesDisplay note={note} ignoredAttributes={[api.statusAttribute]} />
+                    <UserAttributesDisplay note={note} ignoredAttributes={[statusAttribute]} />
                 </>
             ) : (
                 <TitleEditor
@@ -132,7 +138,8 @@ function Card({
  * re-renders a context consumer whatever its memo boundary says, so subscribing there would make
  * the comparison below unreachable. `isEditing` and `isDragging` arrive as props for that reason.
  *
- * Note that `api` is rebuilt whenever the board's data is, so a refresh still re-renders every card
- * regardless. This bails out on the drag and edit redraws, not on those.
+ * `api` keeps one identity for as long as the board is mounted, so a refresh reaches only the cards
+ * whose own props changed. Anything a card reads off the api while rendering has to arrive as a prop
+ * instead, which is why `statusAttribute` is one.
  */
 export default memo(Card);

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -10,15 +10,6 @@ import { t } from "../../../services/i18n";
 import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
 import { useNoteIcon, useNoteLabelBoolean, useTriliumEvent } from "../../react/hooks";
 
-export const CARD_CLIPBOARD_TYPE = "trilium/board-card";
-
-export interface CardDragData {
-    noteId: string;
-    branchId: string;
-    index: number;
-    fromColumn: string;
-}
-
 function Card({
     api,
     note,
@@ -43,11 +34,10 @@ function Card({
     /** Puts focus back on this card once a change of column has drawn it under another one. */
     onFocusCard: (noteId: string) => void
 }) {
-    const { setBranchIdToEdit, setDraggedCard } = useContext(BoardActionsContext);
+    const { setBranchIdToEdit } = useContext(BoardActionsContext);
     const colorClass = note.getColorClass() || '';
     const editorRef = useRef<HTMLInputElement>(null);
     const [ isArchived ] = useNoteLabelBoolean(note, "archived");
-    const [ isVisible, setVisible ] = useState(true);
     const [ title, setTitle ] = useState(note.title);
     // Tracks the `iconClass` label, which an attribute change carries and the note row never does.
     const icon = useNoteIcon(note);
@@ -60,17 +50,6 @@ function Card({
             setTitle(row.title);
         }
     });
-
-    const handleDragStart = useCallback((e: DragEvent) => {
-        e.dataTransfer!.effectAllowed = 'move';
-        const data: CardDragData = { noteId: note.noteId, branchId: branch.branchId, fromColumn: column, index };
-        setDraggedCard(data);
-        e.dataTransfer!.setData(CARD_CLIPBOARD_TYPE, JSON.stringify(data));
-    }, [note.noteId, branch.branchId, column, index]);
-
-    const handleDragEnd = useCallback((e: DragEvent) => {
-        setDraggedCard(null);
-    }, [setDraggedCard]);
 
     const handleContextMenu = useCallback((e: ContextMenuEvent) => {
         openNoteContextMenu(api, e, note, branch.branchId, column, onFocusCard);
@@ -108,23 +87,13 @@ function Card({
         setTitle(note.title);
     }, [ note ]);
 
-    useEffect(() => {
-        setVisible(!isDragging);
-    }, [ isDragging ]);
-
     return (
         <div
             className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""}`}
             data-note-id={note.noteId}
-            draggable
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
             onContextMenu={handleContextMenu}
             onClick={!isEditing ? handleOpen : undefined}
             onKeyDown={handleKeyDown}
-            style={{
-                display: !isVisible ? "none" : undefined
-            }}
             tabIndex={300}
         >
             {!isEditing ? (

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -1,5 +1,7 @@
 import { memo } from "preact/compat";
-import { useCallback, useContext, useEffect, useRef, useState } from "preact/hooks";
+import {
+    useCallback, useContext, useEffect, useLayoutEffect, useRef, useState
+} from "preact/hooks";
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
 import BoardApi from "./api";
@@ -17,6 +19,7 @@ function Card({
     column,
     index,
     statusAttribute,
+    isNew,
     isDragging,
     isEditing,
     onFocusCard
@@ -31,6 +34,8 @@ function Card({
      * one identity for the life of the board, which a `memo` comparison cannot see through.
      */
     statusAttribute: string,
+    /** Whether this is the card the new-item editor has just made, which is revealed on arrival. */
+    isNew: boolean,
     isDragging: boolean,
     /**
      * Passed down rather than derived here from the drag state's `branchIdToEdit`, so that a card
@@ -43,6 +48,7 @@ function Card({
     const { setBranchIdToEdit } = useContext(BoardActionsContext);
     const colorClass = note.getColorClass() || '';
     const editorRef = useRef<HTMLInputElement>(null);
+    const cardRef = useRef<HTMLDivElement>(null);
     const [ isArchived ] = useNoteLabelBoolean(note, "archived");
     const [ title, setTitle ] = useState(note.title);
     // Tracks the `iconClass` label, which an attribute change carries and the note row never does.
@@ -93,9 +99,24 @@ function Card({
         setTitle(note.title);
     }, [ note ]);
 
+    // A card is added at the end of its column, which on a full column is below the fold. The
+    // column is taken to its end rather than the card into view, so the card lands clear of the
+    // fade the scrolling body draws over its bottom edge.
+    useLayoutEffect(() => {
+        if (!isNew) {
+            return;
+        }
+
+        const content = cardRef.current?.closest(".board-column-content");
+        if (content) {
+            content.scrollTop = content.scrollHeight;
+        }
+    }, [ isNew ]);
+
     return (
         <div
-            className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""}`}
+            ref={cardRef}
+            className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""} ${isNew ? "appearing" : ""}`}
             data-note-id={note.noteId}
             onContextMenu={handleContextMenu}
             onClick={!isEditing ? handleOpen : undefined}

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -76,7 +76,13 @@ export default function Column({
     onFocusCard: (noteId: string) => void
 } & DragContext) {
     const [ isCreatingNewItem, setIsCreatingNewItem ] = useState(false);
-    const [ createdNoteId, setCreatedNoteId ] = useState<string>();
+    const [ created, setCreated ] = useState<{ noteId?: string, takesFocus: boolean }>();
+    // A card inserted next to another one is where the reader is working, so it is left focused; one
+    // made in the footer is not, or every card would take focus from the editor still being typed in.
+    const cardInserted = useCallback(
+        (noteId: string | undefined) => setCreated({ noteId, takesFocus: true }), []);
+    const cardAdded = useCallback(
+        (noteId: string | undefined) => setCreated({ noteId, takesFocus: false }), []);
     const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn } =
         useContext(BoardActionsContext);
     const { branchIdToEdit, columnNameToEdit, dropTarget, draggedCard, dropPosition } = useContext(BoardDragStateContext);
@@ -305,10 +311,14 @@ export default function Column({
                                 column={column}
                                 index={index}
                                 statusAttribute={api.statusAttribute}
-                                isNew={note.noteId === createdNoteId}
+                                isNew={note.noteId === created?.noteId}
+                                focusOnArrival={
+                                    note.noteId === created?.noteId && created.takesFocus
+                                }
                                 isDragging={draggedCard?.noteId === note.noteId}
                                 isEditing={branch.branchId === branchIdToEdit}
                                 onFocusCard={onFocusCard}
+                                onCreated={cardInserted}
                             />
                         </Fragment>
                     );
@@ -323,7 +333,7 @@ export default function Column({
                 column={column}
                 isCreating={isCreatingNewItem}
                 setIsCreating={setIsCreatingNewItem}
-                onCreated={setCreatedNoteId}
+                onCreated={cardAdded}
             />}
         </div>
     );

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -303,6 +303,7 @@ export default function Column({
                                 branch={branch}
                                 column={column}
                                 index={index}
+                                statusAttribute={api.statusAttribute}
                                 isDragging={draggedCard?.noteId === note.noteId}
                                 isEditing={branch.branchId === branchIdToEdit}
                                 onFocusCard={onFocusCard}

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -21,7 +21,7 @@ import { useScrollFade } from "../../react/scroll_fade";
 import NoteLink from "../../react/NoteLink";
 import { BoardActionsContext, BoardDragStateContext, TitleEditor } from ".";
 import BoardApi from "./api";
-import Card, { CARD_CLIPBOARD_TYPE, CardDragData } from "./card";
+import Card from "./card";
 import { DEFAULT_COLUMN_ICON, INBOX_COLUMN } from "./columns";
 import { openColumnContextMenu } from "./context_menu";
 
@@ -45,12 +45,9 @@ export default function Column({
     isActive,
     nested,
     limit,
-    isDraggingColumn,
     columnItems,
     api,
     parentNote,
-    onColumnHover,
-    isAnyColumnDragging,
     isInRelationMode
 }: {
     columnItems?: { note: FNote, branch: FBranch }[];
@@ -68,11 +65,8 @@ export default function Column({
     nested?: boolean,
     /** The note limit, absent if disabled. */
     limit?: number,
-    isDraggingColumn: boolean,
     api: BoardApi,
     parentNote: FNote,
-    onColumnHover?: (index: number, mouseX: number, rect: DOMRect) => void,
-    isAnyColumnDragging?: boolean,
     isInRelationMode: boolean,
     /** The columns as drawn, which is what the menu offers to place this one among. */
     columns: string[],
@@ -81,7 +75,6 @@ export default function Column({
     onFocusColumn: (column: string) => void,
     onFocusCard: (noteId: string) => void
 } & DragContext) {
-    const [ isVisible, setVisible ] = useState(true);
     const [ isCreatingNewItem, setIsCreatingNewItem ] = useState(false);
     const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn } =
         useContext(BoardActionsContext);
@@ -90,9 +83,16 @@ export default function Column({
     const editorRef = useRef<HTMLInputElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const scrollFade = useScrollFade(contentRef);
-    const { handleColumnDragStart, handleColumnDragEnd, handleDragOver, handleDragLeave, handleDrop } = useDragging({
+    const { handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote
     });
+
+    // Measured rather than styled: the gap stands for the card being carried, which is whatever
+    // height its own content gave it. A drag from the note tree carries no card, so the stock
+    // height stands.
+    const gapStyle = draggedCard?.height
+        ? { height: `${draggedCard.height}px` }
+        : undefined;
 
     // Read here rather than in the badge: the column body shows an outline as well.
     const isOverLimit = limit !== undefined && (columnItems?.length ?? 0) > limit;
@@ -174,17 +174,6 @@ export default function Column({
         editorRef.current?.focus();
     }, [ isEditing ]);
 
-    useEffect(() => {
-        setVisible(!isDraggingColumn);
-    }, [ isDraggingColumn ]);
-
-    const handleColumnDragOver = useCallback((e: DragEvent) => {
-        if (!isAnyColumnDragging || !onColumnHover) return;
-        e.preventDefault();
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-        onColumnHover(columnIndex, e.clientX, rect);
-    }, [isAnyColumnDragging, onColumnHover, columnIndex]);
-
     return (
         <div
             data-column={column}
@@ -200,13 +189,10 @@ export default function Column({
             // A click and not a press: a press may be the start of a drag, which must leave the
             // column as it is, and a drag produces no click.
             onClick={select}
-            onDragOver={isAnyColumnDragging ? handleColumnDragOver : handleDragOver}
+            onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
-            style={{
-                display: !isVisible ? "none" : undefined,
-                "--board-column-custom-hue": hue
-            }}
+            style={{ "--board-column-custom-hue": hue }}
         >
             <h3
                 className={`${isEditing ? "editing" : ""}`}
@@ -215,9 +201,6 @@ export default function Column({
                 // nothing, so neither is claimed.
                 role={isCollapsed ? "button" : undefined}
                 aria-expanded={isCollapsed ? false : undefined}
-                draggable
-                onDragStart={handleColumnDragStart}
-                onDragEnd={handleColumnDragEnd}
                 onContextMenu={openMenu}
                 onKeyDown={handleTitleKeyDown}
                 tabIndex={300}
@@ -312,7 +295,7 @@ export default function Column({
                     return (
                         <Fragment key={note.noteId}>
                             {showIndicatorBefore && (
-                                <div className="board-drop-placeholder show" />
+                                <div className="board-drop-placeholder show" style={gapStyle} />
                             )}
                             <Card
                                 api={api}
@@ -328,7 +311,7 @@ export default function Column({
                     );
                 })}
                 {dropPosition?.column === column && dropPosition.index === (columnItems?.length ?? 0) && (
-                    <div className="board-drop-placeholder show" />
+                    <div className="board-drop-placeholder show" style={gapStyle} />
                 )}
 
                 <AddNewItem
@@ -500,7 +483,8 @@ function useDragging({ column, columnIndex, columnItems, isEditing, api, parentN
 
     const handleDragOver = useCallback((e: DragEvent) => {
         if (isEditing || draggedColumn || isDraggingRef.current) return; // Don't handle card drops when dragging columns
-        if (!e.dataTransfer?.types.includes(CARD_CLIPBOARD_TYPE) && !e.dataTransfer?.types.includes(TREE_CLIPBOARD_TYPE)) return;
+        // Cards are carried by pointer now; what still arrives this way comes from the note tree.
+        if (!e.dataTransfer?.types.includes(TREE_CLIPBOARD_TYPE)) return;
 
         e.preventDefault();
         setDropTarget(column);
@@ -545,19 +529,18 @@ function useDragging({ column, columnIndex, columnItems, isEditing, api, parentN
         setDropTarget(null);
         setDropPosition(null);
 
-        const data = e.dataTransfer?.getData(CARD_CLIPBOARD_TYPE) || e.dataTransfer?.getData("text");
+        const data = e.dataTransfer?.getData("text");
         if (!data) return;
 
-        let draggedCard: CardDragData | DragData[];
+        let dropped: DragData[];
         try {
-            draggedCard = JSON.parse(data);
+            dropped = JSON.parse(data);
         } catch (e) {
             return;
         }
 
-        if (Array.isArray(draggedCard)) {
-            // From note tree.
-            const { noteId, branchId } = draggedCard[0];
+        if (Array.isArray(dropped)) {
+            const { noteId, branchId } = dropped[0];
             const targetNote = await froca.getNote(noteId, true);
             const parentNoteId = parentNote.noteId;
             if (!dropPosition) return;
@@ -579,10 +562,7 @@ function useDragging({ column, columnIndex, columnItems, isEditing, api, parentN
             } else if (targetBranch) {
                 await branches.moveAfterBranch([ branchId ], targetBranch.branchId);
             }
-        } else if (draggedCard && dropPosition) {
-            api.moveWithinBoard(draggedCard.noteId, draggedCard.branchId, draggedCard.index, dropPosition.index, draggedCard.fromColumn, column);
         }
-
     }, [ api, draggedColumn, dropPosition, columnItems, column, setDropTarget, setDropPosition ]);
 
     return { handleColumnDragStart, handleColumnDragEnd, handleDragOver, handleDragLeave, handleDrop };

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { Fragment } from "preact";
 import {
-    useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState
+    useCallback, useContext, useEffect, useMemo, useRef, useState
 } from "preact/hooks";
 import { JSX } from "preact/jsx-runtime";
 
@@ -76,6 +76,7 @@ export default function Column({
     onFocusCard: (noteId: string) => void
 } & DragContext) {
     const [ isCreatingNewItem, setIsCreatingNewItem ] = useState(false);
+    const [ createdNoteId, setCreatedNoteId ] = useState<string>();
     const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn } =
         useContext(BoardActionsContext);
     const { branchIdToEdit, columnNameToEdit, dropTarget, draggedCard, dropPosition } = useContext(BoardDragStateContext);
@@ -304,6 +305,7 @@ export default function Column({
                                 column={column}
                                 index={index}
                                 statusAttribute={api.statusAttribute}
+                                isNew={note.noteId === createdNoteId}
                                 isDragging={draggedCard?.noteId === note.noteId}
                                 isEditing={branch.branchId === branchIdToEdit}
                                 onFocusCard={onFocusCard}
@@ -314,15 +316,15 @@ export default function Column({
                 {dropPosition?.column === column && dropPosition.index === (columnItems?.length ?? 0) && (
                     <div className="board-drop-placeholder show" style={gapStyle} />
                 )}
-
-                <AddNewItem
-                    api={api}
-                    column={column}
-                    itemCount={columnItems?.length ?? 0}
-                    isCreating={isCreatingNewItem}
-                    setIsCreating={setIsCreatingNewItem}
-                />
             </div>}
+
+            {!isCollapsed && <AddNewItem
+                api={api}
+                column={column}
+                isCreating={isCreatingNewItem}
+                setIsCreating={setIsCreatingNewItem}
+                onCreated={setCreatedNoteId}
+            />}
         </div>
     );
 }
@@ -331,34 +333,15 @@ export default function Column({
  * The editor a new card is named in, opened by the button below the column or by its menu. The
  * state is the column's rather than this component's, since the menu is raised from the header.
  */
-function AddNewItem({ column, api, itemCount, isCreating, setIsCreating }: {
+function AddNewItem({ column, api, isCreating, setIsCreating, onCreated }: {
     column: string,
     api: BoardApi,
-    /** How many cards stand above it, which is what moves it out of view as they come and go. */
-    itemCount: number,
     isCreating: boolean,
-    setIsCreating: (isCreating: boolean) => void
+    setIsCreating: (isCreating: boolean) => void,
+    /** Names the card just made, which the column reveals once the board has drawn it. */
+    onCreated: (noteId: string | undefined) => void
 }) {
     const [ initialTitle, setInitialTitle ] = useState("");
-    const slotRef = useRef<HTMLDivElement>(null);
-
-    // Reaching the button means reaching the end of the column, so what is under it comes into view
-    // with it. The browser scrolls only far enough to show the button itself.
-    const scrollToEnd = useCallback(() => {
-        const content = slotRef.current?.closest(".board-column-content");
-        if (content) {
-            content.scrollTop = content.scrollHeight;
-        }
-    }, []);
-
-    // A card added lands above the button and pushes it out of sight, and the editor stands taller
-    // than the button it replaces. Neither raises a focus event, so whatever is focused in here has
-    // to be followed back into view.
-    useLayoutEffect(() => {
-        if (slotRef.current?.contains(document.activeElement)) {
-            scrollToEnd();
-        }
-    }, [ itemCount, isCreating, scrollToEnd ]);
 
     const open = useCallback((title: string) => {
         setInitialTitle(title);
@@ -384,11 +367,9 @@ function AddNewItem({ column, api, itemCount, isCreating, setIsCreating }: {
 
     return (
         <div
-            ref={slotRef}
             className={`board-new-item ${isCreating ? "editing" : ""}`}
             onClick={() => open("")}
             onKeyDown={handleKeyDown}
-            onFocus={scrollToEnd}
             tabIndex={300}
         >
             {!isCreating ? (
@@ -400,10 +381,11 @@ function AddNewItem({ column, api, itemCount, isCreating, setIsCreating }: {
                 <TitleEditor
                     currentValue={initialTitle}
                     placeholder={t("board_view.new-item-placeholder")}
-                    save={(title) => api.createNewItem(column, title)}
+                    save={async (title) => onCreated(await api.createNewItem(column, title))}
                     dismiss={() => setIsCreating(false)}
                     mode="multiline" isNewItem
                     selectOnFocus={false}
+                    saveAndContinue
                 />
             )}
         </div>

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import { Fragment } from "preact";
+import { flushSync } from "preact/compat";
 import {
     useCallback, useContext, useEffect, useMemo, useRef, useState
 } from "preact/hooks";
@@ -295,9 +296,11 @@ export default function Column({
                 onWheel={handleScroll}
             >
                 {(columnItems ?? []).map(({ note, branch }, index) => {
+                    // The card being carried is out of the flow, so the gap stands in its own
+                    // place too: held still, which a touch does before it moves, that is where it
+                    // was picked up from.
                     const showIndicatorBefore = dropPosition?.column === column &&
-                                            dropPosition.index === index &&
-                                            draggedCard?.noteId !== note.noteId;
+                                            dropPosition.index === index;
 
                     return (
                         <Fragment key={note.noteId}>
@@ -351,6 +354,8 @@ function AddNewItem({ column, api, isCreating, setIsCreating, onCreated }: {
     /** Names the card just made, which the column reveals once the board has drawn it. */
     onCreated: (noteId: string | undefined) => void
 }) {
+    // What the editor opens with: empty to begin with, then whatever was typed into it and left
+    // unsaved, so that reaching for something else and coming back does not cost the title.
     const [ initialTitle, setInitialTitle ] = useState("");
 
     const open = useCallback((title: string) => {
@@ -362,7 +367,7 @@ function AddNewItem({ column, api, isCreating, setIsCreating, onCreated }: {
         if (isCreating) return;
 
         if (e.key === "Enter" && !e.ctrlKey) {
-            open("");
+            setIsCreating(true);
             return;
         }
 
@@ -373,12 +378,12 @@ function AddNewItem({ column, api, isCreating, setIsCreating, onCreated }: {
             e.preventDefault();
             open(e.key);
         }
-    }, [ isCreating, open ]);
+    }, [ isCreating, open, setIsCreating ]);
 
     return (
         <div
             className={`board-new-item ${isCreating ? "editing" : ""}`}
-            onClick={() => open("")}
+            onClick={() => flushSync(() => setIsCreating(true))}
             onKeyDown={handleKeyDown}
             tabIndex={300}
         >
@@ -396,6 +401,7 @@ function AddNewItem({ column, api, isCreating, setIsCreating, onCreated }: {
                     mode="multiline" isNewItem
                     selectOnFocus={false}
                     saveAndContinue
+                    abandon={setInitialTitle}
                 />
             )}
         </div>

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -17,6 +17,7 @@ import ActionButton from "../../react/ActionButton";
 import Icon from "../../react/Icon";
 import { IconPickerButton } from "../../react/IconPicker";
 import { useStaticTooltip } from "../../react/hooks";
+import { useScrollFade } from "../../react/scroll_fade";
 import NoteLink from "../../react/NoteLink";
 import { BoardActionsContext, BoardDragStateContext, TitleEditor } from ".";
 import BoardApi from "./api";
@@ -87,6 +88,8 @@ export default function Column({
     const { branchIdToEdit, columnNameToEdit, dropTarget, draggedCard, dropPosition } = useContext(BoardDragStateContext);
     const isEditing = (columnNameToEdit === column);
     const editorRef = useRef<HTMLInputElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const scrollFade = useScrollFade(contentRef);
     const { handleColumnDragStart, handleColumnDragEnd, handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote
     });
@@ -295,7 +298,12 @@ export default function Column({
                 </>)}
             </h3>
 
-            {!isCollapsed && <div className="board-column-content" onWheel={handleScroll}>
+            {!isCollapsed && <div
+                ref={contentRef}
+                className={clsx("board-column-content", scrollFade.className)}
+                style={scrollFade.style}
+                onWheel={handleScroll}
+            >
                 {(columnItems ?? []).map(({ note, branch }, index) => {
                     const showIndicatorBefore = dropPosition?.column === column &&
                                             dropPosition.index === index &&

--- a/apps/client/src/widgets/collections/board/context_menu.spec.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.spec.ts
@@ -452,7 +452,7 @@ describe("Board item context menu", () => {
             { getStatusLabel: () => "Status", getColumnTitle: (name: string) => name }, api);
         openNoteContextMenu(
             withDefaults, event, buildNote({ title: "Card" }) as FNote, "branchId", column,
-            focusCard);
+            focusCard, () => {});
 
         return show.mock.calls.at(-1)?.[0].items ?? [];
     }

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -251,7 +251,9 @@ function buildColumnItems(
 export function openNoteContextMenu(
     api: Api, event: ContextMenuEvent, note: FNote, branchId: string, column: string,
     /** Puts focus back on the card once a change of column has drawn it under another one. */
-    onFocusCard: (noteId: string) => void
+    onFocusCard: (noteId: string) => void,
+    /** Names the card an insert makes, which the column reveals once the board has drawn it. */
+    onCreated: (noteId: string | undefined) => void
 ) {
     event.preventDefault();
     event.stopPropagation();
@@ -267,12 +269,14 @@ export function openNoteContextMenu(
                 uiIcon: "bx bx-list-plus",
                 shortcut: "Shift+Enter",
                 handler: () => api.insertRowAtPosition(column, branchId, "before")
+                    .then(created => onCreated(created?.noteId))
             },
             {
                 title: t("board_view.insert-below"),
                 uiIcon: "bx bx-empty",
                 shortcut: "Enter",
                 handler: () => api.insertRowAtPosition(column, branchId, "after")
+                    .then(created => onCreated(created?.noteId))
             },
             { kind: "header", title: api.getStatusLabel() },
             ...buildColumnItems(api, note, column, onFocusCard),

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -3,7 +3,62 @@ import { describe, expect, it } from "vitest";
 import FBranch from "../../../entities/fbranch";
 import froca from "../../../services/froca";
 import { buildNote } from "../../../test/easy-froca";
-import { getBoardData } from "./data";
+import { applyCardMove, type ColumnMap, getBoardData } from "./data";
+
+describe("applyCardMove", () => {
+    /** Cards named by their note id, which is all this reads them for. */
+    function board(columns: Record<string, string[]>): ColumnMap {
+        return new Map(Object.entries(columns).map(([ column, ids ]) => [
+            column,
+            ids.map((noteId) => ({ note: { noteId }, branch: { branchId: `b_${noteId}` } }))
+        ])) as unknown as ColumnMap;
+    }
+
+    const names = (map: ColumnMap, column: string) =>
+        (map.get(column) ?? []).map((item) => item.note.noteId);
+
+    it("takes a card out of one column and puts it in another", () => {
+        const next = applyCardMove(board({ A: [ "a1", "a2", "a3" ], B: [ "b1", "b2" ] }),
+            "a2", "A", "B", 1);
+
+        expect(names(next, "A")).toEqual([ "a1", "a3" ]);
+        expect(names(next, "B")).toEqual([ "b1", "a2", "b2" ]);
+    });
+
+    it("puts it at either end of the column it lands in", () => {
+        const start = applyCardMove(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), "a1", "A", "B", 0);
+        expect(names(start, "B")).toEqual([ "a1", "b1", "b2" ]);
+
+        const end = applyCardMove(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), "a1", "A", "B", 2);
+        expect(names(end, "B")).toEqual([ "b1", "b2", "a1" ]);
+    });
+
+    it("puts it in a column holding none", () => {
+        const next = applyCardMove(board({ A: [ "a1" ], B: [] }), "a1", "A", "B", 0);
+
+        expect(names(next, "A")).toEqual([]);
+        expect(names(next, "B")).toEqual([ "a1" ]);
+    });
+
+    /**
+     * The place counts the column as it stood, the card included, so a place beyond where the card
+     * was names one card earlier once it has been taken out.
+     */
+    it("counts a move down its own column against the list it came from", () => {
+        const start = board({ A: [ "a1", "a2", "a3" ] });
+
+        expect(names(applyCardMove(start, "a1", "A", "A", 3), "A")).toEqual([ "a2", "a3", "a1" ]);
+        expect(names(applyCardMove(start, "a1", "A", "A", 2), "A")).toEqual([ "a2", "a1", "a3" ]);
+        expect(names(applyCardMove(start, "a3", "A", "A", 0), "A")).toEqual([ "a3", "a1", "a2" ]);
+        expect(names(applyCardMove(start, "a3", "A", "A", 1), "A")).toEqual([ "a1", "a3", "a2" ]);
+    });
+
+    it("leaves the board alone for a card it does not hold", () => {
+        const start = board({ A: [ "a1" ], B: [] });
+
+        expect(applyCardMove(start, "nope", "A", "B", 0)).toBe(start);
+    });
+});
 
 describe("Board data", () => {
     it("deduplicates cloned notes", async () => {

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -9,6 +9,38 @@ export type ColumnMap = Map<string, {
 }[]>;
 
 /**
+ * The columns as they stand once a card has moved, for drawing the outcome before the writes land.
+ *
+ * A card crossing columns is written twice, the value first and the branch after, and each lands a
+ * redraw of its own. The first shows the card in its new column at whatever place its old branch
+ * gives it, which is above every card already there.
+ *
+ * @param index where the card goes, counting the target column as it stands at the moment of the
+ *              drop, the card itself included where it does not leave its column.
+ */
+export function applyCardMove(
+    byColumn: ColumnMap, noteId: string, from: string, to: string, index: number
+): ColumnMap {
+    const source = [ ...(byColumn.get(from) ?? []) ];
+    const at = source.findIndex((item) => item.note.noteId === noteId);
+    if (at < 0) {
+        return byColumn;
+    }
+
+    const [ moved ] = source.splice(at, 1);
+    const next = new Map(byColumn);
+    next.set(from, source);
+
+    const target = from === to ? source : [ ...(byColumn.get(to) ?? []) ];
+    // Taking the card out shifts everything after it up one, so a place beyond where it stood
+    // names one card earlier in the list left behind.
+    target.splice(from === to && index > at ? index - 1 : index, 0, moved);
+    next.set(to, target);
+
+    return next;
+}
+
+/**
  * @param definitionOptions the choices the board's group-by definition offers, empty when it has no
  *                          select definition of its own to lead the column order.
  * @param pendingRenames the columns the board is in the middle of renaming or deleting. Read

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -467,14 +467,17 @@ describe("Board column reordering", () => {
         expect(placeholder?.style.width).toBe("");
     });
 
-    /** A copy of it is carried, cut to a set height so a tall column does not cover the board. */
+    /** A copy of it is carried, capped so a tall column does not cover the board it is placed on. */
     it("carries a copy, hiding the column until it is let go", async () => {
         const { columns, board } = await renderColumns();
 
         await carryColumn(columns[0], 280, { release: false });
         const copy = board.querySelector<HTMLElement>(".board-column.board-drag-preview");
         expect(copy).toBeTruthy();
-        expect(copy?.style.height).toBe("150px");
+        expect(copy?.style.maxHeight).toBe("150px");
+        expect(copy?.style.height).toBe("");
+        // Nothing on the copy can be used, and the footer would stand under cards it cannot add to.
+        expect(copy?.querySelector(".board-new-item")).toBeNull();
         expect(columns[0].style.display).toBe("none");
 
         await columnPointer(board, "pointerup", 280);

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -14,7 +14,6 @@ import { buildNote } from "../../../test/easy-froca";
 import { TREE_CLIPBOARD_TYPE } from "../../note_tree";
 import { ParentComponent } from "../../react/react_utils";
 import BoardView, { BoardViewData } from ".";
-import { CARD_CLIPBOARD_TYPE } from "./card";
 
 vi.mock("../../../services/branches", () => ({
     default: {
@@ -32,6 +31,15 @@ const PREACT_DRAG_EVENTS = {
     drop: "Drop"
 } as const;
 
+// Hoisted with the mock, which is lifted above everything a test file declares.
+const layout = vi.hoisted(() => ({ onMobile: false }));
+
+// Spread rather than replaced: the board reads far more of this than the one export a test steers.
+vi.mock("../../../services/utils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../../services/utils")>()),
+    isMobile: () => layout.onMobile
+}));
+
 describe("Board drag and drop", () => {
     let container: HTMLElement | undefined;
 
@@ -45,6 +53,7 @@ describe("Board drag and drop", () => {
     });
 
     afterEach(() => {
+        (document.activeElement as HTMLElement | null)?.blur?.();
         if (container) {
             render(null, container);
             container.remove();
@@ -56,7 +65,7 @@ describe("Board drag and drop", () => {
         const { columns } = await renderBoard();
 
         // Above the middle of the second card, so the drop lands between the two.
-        await drag(columns[0], "dragover", { types: [ CARD_CLIPBOARD_TYPE ] }, 120);
+        await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 120);
 
         const placeholders = [ ...columns[0].querySelectorAll(".board-column-content > *") ]
             .map(child => child.className);
@@ -66,7 +75,7 @@ describe("Board drag and drop", () => {
     it("clears the mark once the pointer leaves the column altogether", async () => {
         const { columns } = await renderBoard();
 
-        await drag(columns[0], "dragover", { types: [ CARD_CLIPBOARD_TYPE ] }, 120);
+        await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 120);
         expect(columns[0].querySelector(".board-drop-placeholder")).toBeTruthy();
 
         await drag(columns[0], "dragleave", { types: [] });
@@ -79,25 +88,6 @@ describe("Board drag and drop", () => {
         await drag(columns[0], "dragover", { types: [ "text/uri-list" ] }, 120);
 
         expect(columns[0].querySelector(".board-drop-placeholder")).toBeNull();
-    });
-
-    it("moves a card dropped from another column of the same board", async () => {
-        const { columns, cards } = await renderBoard();
-        const payload = {
-            noteId: cards[0].noteId,
-            branchId: cards[0].branchId,
-            fromColumn: "To Do",
-            index: 0
-        };
-
-        await drag(columns[0], "dragover", { types: [ CARD_CLIPBOARD_TYPE ] }, 120);
-        await drag(columns[0], "drop", {
-            types: [ CARD_CLIPBOARD_TYPE ],
-            data: { [CARD_CLIPBOARD_TYPE]: JSON.stringify(payload) }
-        });
-
-        expect(branches.moveBeforeBranch)
-            .toHaveBeenCalledWith([ cards[0].branchId ], cards[1].branchId);
     });
 
     it("clones a note dragged in from the tree, which the board does not hold", async () => {
@@ -147,12 +137,12 @@ describe("Board drag and drop", () => {
     it("does nothing for a drop carrying nothing it can read", async () => {
         const { columns } = await renderBoard();
 
-        await drag(columns[0], "dragover", { types: [ CARD_CLIPBOARD_TYPE ] }, 120);
+        await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 120);
         await drag(columns[0], "drop", {
-            types: [ CARD_CLIPBOARD_TYPE ],
-            data: { [CARD_CLIPBOARD_TYPE]: "not json at all" }
+            types: [ TREE_CLIPBOARD_TYPE ],
+            data: { text: "not json at all" }
         });
-        await drag(columns[0], "drop", { types: [ CARD_CLIPBOARD_TYPE ], data: {} });
+        await drag(columns[0], "drop", { types: [ TREE_CLIPBOARD_TYPE ], data: {} });
 
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
@@ -167,13 +157,155 @@ describe("Board drag and drop", () => {
 
         expect(columns[0].classList.contains("collapsed")).toBe(true);
 
-        await drag(columns[0], "dragover", { types: [ CARD_CLIPBOARD_TYPE ] }, 50);
+        await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 50);
         expect(columns[0].classList.contains("collapsed")).toBe(false);
         expect(columns[0].querySelectorAll(".board-note")).toHaveLength(2);
 
-        await drag(columns[0], "dragleave", { types: [ CARD_CLIPBOARD_TYPE ] });
+        await drag(columns[0], "dragleave", { types: [ TREE_CLIPBOARD_TYPE ] });
         expect(columns[0].classList.contains("collapsed")).toBe(false);
     });
+
+    /**
+     * What the gesture is for: the same move the old clipboard drop made, made by pointer. The
+     * board's own wiring is what this covers, the gesture itself being tested on its own.
+     */
+    it("moves a card carried by pointer to where it was let go", async () => {
+        const { columns, cards } = await renderBoard();
+        const card = columns[0].querySelector<HTMLElement>(".board-note");
+        if (!card) throw new Error("expected a card");
+
+        // The gesture listens from an effect, which Preact defers past the render the board is
+        // drawn by. A reader could not press before that; a test can.
+        await act(async () => { await settle(); });
+
+        // Taken from the first card and let go above the second's middle, so it lands between them.
+        await pointer(card, "pointerdown", 50, 50);
+        await pointer(columns[0], "pointermove", 50, 120);
+        await act(async () => { await settle(); });
+        await pointer(columns[0], "pointerup", 50, 120);
+        await act(async () => { await settle(); });
+
+        expect(branches.moveBeforeBranch)
+            .toHaveBeenCalledWith([ cards[0].branchId ], cards[1].branchId);
+    });
+
+    /**
+     * A board that scrolls one column at a time has its snapping off while something is carried, so
+     * letting go would otherwise leave the reader looking at two half columns.
+     */
+    it("brings the column the card landed in to the middle, on a board that snaps", async () => {
+        layout.onMobile = true;
+        const revealed: { element: Element, options: unknown }[] = [];
+        const original = Element.prototype.scrollIntoView;
+        Element.prototype.scrollIntoView = function (this: Element, options: unknown) {
+            revealed.push({ element: this, options });
+        } as typeof original;
+
+        try {
+            const { columns } = await renderBoard();
+            const card = columns[0].querySelector<HTMLElement>(".board-note");
+            if (!card) throw new Error("expected a card");
+            await act(async () => { await settle(); });
+
+            await pointer(card, "pointerdown", 50, 50);
+            await pointer(columns[0], "pointermove", 50, 120);
+            await pointer(columns[0], "pointerup", 50, 120);
+            await act(async () => { await new Promise(requestAnimationFrame); });
+
+            const landed = revealed.at(-1);
+            expect(landed?.element).toBe(columns[0]);
+            expect(landed?.options).toMatchObject({ inline: "center" });
+        } finally {
+            Element.prototype.scrollIntoView = original;
+            layout.onMobile = false;
+        }
+    });
+
+    /** Nothing is brought anywhere on a board the reader scrolls freely. */
+    it("leaves the board where it is when it does not snap", async () => {
+        const revealed: Element[] = [];
+        const original = Element.prototype.scrollIntoView;
+        Element.prototype.scrollIntoView = function (this: Element) {
+            revealed.push(this);
+        } as typeof original;
+
+        try {
+            const { columns } = await renderBoard();
+            const card = columns[0].querySelector<HTMLElement>(".board-note");
+            if (!card) throw new Error("expected a card");
+            await act(async () => { await settle(); });
+
+            await pointer(card, "pointerdown", 50, 50);
+            await pointer(columns[0], "pointermove", 50, 120);
+            await pointer(columns[0], "pointerup", 50, 120);
+            await act(async () => { await new Promise(requestAnimationFrame); });
+
+            expect(revealed.filter(element =>
+                element.classList.contains("board-column"))).toEqual([]);
+        } finally {
+            Element.prototype.scrollIntoView = original;
+        }
+    });
+
+    /**
+     * The press focuses the card, the card is then taken out of the page, and a card that crossed
+     * columns is drawn as a new element: whichever happened, the focus has to be put back.
+     */
+    it("focuses the card again once it is let go", async () => {
+        const { columns } = await renderBoard();
+        const card = columns[0].querySelector<HTMLElement>(".board-note");
+        if (!card) throw new Error("expected a card");
+        // Twice: the gesture listens from an effect, and the board redraws once more as its own
+        // first refresh lands, which is what tells the effect the container is there.
+        await act(async () => { await settle(); });
+        await act(async () => { await settle(); });
+
+        await pointer(card, "pointerdown", 50, 50);
+        await pointer(columns[0], "pointermove", 50, 120);
+        await pointer(columns[0], "pointerup", 50, 120);
+        await act(async () => { await settle(); });
+
+        expect(document.activeElement?.getAttribute("data-note-id"))
+            .toBe(card.getAttribute("data-note-id"));
+    });
+
+    /** The gap stands in for the card, so it is the height the card was measured at. */
+    it("holds open a gap the height of the card being carried", async () => {
+        const { columns } = await renderBoard();
+        const card = columns[0].querySelector<HTMLElement>(".board-note");
+        if (!card) throw new Error("expected a card");
+        await act(async () => { await settle(); });
+
+        await pointer(card, "pointerdown", 50, 50);
+        await pointer(columns[0], "pointermove", 50, 120);
+
+        const gap = columns[0].querySelector<HTMLElement>(".board-drop-placeholder");
+        expect(gap?.style.height).toBe("100px");
+    });
+
+    function place(
+        element: HTMLElement | null,
+        box: { left: number, top: number, width: number, height: number }
+    ) {
+        if (element) {
+            element.getBoundingClientRect = () => ({
+                ...box, right: box.left + box.width, bottom: box.top + box.height
+            }) as DOMRect;
+        }
+    }
+
+    async function pointer(target: HTMLElement, type: string, clientX: number, clientY: number) {
+        const event = new Event(type, { bubbles: true, cancelable: true });
+        for (const [ name, value ] of Object.entries({
+            clientX, clientY, pointerId: 1, button: 0, pointerType: "mouse"
+        })) {
+            Object.defineProperty(event, name, { value, configurable: true });
+        }
+        await act(async () => {
+            target.dispatchEvent(event);
+            await settle();
+        });
+    }
 
     /** A board of one column of two cards, each given a height the pointer can be placed in. */
     async function renderBoard({ collapsed }: { collapsed?: boolean } = {}) {
@@ -214,8 +346,19 @@ describe("Board drag and drop", () => {
         // happy-dom lays nothing out, so the cards are given the geometry the drop maths reads.
         for (const [ index, card ] of [ ...columns[0].querySelectorAll(".board-note") ].entries()) {
             card.getBoundingClientRect = () => ({
-                top: index * 100, height: 100
+                left: 0, top: index * 100, width: 100, height: 100
             }) as DOMRect;
+        }
+
+        // The pointer gesture measures the board itself, so its boxes are declared as well.
+        const board = mountPoint.querySelector<HTMLElement>(".board-view-container");
+        place(board, { left: 0, top: 0, width: 400, height: 400 });
+        Object.defineProperty(board, "scrollLeft", { value: 0, configurable: true });
+        place(columns[0], { left: 0, top: 0, width: 100, height: 400 });
+        const area = columns[0].querySelector<HTMLElement>(".board-column-content");
+        if (area) {
+            place(area, { left: 0, top: 0, width: 100, height: 400 });
+            Object.defineProperty(area, "scrollTop", { value: 0, configurable: true });
         }
 
         const cards = note.getChildBranches()
@@ -272,6 +415,7 @@ describe("Board column reordering", () => {
     });
 
     afterEach(() => {
+        (document.activeElement as HTMLElement | null)?.blur?.();
         if (container) {
             render(null, container);
             container.remove();
@@ -280,24 +424,20 @@ describe("Board column reordering", () => {
     });
 
     it("drops a column to the right of the one it was let go over", async () => {
-        const { columns, board } = await renderColumns();
+        const { columns } = await renderColumns();
 
-        await dragColumn(columns[0], "dragstart");
         // Past the middle of the last column, which spans 200 to 300, so it lands after it.
-        await dragColumn(columns[2], "dragover", 280);
-        await dragColumn(board, "drop");
+        await carryColumn(columns[0], 280);
 
         expect(saved.at(-1)?.columns?.map(column => column.value))
             .toEqual([ "Doing", "Done", "To Do" ]);
     });
 
     it("drops it to the left when let go over the first half of a column", async () => {
-        const { columns, board } = await renderColumns();
+        const { columns } = await renderColumns();
 
-        await dragColumn(columns[2], "dragstart");
         // Short of the middle of the second column, which spans 100 to 200.
-        await dragColumn(columns[1], "dragover", 120);
-        await dragColumn(board, "drop");
+        await carryColumn(columns[2], 120);
 
         expect(saved.at(-1)?.columns?.map(column => column.value))
             .toEqual([ "To Do", "Done", "Doing" ]);
@@ -307,40 +447,164 @@ describe("Board column reordering", () => {
      * The gap held open while a column is carried stands in for that column, and a collapsed one
      * is a strip. A placeholder of the stock width would promise a space the column will not fill.
      */
-    it("holds open a gap the size of the column being dragged", async () => {
-        const { columns, board } = await renderColumns();
-        for (const [ name, value ] of Object.entries({ offsetWidth: 36, offsetHeight: 140 })) {
-            Object.defineProperty(columns[0], name, { value, configurable: true });
-        }
+    it("holds open a gap the size of the column being carried", async () => {
+        const { columns, board } = await renderColumns({ height: 140 });
 
-        await dragColumn(columns[0], "dragstart");
-        await dragColumn(columns[2], "dragover", 280);
+        await carryColumn(columns[0], 280, { release: false });
 
         const placeholder = board.querySelector<HTMLElement>(".column-drop-placeholder");
-        expect(placeholder?.style.width).toBe("36px");
+        expect(placeholder?.style.width).toBe("100px");
         expect(placeholder?.style.height).toBe("140px");
     });
 
     /** happy-dom lays nothing out, which is what an element with no size on screen reports too. */
     it("leaves the gap at its stock size when the column measures nothing", async () => {
-        const { columns, board } = await renderColumns();
+        const { columns, board } = await renderColumns({ width: 0 });
 
-        await dragColumn(columns[0], "dragstart");
-        await dragColumn(columns[2], "dragover", 280);
+        await carryColumn(columns[0], 280, { release: false });
 
         const placeholder = board.querySelector<HTMLElement>(".column-drop-placeholder");
         expect(placeholder?.style.width).toBe("");
     });
 
-    it("hides the column being dragged, and shows it again once let go", async () => {
-        const { columns } = await renderColumns();
+    /** A copy of it is carried, cut to a set height so a tall column does not cover the board. */
+    it("carries a copy, hiding the column until it is let go", async () => {
+        const { columns, board } = await renderColumns();
 
-        await dragColumn(columns[0], "dragstart");
+        await carryColumn(columns[0], 280, { release: false });
+        const copy = board.querySelector<HTMLElement>(".board-column.board-drag-preview");
+        expect(copy).toBeTruthy();
+        expect(copy?.style.height).toBe("150px");
         expect(columns[0].style.display).toBe("none");
 
-        await dragColumn(columns[0], "dragend");
-        expect(columns[0].style.display).not.toBe("none");
+        await columnPointer(board, "pointerup", 280);
+        expect(board.querySelector(".board-drag-preview")).toBeNull();
+        expect(columns[0].style.display).toBe("");
     });
+
+    /**
+     * Let go either side of where it stands, a column lands where it started, and the board is not
+     * written to for a move that moves nothing.
+     */
+    it("saves nothing for a column carried back to where it was", async () => {
+        const { columns } = await renderColumns();
+
+        await carryColumn(columns[1], 120);
+
+        expect(saved).toEqual([]);
+    });
+
+    /** The board's row as it is laid out: the columns' wrapper is `display: contents`. */
+    function laidOut(board: HTMLElement) {
+        return [ ...board.children ].flatMap((child) =>
+            child.classList.contains("board-columns") ? [ ...child.children ] : [ child ]);
+    }
+
+    /**
+     * What a drop leads to: the board is drawn again with the columns in a new order. Their
+     * elements are keyed, so Preact moves them, and it places what it moves against the parent's
+     * own children. Anything among them it is not keeping track of can be stepped over.
+     */
+    it("keeps the button after every column once they are drawn in a new order", async () => {
+        const { board } = await renderColumns();
+        const order = () => laidOut(board)
+            .filter(child => child.classList.contains("board-column")
+                || child.classList.contains("board-add-column"))
+            .map(child => child.getAttribute("data-column") ?? "add");
+
+        expect(order()).toEqual([ "To Do", "Doing", "Done", "add" ]);
+
+        await drawColumns([ "Done", "To Do", "Doing" ]);
+        expect(order()).toEqual([ "Done", "To Do", "Doing", "add" ]);
+
+        await drawColumns([ "Doing", "Done", "To Do" ]);
+        expect(order()).toEqual([ "Doing", "Done", "To Do", "add" ]);
+    });
+
+    /**
+     * The drop changes two things at once: the columns take a new order and the gap held open for
+     * the carried one goes. Both land in a single redraw, which is where the button is placed.
+     */
+    it("keeps the button after every column once a carried one is let go", async () => {
+        const { columns, board } = await renderColumns();
+        const order = () => laidOut(board)
+            .filter(child => (child.classList.contains("board-column")
+                && !child.classList.contains("board-drag-preview"))
+                || child.classList.contains("board-add-column"))
+            .map(child => child.getAttribute("data-column") ?? "add");
+
+        // Past the middle of the last column, so it is let go at the end.
+        await carryColumn(columns[0], 280);
+
+        expect(order()).toEqual([ "Doing", "Done", "To Do", "add" ]);
+    });
+
+    /** The button that adds a column stands at the end, whatever the gap does among the columns. */
+    it("keeps the button that adds a column at the end while one is carried", async () => {
+        const { columns, board } = await renderColumns();
+
+        /** Whether the button stands after every column, the overlays after it being no columns. */
+        const afterEveryColumn = () => {
+            const children = laidOut(board);
+            const button = children.findIndex(child =>
+                child.classList.contains("board-add-column"));
+            // The copy being carried wears the column's classes so the board's styling reaches it,
+            // and is placed against the window rather than among them.
+            const lastColumn = children.findLastIndex(child =>
+                child.classList.contains("board-column")
+                    && !child.classList.contains("board-drag-preview"));
+            return button > lastColumn && button >= 0;
+        };
+
+        expect(afterEveryColumn()).toBe(true);
+
+        // Over each column in turn, so the gap opens at every place among them.
+        await carryColumn(columns[0], 120, { release: false });
+        expect(afterEveryColumn()).toBe(true);
+
+        await columnPointer(board, "pointermove", 220);
+        expect(afterEveryColumn()).toBe(true);
+
+        await columnPointer(board, "pointermove", 280);
+        expect(afterEveryColumn()).toBe(true);
+
+        await columnPointer(board, "pointerup", 280);
+        expect(afterEveryColumn()).toBe(true);
+    });
+
+    /** Takes hold of a column by its heading, carries it to `clientX` and lets it go there. */
+    async function carryColumn(
+        column: HTMLElement,
+        clientX: number,
+        { release = true }: { release?: boolean } = {}
+    ) {
+        const heading = column.querySelector<HTMLElement>("h3");
+        if (!heading) throw new Error("expected a column heading");
+
+        const board = column.closest<HTMLElement>(".board-view-container");
+        if (!board) throw new Error("expected a board");
+
+        // Taken by a point inside the column, so where its middle stands follows the pointer.
+        const { left, width } = column.getBoundingClientRect();
+        await columnPointer(heading, "pointerdown", left + width / 2);
+        await columnPointer(board, "pointermove", clientX);
+        if (release) {
+            await columnPointer(board, "pointerup", clientX);
+        }
+    }
+
+    async function columnPointer(target: HTMLElement, type: string, clientX: number) {
+        const event = new Event(type, { bubbles: true, cancelable: true });
+        for (const [ name, value ] of Object.entries({
+            clientX, clientY: 0, pointerId: 1, button: 0, pointerType: "mouse"
+        })) {
+            Object.defineProperty(event, name, { value, configurable: true });
+        }
+        await act(async () => {
+            target.dispatchEvent(event);
+            await settle();
+        });
+    }
 
     it("saves nothing for a column let go where it already was", async () => {
         const { columns, board } = await renderColumns();
@@ -353,7 +617,9 @@ describe("Board column reordering", () => {
     });
 
     /** A board of three columns, each given the geometry the drop maths reads. */
-    async function renderColumns() {
+    let drawColumns: (order: string[]) => Promise<void> = async () => {};
+
+    async function renderColumns({ width = 100, height = 400 } = {}) {
         const note = buildNote({
             title: "Board",
             "#collection": "",
@@ -369,36 +635,44 @@ describe("Board column reordering", () => {
         container = mountPoint;
         document.body.appendChild(mountPoint);
 
-        await act(async () => {
-            render(
-                <ParentComponent.Provider value={new Component()}>
-                    <BoardView
-                        note={note}
-                        notePath={`root/${note.noteId}`}
-                        noteIds={[ ...note.getChildNoteIds() ]}
-                        highlightedTokens={null}
-                        viewConfig={{
-                            columns: [ { value: "To Do" }, { value: "Doing" }, { value: "Done" } ]
-                        }}
-                        saveConfig={(config) => saved.push(config)}
-                        media="screen"
-                        onReady={() => {}}
-                    />
-                </ParentComponent.Provider>,
-                mountPoint
-            );
-        });
-        await settle();
+        drawColumns = async (order: string[]) => {
+            await act(async () => {
+                render(
+                    <ParentComponent.Provider value={new Component()}>
+                        <BoardView
+                            note={note}
+                            notePath={`root/${note.noteId}`}
+                            noteIds={[ ...note.getChildNoteIds() ]}
+                            highlightedTokens={null}
+                            viewConfig={{ columns: order.map(value => ({ value })) }}
+                            saveConfig={(config) => saved.push(config)}
+                            media="screen"
+                            onReady={() => {}}
+                        />
+                    </ParentComponent.Provider>,
+                    mountPoint
+                );
+                await settle();
+            });
+            await act(async () => { await settle(); });
+        };
+
+        await drawColumns([ "To Do", "Doing", "Done" ]);
 
         const columns = [ ...mountPoint.querySelectorAll<HTMLElement>(".board-column") ];
         for (const [ index, column ] of columns.entries()) {
             column.getBoundingClientRect = () => ({
-                left: index * 100, width: 100
+                left: index * 100, top: 0, width, height
             }) as DOMRect;
         }
 
         const board = mountPoint.querySelector<HTMLElement>(".board-view-container");
         if (!board) throw new Error("expected the board container");
+
+        board.getBoundingClientRect = () => ({ left: 0, top: 0, width: 400, height }) as DOMRect;
+        Object.defineProperty(board, "scrollLeft", { value: 0, configurable: true });
+        // The gesture listens from an effect, which Preact defers past the render.
+        await act(async () => { await settle(); });
 
         return { columns, board };
     }

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -178,15 +178,16 @@ describe("Board drag and drop", () => {
         // drawn by. A reader could not press before that; a test can.
         await act(async () => { await settle(); });
 
-        // Taken from the first card and let go above the second's middle, so it lands between them.
-        await pointer(card, "pointerdown", 50, 50);
-        await pointer(columns[0], "pointermove", 50, 120);
+        // The second card, carried up until its top stands above the first, so it lands before it.
+        const second = columns[0].querySelectorAll<HTMLElement>(".board-note")[1];
+        await pointer(second, "pointerdown", 50, 150);
+        await pointer(columns[0], "pointermove", 50, 60);
         await act(async () => { await settle(); });
-        await pointer(columns[0], "pointerup", 50, 120);
+        await pointer(columns[0], "pointerup", 50, 60);
         await act(async () => { await settle(); });
 
         expect(branches.moveBeforeBranch)
-            .toHaveBeenCalledWith([ cards[0].branchId ], cards[1].branchId);
+            .toHaveBeenCalledWith([ cards[1].branchId ], cards[0].branchId);
     });
 
     /**

--- a/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    type CardBox, cardInsertionIndex, columnAt, type ColumnBox, columnCovers,
+    columnInsertionIndex, movesColumn
+} from "./drag_geometry";
+
+/** Three 100px columns with a 20px gap, standing 400 tall from the top of the page. */
+function columns(cards: Record<string, CardBox[]> = {}): ColumnBox[] {
+    return [ "To Do", "Doing", "Done" ].map((value, index) => ({
+        value,
+        left: index * 120,
+        width: 100,
+        top: 0,
+        height: 400,
+        cards: cards[value] ?? []
+    }));
+}
+
+/** Cards of the given heights, stacked from the top of the card area. */
+function stack(...heights: number[]): CardBox[] {
+    let top = 0;
+    return heights.map((height) => {
+        const card = { top, height };
+        top += height;
+        return card;
+    });
+}
+
+describe("columnAt", () => {
+    it("answers with the column the point stands in", () => {
+        const board = columns();
+
+        expect(columnAt(board, 0)?.value).toBe("To Do");
+        expect(columnAt(board, 99)?.value).toBe("To Do");
+        expect(columnAt(board, 120)?.value).toBe("Doing");
+        expect(columnAt(board, 299)?.value).toBe("Done");
+    });
+
+    /** The board leaves a gap between columns, which a drag passes through. */
+    it("answers with the nearer column for a point in the gap between two", () => {
+        const board = columns();
+
+        expect(columnAt(board, 104)?.value).toBe("To Do");
+        expect(columnAt(board, 116)?.value).toBe("Doing");
+    });
+
+    /** Held past an end while the board scrolls itself, the drag still has somewhere to go. */
+    it("answers with the end column for a point beyond the board", () => {
+        const board = columns();
+
+        expect(columnAt(board, -500)?.value).toBe("To Do");
+        expect(columnAt(board, 5000)?.value).toBe("Done");
+    });
+
+    it("answers with nothing for a board of no columns", () => {
+        expect(columnAt([], 50)).toBeUndefined();
+    });
+});
+
+describe("columnCovers", () => {
+    /** The gap beside a column is answered for by it, and is not part of it. */
+    it("tells standing on a column from being nearest to it", () => {
+        const [ first, second ] = columns();
+
+        expect(columnCovers(first, 0, 200)).toBe(true);
+        expect(columnCovers(first, 99, 200)).toBe(true);
+        expect(columnCovers(first, 100, 200)).toBe(false);
+        expect(columnCovers(first, 104, 200)).toBe(false);
+        expect(columnAt(columns(), 104)?.value).toBe("To Do");
+
+        expect(columnCovers(second, 120, 200)).toBe(true);
+        expect(columnCovers(second, -5000, 200)).toBe(false);
+    });
+
+    /**
+     * A collapsed column is only as tall as its heading, and the empty space below it belongs to
+     * no column the reader can see.
+     */
+    it("tells the column from the empty space below a short one", () => {
+        const strip: ColumnBox = {
+            value: "Parked", left: 0, width: 36, top: 0, height: 90, cards: []
+        };
+
+        expect(columnCovers(strip, 18, 0)).toBe(true);
+        expect(columnCovers(strip, 18, 89)).toBe(true);
+        expect(columnCovers(strip, 18, 90)).toBe(false);
+        expect(columnCovers(strip, 18, 300)).toBe(false);
+        // Still the nearest column, so a card held there has somewhere to go.
+        expect(columnAt([ strip ], 18)?.value).toBe("Parked");
+    });
+});
+
+describe("cardInsertionIndex", () => {
+    it("places the card before the one it is held over the top half of", () => {
+        const cards = stack(50, 50, 50);
+
+        expect(cardInsertionIndex(cards, 0)).toBe(0);
+        expect(cardInsertionIndex(cards, 24)).toBe(0);
+        // Past the first card's middle, so it goes after it.
+        expect(cardInsertionIndex(cards, 26)).toBe(1);
+        expect(cardInsertionIndex(cards, 74)).toBe(1);
+        expect(cardInsertionIndex(cards, 76)).toBe(2);
+    });
+
+    it("places the card at the end when it is held below them all", () => {
+        expect(cardInsertionIndex(stack(50, 50, 50), 500)).toBe(3);
+        expect(cardInsertionIndex(stack(50), 40)).toBe(1);
+    });
+
+    it("places the card first in a column holding none", () => {
+        expect(cardInsertionIndex([], 0)).toBe(0);
+        expect(cardInsertionIndex([], 500)).toBe(0);
+    });
+
+    /** Cards are not all one height: a tall one's middle is further down than its neighbour's. */
+    it("counts each card's own middle rather than a shared height", () => {
+        const cards = stack(20, 200, 20);
+
+        expect(cardInsertionIndex(cards, 9)).toBe(0);
+        expect(cardInsertionIndex(cards, 11)).toBe(1);
+        // The tall card runs from 20 to 220, so its middle is at 120.
+        expect(cardInsertionIndex(cards, 119)).toBe(1);
+        expect(cardInsertionIndex(cards, 121)).toBe(2);
+    });
+
+    /** A point above the first card is still a point above its middle. */
+    it("places the card first when it is held above the card area", () => {
+        expect(cardInsertionIndex(stack(50, 50), -80)).toBe(0);
+    });
+});
+
+describe("columnInsertionIndex", () => {
+    it("places the column before the one it is held over the left half of", () => {
+        const board = columns();
+
+        expect(columnInsertionIndex(board, 0)).toBe(0);
+        expect(columnInsertionIndex(board, 49)).toBe(0);
+        expect(columnInsertionIndex(board, 51)).toBe(1);
+        expect(columnInsertionIndex(board, 169)).toBe(1);
+        expect(columnInsertionIndex(board, 171)).toBe(2);
+    });
+
+    it("places the column at the end when it is held past them all", () => {
+        expect(columnInsertionIndex(columns(), 5000)).toBe(3);
+    });
+
+    it("places the column first on a board holding none", () => {
+        expect(columnInsertionIndex([], 50)).toBe(0);
+    });
+
+    /** The gap belongs to whichever half of a column it borders, as any other point does. */
+    it("counts the gap between two columns as past the left one", () => {
+        expect(columnInsertionIndex(columns(), 110)).toBe(1);
+    });
+});
+
+describe("movesColumn", () => {
+    /** A column dropped either side of where it stands lands where it started. */
+    it("knows the two places that leave a column where it is", () => {
+        expect(movesColumn(1, 1)).toBe(false);
+        expect(movesColumn(1, 2)).toBe(false);
+
+        expect(movesColumn(1, 0)).toBe(true);
+        expect(movesColumn(1, 3)).toBe(true);
+    });
+
+    it("knows the ends", () => {
+        expect(movesColumn(0, 0)).toBe(false);
+        expect(movesColumn(0, 1)).toBe(false);
+        expect(movesColumn(0, 2)).toBe(true);
+    });
+});

--- a/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
@@ -92,20 +92,21 @@ describe("columnCovers", () => {
 });
 
 describe("cardInsertionIndex", () => {
-    it("places the card before the one it is held over the top half of", () => {
+    it("places the card in the place its top edge has reached", () => {
         const cards = stack(50, 50, 50);
 
         expect(cardInsertionIndex(cards, 0)).toBe(0);
-        expect(cardInsertionIndex(cards, 24)).toBe(0);
-        // Past the first card's middle, so it goes after it.
-        expect(cardInsertionIndex(cards, 26)).toBe(1);
-        expect(cardInsertionIndex(cards, 74)).toBe(1);
-        expect(cardInsertionIndex(cards, 76)).toBe(2);
+        expect(cardInsertionIndex(cards, 49)).toBe(0);
+        // The line between one place and the next runs where one card ends and the next begins.
+        expect(cardInsertionIndex(cards, 51)).toBe(1);
+        expect(cardInsertionIndex(cards, 99)).toBe(1);
+        expect(cardInsertionIndex(cards, 101)).toBe(2);
     });
 
     it("places the card at the end when it is held below them all", () => {
         expect(cardInsertionIndex(stack(50, 50, 50), 500)).toBe(3);
-        expect(cardInsertionIndex(stack(50), 40)).toBe(1);
+        expect(cardInsertionIndex(stack(50), 40)).toBe(0);
+        expect(cardInsertionIndex(stack(50), 60)).toBe(1);
     });
 
     it("places the card first in a column holding none", () => {
@@ -113,18 +114,18 @@ describe("cardInsertionIndex", () => {
         expect(cardInsertionIndex([], 500)).toBe(0);
     });
 
-    /** Cards are not all one height: a tall one's middle is further down than its neighbour's. */
-    it("counts each card's own middle rather than a shared height", () => {
+    /** Cards are not all one height: a tall one's place reaches much further down. */
+    it("counts each card's own height rather than a shared one", () => {
         const cards = stack(20, 200, 20);
 
-        expect(cardInsertionIndex(cards, 9)).toBe(0);
-        expect(cardInsertionIndex(cards, 11)).toBe(1);
-        // The tall card runs from 20 to 220, so its middle is at 120.
-        expect(cardInsertionIndex(cards, 119)).toBe(1);
-        expect(cardInsertionIndex(cards, 121)).toBe(2);
+        expect(cardInsertionIndex(cards, 19)).toBe(0);
+        expect(cardInsertionIndex(cards, 21)).toBe(1);
+        // The tall card runs from 20 to 220, and its place runs with it.
+        expect(cardInsertionIndex(cards, 219)).toBe(1);
+        expect(cardInsertionIndex(cards, 221)).toBe(2);
     });
 
-    /** A point above the first card is still a point above its middle. */
+    /** A point above the first card is above every place it could take. */
     it("places the card first when it is held above the card area", () => {
         expect(cardInsertionIndex(stack(50, 50), -80)).toBe(0);
     });

--- a/apps/client/src/widgets/collections/board/drag_geometry.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.ts
@@ -77,15 +77,23 @@ export function columnCovers(column: ColumnBox, x: number, y: number): boolean {
 }
 
 /**
- * Where a card would be inserted in a column: before the first card the point is above the middle
- * of, or at the end.
+ * Where a card would be inserted in a column: in the place the point falls in, or at the end.
+ *
+ * The line between one place and the next runs through the space between two cards, not through
+ * the middle of a card. What is carried is placed by its top edge, which reaches that space half a
+ * card before its middle does, so a middle would leave the gap trailing what is being carried.
  *
  * @param cards the column's cards, in order.
- * @param y in the content space of the card area holding them.
+ * @param y the top of what is carried, in the content space of the card area holding them.
  */
 export function cardInsertionIndex(cards: CardBox[], y: number): number {
     for (const [ index, card ] of cards.entries()) {
-        if (y < card.top + card.height / 2) {
+        const next = cards[index + 1];
+        const boundary = next
+            ? (card.top + card.height + next.top) / 2
+            : card.top + card.height;
+
+        if (y < boundary) {
             return index;
         }
     }

--- a/apps/client/src/widgets/collections/board/drag_geometry.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.ts
@@ -1,0 +1,126 @@
+/**
+ * Where a dragged card or column would land.
+ *
+ * Pure arithmetic over boxes measured once at the start of a drag, so a move costs no layout reads.
+ * Two coordinate spaces are used, each chosen so that scrolling does not invalidate the measurement:
+ * columns are placed along the board's content space, which the board's horizontal scrolling does
+ * not move them in, and cards along their own column's card-area content space, which that column's
+ * vertical scrolling does not move them in.
+ */
+
+/** A card, in the content space of the card area holding it. */
+export interface CardBox {
+    top: number;
+    height: number;
+}
+
+/** A column, placed across in the board's content space and down in the page's. */
+export interface ColumnBox {
+    /** The grouping value identifying the column. */
+    value: string;
+    left: number;
+    width: number;
+    /**
+     * Where it stands down the page, and how tall it is. The board does not scroll this way, so
+     * these hold for the length of a drag. A collapsed column is only as tall as its heading, which
+     * is what tells standing on it from standing in the empty space under it.
+     */
+    top: number;
+    height: number;
+    /**
+     * The cards as drawn, in order, the dragged one included. Counting it keeps the index in the
+     * same terms as the list the board holds, which is what a move is expressed in.
+     */
+    cards: CardBox[];
+}
+
+/**
+ * The column a point falls in, or the nearest one where it falls between columns or past an end.
+ *
+ * Nearest rather than nothing, so a drag carried into the gap between two columns, or held past the
+ * last one while the board scrolls itself, still has somewhere to go.
+ *
+ * @param columns the columns as drawn, in order.
+ * @param x in the board's content space.
+ */
+export function columnAt(columns: ColumnBox[], x: number): ColumnBox | undefined {
+    let nearest: ColumnBox | undefined;
+    let shortest = Infinity;
+
+    for (const column of columns) {
+        if (x >= column.left && x < column.left + column.width) {
+            return column;
+        }
+
+        const distance = x < column.left
+            ? column.left - x
+            : x - (column.left + column.width);
+
+        if (distance < shortest) {
+            shortest = distance;
+            nearest = column;
+        }
+    }
+
+    return nearest;
+}
+
+/**
+ * Whether a point stands on a column itself, rather than merely being nearest to it or standing in
+ * the empty space below it.
+ *
+ * @param x in the board's content space, and @param y down the page.
+ */
+export function columnCovers(column: ColumnBox, x: number, y: number): boolean {
+    return x >= column.left && x < column.left + column.width
+        && y >= column.top && y < column.top + column.height;
+}
+
+/**
+ * Where a card would be inserted in a column: before the first card the point is above the middle
+ * of, or at the end.
+ *
+ * @param cards the column's cards, in order.
+ * @param y in the content space of the card area holding them.
+ */
+export function cardInsertionIndex(cards: CardBox[], y: number): number {
+    for (const [ index, card ] of cards.entries()) {
+        if (y < card.top + card.height / 2) {
+            return index;
+        }
+    }
+
+    return cards.length;
+}
+
+/**
+ * Where a dragged column would be inserted: before the column the point is left of the middle of,
+ * or after it.
+ *
+ * The answer counts the columns as they stand, the dragged one included, so it names a place in the
+ * list rather than a place in the list without it.
+ *
+ * @param columns the columns as drawn, in order.
+ * @param x in the board's content space.
+ */
+export function columnInsertionIndex(columns: ColumnBox[], x: number): number {
+    if (!columns.length) {
+        return 0;
+    }
+
+    for (const [ index, column ] of columns.entries()) {
+        if (x < column.left + column.width / 2) {
+            return index;
+        }
+    }
+
+    return columns.length;
+}
+
+/**
+ * Whether inserting at the given place would move the column at all. A column dropped just before
+ * or just after where it already stands lands where it started.
+ */
+export function movesColumn(from: number, to: number): boolean {
+    return to !== from && to !== from + 1;
+}

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { cardInsertionIndex, columnAt } from "./drag_geometry";
+import { measureBoard, toAreaY, toBoardX } from "./drag_measure";
+
+let container: HTMLElement | undefined;
+
+afterEach(() => {
+    container?.remove();
+    container = undefined;
+});
+
+/**
+ * happy-dom lays nothing out, so every box is declared. The board is placed 50px into the page and
+ * scrolled 200px along, which is what tells a content-space measurement from a viewport one.
+ */
+function buildBoard({ scrollLeft = 200, areaScrollTop = 20, cardCounts = [ 2, 1 ] } = {}) {
+    container = document.createElement("div");
+    container.className = "board-view-container";
+    document.body.appendChild(container);
+    place(container, { left: 50, top: 0, width: 500, height: 400 });
+    Object.defineProperty(container, "scrollLeft", { value: scrollLeft, configurable: true });
+
+    for (const [ index, cards ] of cardCounts.entries()) {
+        const column = document.createElement("div");
+        column.className = "board-column";
+        column.dataset.column = [ "To Do", "Doing", "Done" ][index];
+        container.appendChild(column);
+        // On screen the columns have already been scrolled 200px to the left.
+        place(column, { left: 50 + index * 120 - scrollLeft, top: 0, width: 100, height: 400 });
+
+        const area = document.createElement("div");
+        area.className = "board-column-content";
+        column.appendChild(area);
+        place(area, { left: 0, top: 40, width: 100, height: 360 });
+        Object.defineProperty(area, "scrollTop", { value: areaScrollTop, configurable: true });
+
+        for (let card = 0; card < cards; card++) {
+            const note = document.createElement("div");
+            note.className = "board-note";
+            area.appendChild(note);
+            // Stated where the card stands in the area's content, then drawn where that leaves it
+            // on screen once the area has been scrolled.
+            place(note, {
+                left: 0,
+                top: 40 + cardContentTop(card) - areaScrollTop,
+                width: 100,
+                height: 50
+            });
+        }
+    }
+
+    return container;
+}
+
+/** Where card `index` stands in its area's content, whatever the area is scrolled to. */
+function cardContentTop(index: number) {
+    return 10 + index * 60;
+}
+
+function place(element: HTMLElement, box: { left: number, top: number, width: number, height: number }) {
+    element.getBoundingClientRect = () => ({
+        left: box.left,
+        top: box.top,
+        width: box.width,
+        height: box.height,
+        right: box.left + box.width,
+        bottom: box.top + box.height
+    }) as DOMRect;
+}
+
+describe("measureBoard", () => {
+    it("places the columns past the board's own scrolling", () => {
+        const board = buildBoard();
+
+        const { columns } = measureBoard(board);
+
+        // On screen the first column starts at -150; in the board's content space it starts at 0.
+        expect(columns.map((column) => ({ value: column.value, left: column.left })))
+            .toEqual([ { value: "To Do", left: 0 }, { value: "Doing", left: 120 } ]);
+    });
+
+    it("places the cards past their own column's scrolling", () => {
+        const expected = [ { top: 10, height: 50 }, { top: 70, height: 50 } ];
+
+        // The same cards, drawn at different places on screen, measure to the same content.
+        expect(measureBoard(buildBoard({ areaScrollTop: 0 })).columns[0].cards).toEqual(expected);
+        container?.remove();
+        expect(measureBoard(buildBoard({ areaScrollTop: 90 })).columns[0].cards).toEqual(expected);
+    });
+
+    it("hands back each column's card area, and counts a column holding none", () => {
+        const board = buildBoard({ cardCounts: [ 0, 1 ] });
+
+        const { columns, areas } = measureBoard(board);
+
+        expect(columns[0].cards).toEqual([]);
+        expect(areas.get("To Do")).toBe(board.querySelector(".board-column-content"));
+    });
+
+    /** A collapsed column draws no card area at all. */
+    it("counts a column with no card area as holding no cards", () => {
+        const board = buildBoard();
+        board.querySelector(".board-column-content")?.remove();
+
+        const { columns, areas } = measureBoard(board);
+
+        expect(columns[0].cards).toEqual([]);
+        expect(areas.has("To Do")).toBe(false);
+    });
+
+    it("measures nothing for a board with no columns", () => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        place(container, { left: 0, top: 0, width: 100, height: 100 });
+
+        expect(measureBoard(container).columns).toEqual([]);
+    });
+});
+
+describe("reading a point against a measurement", () => {
+    /** What a move does: two rectangles read, whatever the board holds. */
+    it("finds the column and the place a card would take", () => {
+        const board = buildBoard();
+        const { columns, areas } = measureBoard(board);
+
+        // Over the second column on screen, which starts at -30 and runs 100 wide.
+        const column = columnAt(columns, toBoardX(board, 20));
+        expect(column?.value).toBe("Doing");
+
+        const area = areas.get("Doing");
+        if (!area) throw new Error("expected a card area");
+
+        // Its one card stands at 10 in the area's content and is 50 tall, so its middle is at 35.
+        // The area is 20 scrolled and starts 40 down the page, so that middle is at 55 on screen.
+        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 50))).toBe(0);
+        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 60))).toBe(1);
+    });
+
+    it("reads a point over the same column the same way however far the board is scrolled", () => {
+        for (const scrollLeft of [ 0, 200, 640 ]) {
+            const board = buildBoard({ scrollLeft });
+            const { columns } = measureBoard(board);
+
+            // Where the first column is drawn moves with the scrolling; what it measures to does
+            // not, which is what leaves a measurement good for the whole gesture.
+            const onScreen = 50 - scrollLeft + 10;
+            expect(toBoardX(board, onScreen)).toBe(10);
+            expect(columnAt(columns, toBoardX(board, onScreen))?.value).toBe("To Do");
+            board.remove();
+        }
+    });
+});

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -146,10 +146,10 @@ describe("reading a point against a measurement", () => {
         const area = areas.get("Doing");
         if (!area) throw new Error("expected a card area");
 
-        // Its one card stands at 10 in the area's content and is 50 tall, so its middle is at 35.
-        // The area is 20 scrolled and starts 40 down the page, so that middle is at 55 on screen.
-        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 50))).toBe(0);
-        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 60))).toBe(1);
+        // Its one card stands at 10 in the area's content and is 50 tall, so its place ends at 60.
+        // The area is 20 scrolled and starts 40 down the page, so that end is at 80 on screen.
+        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 70))).toBe(0);
+        expect(cardInsertionIndex(column?.cards ?? [], toAreaY(area, 90))).toBe(1);
     });
 
     it("reads a point over the same column the same way however far the board is scrolled", () => {

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -70,6 +70,21 @@ function place(element: HTMLElement, box: { left: number, top: number, width: nu
 }
 
 describe("measureBoard", () => {
+    it("leaves the copy being carried out of the columns it measures", () => {
+        const board = buildBoard();
+        const carried = board.querySelector<HTMLElement>(".board-column")?.cloneNode(true);
+        if (!(carried instanceof HTMLElement)) throw new Error("expected a column to copy");
+
+        carried.classList.add("board-drag-preview");
+        board.appendChild(carried);
+        place(carried, { left: 500, top: 0, width: 100, height: 400 });
+
+        // One place per column drawn, and none for the copy: counting it would offer a place one
+        // past every place the board has.
+        expect(measureBoard(board).columns).toHaveLength(
+            board.querySelectorAll(".board-column:not(.board-drag-preview)").length);
+    });
+
     it("places the columns past the board's own scrolling", () => {
         const board = buildBoard();
 

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -1,0 +1,74 @@
+import { type ColumnBox } from "./drag_geometry";
+
+/** What a drag measures once at its start, and reads for the rest of the gesture. */
+export interface BoardMeasurement {
+    /** The columns as drawn, in order, for {@link columnAt} and {@link columnInsertionIndex}. */
+    columns: ColumnBox[];
+    /** Each column's card area, which a point has to be read against to place a card in it. */
+    areas: Map<string, HTMLElement>;
+}
+
+/**
+ * Measures every column and card on the board.
+ *
+ * Called once when a drag starts. A gesture reads two rectangles per move afterwards, whatever the
+ * board holds, where measuring per move would read one for every card on it.
+ */
+export function measureBoard(container: HTMLElement): BoardMeasurement {
+    const origin = container.getBoundingClientRect().left - container.scrollLeft;
+    const columns: ColumnBox[] = [];
+    const areas = new Map<string, HTMLElement>();
+
+    for (const element of container.querySelectorAll<HTMLElement>(".board-column")) {
+        const value = element.dataset.column ?? "";
+        const rect = element.getBoundingClientRect();
+        const area = element.querySelector<HTMLElement>(".board-column-content");
+
+        if (area) {
+            areas.set(value, area);
+        }
+
+        columns.push({
+            value,
+            left: rect.left - origin,
+            width: rect.width,
+            top: rect.top,
+            height: rect.height,
+            cards: measureCards(area)
+        });
+    }
+
+    return { columns, areas };
+}
+
+/** A point in the board's content space, which its horizontal scrolling does not move columns in. */
+export function toBoardX(container: HTMLElement, clientX: number): number {
+    return clientX - container.getBoundingClientRect().left + container.scrollLeft;
+}
+
+/**
+ * A point in a card area's content space, which that column's vertical scrolling does not move its
+ * cards in.
+ */
+export function toAreaY(area: HTMLElement, clientY: number): number {
+    return clientY - area.getBoundingClientRect().top + area.scrollTop;
+}
+
+/**
+ * The cards of one column, in the area's content space.
+ *
+ * The dragged card is measured with the rest: the index this leads to names a place in the list the
+ * board holds, which is the list a move is expressed against.
+ */
+function measureCards(area: HTMLElement | null) {
+    if (!area) {
+        return [];
+    }
+
+    const top = area.getBoundingClientRect().top - area.scrollTop;
+
+    return [ ...area.querySelectorAll<HTMLElement>(".board-note") ].map((card) => {
+        const rect = card.getBoundingClientRect();
+        return { top: rect.top - top, height: rect.height };
+    });
+}

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -19,7 +19,11 @@ export function measureBoard(container: HTMLElement): BoardMeasurement {
     const columns: ColumnBox[] = [];
     const areas = new Map<string, HTMLElement>();
 
-    for (const element of container.querySelectorAll<HTMLElement>(".board-column")) {
+    // The copy being carried is a column too, and measuring again mid-drag would count it as a
+    // place to drop into, one past every place the board actually has.
+    const drawn = container.querySelectorAll<HTMLElement>(".board-column:not(.board-drag-preview)");
+
+    for (const element of drawn) {
         const value = element.dataset.column ?? "";
         const rect = element.getBoundingClientRect();
         const area = element.querySelector<HTMLElement>(".board-column-content");

--- a/apps/client/src/widgets/collections/board/edge_scroll.spec.ts
+++ b/apps/client/src/widgets/collections/board/edge_scroll.spec.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { canScroll, createEdgeScroller, edgePull } from "./edge_scroll";
+
+describe("edgePull", () => {
+    /** A box from 100 to 500, with the pull reaching 50 in from each edge. */
+    const pull = (position: number) => edgePull(100, 500, position, 50);
+
+    it("pulls at nothing while the point stands clear of both edges", () => {
+        expect(pull(300)).toBe(0);
+        expect(pull(151)).toBe(0);
+        expect(pull(449)).toBe(0);
+    });
+
+    it("pulls harder the nearer the point comes to an edge", () => {
+        expect(pull(125)).toBeCloseTo(-0.5);
+        expect(pull(475)).toBeCloseTo(0.5);
+        expect(Math.abs(pull(110))).toBeGreaterThan(Math.abs(pull(140)));
+    });
+
+    it("pulls at full strength from the edge outwards", () => {
+        expect(pull(100)).toBe(-1);
+        expect(pull(-500)).toBe(-1);
+        expect(pull(500)).toBe(1);
+        expect(pull(5000)).toBe(1);
+    });
+
+    /** Both margins would meet, and every point would be pulled two ways at once. */
+    it("pulls at nothing in a box no wider than its own margins", () => {
+        expect(edgePull(0, 100, 10, 50)).toBe(0);
+        expect(edgePull(0, 100, 50, 50)).toBe(0);
+    });
+});
+
+describe("canScroll", () => {
+    function box({ offset = 50, size = 100, content = 400 } = {}) {
+        const element = document.createElement("div");
+        for (const [ name, value ] of Object.entries({
+            scrollLeft: offset, clientWidth: size, scrollWidth: content,
+            scrollTop: offset, clientHeight: size, scrollHeight: content
+        })) {
+            Object.defineProperty(element, name, { value, configurable: true, writable: true });
+        }
+        return element;
+    }
+
+    it("knows there is more to reach in either direction", () => {
+        expect(canScroll(box(), "x", -1)).toBe(true);
+        expect(canScroll(box(), "x", 1)).toBe(true);
+        expect(canScroll(box(), "y", -1)).toBe(true);
+    });
+
+    it("knows an end when it reaches one", () => {
+        expect(canScroll(box({ offset: 0 }), "x", -1)).toBe(false);
+        expect(canScroll(box({ offset: 0 }), "x", 1)).toBe(true);
+        expect(canScroll(box({ offset: 300 }), "y", 1)).toBe(false);
+        expect(canScroll(box({ offset: 300 }), "y", -1)).toBe(true);
+    });
+
+    it("knows a container with nothing to scroll", () => {
+        const fits = box({ offset: 0, size: 400, content: 400 });
+        expect(canScroll(fits, "x", 1)).toBe(false);
+        expect(canScroll(fits, "x", -1)).toBe(false);
+    });
+});
+
+describe("createEdgeScroller", () => {
+    let scroller: ReturnType<typeof createEdgeScroller> | undefined;
+
+    beforeEach(() => vi.useFakeTimers());
+
+    afterEach(() => {
+        scroller?.stop();
+        scroller = undefined;
+        vi.useRealTimers();
+    });
+
+    /** A 400x400 box on screen at 0,0 holding content four times its size. */
+    function container() {
+        const element = document.createElement("div");
+        element.getBoundingClientRect = () => ({
+            left: 0, top: 0, right: 400, bottom: 400, width: 400, height: 400
+        }) as DOMRect;
+        for (const [ name, value ] of Object.entries({
+            clientWidth: 400, scrollWidth: 1600, clientHeight: 400, scrollHeight: 1600
+        })) {
+            Object.defineProperty(element, name, { value, configurable: true });
+        }
+        element.scrollLeft = 200;
+        element.scrollTop = 200;
+        return element;
+    }
+
+    it("walks a container along while the pointer is held at its edge", () => {
+        const element = container();
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element, axis: "x" } ], 395, 200);
+        vi.advanceTimersByTime(200);
+
+        expect(element.scrollLeft).toBeGreaterThan(200);
+        expect(element.scrollTop).toBe(200);
+    });
+
+    it("walks it the other way at the other edge", () => {
+        const element = container();
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element, axis: "x" } ], 5, 200);
+        vi.advanceTimersByTime(200);
+
+        expect(element.scrollLeft).toBeLessThan(200);
+    });
+
+    it("leaves it alone while the pointer stands clear of the edges", () => {
+        const element = container();
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element, axis: "x" } ], 200, 200);
+        vi.advanceTimersByTime(500);
+
+        expect(element.scrollLeft).toBe(200);
+    });
+
+    /** A card carried into a corner walks the board along and the column down at once. */
+    it("walks every container it is given", () => {
+        const board = container();
+        const column = container();
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element: board, axis: "x" }, { element: column, axis: "y" } ], 395, 395);
+        vi.advanceTimersByTime(200);
+
+        expect(board.scrollLeft).toBeGreaterThan(200);
+        expect(column.scrollTop).toBeGreaterThan(200);
+    });
+
+    it("says so after each frame that moved something", () => {
+        const element = container();
+        const onScroll = vi.fn();
+        scroller = createEdgeScroller({ onScroll });
+
+        scroller.update([ { element, axis: "x" } ], 395, 200);
+        vi.advanceTimersByTime(100);
+        expect(onScroll).toHaveBeenCalled();
+
+        // Back to the middle: nothing moves, so nothing is reported.
+        onScroll.mockClear();
+        scroller.update([ { element, axis: "x" } ], 200, 200);
+        vi.advanceTimersByTime(100);
+        expect(onScroll).not.toHaveBeenCalled();
+    });
+
+    it("stops when it is told to, and stays stopped", () => {
+        const element = container();
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element, axis: "x" } ], 395, 200);
+        vi.advanceTimersByTime(100);
+        const reached = element.scrollLeft;
+
+        scroller.stop();
+        vi.advanceTimersByTime(500);
+        expect(element.scrollLeft).toBe(reached);
+    });
+
+    it("stops at the end rather than counting past it", () => {
+        const element = container();
+        element.scrollLeft = 1200;
+        Object.defineProperty(element, "scrollLeft", { value: 1200, configurable: true });
+        scroller = createEdgeScroller();
+
+        scroller.update([ { element, axis: "x" } ], 395, 200);
+        vi.advanceTimersByTime(300);
+
+        expect(element.scrollLeft).toBe(1200);
+    });
+});

--- a/apps/client/src/widgets/collections/board/edge_scroll.ts
+++ b/apps/client/src/widgets/collections/board/edge_scroll.ts
@@ -1,0 +1,121 @@
+/**
+ * Scrolls a container while something is carried near its edge.
+ *
+ * The board scrolls sideways and a column's cards scroll up and down, so a target names which of the
+ * two axes it answers for. Several can be pulled at once: a card carried into the bottom corner of
+ * the last column walks the board along and the column down together.
+ */
+
+/** How near an edge the pointer comes before the container starts to move, in pixels. */
+const MARGIN = 60;
+
+/** How fast it moves with the pointer at the very edge, in pixels a second. */
+const SPEED = 1350;
+
+export interface ScrollTarget {
+    element: HTMLElement;
+    axis: "x" | "y";
+}
+
+export interface EdgeScrollOptions {
+    margin?: number;
+    speed?: number;
+    /** Called after each frame that moved something, the places on screen having changed. */
+    onScroll?: () => void;
+}
+
+/**
+ * How hard a point pulls a box towards one of its edges.
+ *
+ * Answers -1 at the near edge and +1 at the far one, easing off to 0 at the inner limit of the
+ * margin, so the pull grows as the pointer closes on the edge rather than switching on at it. A
+ * point outside the box pulls at full strength, which is what carries something held beyond the
+ * board along.
+ *
+ * @param near the box's near edge, and @param far its far one, along the axis in question.
+ * @param position the point, in the same terms.
+ * @param margin how far in from each edge the pull reaches.
+ */
+export function edgePull(near: number, far: number, position: number, margin: number): number {
+    if (far - near <= margin * 2) {
+        return 0;
+    }
+
+    if (position < near + margin) {
+        return -Math.min(1, (near + margin - position) / margin);
+    }
+
+    if (position > far - margin) {
+        return Math.min(1, (position - (far - margin)) / margin);
+    }
+
+    return 0;
+}
+
+/** Whether a container has anywhere left to go in the given direction. */
+export function canScroll(element: HTMLElement, axis: "x" | "y", pull: number): boolean {
+    const [ offset, size, content ] = axis === "x"
+        ? [ element.scrollLeft, element.clientWidth, element.scrollWidth ]
+        : [ element.scrollTop, element.clientHeight, element.scrollHeight ];
+
+    return pull < 0 ? offset > 0 : offset < content - size;
+}
+
+export function createEdgeScroller({
+    margin = MARGIN, speed = SPEED, onScroll
+}: EdgeScrollOptions = {}) {
+    let targets: ScrollTarget[] = [];
+    let point = { x: 0, y: 0 };
+    let frame: number | undefined;
+    let previous = 0;
+
+    const step = (now: number) => {
+        const elapsed = Math.min(now - previous, 50);
+        previous = now;
+        let moved = false;
+
+        for (const { element, axis } of targets) {
+            const box = element.getBoundingClientRect();
+            const pull = axis === "x"
+                ? edgePull(box.left, box.right, point.x, margin)
+                : edgePull(box.top, box.bottom, point.y, margin);
+
+            if (!pull || !canScroll(element, axis, pull)) continue;
+
+            const distance = pull * speed * elapsed / 1000;
+            if (axis === "x") {
+                element.scrollLeft += distance;
+            } else {
+                element.scrollTop += distance;
+            }
+            moved = true;
+        }
+
+        if (moved) {
+            onScroll?.();
+        }
+
+        frame = targets.length ? requestAnimationFrame(step) : undefined;
+    };
+
+    return {
+        /** Points it at the containers to walk along, and at where the pointer stands. */
+        update(next: ScrollTarget[], clientX: number, clientY: number) {
+            targets = next;
+            point = { x: clientX, y: clientY };
+
+            if (targets.length && frame === undefined) {
+                previous = performance.now();
+                frame = requestAnimationFrame(step);
+            }
+        },
+
+        stop() {
+            targets = [];
+            if (frame !== undefined) {
+                cancelAnimationFrame(frame);
+                frame = undefined;
+            }
+        }
+    };
+}

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -269,6 +269,14 @@ body.mobile .board-view-container .board-add-column {
   --board-item-hue: var(--board-column-custom-hue);
 }
 
+/* A carried copy stands in the drag layer rather than in its column, so it is tinted directly. Left
+   above the rules below, which a card with a colour of its own is painted by instead. */
+.board-view-container .board-drag-preview.column-tinted {
+  --board-item-hue: var(--board-column-custom-hue);
+  --board-item-saturation: var(--board-item-background-saturation);
+  --board-item-hover-saturation: var(--board-item-hover-background-saturation);
+}
+
 /* ...and its own wherever it has one, the second selector outweighing the column's rule above
    rather than merely following it. A card wears `with-hue` only for a colour of its own, which is
    what tells it apart from one inheriting the hue of the note the board is shown in. */

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -434,6 +434,14 @@ body.mobile .board-view-container .board-add-column {
   touch-action: none;
 }
 
+/* The gap opening and closing moves content above whatever the browser has anchored to, and it
+   shifts the column to keep that still. The shift moves the card under the pointer, which moves the
+   gap, which shifts the column again: at the foot of a tall column the two chase each other and it
+   never settles on the last place. */
+.board-view-container.board-dragging .board-column-content {
+  overflow-anchor: none;
+}
+
 /* A long press on a card is how it is picked up, not how it is selected or looked up. */
 .board-view-container .board-note {
   -webkit-touch-callout: none;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -230,9 +230,18 @@ body.mobile .board-view-container .board-add-column {
 
 .board-view-container .board-column > .board-column-content {
   flex-grow: 1;
+  /* Without this the cards set the floor for the column's height and push the footer past it. */
+  min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0.5em;
+}
+
+.board-view-container .board-column > .board-new-item {
+  flex-shrink: 0;
+  /* Matches the padding of the scrolling body above, so the footer lines up with the cards. */
+  margin-inline: 0.5em;
+  margin-block-end: 0.5em;
 }
 
 .board-view-container .board-note:hover .edit-icon {
@@ -243,7 +252,7 @@ body.mobile .board-view-container .board-add-column {
 .board-view-container .board-note,
 .board-view-container .board-new-item.editing {
   box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
-  margin: 0.65em 0;
+  margin-block: 0.65em;
   padding: var(--card-padding);
   border-radius: 5px;
   position: relative;
@@ -472,6 +481,22 @@ body.mobile .board-view-container .board-add-column {
   resize: none;
 }
 
+/* A card lands at the end of a column the reader may not be looking at, so it announces itself. */
+@keyframes board-card-appear {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.board-view-container .board-note.appearing {
+  animation: board-card-appear 500ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board-view-container .board-note.appearing {
+    animation: none;
+  }
+}
+
 .board-drop-placeholder {
   height: 40px;
   margin: 0.65em 0;
@@ -503,7 +528,6 @@ body.mobile .board-view-container .board-add-column {
 }
 
 .board-new-item {
-  margin-top: 0.5em;
   padding: 0.25em 0.5em;
   border-radius: 5px;
   color: var(--muted-text-color);

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -231,7 +231,6 @@ body.mobile .board-view-container .board-add-column {
   margin: 0.65em 0;
   padding: var(--card-padding);
   border-radius: 5px;
-  cursor: move;
   position: relative;
   background-color: var(--main-background-color);
   opacity: 1;
@@ -369,7 +368,13 @@ body.mobile .board-view-container .board-add-column {
   to { opacity: 0; transform: translateY(-10px); }
 }
 
+/* A click opens the card; only carrying it is a move. */
+.board-view-container .board-note {
+  cursor: pointer;
+}
+
 .board-view-container .board-note.dragging {
+  cursor: move;
   opacity: 0.5;
   transform: rotate(5deg);
   z-index: 1000;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -234,7 +234,8 @@ body.mobile .board-view-container .board-add-column {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
-  padding: 0.5em;
+  /* No padding below: the last card's own gap stands between it and the footer. */
+  padding: 0.5em 0.5em 0;
 }
 
 .board-view-container .board-column > .board-new-item {
@@ -471,6 +472,12 @@ body.mobile .board-view-container .board-add-column {
   padding: 0;
 }
 
+.board-view-container .board-new-item textarea.form-control {
+  /* One line stands exactly as tall as the closed button; typing more grows it from there. */
+  min-height: calc(var(--card-line-height) * 1em + 2 * var(--card-padding));
+  height: calc(var(--card-line-height) * 1em + 2 * var(--card-padding));
+}
+
 .board-view-container .board-note.editing textarea,
 .board-view-container .board-new-item textarea.form-control {
   background: transparent;
@@ -538,7 +545,9 @@ body.mobile .board-view-container .board-add-column {
 }
 
 .board-new-item {
-  padding: 0.25em 0.5em;
+  /* The same box the editor it opens into has, so clicking it changes nothing but its content. */
+  padding: var(--card-padding);
+  line-height: var(--card-line-height);
   border-radius: 5px;
   color: var(--muted-text-color);
   cursor: pointer;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -36,6 +36,12 @@
   --card-padding: 0.6em;
 }
 
+/* Lays nothing out: the columns stay the board's own flex items, and Preact has a parent of its own
+   to move them within. */
+.board-view-container .board-columns {
+  display: contents;
+}
+
 .board-view-container {
   height: 100%;
   display: flex;
@@ -55,7 +61,7 @@
   cursor: grabbing;
 }
 
-.board-view-container.pannable > .board-column,
+.board-view-container.pannable .board-column,
 .board-view-container.pannable > .board-add-column {
   cursor: auto;
 }
@@ -64,6 +70,15 @@ body.mobile .board-view-container {
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
   scroll-behavior: smooth;
+}
+
+/* Both of the above fight a scroll written a frame at a time, which is how the board walks itself
+   along while something is carried to its edge: smooth turns each step into an animation the next
+   step restarts, and snapping pulls the board back to the nearest column. The column's own cards
+   scroll either way, having neither. */
+body.mobile .board-view-container.board-dragging {
+  scroll-snap-type: none;
+  scroll-behavior: auto;
 }
 
 .board-view-container .board-column {
@@ -373,12 +388,55 @@ body.mobile .board-view-container .board-add-column {
   cursor: pointer;
 }
 
-.board-view-container .board-note.dragging {
-  cursor: move;
-  opacity: 0.5;
-  transform: rotate(5deg);
+/* The copy that follows the pointer. Positioned against the window, so the column's own scrolling
+   cannot cut it off, and left out of hit testing so it never stands in front of what it is over.
+   No `transform` here: the gesture writes the movement and the shrink together, and a rule of its
+   own would replace both. */
+/* A carried column is cut to a set height by the gesture, so a tall one does not cover the board
+   it is being placed on; what it holds is clipped rather than reflowed. */
+/* Takes no room and lays nothing out: what it holds is placed against the window, and it stands
+   inside the board so that the board's own styling still reaches it. */
+.board-view-container .board-drag-layer {
+  position: fixed;
+  top: 0;
+  inset-inline-start: 0;
+  width: 0;
+  height: 0;
+}
+
+.board-view-container .board-column.board-drag-preview {
+  overflow: hidden;
+}
+
+/* The card is focused by the press that picks it up and then taken out of the page, which drops the
+   focus; the copy carries the ring on so what is being moved still reads as what is focused. */
+.board-view-container .board-note.board-drag-preview {
+  outline: 3px solid var(--board-focus-outline-color, var(--board-focus-outline-plain-color));
+  outline-offset: 0;
+}
+
+.board-view-container .board-note.board-drag-preview,
+.board-view-container .board-column.board-drag-preview {
+  position: fixed;
+  margin: 0;
+  /* The card's own transition would animate towards each frame's position instead of taking it. */
+  transition: none;
+  will-change: transform;
   z-index: 1000;
+  pointer-events: none;
+  cursor: move;
+  opacity: 0.85;
   box-shadow: 4px 8px 16px rgba(0, 0, 0, 0.5);
+}
+
+/* While a card is carried, so the page does not take the touch for a scroll. */
+.board-view-container.board-dragging {
+  touch-action: none;
+}
+
+/* A long press on a card is how it is picked up, not how it is selected or looked up. */
+.board-view-container .board-note {
+  -webkit-touch-callout: none;
 }
 
 .board-view-container .board-note.editing,
@@ -495,22 +553,6 @@ body.mobile .board-view-container .board-add-column {
   font-size: inherit;
   width: 100%;
   text-align: center;
-}
-
-.board-drag-preview {
-  position: fixed;
-  z-index: 10000;
-  pointer-events: none;
-  opacity: 0.8;
-  transform: rotate(5deg);
-  box-shadow: 4px 8px 16px rgba(0, 0, 0, 0.5);
-  background-color: var(--main-background-color);
-  border: 1px solid var(--main-border-color);
-  border-radius: 5px;
-  padding: 0.5em;
-  font-size: 0.9em;
-  max-width: 200px;
-  word-wrap: break-word;
 }
 
 /* The menu is drawn outside the board, so the columns it lists are named rather than reached

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -45,6 +45,21 @@
   overflow-x: auto;
 }
 
+/* Only where there is somewhere to pan. The columns set their own, so the grab hand shows over the
+   board's background alone. */
+.board-view-container.pannable {
+  cursor: grab;
+}
+
+.board-view-container.panning {
+  cursor: grabbing;
+}
+
+.board-view-container.pannable > .board-column,
+.board-view-container.pannable > .board-add-column {
+  cursor: auto;
+}
+
 body.mobile .board-view-container {
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -450,6 +450,19 @@ body.mobile .board-view-container .board-add-column {
   touch-action: none;
 }
 
+/* Reaching the end of the board or of a column scrolls neither the page nor anything else. */
+.board-view-container,
+.board-view-container .board-column-content {
+  overscroll-behavior: contain;
+}
+
+/* And while something is carried, the end does not spring back either: the copy is positioned
+   against the window, which an overscroll moves on WebKit, taking the copy with it. */
+.board-view-container.board-dragging,
+.board-view-container.board-dragging .board-column-content {
+  overscroll-behavior: none;
+}
+
 /* The gap opening and closing moves content above whatever the browser has anchored to, and it
    shifts the column to keep that still. The shift moves the card under the pointer, which moves the
    gap, which shifts the column again: at the foot of a tall column the two chase each other and it

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -252,7 +252,6 @@ body.mobile .board-view-container .board-add-column {
 .board-view-container .board-note,
 .board-view-container .board-new-item.editing {
   box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.1);
-  margin-block: 0.65em;
   padding: var(--card-padding);
   border-radius: 5px;
   position: relative;
@@ -313,10 +312,6 @@ body.mobile .board-view-container .board-add-column {
   );
 }
 
-.board-view-container .board-note:first-of-type {
-  margin-top: 0;
-}
-
 /* The outline of whatever is focused within, taking the hue of the nearest thing that has one: the
    column for its header and buttons, the card for itself and what it holds. */
 .board-view-container .board-column.with-hue {
@@ -344,7 +339,10 @@ body.mobile .board-view-container .board-add-column {
 }
 
 .board-view-container .board-note {
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.15s ease, margin-top 0.2s ease;
+  /* Below only: a top margin would be the first card's to drop, and a drop placeholder standing
+     above it takes that place and moves the card down by it. */
+  margin-block: 0 0.65em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.15s ease;
 }
 
 .board-view-container .board-column.board-column-archived {
@@ -507,12 +505,16 @@ body.mobile .board-view-container .board-add-column {
 
 .board-drop-placeholder {
   height: 40px;
-  margin: 0.65em 0;
+  /* The gap below is the card's, in em, so it has to be read at the card's own font size. */
+  font-size: var(--card-font-size);
+  margin-block: 0 0.65em;
   padding: 0.5em;
   border-radius: 5px;
   background-color: rgba(0, 0, 0, 0.15);
   opacity: 0;
-  transition: opacity 0.15s ease, height 0.2s ease;
+  /* Opacity only: the height is the carried card's, so any change in it is a mismatch to see
+     rather than a movement to smooth over. */
+  transition: opacity 0.15s ease;
   box-sizing: border-box;
 }
 
@@ -540,7 +542,7 @@ body.mobile .board-view-container .board-add-column {
   border-radius: 5px;
   color: var(--muted-text-color);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
   background-color: transparent;
   font-size: var(--card-font-size);
 }

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -400,6 +400,82 @@ describe("Collapsed board columns", () => {
     });
 });
 
+describe("A board in a tab the reader is not looking at", () => {
+    let container: HTMLElement | undefined;
+
+    afterEach(() => {
+        saved.length = 0;
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    /**
+     * Every mounted board hears every change, so a card renamed once would redraw the board in each
+     * tab it is open in. A board nobody is looking at remembers the change instead.
+     */
+    it("does not redraw for a change while its tab is in the background", async () => {
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "one", title: "First", "#status": "To Do" },
+                { id: "two", title: "Second", "#status": "Done" }
+            ]
+        });
+
+        // The context the board belongs to, reached the way `useNoteContext` reaches it: from the
+        // nearest ancestor carrying one.
+        let active = true;
+        const host = new Component();
+        Object.assign(host, { noteContext: { isActive: () => active } });
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        const draw = async () => {
+            await act(async () => {
+                render(
+                    <ParentComponent.Provider value={host}>
+                        <Harness
+                            note={note}
+                            noteIds={[ ...note.getChildNoteIds() ]}
+                            initialConfig={{ columns: [ { value: "To Do" }, { value: "Done" } ] }}
+                        />
+                    </ParentComponent.Provider>,
+                    mountPoint
+                );
+            });
+            await act(async () => { await flush(); });
+        };
+
+        const columnOf = (title: string) => [ ...mountPoint.querySelectorAll(".board-column") ]
+            .find(column => [ ...column.querySelectorAll(".board-note") ]
+                .some(card => card.textContent?.includes(title)))
+            ?.getAttribute("data-column");
+
+        await draw();
+        expect(columnOf("First")).toBe("To Do");
+
+        // The card moves column while the tab is in the background.
+        active = false;
+        for (const attribute of froca.getNoteFromCache("one")?.getAttributes() ?? []) {
+            if (attribute.name === "status") attribute.value = "Done";
+        }
+        await draw();
+        expect(columnOf("First")).toBe("To Do");
+
+        // Looked at again, it catches up with what it missed.
+        active = true;
+        await draw();
+        expect(columnOf("First")).toBe("Done");
+    });
+});
+
 describe("Board column creation", () => {
     let container: HTMLElement | undefined;
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -311,12 +311,9 @@ describe("Collapsed board columns", () => {
         expect(isCollapsed(mountPoint, 0)).toBe(false);
     });
 
-    it("keeps the collapsed column movable and stored as collapsed", async () => {
+    it("opens a collapsed column without writing anything", async () => {
         const { mountPoint } = await setup();
 
-        // The header is the drag handle whether or not the column is drawn as a strip.
-        expect(columnAt(mountPoint, 0).querySelector("h3")?.getAttribute("draggable"))
-            .toBe("true");
         // Opening it by selection is not a change to the config, so nothing is written at all.
         await select(mountPoint, 0);
         expect(isCollapsed(mountPoint, 0)).toBe(false);

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -1349,6 +1349,47 @@ describe("Board column rename", () => {
         expect(cameFrom).not.toHaveBeenCalled();
     });
 
+    /**
+     * The footer editor stays open between cards, so it is left behind with something typed in it
+     * often enough that saving on the way out would make cards nobody asked for.
+     */
+    it("gives up what is typed in the new-item editor when it loses focus", async () => {
+        const { container } = await setup();
+        // Cleared: the spy outlives the test that first stood it up, and its calls with it.
+        const created = vi.spyOn(BoardApi.prototype, "createNewItem")
+            .mockResolvedValue(undefined);
+        created.mockClear();
+        const slot = container.querySelectorAll<HTMLElement>(".board-column")[1]
+            .querySelector<HTMLElement>(".board-new-item");
+
+        await act(async () => {
+            slot?.click();
+            await flush();
+        });
+
+        const editor = slot?.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the new-item editor to be open");
+
+        editor.value = "Half a thought";
+        await act(async () => {
+            editor.dispatchEvent(new FocusEvent("blur"));
+            editor.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+            await flush();
+        });
+
+        expect(created).not.toHaveBeenCalled();
+        expect(slot?.querySelector("textarea")).toBeNull();
+        expect(slot?.classList.contains("editing")).toBe(false);
+
+        // What was typed is waiting in the editor when it is opened again.
+        await act(async () => {
+            slot?.click();
+            await flush();
+        });
+        expect(slot?.querySelector<HTMLTextAreaElement>("textarea")?.value)
+            .toBe("Half a thought");
+    });
+
     it("starts the new item off with the character typed on its button", async () => {
         const { container } = await setup();
         const slot = container.querySelectorAll<HTMLElement>(".board-column")[1]

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -1209,6 +1209,121 @@ describe("Board column rename", () => {
         expect(others.some(other => other.classList.contains("appearing"))).toBe(false);
     });
 
+    it("reveals a card inserted next to another one, without leaving its place", async () => {
+        const { note, container } = await setup();
+
+        // A second card in the same column, so the one standing in for the insert has a card after
+        // it and the column is brought to it rather than run to its end.
+        addCard(note, "Doing");
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={new Component()}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={DEFAULT_CONFIG}
+                    />
+                </ParentComponent.Provider>,
+                container
+            );
+            await flush();
+        });
+        await act(async () => { await flush(); });
+
+        const column = container.querySelectorAll<HTMLElement>(".board-column")[1];
+        const [ first, second ] = column.querySelectorAll<HTMLElement>(".board-note");
+        const noteId = first?.getAttribute("data-note-id");
+        if (!first || !second || !noteId) throw new Error("expected a column of two cards");
+
+        const scrolled = vi.fn();
+        Object.defineProperty(first, "scrollIntoView",
+            { value: scrolled, configurable: true, writable: true });
+        const content = column.querySelector<HTMLElement>(".board-column-content");
+        Object.defineProperty(content, "scrollHeight",
+            { value: 500, configurable: true, writable: true });
+        vi.spyOn(BoardApi.prototype, "insertRowAtPosition")
+            .mockResolvedValue({ noteId } as never);
+
+        await act(async () => {
+            second.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(first.classList.contains("appearing")).toBe(true);
+        expect(scrolled).toHaveBeenCalled();
+        expect(content?.scrollTop).toBe(0);
+    });
+
+    /**
+     * The editor an insert opens holds focus while the title is typed; the card takes it once that
+     * editor is done, so the arrow keys carry on from the card just made.
+     */
+    it("leaves an inserted card focused, and a card added in the footer unfocused", async () => {
+        const { container } = await setup();
+        const column = container.querySelectorAll<HTMLElement>(".board-column")[1];
+        const card = column.querySelector<HTMLElement>(".board-note");
+        const noteId = card?.getAttribute("data-note-id");
+        if (!card || !noteId) throw new Error("expected a card in the column");
+
+        vi.spyOn(BoardApi.prototype, "insertRowAtPosition")
+            .mockResolvedValue({ noteId } as never);
+        await act(async () => {
+            card.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(document.activeElement).toBe(card);
+
+        // The footer's own editor keeps focus instead, so a run of cards can be typed into it.
+        vi.spyOn(BoardApi.prototype, "createNewItem").mockResolvedValue(noteId);
+        const slot = column.querySelector<HTMLElement>(".board-new-item");
+        await act(async () => {
+            slot?.click();
+            await flush();
+        });
+
+        const editor = slot?.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the new-item editor to be open");
+        editor.value = "Another";
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(document.activeElement).toBe(editor);
+    });
+
+    /**
+     * The editor used to hand focus back to whatever held it before it opened, which for a card
+     * whose editor was opened for it is a different card: that one lit up on the way past.
+     */
+    it("closes a card editor onto its own card, not the one focus came from", async () => {
+        const { container } = await setup();
+        const columns = container.querySelectorAll<HTMLElement>(".board-column");
+        const from = columns[0].querySelector<HTMLElement>(".board-note");
+        const edited = columns[1].querySelector<HTMLElement>(".board-note");
+        if (!from || !edited) throw new Error("expected a card in each of two columns");
+
+        from.focus();
+        const cameFrom = vi.spyOn(from, "focus");
+
+        await act(async () => {
+            edited.dispatchEvent(new KeyboardEvent("keydown", { key: "F2", bubbles: true }));
+            await flush();
+        });
+
+        const editor = edited.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the card editor to be open");
+
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+            await flush();
+        });
+
+        expect(document.activeElement).toBe(edited);
+        expect(cameFrom).not.toHaveBeenCalled();
+    });
+
     it("starts the new item off with the character typed on its button", async () => {
         const { container } = await setup();
         const slot = container.querySelectorAll<HTMLElement>(".board-column")[1]

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -19,7 +19,7 @@ import { buildNote } from "../../../test/easy-froca";
 import { ParentComponent } from "../../react/react_utils";
 import BoardView, { BoardViewData } from ".";
 import { collectShortcutHints } from "../../../services/shortcut_hints";
-import { getPendingWrites } from "./api";
+import BoardApi, { getPendingWrites } from "./api";
 import { DEFAULT_COLUMN_ICON } from "./columns";
 
 // Stands in for the server: by the time the bulk action resolves, the notes carry the new value,
@@ -1115,44 +1115,98 @@ describe("Board column rename", () => {
         show.mockRestore();
     });
 
-    it("scrolls the column to its end when the new-item button takes focus", async () => {
-        const { note, container } = await setup();
+    it("keeps the new-item slot out of the column's scrolling body", async () => {
+        const { container } = await setup();
         const column = container.querySelectorAll<HTMLElement>(".board-column")[1];
-        const content = column.querySelector<HTMLElement>(".board-column-content");
-        if (!content) throw new Error("expected a scrollable column body");
+        const slot = column.querySelector<HTMLElement>(".board-new-item");
+
+        expect(slot).toBeTruthy();
+        expect(slot?.closest(".board-column-content")).toBeNull();
+        expect(slot?.parentElement).toBe(column);
+    });
+
+    /**
+     * Cards are added in runs, so the editor stays where it is with an empty field rather than
+     * closing and having to be opened again for the next one.
+     */
+    it("clears the new-item editor on Enter and leaves it open", async () => {
+        const { container } = await setup();
+        const created = vi.spyOn(BoardApi.prototype, "createNewItem")
+            .mockResolvedValue(undefined);
+        const slot = container.querySelectorAll<HTMLElement>(".board-column")[1]
+            .querySelector<HTMLElement>(".board-new-item");
+
+        await act(async () => {
+            slot?.click();
+            await flush();
+        });
+
+        const editor = slot?.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the new-item editor to be open");
+
+        editor.value = "First";
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(created).toHaveBeenCalledWith("Doing", "First");
+        expect(slot?.querySelector("textarea")).toBe(editor);
+        expect(editor.value).toBe("");
+        expect(document.activeElement).toBe(editor);
+
+        // The one already saved is not written a second time by the one that follows it.
+        editor.value = "Second";
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(created).toHaveBeenCalledTimes(2);
+        expect(created).toHaveBeenLastCalledWith("Doing", "Second");
+    });
+
+    /**
+     * A card is added at the end of its column, which on a full column is out of sight, so it is
+     * scrolled to and faded in rather than appearing wherever the reader is not looking.
+     */
+    it("reveals the card the editor just made", async () => {
+        const { container } = await setup();
+        const card = container.querySelector<HTMLElement>(".board-note");
+        const noteId = card?.getAttribute("data-note-id");
+        const column = card?.closest<HTMLElement>(".board-column");
+        if (!card || !noteId || !column) throw new Error("expected a card to stand in for the new one");
 
         // happy-dom lays nothing out, so the scrollable height has to be stood in for.
-        Object.defineProperty(content, "scrollHeight", { value: 500, configurable: true });
+        const content = column.querySelector<HTMLElement>(".board-column-content");
+        if (!content) throw new Error("expected a scrollable column body");
+        Object.defineProperty(content, "scrollHeight",
+            { value: 500, configurable: true, writable: true });
         expect(content.scrollTop).toBe(0);
 
+        vi.spyOn(BoardApi.prototype, "createNewItem").mockResolvedValue(noteId);
+
+        const slot = column.querySelector<HTMLElement>(".board-new-item");
         await act(async () => {
-            column.querySelector<HTMLElement>(".board-new-item")?.focus();
+            slot?.click();
             await flush();
         });
 
+        const editor = slot?.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the new-item editor to be open");
+        editor.value = "Fresh";
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(card.classList.contains("appearing")).toBe(true);
         expect(content.scrollTop).toBe(500);
 
-        // The card just made lands above the button, pushing it out of sight again. Nothing is
-        // focused afresh by that, so only the effect watching the count brings it back.
-        Object.defineProperty(content, "scrollHeight", { value: 900, configurable: true });
-        addCard(note, "Doing");
-        await act(async () => {
-            render(
-                <ParentComponent.Provider value={new Component()}>
-                    <Harness
-                        note={note}
-                        noteIds={[ ...note.getChildNoteIds() ]}
-                        initialConfig={DEFAULT_CONFIG}
-                    />
-                </ParentComponent.Provider>,
-                container
-            );
-            await flush();
-        });
-        await act(async () => { await flush(); });
-
-        expect(columnTitles(container)).toEqual([ "To Do", "Doing", "Done" ]);
-        expect(content.scrollTop).toBe(900);
+        // The cards that were already there are left alone.
+        const others = [ ...container.querySelectorAll(".board-note") ]
+            .filter(other => other !== card);
+        expect(others.some(other => other.classList.contains("appearing"))).toBe(false);
     });
 
     it("starts the new item off with the character typed on its button", async () => {

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -1171,7 +1171,7 @@ describe("Board column rename", () => {
      * scrolled to and faded in rather than appearing wherever the reader is not looking.
      */
     it("reveals the card the editor just made", async () => {
-        const { container } = await setup();
+        const { note, container } = await setup();
         const card = container.querySelector<HTMLElement>(".board-note");
         const noteId = card?.getAttribute("data-note-id");
         const column = card?.closest<HTMLElement>(".board-column");
@@ -1202,6 +1202,31 @@ describe("Board column rename", () => {
 
         expect(card.classList.contains("appearing")).toBe(true);
         expect(content.scrollTop).toBe(500);
+
+        // Shown once: the card stays the one just made, and a redraw of the column must not play
+        // the reveal again.
+        await act(async () => {
+            card.dispatchEvent(new AnimationEvent("animationend", {
+                animationName: "board-card-appear", bubbles: true
+            }));
+            await flush();
+        });
+        expect(card.classList.contains("appearing")).toBe(false);
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={new Component()}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={DEFAULT_CONFIG}
+                    />
+                </ParentComponent.Provider>,
+                container
+            );
+            await flush();
+        });
+        expect(card.classList.contains("appearing")).toBe(false);
 
         // The cards that were already there are left alone.
         const others = [ ...container.querySelectorAll(".board-note") ]

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -1,5 +1,7 @@
 import "./index.css";
 
+import clsx from "clsx";
+
 import { createContext, TargetedKeyboardEvent } from "preact";
 import { createPortal } from "preact/compat";
 import { Dispatch, StateUpdater, useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
@@ -21,6 +23,7 @@ import Icon from "../../react/Icon";
 import NoteAutocomplete from "../../react/NoteAutocomplete";
 import ShortcutHintButton from "../../shortcut_hints/shortcut_hint_button";
 import { onWheelHorizontalScroll } from "../../widget_utils";
+import { useDragPan } from "../../react/drag_pan";
 import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
 import BoardApi from "./api";
@@ -330,6 +333,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             });
     }
 
+    // Only the board's own background, so a press on a column, a card or the button that adds one
+    // is left to whatever it belongs to.
+    const { isPannable, isPanning } = useDragPan(containerRef);
+
     // The board is not drawn afresh for another note, so the column opened on one would otherwise
     // still be open on the next, over whatever that board stores for a column of the same name.
     useEffect(() => setActiveColumn(undefined), [ parentNote ]);
@@ -422,7 +429,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                 <BoardDragStateContext.Provider value={boardDragState}>
                     {byColumn && columns && <div
                         ref={containerRef}
-                        className="board-view-container"
+                        className={clsx("board-view-container", {
+                            pannable: isPannable,
+                            panning: isPanning
+                        })}
                         onKeyDown={handleKeyDown}
                         onDragOver={handleColumnDragOver}
                         onDrop={handleContainerDrop}

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -435,11 +435,14 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     });
 
     // A column opened to take the card moves every column after it, which the measurement predates.
+    // Only for a card: a carried column is measured among the columns as they stood when it was
+    // picked up, which is the list the place it would take is counted against, and measuring again
+    // with it out of the flow would count one place fewer than the board has.
     useLayoutEffect(() => {
-        if (isDraggingItem) {
+        if (isDraggingItem && !draggedColumn) {
             remeasure();
         }
-    }, [ isDraggingItem, remeasure, activeColumn, shownColumns ]);
+    }, [ isDraggingItem, draggedColumn, remeasure, activeColumn, shownColumns ]);
 
     // Only the board's own background, so a press on a column, a card or the button that adds one
     // is left to whatever it belongs to. Suppressed while a card is carried: the gesture owns the
@@ -715,7 +718,7 @@ function AddNewColumn({ api, isInRelationMode }: { api: BoardApi, isInRelationMo
 
 export function TitleEditor({
     currentValue, placeholder, save, dismiss, mode, isNewItem, selectOnFocus = true,
-    saveAndContinue = false, returnFocusTo
+    saveAndContinue = false, returnFocusTo, abandon
 }: {
     currentValue?: string;
     placeholder?: string;
@@ -725,9 +728,14 @@ export function TitleEditor({
     mode?: "normal" | "multiline" | "relation";
     /**
      * Whether Enter saves and clears the editor rather than closing it, so that a run of cards can
-     * be typed one after another. Escape and clicking away still close it.
+     * be typed one after another. Enter is then the only thing that saves: Escape and losing focus
+     * both give up what was typed and close the editor, since an editor that stays open between
+     * cards is left behind often enough that saving on the way out would make cards nobody asked
+     * for.
      */
     saveAndContinue?: boolean;
+    /** What was typed and not saved, handed over so that reopening the editor can carry it back. */
+    abandon?: (typed: string) => void;
     /**
      * Where focus goes when the editor closes, instead of back to whatever held it before. A card
      * whose editor was opened for it rather than by it names itself, so that closing does not light
@@ -746,7 +754,9 @@ export function TitleEditor({
     const dismissOnNextRefreshRef = useRef(false);
     const shouldDismiss = useRef(false);
 
-    useEffect(() => {
+    // Laid out rather than deferred: with the open drawn synchronously, this puts focus on the
+    // editor inside the press that asked for it, which is what opens a phone's keyboard.
+    useLayoutEffect(() => {
         focusElRef.current = document.activeElement !== document.body ? document.activeElement : null;
         inputRef.current?.focus();
 
@@ -798,6 +808,12 @@ export function TitleEditor({
     };
 
     const onBlur = (newValue: string) => {
+        if (saveAndContinue) {
+            abandon?.(newValue);
+            dismiss();
+            return;
+        }
+
         if (!shouldDismiss.current && newValue.trim() && (newValue !== currentValue || isNewItem)) {
             commit(newValue);
             dismissOnNextRefreshRef.current = true;

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -3,7 +3,7 @@ import "./index.css";
 import clsx from "clsx";
 
 import { createContext, Fragment, TargetedKeyboardEvent } from "preact";
-import { createPortal } from "preact/compat";
+import { createPortal, RefObject } from "preact/compat";
 import {
     Dispatch, StateUpdater, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState
 } from "preact/hooks";
@@ -715,7 +715,7 @@ function AddNewColumn({ api, isInRelationMode }: { api: BoardApi, isInRelationMo
 
 export function TitleEditor({
     currentValue, placeholder, save, dismiss, mode, isNewItem, selectOnFocus = true,
-    saveAndContinue = false
+    saveAndContinue = false, returnFocusTo
 }: {
     currentValue?: string;
     placeholder?: string;
@@ -728,6 +728,12 @@ export function TitleEditor({
      * be typed one after another. Escape and clicking away still close it.
      */
     saveAndContinue?: boolean;
+    /**
+     * Where focus goes when the editor closes, instead of back to whatever held it before. A card
+     * whose editor was opened for it rather than by it names itself, so that closing does not light
+     * up the card the reader came from on the way.
+     */
+    returnFocusTo?: RefObject<HTMLElement>;
     /**
      * Whether opening the editor selects what is already in it, which is what a rename wants. An
      * editor opened part-typed puts the caret after the text instead, so the next key carries on
@@ -781,9 +787,10 @@ export function TitleEditor({
         if (e.key === "Enter" || e.key === "Escape") {
             e.preventDefault();
             e.stopPropagation();
-            if (focusElRef.current instanceof HTMLElement) {
+            const target = returnFocusTo?.current ?? focusElRef.current;
+            if (target instanceof HTMLElement) {
                 shouldDismiss.current = (e.key === "Escape");
-                focusElRef.current.focus();
+                target.focus();
             } else {
                 dismiss();
             }

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -251,14 +251,24 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const statusDefinition = useMemo(
         () => getStatusDefinition(parentNote, statusAttributeWithPrefix),
         [ parentNote, statusAttributeWithPrefix, definitionRevision ]);
-    const api = useMemo(() => {
-        return new Api(
-            byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig ?? {},
-            saveConfig, setBranchIdToEdit, pendingRenamesRef.current.writes, statusDefinition);
-    }, [
-        byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
-        saveConfig, setBranchIdToEdit, statusDefinition
-    ]);
+    // One api for as long as the board is shown, pointed at each refresh's data rather than built
+    // again: a new object would be a new prop on every card, and `memo` would then redraw all of
+    // them for a move that touched one. Another board takes a new one, since this instance is
+    // reused across boards and the api holds that board's record of the writes in flight.
+    const apiRef = useRef<{ board: string, api: Api }>();
+    if (!apiRef.current || apiRef.current.board !== boardIdentity) {
+        apiRef.current = {
+            board: boardIdentity,
+            api: new Api(
+                byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
+                saveConfig, setBranchIdToEdit, pendingRenamesRef.current.writes, statusDefinition)
+        };
+    } else {
+        apiRef.current.api.update(
+            byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
+            saveConfig, setBranchIdToEdit, statusDefinition);
+    }
+    const api = apiRef.current.api;
     // Every member is one of useState's own setters, so this value is built once and never changes
     // identity -- a drag cannot reach anything that reads only this.
     const boardActions = useMemo<BoardActions>(() => ({

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -2,9 +2,11 @@ import "./index.css";
 
 import clsx from "clsx";
 
-import { createContext, TargetedKeyboardEvent } from "preact";
+import { createContext, Fragment, TargetedKeyboardEvent } from "preact";
 import { createPortal } from "preact/compat";
-import { Dispatch, StateUpdater, useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import {
+    Dispatch, StateUpdater, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState
+} from "preact/hooks";
 
 import FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
@@ -26,6 +28,8 @@ import { onWheelHorizontalScroll } from "../../widget_utils";
 import { useDragPan } from "../../react/drag_pan";
 import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
+import { useBoardDrag } from "./board_drag";
+import { movesColumn } from "./drag_geometry";
 import BoardApi from "./api";
 import { DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
 import Column from "./column";
@@ -69,6 +73,8 @@ interface CardDrag {
     branchId: string;
     fromColumn: string;
     index: number;
+    /** How tall the card stands, absent for a drag from the note tree, which carries no card. */
+    height?: number;
 }
 
 interface ColumnDrag {
@@ -197,12 +203,11 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const [ byColumn, setByColumn ] = useState<ColumnMap>();
     const [ columns, setColumns ] = useState<string[]>();
     const [ isInRelationMode, setIsRelationMode ] = useState(false);
-    const [ draggedCard, setDraggedCard ] = useState<{ noteId: string, branchId: string, fromColumn: string, index: number } | null>(null);
+    const [ draggedCard, setDraggedCard ] = useState<CardDrag | null>(null);
     const [ dropTarget, setDropTarget ] = useState<string | null>(null);
     const [ dropPosition, setDropPosition ] = useState<{ column: string, index: number } | null>(null);
     const [ draggedColumn, setDraggedColumn ] = useState<ColumnDrag | null>(null);
     const [ columnDropPosition, setColumnDropPosition ] = useState<number | null>(null);
-    const [ columnHoverIndex, setColumnHoverIndex ] = useState<number | null>(null);
     const [ branchIdToEdit, setBranchIdToEdit ] = useState<string>();
     const [ columnNameToEdit, setColumnNameToEdit ] = useState<string>();
     const [ columnLimitToEdit, setColumnLimitToEdit ] = useState<string>();
@@ -333,9 +338,86 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             });
     }
 
+    // The gesture drives the same state a drag from the note tree does, so the placeholders and the
+    // card's own dimming are drawn from one place whichever brought the card here.
+    const { isDragging: isDraggingItem, remeasure } = useBoardDrag(containerRef, {
+        onCardStart: (card) => setDraggedCard({
+            noteId: card.noteId,
+            branchId: byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId ?? "",
+            fromColumn: card.fromColumn,
+            index: card.index,
+            height: card.height
+        }),
+        onCardMove: (position, inside) => {
+            setDropTarget(position?.column ?? null);
+            setDropPosition(position);
+            // Answers for what a `dragover` did, for a collapsed column the card is actually over:
+            // one merely passed near keeps to itself, and one already opened stays open, since
+            // closing it under a drag would move every column after it.
+            if (position && inside && storedColumns.get(position.column)?.collapsed) {
+                setActiveColumn(position.column);
+            }
+        },
+        onCardEnd: (card, position) => {
+            const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
+            if (position && branchId) {
+                api.moveWithinBoard(
+                    card.noteId, branchId, card.index, position.index,
+                    card.fromColumn, position.column);
+            }
+            setDraggedCard(null);
+            setDropTarget(null);
+            setDropPosition(null);
+            // Asked for by name: the card is drawn again where it landed, and a card that crossed
+            // columns is drawn as a new element, so the one that was focused is gone.
+            focusCard(card.noteId);
+            if (position) {
+                revealColumn(position.column);
+            }
+        },
+        onColumnStart: (column, index, size) => setDraggedColumn({ column, index, size }),
+        onColumnMove: setColumnDropPosition,
+        onColumnEnd: (from, to) => {
+            if (to !== null && movesColumn(from, to)) {
+                handleColumnDrop(from, to);
+            }
+            setDraggedColumn(null);
+            setColumnDropPosition(null);
+        }
+    });
+
+    // A column opened to take the card moves every column after it, which the measurement predates.
+    useLayoutEffect(() => {
+        if (isDraggingItem) {
+            remeasure();
+        }
+    }, [ isDraggingItem, remeasure, activeColumn, shownColumns ]);
+
     // Only the board's own background, so a press on a column, a card or the button that adds one
-    // is left to whatever it belongs to.
-    const { isPannable, isPanning } = useDragPan(containerRef);
+    // is left to whatever it belongs to. Suppressed while a card is carried: the gesture owns the
+    // pointer, and the board must not slide under it.
+    const { isPannable, isPanning } = useDragPan(containerRef, { disabled: isDraggingItem });
+
+    /**
+     * Brings a column to the middle of the screen, for a board that scrolls one column at a time.
+     *
+     * Snapping is off while something is carried, so letting go leaves the board wherever the
+     * gesture took it and the reader looking at two half-columns. Asked for on the next frame: the
+     * board is drawn again around the card that landed, and the column moves with it.
+     */
+    const revealColumn = useCallback((column: string) => {
+        if (!isMobile()) return;
+
+        requestAnimationFrame(() => {
+            const columns = containerRef.current?.querySelectorAll<HTMLElement>(".board-column");
+            for (const element of columns ?? []) {
+                if (element.dataset.column === column) {
+                    element.scrollIntoView({ inline: "center", block: "nearest" });
+                    return;
+                }
+            }
+        });
+    }, []);
 
     // The board is not drawn afresh for another note, so the column opened on one would otherwise
     // still be open on the next, over whatever that board stores for a column of the same name.
@@ -389,38 +471,11 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         }
     });
 
-    const handleColumnDragOver = useCallback((e: DragEvent) => {
-        if (!draggedColumn) return;
-        e.preventDefault();
-    }, [draggedColumn]);
-
-    const handleColumnHover = useCallback((index: number, mouseX: number, columnRect: DOMRect) => {
-        if (!draggedColumn) return;
-
-        const columnMiddle = columnRect.left + columnRect.width / 2;
-
-        // Determine if we should insert before or after this column
-        const insertBefore = mouseX < columnMiddle;
-
-        // Calculate the target position
-        const targetIndex = insertBefore ? index : index + 1;
-
-        setColumnDropPosition(targetIndex);
-    }, [draggedColumn]);
-
     // Measured rather than styled: a collapsed column is a strip, and the placeholder stands in
     // for whichever column is being dragged.
     const placeholderSize = draggedColumn?.size?.width
         ? { width: `${draggedColumn.size.width}px`, height: `${draggedColumn.size.height}px` }
         : undefined;
-
-    const handleContainerDrop = useCallback((e: DragEvent) => {
-        e.preventDefault();
-        if (draggedColumn && columnDropPosition !== null) {
-            handleColumnDrop(draggedColumn.index, columnDropPosition);
-        }
-        setColumnHoverIndex(null);
-    }, [draggedColumn, columnDropPosition, handleColumnDrop]);
 
     return (
         <div className="board-view">
@@ -434,12 +489,21 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                             panning: isPanning
                         })}
                         onKeyDown={handleKeyDown}
-                        onDragOver={handleColumnDragOver}
-                        onDrop={handleContainerDrop}
                         onWheel={onWheelHorizontalScroll}
                     >
+                        {/* The columns are keyed by value, so a reorder moves each column's
+                            element with it rather than repurposing elements in place, which would
+                            carry the `collapsed` class from one column to another and run its width
+                            transition on a column that never collapsed.
+
+                            They are wrapped because a moved element is placed before its next
+                            sibling, and the last ones have none: in a parent that also holds the
+                            button, the layer and the overlays, Preact appends them past all three.
+                            The wrapper lays nothing out, so the columns are still the board's own
+                            flex items. */}
+                        <div className="board-columns">
                         {shownColumns.map((column, index) => (
-                            <>
+                            <Fragment key={column}>
                                 {columnDropPosition === index && (
                                     <div
                                         className="column-drop-placeholder show"
@@ -464,17 +528,18 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                                     onFocusColumn={focusColumn}
                                     onFocusCard={focusCard}
                                     columnItems={byColumn.get(column)}
-                                    isDraggingColumn={draggedColumn?.column === column}
-                                    onColumnHover={handleColumnHover}
-                                    isAnyColumnDragging={!!draggedColumn}
                                 />
-                            </>
+                            </Fragment>
                         ))}
                         {columnDropPosition === shownColumns.length && draggedColumn && (
                             <div className="column-drop-placeholder show" style={placeholderSize} />
                         )}
+                        </div>
 
                         <AddNewColumn api={api} isInRelationMode={isInRelationMode} />
+                        {/* Where what is being carried is put. Preact draws the layer and never
+                            its contents, so the copy is not among the children it places. */}
+                        <div className="board-drag-layer" />
                         {/* Out of the board and onto the page: the dialog is positioned against
                             the window, and Bootstrap puts its backdrop on the body, so a stacking
                             context above the board would trap it underneath. */}

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -19,7 +19,8 @@ import CollectionProperties from "../../note_bars/CollectionProperties";
 import FormTextArea from "../../react/FormTextArea";
 import FormTextBox from "../../react/FormTextBox";
 import {
-    useContextualShortcutHints, useNoteLabelBoolean, useNoteLabelWithDefault, useTriliumEvent
+    useContextualShortcutHints, useNoteContext, useNoteLabelBoolean, useNoteLabelWithDefault,
+    useTrackedElement, useTriliumEvent
 } from "../../react/hooks";
 import Icon from "../../react/Icon";
 import NoteAutocomplete from "../../react/NoteAutocomplete";
@@ -197,6 +198,7 @@ const BOARD_HINTS: ShortcutHintDefinition = [
 ];
 
 export default function BoardView({ note: parentNote, noteIds, viewConfig, saveConfig }: ViewModeProps<BoardViewData>) {
+    const { noteContext } = useNoteContext();
     const [ statusAttributeWithPrefix ] = useNoteLabelWithDefault(parentNote, "board:groupBy", DEFAULT_GROUP_BY);
     const [ includeArchived ] = useNoteLabelBoolean(parentNote, "includeArchived");
     const [ inboxEnabled ] = useNoteLabelBoolean(parentNote, "enableInboxColumn");
@@ -302,6 +304,17 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         // caller, since a card crossing columns changes both the note and the board's children, and
         // either of those reaches this by a path of its own.
         if (movesInFlight.current) {
+            return;
+        }
+
+        // A board in a tab the reader is not looking at draws for nobody, and every mounted board
+        // hears every change: a card renamed once redraws each of them, whichever is on screen. The
+        // change is remembered instead, and drawn once the tab is looked at again. Asked of the
+        // context rather than of the box, which is empty for a board that has not drawn yet.
+        // Only once it has drawn: a board opened straight into a background tab has to draw at
+        // least once, or there is no container to notice the tab being shown and it stays empty.
+        if (byColumn && noteContext && !noteContext.isActive()) {
+            isStale.current = true;
             return;
         }
 
@@ -443,6 +456,28 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             }
         });
     }, []);
+
+    // Whether a change arrived while the board was in a background tab.
+    const isStale = useRef(false);
+    const latestRefresh = useRef(refresh);
+    latestRefresh.current = refresh;
+
+    // Caught up when the board is given a size again, which is what showing its tab does. Keyed on
+    // that rather than on the context becoming active: the board is drawn from what the tab switch
+    // lays out, and a size is the one signal that is certainly in by then.
+    const boardElement = useTrackedElement(containerRef);
+    useEffect(() => {
+        if (!boardElement) return;
+
+        const observer = new ResizeObserver(() => {
+            if (isStale.current && boardElement.getBoundingClientRect().width > 0) {
+                isStale.current = false;
+                latestRefresh.current();
+            }
+        });
+        observer.observe(boardElement);
+        return () => observer.disconnect();
+    }, [ boardElement ]);
 
     // The board is not drawn afresh for another note, so the column opened on one would otherwise
     // still be open on the next, over whatever that board stores for a column of the same name.

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -714,7 +714,8 @@ function AddNewColumn({ api, isInRelationMode }: { api: BoardApi, isInRelationMo
 }
 
 export function TitleEditor({
-    currentValue, placeholder, save, dismiss, mode, isNewItem, selectOnFocus = true
+    currentValue, placeholder, save, dismiss, mode, isNewItem, selectOnFocus = true,
+    saveAndContinue = false
 }: {
     currentValue?: string;
     placeholder?: string;
@@ -722,6 +723,11 @@ export function TitleEditor({
     dismiss: () => void;
     isNewItem?: boolean;
     mode?: "normal" | "multiline" | "relation";
+    /**
+     * Whether Enter saves and clears the editor rather than closing it, so that a run of cards can
+     * be typed one after another. Escape and clicking away still close it.
+     */
+    saveAndContinue?: boolean;
     /**
      * Whether opening the editor selects what is already in it, which is what a rename wants. An
      * editor opened part-typed puts the caret after the text instead, so the next key carries on
@@ -760,6 +766,18 @@ export function TitleEditor({
             return;
         }
 
+        if (e.key === "Enter" && saveAndContinue) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const input = inputRef.current;
+            if (input?.value.trim()) {
+                commit(input.value);
+                input.value = "";
+            }
+            return;
+        }
+
         if (e.key === "Enter" || e.key === "Escape") {
             e.preventDefault();
             e.stopPropagation();
@@ -774,18 +792,22 @@ export function TitleEditor({
 
     const onBlur = (newValue: string) => {
         if (!shouldDismiss.current && newValue.trim() && (newValue !== currentValue || isNewItem)) {
-            // The editor is closing either way, and what a save writes has already been put back by
-            // whatever could not write it; all that is left is to say so rather than to reject
-            // unhandled, which is what a save reaching nobody used to do.
-            Promise.resolve(save(newValue)).catch((e) => {
-                console.error("Failed to save what the board editor was given:", e);
-                toast.showError(t("board_view.save-error"));
-            });
+            commit(newValue);
             dismissOnNextRefreshRef.current = true;
         } else {
             dismiss();
         }
     };
+
+    // The editor is closing either way, and what a save writes has already been put back by
+    // whatever could not write it; all that is left is to say so rather than to reject unhandled,
+    // which is what a save reaching nobody used to do.
+    function commit(newValue: string) {
+        Promise.resolve(save(newValue)).catch((e) => {
+            console.error("Failed to save what the board editor was given:", e);
+            toast.showError(t("board_view.save-error"));
+        });
+    }
 
     if (mode !== "relation") {
         const Element = mode === "multiline" ? FormTextArea : FormTextBox;

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -34,7 +34,7 @@ import BoardApi from "./api";
 import { DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
 import Column from "./column";
 import ColumnLimitDialog from "./column_limit";
-import { ColumnMap, getBoardData } from "./data";
+import { applyCardMove, ColumnMap, getBoardData } from "./data";
 import { useBoardKeyboard } from "./keyboard";
 
 export interface BoardViewData {
@@ -212,6 +212,9 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const [ columnNameToEdit, setColumnNameToEdit ] = useState<string>();
     const [ columnLimitToEdit, setColumnLimitToEdit ] = useState<string>();
     const [ activeColumn, setActiveColumn ] = useState<string>();
+    // How many card moves are still being written. The board is drawn as they will leave it, so a
+    // redraw from the first of a move's two writes would take that back.
+    const movesInFlight = useRef(0);
     /** Bumped when the definition changes, since it is read off the note rather than held in state. */
     const [ definitionRevision, setDefinitionRevision ] = useState(0);
     // A ref rather than state: `api` is rebuilt on every refresh, and the map has to outlive those
@@ -295,6 +298,13 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     }), [ branchIdToEdit, columnNameToEdit, draggedCard, draggedColumn, dropPosition, dropTarget ]);
 
     function refresh() {
+        // A move under way has already been drawn where it will land. Held here rather than at each
+        // caller, since a card crossing columns changes both the note and the board's children, and
+        // either of those reaches this by a path of its own.
+        if (movesInFlight.current) {
+            return;
+        }
+
         // `getBoardData` reads notes, so refreshes can resolve out of order and one issued for the
         // board the user has left can arrive after the next board's. What it has to say is about
         // sources no longer on screen, the pending renames it reports as settled included.
@@ -304,7 +314,9 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             parentNote, statusAttributeWithPrefix, viewConfig ?? {}, includeArchived,
             statusDefinition?.options ?? [], pendingRenamesRef.current.writes.renames, inboxEnabled)
             .then(({ byColumn, columns, newPersistedData, isInRelationMode, settledRenames }) => {
-                if (refreshId !== refreshSeqRef.current) return;
+                if (refreshId !== refreshSeqRef.current) {
+                    return;
+                }
 
                 for (const settled of settledRenames) {
                     settleColumn(pendingRenamesRef.current.writes, settled);
@@ -360,10 +372,23 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         },
         onCardEnd: (card, position) => {
             const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
-            if (position && branchId) {
+            if (position && branchId && byColumn) {
+                // Drawn where it landed at once, and held there until both writes are in: each of
+                // them lands a redraw, and the first would show the card at the top of the column.
+                setByColumn(applyCardMove(
+                    byColumn, card.noteId, card.fromColumn, position.column, position.index));
+                movesInFlight.current++;
+                // Any refresh already on its way is about the board as it stood before the drop,
+                // and would put the card back where it came from as it resolves.
+                refreshSeqRef.current++;
                 api.moveWithinBoard(
                     card.noteId, branchId, card.index, position.index,
-                    card.fromColumn, position.column);
+                    card.fromColumn, position.column)
+                    // Nothing is asked for once the writes are in: `froca` learns of the branch
+                    // move from the server a moment later, so a refresh here reads the new column
+                    // with the old order and puts the card at the top of it. The change reaches the
+                    // board as an entity reload, which settles it once there is something to read.
+                    .finally(() => { movesInFlight.current--; });
             }
             setDraggedCard(null);
             setDropTarget(null);

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -82,8 +82,8 @@ export interface BoardKeyboardOptions {
  * handlers keep what is theirs (F2 to rename, Enter to add a card, typing to start one).
  *
  * Focus follows what is under it rather than where it sits: a card moved to another column is
- * drawn as a new element, and columns are drawn unkeyed, so a header would otherwise be left
- * focused on whichever column took its place.
+ * drawn as a new element, and a column moved in the page is blurred by the browser, so a header
+ * would otherwise be left focused on nothing.
  */
 export function useBoardKeyboard({
     containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn
@@ -98,8 +98,8 @@ export function useBoardKeyboard({
         if (!pending || !container) return;
 
         if (!("noteId" in pending.intent)) {
-            // The columns are drawn unkeyed, so what was focused is now over whichever column took
-            // the old one's place. Focus is pointed at the right one and the hold is done with.
+            // Moving a focused element blurs it, so the header is focused again by name once the
+            // board has drawn it in its new place, and the hold is done with.
             const element = findInColumn(container, pending.intent.column, pending.intent.part);
             if (element) {
                 element.focus();
@@ -122,8 +122,8 @@ export function useBoardKeyboard({
 
     /**
      * Puts focus on a column's heading once the board has drawn it again, for a move made from
-     * somewhere other than the keyboard. The columns are drawn unkeyed, so an element held onto
-     * across the move would be left standing over whichever column took the old one's place.
+     * somewhere other than the keyboard. The browser blurs an element it moves, so an element
+     * held onto across the move would be left focused on nothing.
      */
     const focusColumn = useCallback((column: string) => {
         pendingFocus.current = { intent: { column, part: "header" } };
@@ -472,8 +472,8 @@ function move(
 
 /**
  * Moves the column focus is in, answering with what to put focus back on. Whatever was focused
- * stays focused: the columns are drawn unkeyed, so the element would otherwise be left standing
- * over whichever column took the old one's place.
+ * stays focused: the browser blurs an element it moves, so it would otherwise be left focused on
+ * nothing.
  */
 function shiftColumn(
     spot: Spot,

--- a/apps/client/src/widgets/react/ScrollableLabel.css
+++ b/apps/client/src/widgets/react/ScrollableLabel.css
@@ -1,69 +1,17 @@
 /*
- * A custom property only animates once it is registered with a type, so the two ends are declared as
- * lengths for the transition below to have something to interpolate: the mask is recomputed as they
- * grow, and a fade arrives and leaves over its 300ms instead of appearing whole. Where `@property` is
- * not supported the fades simply snap, as they did before, and the `var()` fallbacks in the mask keep
- * standing in for the initial values.
- */
-@property --scrollable-label-fade-start {
-    syntax: "<length>";
-    inherits: false;
-    initial-value: 0px;
-}
-
-@property --scrollable-label-fade-end {
-    syntax: "<length>";
-    inherits: false;
-    initial-value: 0px;
-}
-
-/*
- * One line of text, swiped along where it does not fit, fading out at whichever edge it continues
- * past. The fade is a mask rather than a painted gradient, as `.scroll-edge-fade` in style.css is for
- * the vertical axis: it holds over any background, including a semi-transparent tint over a window
- * material, which no painted color could match.
- *
- * The two ends are `var()` fallbacks rather than declarations, so a consumer's own fade width wins
- * regardless of how the stylesheets end up bundled; the classes below are set by the component as the
- * line is scrolled. The gradient's direction is a variable because a gradient can only be given a
- * physical one, and the ends swap in a right-to-left page.
+ * One line of text, swiped along where it does not fit. The edges it continues past are faded by
+ * `useScrollFade`, which paints the mask and holds the classes.
  */
 .scrollable-label {
     overflow-x: auto;
     /* The swipe belongs to the label: without this it carries on into whatever the label sits in once
        the line reaches its end, which on a phone is the page or the gesture that changes tabs. */
     overscroll-behavior-inline: contain;
-    mask-image: linear-gradient(
-        var(--scrollable-label-direction, to right),
-        transparent,
-        black var(--scrollable-label-fade-start, 0px),
-        black calc(100% - var(--scrollable-label-fade-end, 0px)),
-        transparent
-    );
     white-space: nowrap;
     /* No room for a bar under a single line, and nothing for it to say that the fades do not. */
     scrollbar-width: none;
-    transition:
-        --scrollable-label-fade-start 300ms ease,
-        --scrollable-label-fade-end 300ms ease;
 }
 
 .scrollable-label::-webkit-scrollbar {
     display: none;
-}
-
-/* Far enough to read as a fade rather than as a cut, and no further: the text under it is still
-   being read. */
-.scrollable-label-fade-start {
-    --scrollable-label-fade-start: 20px;
-}
-
-.scrollable-label-fade-end {
-    --scrollable-label-fade-end: 20px;
-}
-
-/* Flipping the gradient flips which physical edge each end names, so the two stops above go on
-   meaning the start and the end of the line. */
-body[dir=rtl] .scrollable-label {
-    --scrollable-label-direction: to left;
 }

--- a/apps/client/src/widgets/react/ScrollableLabel.spec.tsx
+++ b/apps/client/src/widgets/react/ScrollableLabel.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from "preact";
+import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import ScrollableLabel from "./ScrollableLabel";
@@ -18,10 +19,15 @@ afterEach(() => {
  * writable already; the two widths are not, and stand for a line of the given length in a 100px box.
  */
 function renderLabel(text: string, scrollWidth: number, clientWidth = 100, autoScroll = false) {
-    container = document.body.appendChild(document.createElement("div"));
-    render(<ScrollableLabel autoScroll={autoScroll}>{text}</ScrollableLabel>, container);
+    const mountPoint = document.body.appendChild(document.createElement("div"));
+    container = mountPoint;
+    // Flushed here: the fade attaches its listeners from an effect, which Preact defers past the
+    // render, and a test that scrolled before that would be scrolling at nothing.
+    act(() => {
+        render(<ScrollableLabel autoScroll={autoScroll}>{text}</ScrollableLabel>, mountPoint);
+    });
 
-    const label = container.querySelector<HTMLDivElement>(".scrollable-label");
+    const label = mountPoint.querySelector<HTMLDivElement>(".scrollable-label");
 
     if (!label) {
         throw new Error("the label did not render");
@@ -41,7 +47,7 @@ async function scrollTo(label: HTMLDivElement, scrollLeft: number) {
     label.scrollLeft = scrollLeft;
     label.dispatchEvent(new Event("scroll"));
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
 }
 
 describe("ScrollableLabel", () => {
@@ -50,30 +56,30 @@ describe("ScrollableLabel", () => {
 
         // Sitting at the start: the end continues, nothing is cut off behind.
         await scrollTo(label, 0);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(false);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(true);
+        expect(label.classList.contains("scroll-fade-start")).toBe(false);
+        expect(label.classList.contains("scroll-fade-end")).toBe(true);
 
         // Part way along: cut off at both ends.
         await scrollTo(label, 100);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(true);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(true);
+        expect(label.classList.contains("scroll-fade-start")).toBe(true);
+        expect(label.classList.contains("scroll-fade-end")).toBe(true);
 
         // Scrolled to the end: only what is behind is cut off.
         await scrollTo(label, 200);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(true);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(false);
+        expect(label.classList.contains("scroll-fade-start")).toBe(true);
+        expect(label.classList.contains("scroll-fade-end")).toBe(false);
     });
 
     it("takes a right-to-left line's negative offsets as the same distance travelled", async () => {
         const label = renderLabel("a right-to-left name", 300);
 
         await scrollTo(label, -100);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(true);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(true);
+        expect(label.classList.contains("scroll-fade-start")).toBe(true);
+        expect(label.classList.contains("scroll-fade-end")).toBe(true);
 
         await scrollTo(label, -200);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(true);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(false);
+        expect(label.classList.contains("scroll-fade-start")).toBe(true);
+        expect(label.classList.contains("scroll-fade-end")).toBe(false);
     });
 
     it("walks an auto-scrolling label at its own pace, and stops it at the end", () => {
@@ -160,7 +166,7 @@ describe("ScrollableLabel", () => {
         const label = renderLabel("short", 100);
 
         await scrollTo(label, 0);
-        expect(label.classList.contains("scrollable-label-fade-start")).toBe(false);
-        expect(label.classList.contains("scrollable-label-fade-end")).toBe(false);
+        expect(label.classList.contains("scroll-fade-start")).toBe(false);
+        expect(label.classList.contains("scroll-fade-end")).toBe(false);
     });
 });

--- a/apps/client/src/widgets/react/ScrollableLabel.tsx
+++ b/apps/client/src/widgets/react/ScrollableLabel.tsx
@@ -2,10 +2,9 @@ import "./ScrollableLabel.css";
 
 import clsx from "clsx";
 import type { ComponentChildren } from "preact";
-import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef } from "preact/hooks";
 
-/** Fractional scroll offsets are reported at sub-pixel precision, so an edge is never tested exactly. */
-const EDGE_EPSILON = 1;
+import { useScrollFade } from "./scroll_fade";
 
 /** How fast a label reads itself out, in pixels a second: walking pace for the eye, not a marquee. */
 const AUTO_SCROLL_SPEED = 30;
@@ -35,12 +34,10 @@ interface ScrollableLabelProps {
  */
 export default function ScrollableLabel({ children, className, autoScroll }: ScrollableLabelProps) {
     const ref = useRef<HTMLDivElement>(null);
-    const [ fades, setFades ] = useState({ start: false, end: false });
-    // How much of the line lies outside the box. Kept because the walk below starts over whenever it
-    // changes, which is what walks a label whose words arrived after it did — a path waiting on its
-    // titles — without asking the caller to say so, and without restarting on a render that changed
-    // nothing (children given as elements rather than as text are a new value every time).
-    const [ overflow, setOverflow ] = useState(0);
+    // The walk below starts over whenever the overflow changes, which is what walks a label whose
+    // words arrived after it did, a path waiting on its titles, without asking the caller to say so
+    // and without restarting on a render that changed nothing.
+    const { className: fadeClass, overflow } = useScrollFade(ref, { direction: "horizontal" });
     // Set by the reader's own first scroll, and cleared only by a remount, which is what a new label
     // is: a walk they interrupted must not start again while the same line is still on screen. A
     // consumer whose label changes what it names keys it, so the new one arrives with a fresh walk.
@@ -48,49 +45,6 @@ export default function ScrollableLabel({ children, className, autoScroll }: Scr
     const handOver = useCallback(() => {
         handedOver.current = true;
     }, []);
-
-    const update = useCallback(() => {
-        const element = ref.current;
-
-        if (!element) {
-            return;
-        }
-
-        // Read as a distance travelled rather than as a coordinate: a right-to-left page scrolls the
-        // same line towards negative offsets, and both ends are the same question either way.
-        const travelled = Math.abs(element.scrollLeft);
-        const total = element.scrollWidth - element.clientWidth;
-
-        setOverflow(total);
-
-        const next = {
-            start: travelled > EDGE_EPSILON,
-            end: travelled < total - EDGE_EPSILON
-        };
-
-        setFades((current) =>
-            current.start === next.start && current.end === next.end ? current : next);
-    }, []);
-
-    useEffect(() => {
-        const element = ref.current;
-
-        if (!element) {
-            return;
-        }
-
-        update();
-
-        // The box can be resized without the text changing, and the pane this sits in is resized by
-        // everything from a rotation to a keyboard opening.
-        const observer = new ResizeObserver(update);
-
-        observer.observe(element);
-
-        return () => observer.disconnect();
-        // Re-measured on a new label as well: the same box holding a longer name overflows where the
-        // last one did not, and no resize says so.
-    }, [ update, children ]);
 
     useEffect(() => {
         const element = ref.current;
@@ -147,13 +101,7 @@ export default function ScrollableLabel({ children, className, autoScroll }: Scr
     return (
         <div
             ref={ref}
-            className={clsx(
-                "scrollable-label",
-                fades.start && "scrollable-label-fade-start",
-                fades.end && "scrollable-label-fade-end",
-                className
-            )}
-            onScroll={update}
+            className={clsx("scrollable-label", fadeClass, className)}
             // The gesture rather than the scrolling it causes: a pointer going down on the label, or a
             // wheel over it, says the reader has taken over before the line has moved an inch. Which
             // is also why this is not read off the scroll events, where the walk's own scrolling and

--- a/apps/client/src/widgets/react/drag_pan.spec.tsx
+++ b/apps/client/src/widgets/react/drag_pan.spec.tsx
@@ -1,0 +1,237 @@
+import { render } from "preact";
+import { useRef, useState } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DragPanOptions, useDragPan } from "./drag_pan";
+
+vi.mock("../../services/utils", () => ({ isMobile: () => false }));
+
+describe("useDragPan", () => {
+    let container: HTMLElement | undefined;
+
+    // happy-dom lays nothing out, so every element reports what the test declares. Declared on the
+    // prototype rather than on one element, since the hook measures as soon as its container is
+    // drawn, which is before a test can reach it.
+    let scrollWidth = 2000;
+    const originals = new Map<string, PropertyDescriptor | undefined>();
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        scrollWidth = 2000;
+        for (const [ name, get ] of [
+            [ "scrollWidth", () => scrollWidth ], [ "clientWidth", () => 500 ]
+        ] as const) {
+            originals.set(name, Object.getOwnPropertyDescriptor(HTMLElement.prototype, name));
+            Object.defineProperty(HTMLElement.prototype, name, { configurable: true, get });
+        }
+    });
+
+    afterEach(() => {
+        for (const [ name, descriptor ] of originals) {
+            if (descriptor) {
+                Object.defineProperty(HTMLElement.prototype, name, descriptor);
+            } else {
+                delete (HTMLElement.prototype as unknown as Record<string, unknown>)[name];
+            }
+        }
+        originals.clear();
+        vi.useRealTimers();
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    it("pans the container by the distance the pointer moved", () => {
+        const scroller = setup();
+
+        press(scroller, 100);
+        move(scroller, 60);
+
+        expect(scroller.scrollLeft).toBe(40);
+        expect(scroller.className).toContain("panning");
+
+        release(scroller, 60);
+        expect(scroller.className).not.toContain("panning");
+    });
+
+    /**
+     * Boards draw their scroller only once the notes have loaded, so the element the hook is given
+     * is not there on the first render. A ref triggers no render of its own when it is filled in.
+     */
+    it("picks up a container that is drawn after the first render", () => {
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        let show: (ready: boolean) => void = () => {};
+
+        function Harness() {
+            const [ ready, setReady ] = useState(false);
+            const ref = useRef<HTMLDivElement>(null);
+            const { isPannable } = useDragPan(ref);
+            show = setReady;
+
+            return ready
+                ? <div ref={ref} className={isPannable ? "pannable" : ""} />
+                : <span />;
+        }
+
+        act(() => { render(<Harness />, mountPoint); });
+        act(() => { show(true); });
+
+        const scroller = mountPoint.firstElementChild as HTMLElement;
+        expect(scroller.className).toContain("pannable");
+
+        press(scroller, 100);
+        move(scroller, 60);
+        expect(scroller.scrollLeft).toBe(40);
+    });
+
+    it("offers no pan while the content fits", () => {
+        const scroller = setup({ width: 300 });
+
+        expect(scroller.className).not.toContain("pannable");
+
+        press(scroller, 100);
+        move(scroller, 60);
+
+        expect(scroller.scrollLeft).toBe(0);
+    });
+
+    /** The background is the board's own; a press on anything standing on it belongs to that. */
+    it("starts from the container's background and nothing else", () => {
+        const scroller = setup();
+        const child = document.createElement("div");
+        scroller.appendChild(child);
+
+        press(scroller, 100, { target: child });
+        move(scroller, 60);
+
+        expect(scroller.scrollLeft).toBe(0);
+    });
+
+    it("takes the predicate it is given over the background rule", () => {
+        const scroller = setup({ options: { canStart: () => true } });
+        const child = document.createElement("div");
+        scroller.appendChild(child);
+
+        press(scroller, 100, { target: child });
+        move(scroller, 60);
+
+        expect(scroller.scrollLeft).toBe(40);
+    });
+
+    it("ignores a press of any button but the first", () => {
+        const scroller = setup();
+
+        press(scroller, 100, { button: 2 });
+        move(scroller, 60);
+
+        expect(scroller.scrollLeft).toBe(0);
+    });
+
+    it("glides on after the pointer is up, and settles", () => {
+        const scroller = setup();
+
+        press(scroller, 400);
+        move(scroller, 300, 16);
+        release(scroller, 300);
+
+        const released = scroller.scrollLeft;
+        act(() => { vi.advanceTimersByTime(50); });
+        const glided = scroller.scrollLeft;
+        expect(glided).toBeGreaterThan(released);
+
+        act(() => { vi.advanceTimersByTime(2000); });
+        const settled = scroller.scrollLeft;
+        act(() => { vi.advanceTimersByTime(2000); });
+        expect(scroller.scrollLeft).toBe(settled);
+    });
+
+    it("does not glide when the pointer was still before it was let go", () => {
+        const scroller = setup();
+
+        press(scroller, 400);
+        move(scroller, 300, 16);
+        // Long enough that the last stretch carries no speed at all.
+        move(scroller, 299, 400);
+        release(scroller, 299);
+
+        const released = scroller.scrollLeft;
+        act(() => { vi.advanceTimersByTime(500); });
+        expect(scroller.scrollLeft).toBe(released);
+    });
+
+    it("stops a glide when the next pan starts", () => {
+        const scroller = setup();
+
+        press(scroller, 400);
+        move(scroller, 300, 16);
+        release(scroller, 300);
+        act(() => { vi.advanceTimersByTime(20); });
+
+        press(scroller, 200);
+        const held = scroller.scrollLeft;
+        act(() => { vi.advanceTimersByTime(500); });
+
+        expect(scroller.scrollLeft).toBe(held);
+    });
+
+    let clock = 0;
+
+    function setup({ width = 2000, options }: {
+        width?: number,
+        options?: DragPanOptions
+    } = {}) {
+        clock = 0;
+        scrollWidth = width;
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        function Harness() {
+            const ref = useRef<HTMLDivElement>(null);
+            const { isPannable, isPanning } = useDragPan(ref, options);
+            return (
+                <div
+                    ref={ref}
+                    className={`${isPannable ? "pannable" : ""} ${isPanning ? "panning" : ""}`}
+                />
+            );
+        }
+
+        act(() => { render(<Harness />, mountPoint); });
+
+        const scroller = mountPoint.firstElementChild as HTMLElement;
+        scroller.scrollLeft = 0;
+        return scroller;
+    }
+
+    function pointer(type: string, clientX: number, elapsed: number, extra: Record<string, unknown>) {
+        clock += elapsed;
+        const event = new Event(type, { bubbles: true, cancelable: true });
+        for (const [ name, value ] of Object.entries({
+            clientX, pointerId: 1, button: 0, timeStamp: clock, ...extra
+        })) {
+            Object.defineProperty(event, name, { value, configurable: true });
+        }
+        return event;
+    }
+
+    function press(scroller: HTMLElement, clientX: number, extra: Record<string, unknown> = {}) {
+        const { target, ...rest } = extra as { target?: HTMLElement };
+        const event = pointer("pointerdown", clientX, 0, rest);
+        act(() => { (target ?? scroller).dispatchEvent(event); });
+    }
+
+    function move(scroller: HTMLElement, clientX: number, elapsed = 16) {
+        act(() => { scroller.dispatchEvent(pointer("pointermove", clientX, elapsed, {})); });
+    }
+
+    function release(scroller: HTMLElement, clientX: number) {
+        act(() => { scroller.dispatchEvent(pointer("pointerup", clientX, 0, {})); });
+    }
+});

--- a/apps/client/src/widgets/react/drag_pan.spec.tsx
+++ b/apps/client/src/widgets/react/drag_pan.spec.tsx
@@ -5,7 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DragPanOptions, useDragPan } from "./drag_pan";
 
-vi.mock("../../services/utils", () => ({ isMobile: () => false }));
+// Spread rather than replaced: the hook reaches the shared hooks module, which reads far more of
+// this than the one export under test.
+vi.mock("../../services/utils", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../services/utils")>()),
+    isMobile: () => false
+}));
 
 describe("useDragPan", () => {
     let container: HTMLElement | undefined;
@@ -163,6 +168,21 @@ describe("useDragPan", () => {
         const released = scroller.scrollLeft;
         act(() => { vi.advanceTimersByTime(500); });
         expect(scroller.scrollLeft).toBe(released);
+    });
+
+    /** The pointer was taken away rather than let go, so the movement was never finished. */
+    it("does not glide when the gesture is cancelled", () => {
+        const scroller = setup();
+
+        press(scroller, 400);
+        move(scroller, 300, 16);
+        act(() => { scroller.dispatchEvent(pointer("pointercancel", 300, 0, {})); });
+
+        const cancelled = scroller.scrollLeft;
+        act(() => { vi.advanceTimersByTime(500); });
+
+        expect(scroller.scrollLeft).toBe(cancelled);
+        expect(scroller.className).not.toContain("panning");
     });
 
     it("stops a glide when the next pan starts", () => {

--- a/apps/client/src/widgets/react/drag_pan.ts
+++ b/apps/client/src/widgets/react/drag_pan.ts
@@ -1,0 +1,168 @@
+import { RefObject } from "preact";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+
+import { isMobile } from "../../services/utils";
+
+/** How much of the speed survives each frame once the pointer is up. */
+const FRICTION = 0.94;
+
+/** Below this speed, in pixels per millisecond, the glide has nothing left to show. */
+const MIN_VELOCITY = 0.02;
+
+/** How far back the speed is measured, so a pause before releasing ends the gesture still. */
+const VELOCITY_WINDOW_MS = 100;
+
+export interface DragPanOptions {
+    /**
+     * Whether a press here starts a pan. Defaults to the container's own background, which is
+     * whatever its children leave uncovered.
+     */
+    canStart?: (target: HTMLElement, container: HTMLElement) => boolean;
+    /** Whether to offer panning at all. */
+    disabled?: boolean;
+}
+
+export interface DragPanState {
+    /** Whether the content is wider than the container, and so has anywhere to be panned. */
+    isPannable: boolean;
+    /** Whether a pan is under way. */
+    isPanning: boolean;
+}
+
+/**
+ * Pans a horizontally scrolling container by dragging its background, with a glide after the
+ * pointer is up.
+ *
+ * Touch devices scroll it by dragging already, so this is left to pointers that cannot.
+ *
+ * @param ref the scrolling container.
+ * @param options which presses start a pan, and whether to offer it at all.
+ */
+export function useDragPan(ref: RefObject<HTMLElement>, options: DragPanOptions = {}): DragPanState {
+    const { canStart, disabled } = options;
+    const [ isPannable, setPannable ] = useState(false);
+    const [ isPanning, setPanning ] = useState(false);
+    const glideRef = useRef<number>();
+
+    // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
+    // Containers drawn only once their content has loaded are the ordinary case, so the element is
+    // tracked in state instead. Set only when it actually changes, so this settles in one pass.
+    // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
+    // Containers drawn only once their content has loaded are the ordinary case, so the element is
+    // tracked in state instead. Set only when it actually changes, so this settles in one pass.
+    const [ element, setElement ] = useState<HTMLElement | null>(null);
+    useLayoutEffect(() => {
+        if (ref.current !== element) {
+            setElement(ref.current);
+        }
+    });
+
+    const stopGlide = useCallback(() => {
+        if (glideRef.current !== undefined) {
+            cancelAnimationFrame(glideRef.current);
+            glideRef.current = undefined;
+        }
+    }, []);
+
+    useEffect(() => {
+        const container = element;
+        if (!container || disabled || isMobile()) return;
+
+        const measure = () => setPannable(container.scrollWidth > container.clientWidth);
+        measure();
+
+        // Enough to keep the cursor honest: the width is read again when the pan is asked for, so a
+        // measurement this misses cannot let a pan start where there is nowhere to go.
+        const observer = new ResizeObserver(measure);
+        observer.observe(container);
+
+        let pointerId: number | undefined;
+        let lastX = 0;
+        let lastAt = 0;
+        let velocity = 0;
+
+        const onPointerDown = (event: PointerEvent) => {
+            const target = event.target as HTMLElement | null;
+            if (event.button !== 0 || !target) return;
+
+            const starts = canStart ? canStart(target, container) : target === container;
+            if (!starts || container.scrollWidth <= container.clientWidth) return;
+
+            stopGlide();
+            pointerId = event.pointerId;
+            lastX = event.clientX;
+            lastAt = event.timeStamp;
+            velocity = 0;
+            setPanning(true);
+            container.setPointerCapture?.(event.pointerId);
+            // The press would otherwise start a selection, which the drag then extends.
+            event.preventDefault();
+        };
+
+        const onPointerMove = (event: PointerEvent) => {
+            if (event.pointerId !== pointerId) return;
+
+            const dx = event.clientX - lastX;
+            const elapsed = event.timeStamp - lastAt;
+            container.scrollLeft -= dx;
+
+            // Measured over the last stretch only, so a drag that stops before the release glides
+            // no further than it was going.
+            if (elapsed > 0) {
+                velocity = elapsed > VELOCITY_WINDOW_MS ? 0 : dx / elapsed;
+                lastAt = event.timeStamp;
+            }
+            lastX = event.clientX;
+        };
+
+        const glide = () => {
+            let previous = performance.now();
+
+            const step = (now: number) => {
+                const elapsed = now - previous;
+                previous = now;
+
+                const before = container.scrollLeft;
+                container.scrollLeft -= velocity * elapsed;
+                velocity *= FRICTION ** (elapsed / 16);
+
+                // An end of the board is as far as the glide goes: the scroller clamps what it is
+                // given, so nothing moves however much speed is left.
+                const moved = container.scrollLeft !== before;
+                glideRef.current = moved && Math.abs(velocity) > MIN_VELOCITY
+                    ? requestAnimationFrame(step)
+                    : undefined;
+            };
+
+            glideRef.current = requestAnimationFrame(step);
+        };
+
+        const onPointerUp = (event: PointerEvent) => {
+            if (event.pointerId !== pointerId) return;
+
+            pointerId = undefined;
+            setPanning(false);
+            container.releasePointerCapture?.(event.pointerId);
+
+            if (Math.abs(velocity) > MIN_VELOCITY) {
+                glide();
+            }
+        };
+
+        container.addEventListener("pointerdown", onPointerDown);
+        container.addEventListener("pointermove", onPointerMove);
+        container.addEventListener("pointerup", onPointerUp);
+        container.addEventListener("pointercancel", onPointerUp);
+
+        return () => {
+            observer.disconnect();
+            stopGlide();
+            container.removeEventListener("pointerdown", onPointerDown);
+            container.removeEventListener("pointermove", onPointerMove);
+            container.removeEventListener("pointerup", onPointerUp);
+            container.removeEventListener("pointercancel", onPointerUp);
+        };
+    }, [ element, canStart, disabled, stopGlide ]);
+
+    return { isPannable, isPanning };
+}

--- a/apps/client/src/widgets/react/drag_pan.ts
+++ b/apps/client/src/widgets/react/drag_pan.ts
@@ -1,7 +1,8 @@
 import { RefObject } from "preact";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import { isMobile } from "../../services/utils";
+import { useTrackedElement } from "./hooks";
 
 /** How much of the speed survives each frame once the pointer is up. */
 const FRICTION = 0.94;
@@ -47,15 +48,7 @@ export function useDragPan(ref: RefObject<HTMLElement>, options: DragPanOptions 
     // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
     // Containers drawn only once their content has loaded are the ordinary case, so the element is
     // tracked in state instead. Set only when it actually changes, so this settles in one pass.
-    // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
-    // Containers drawn only once their content has loaded are the ordinary case, so the element is
-    // tracked in state instead. Set only when it actually changes, so this settles in one pass.
-    const [ element, setElement ] = useState<HTMLElement | null>(null);
-    useLayoutEffect(() => {
-        if (ref.current !== element) {
-            setElement(ref.current);
-        }
-    });
+    const element = useTrackedElement(ref);
 
     const stopGlide = useCallback(() => {
         if (glideRef.current !== undefined) {
@@ -144,7 +137,10 @@ export function useDragPan(ref: RefObject<HTMLElement>, options: DragPanOptions 
             setPanning(false);
             container.releasePointerCapture?.(event.pointerId);
 
-            if (Math.abs(velocity) > MIN_VELOCITY) {
+            // A cancelled gesture is not a release: the pointer was taken away rather than let go,
+            // so the board stops where it stands instead of carrying the movement on.
+            const cancelled = event.type === "pointercancel";
+            if (!cancelled && Math.abs(velocity) > MIN_VELOCITY) {
                 glide();
             }
         };

--- a/apps/client/src/widgets/react/hooks.spec.tsx
+++ b/apps/client/src/widgets/react/hooks.spec.tsx
@@ -4,7 +4,8 @@ import { useRef } from "preact/hooks";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type DelayedVisibilityPhase, useDelayedVisibility, useImperativeSearchHighlighlighting, useStaticTooltip, useTooltip } from "./hooks";
+import { buildNote } from "../../test/easy-froca";
+import { type DelayedVisibilityPhase, useDelayedVisibility, useImperativeSearchHighlighlighting, useNoteLabelBoolean, useStaticTooltip, useTooltip } from "./hooks";
 
 /**
  * mark.js delegating to the real implementation, so marking still works, while recording the calls
@@ -465,5 +466,40 @@ describe("useImperativeSearchHighlighlighting", () => {
         expect(target.querySelectorAll(".ck-find-result").length).toBe(0);
         expect(target.querySelector("details")?.open).toBe(false);
         target.remove();
+    });
+});
+
+describe("useNoteLabelBoolean", () => {
+    let container: HTMLElement | undefined;
+
+    afterEach(() => {
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    /**
+     * The render that mounts a consumer has already read the label, so forcing another one after it
+     * draws everything twice for a value that has not changed. A board draws this once a card.
+     */
+    it("draws a consumer once for a label that has not changed", async () => {
+        const note = buildNote({ title: "Card", "#archived": "true" });
+        const draws: boolean[] = [];
+
+        function Consumer() {
+            const [ archived ] = useNoteLabelBoolean(note, "archived");
+            draws.push(archived);
+            return <span>{String(archived)}</span>;
+        }
+
+        container = document.body.appendChild(document.createElement("div"));
+        await act(async () => {
+            render(<Consumer />, container as HTMLElement);
+            await new Promise((resolve) => setTimeout(resolve));
+        });
+
+        expect(draws).toEqual([ true ]);
     });
 });

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -738,8 +738,15 @@ export function useNoteLabelWithDefault(note: FNote | undefined | null, labelNam
 export function useNoteLabelBoolean(note: FNote | undefined | null, labelName: FilterLabelsByType<boolean>): [ boolean, (newValue: boolean) => void] {
     const [, forceRender] = useState({});
 
+    // Not on the first run: the render that mounted the component has already read the label, so
+    // forcing another draws every consumer twice for a value that has not changed. 72 components
+    // use this hook, and a board draws it once a card.
+    const seenNote = useRef<FNote | undefined | null>(undefined);
     useEffect(() => {
-        forceRender({});
+        if (seenNote.current !== undefined) {
+            forceRender({});
+        }
+        seenNote.current = note;
     }, [ note ]);
 
     useTriliumEvent("entitiesReloaded", ({ loadResults }) => {

--- a/apps/client/src/widgets/react/hooks.tsx
+++ b/apps/client/src/widgets/react/hooks.tsx
@@ -1367,6 +1367,26 @@ export function useContextualShortcutHints(hints: ShortcutHintDefinition | (() =
     useDebugValue("contextual-shortcut-hints");
 }
 
+/**
+ * The element a ref points at, as state, so an effect keyed on it runs once the element is there.
+ *
+ * Filling a ref triggers no render, so an effect that reads `ref.current` in its dependencies never
+ * hears the element arrive. Containers drawn only once their content has loaded are the ordinary
+ * case for that.
+ */
+export function useTrackedElement<T extends HTMLElement>(ref: RefObject<T>): T | null {
+    const [ element, setElement ] = useState<T | null>(null);
+
+    // Every render, and set only where it changed, so this settles in one further pass.
+    useLayoutEffect(() => {
+        if (ref.current !== element) {
+            setElement(ref.current);
+        }
+    });
+
+    return element;
+}
+
 export function useSyncedRef<T>(externalRef?: Ref<T>, initialValue: T | null = null): RefObject<T> {
     const ref = useRef<T>(initialValue);
 

--- a/apps/client/src/widgets/react/scroll_fade.css
+++ b/apps/client/src/widgets/react/scroll_fade.css
@@ -1,0 +1,59 @@
+/*
+ * A custom property only animates once it is registered with a type, so both ends are declared as
+ * lengths for the transition below to interpolate. Where `@property` is unsupported the fades snap,
+ * and the `var()` fallbacks in the mask stand in for the initial values.
+ */
+@property --scroll-fade-start {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+}
+
+@property --scroll-fade-end {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 0px;
+}
+
+/*
+ * Fades whichever edge a scroll container continues past, so what is cut off reads as going on
+ * rather than as ending.
+ *
+ * A mask rather than a painted gradient: it holds over any background, including a semi-transparent
+ * tint over a window material, which no painted color could match.
+ */
+.scroll-fade {
+    mask-image: linear-gradient(
+        var(--scroll-fade-direction, to bottom),
+        transparent,
+        black var(--scroll-fade-start, 0px),
+        black calc(100% - var(--scroll-fade-end, 0px)),
+        transparent
+    );
+    transition:
+        --scroll-fade-start var(--scroll-fade-duration, 300ms) ease,
+        --scroll-fade-end var(--scroll-fade-duration, 300ms) ease;
+}
+
+/* A gradient can only be given a physical direction, and the ends swap in a right-to-left page. */
+.scroll-fade-horizontal {
+    --scroll-fade-direction: to right;
+}
+
+body[dir=rtl] .scroll-fade-horizontal {
+    --scroll-fade-direction: to left;
+}
+
+.scroll-fade-start {
+    --scroll-fade-start: var(--scroll-fade-size, 20px);
+}
+
+.scroll-fade-end {
+    --scroll-fade-end: var(--scroll-fade-size, 20px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .scroll-fade {
+        transition: none;
+    }
+}

--- a/apps/client/src/widgets/react/scroll_fade.spec.tsx
+++ b/apps/client/src/widgets/react/scroll_fade.spec.tsx
@@ -1,0 +1,169 @@
+import { render } from "preact";
+import { useRef, useState } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScrollFadeOptions, useScrollFade } from "./scroll_fade";
+
+describe("useScrollFade", () => {
+    let container: HTMLElement | undefined;
+
+    // happy-dom lays nothing out, so every element reports what the test declares. Declared on the
+    // prototype rather than on one element, since the hook measures as soon as its container is
+    // drawn, which is before a test can reach it.
+    let content = 1000;
+    let travelled = 0;
+    const originals = new Map<string, PropertyDescriptor | undefined>();
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        content = 1000;
+        travelled = 0;
+
+        const sizes: Record<string, () => number> = {
+            scrollHeight: () => content,
+            clientHeight: () => 200,
+            scrollWidth: () => content,
+            clientWidth: () => 200,
+            scrollTop: () => travelled,
+            scrollLeft: () => travelled
+        };
+        for (const [ name, get ] of Object.entries(sizes)) {
+            originals.set(name, Object.getOwnPropertyDescriptor(HTMLElement.prototype, name));
+            Object.defineProperty(HTMLElement.prototype, name, { configurable: true, get });
+        }
+    });
+
+    afterEach(() => {
+        for (const [ name, descriptor ] of originals) {
+            if (descriptor) {
+                Object.defineProperty(HTMLElement.prototype, name, descriptor);
+            } else {
+                delete (HTMLElement.prototype as unknown as Record<string, unknown>)[name];
+            }
+        }
+        originals.clear();
+        vi.useRealTimers();
+
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    it("fades the end alone while the content is scrolled to the start", () => {
+        const scroller = setup();
+
+        expect(scroller.className).toContain("scroll-fade-end");
+        expect(scroller.className).not.toContain("scroll-fade-start");
+    });
+
+    it("fades both ends once the content is scrolled between them", () => {
+        const scroller = setup();
+
+        scrollTo(scroller, 400);
+
+        expect(scroller.className).toContain("scroll-fade-start");
+        expect(scroller.className).toContain("scroll-fade-end");
+    });
+
+    it("fades the start alone once the content is scrolled to the end", () => {
+        const scroller = setup();
+
+        scrollTo(scroller, 800);
+
+        expect(scroller.className).toContain("scroll-fade-start");
+        expect(scroller.className).not.toContain("scroll-fade-end");
+    });
+
+    it("fades neither end while the content fits", () => {
+        const scroller = setup({ contentSize: 150 });
+
+        expect(scroller.className).not.toContain("scroll-fade-start");
+        expect(scroller.className).not.toContain("scroll-fade-end");
+    });
+
+    /** Cards arrive and leave without the box changing size, which no resize reports. */
+    it("measures again when the content changes", async () => {
+        const scroller = setup({ contentSize: 150 });
+        expect(scroller.className).not.toContain("scroll-fade-end");
+
+        content = 1000;
+        await act(async () => {
+            scroller.appendChild(document.createElement("div"));
+            // The observer delivers on a microtask, and only then is the frame asked for.
+            await Promise.resolve();
+            vi.advanceTimersByTime(20);
+        });
+
+        expect(scroller.className).toContain("scroll-fade-end");
+    });
+
+    it("names the axis it was given, and carries the size and duration into CSS", () => {
+        const scroller = setup({ options: { direction: "horizontal", size: 32, duration: 120 } });
+
+        expect(scroller.className).toContain("scroll-fade-horizontal");
+        expect(scroller.getAttribute("style")).toContain("--scroll-fade-size: 32px");
+        expect(scroller.getAttribute("style")).toContain("--scroll-fade-duration: 120ms");
+    });
+
+    it("leaves the size and duration to CSS when it is given neither", () => {
+        const scroller = setup();
+
+        expect(scroller.getAttribute("style") ?? "").not.toContain("--scroll-fade-size");
+        expect(scroller.className).toContain("scroll-fade-vertical");
+    });
+
+    /** Columns draw their card area only once open, so the element is not there on the first render. */
+    it("picks up a container that is drawn after the first render", () => {
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        let show: (ready: boolean) => void = () => {};
+
+        function Harness() {
+            const [ ready, setReady ] = useState(false);
+            const ref = useRef<HTMLDivElement>(null);
+            const { className } = useScrollFade(ref);
+            show = setReady;
+
+            return ready ? <div ref={ref} className={className} /> : <span />;
+        }
+
+        act(() => { render(<Harness />, mountPoint); });
+        act(() => { show(true); });
+
+        expect((mountPoint.firstElementChild as HTMLElement).className)
+            .toContain("scroll-fade-end");
+    });
+
+    function setup({ contentSize, options }: {
+        contentSize?: number,
+        options?: ScrollFadeOptions
+    } = {}) {
+        if (contentSize !== undefined) content = contentSize;
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        function Harness() {
+            const ref = useRef<HTMLDivElement>(null);
+            const { className, style } = useScrollFade(ref, options);
+            return <div ref={ref} className={className} style={style} />;
+        }
+
+        act(() => { render(<Harness />, mountPoint); });
+        return mountPoint.firstElementChild as HTMLElement;
+    }
+
+    function scrollTo(scroller: HTMLElement, offset: number) {
+        travelled = offset;
+        act(() => {
+            scroller.dispatchEvent(new Event("scroll"));
+            vi.advanceTimersByTime(20);
+        });
+    }
+});

--- a/apps/client/src/widgets/react/scroll_fade.ts
+++ b/apps/client/src/widgets/react/scroll_fade.ts
@@ -3,7 +3,9 @@ import "./scroll_fade.css";
 import clsx from "clsx";
 import { RefObject } from "preact";
 import { CSSProperties } from "preact/compat";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+
+import { useTrackedElement } from "./hooks";
 
 /** Fractional scroll offsets are reported at sub-pixel precision, so an edge is never tested exactly. */
 const EDGE_EPSILON = 1;
@@ -41,13 +43,7 @@ export function useScrollFade(ref: RefObject<HTMLElement>, options: ScrollFadeOp
     const [ overflow, setOverflow ] = useState(0);
     const frameRef = useRef<number>();
 
-    // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
-    const [ element, setElement ] = useState<HTMLElement | null>(null);
-    useLayoutEffect(() => {
-        if (ref.current !== element) {
-            setElement(ref.current);
-        }
-    });
+    const element = useTrackedElement(ref);
 
     const measure = useCallback(() => {
         if (!element) return;

--- a/apps/client/src/widgets/react/scroll_fade.ts
+++ b/apps/client/src/widgets/react/scroll_fade.ts
@@ -1,0 +1,120 @@
+import "./scroll_fade.css";
+
+import clsx from "clsx";
+import { RefObject } from "preact";
+import { CSSProperties } from "preact/compat";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
+
+/** Fractional scroll offsets are reported at sub-pixel precision, so an edge is never tested exactly. */
+const EDGE_EPSILON = 1;
+
+export interface ScrollFadeOptions {
+    /** Which way the container scrolls. */
+    direction?: "horizontal" | "vertical";
+    /** How far the fade reaches from each edge, in pixels. */
+    size?: number;
+    /** How long a fade takes to arrive and to leave, in milliseconds. */
+    duration?: number;
+}
+
+export interface ScrollFade {
+    /** Goes on the scroll container, alongside whatever else it wears. */
+    className: string;
+    /** Carries the size and duration, which CSS reads as lengths and times. */
+    style: CSSProperties;
+    /** How much of the content lies outside the box, along the scrolling axis. */
+    overflow: number;
+    /** Re-measures, for content that changes without the DOM or the box saying so. */
+    measure: () => void;
+}
+
+/**
+ * Fades the edges a scroll container continues past, so the reader can tell there is more without
+ * reading the scrollbar.
+ *
+ * @param ref the scroll container.
+ * @param options which way it scrolls, how far each fade reaches and how long it takes.
+ */
+export function useScrollFade(ref: RefObject<HTMLElement>, options: ScrollFadeOptions = {}): ScrollFade {
+    const { direction = "vertical", size, duration } = options;
+    const [ fades, setFades ] = useState({ start: false, end: false });
+    const [ overflow, setOverflow ] = useState(0);
+    const frameRef = useRef<number>();
+
+    // A ref holds no render of its own, so an effect keyed on one never hears the element arrive.
+    const [ element, setElement ] = useState<HTMLElement | null>(null);
+    useLayoutEffect(() => {
+        if (ref.current !== element) {
+            setElement(ref.current);
+        }
+    });
+
+    const measure = useCallback(() => {
+        if (!element) return;
+
+        const horizontal = direction === "horizontal";
+        // Read as a distance travelled rather than as a coordinate: a right-to-left page scrolls the
+        // same content towards negative offsets, and both ends ask the same question either way.
+        const travelled = Math.abs(horizontal ? element.scrollLeft : element.scrollTop);
+        const total = horizontal
+            ? element.scrollWidth - element.clientWidth
+            : element.scrollHeight - element.clientHeight;
+
+        setOverflow(total);
+        setFades((current) => {
+            const next = {
+                start: travelled > EDGE_EPSILON,
+                end: travelled < total - EDGE_EPSILON
+            };
+            return current.start === next.start && current.end === next.end ? current : next;
+        });
+    }, [ element, direction ]);
+
+    useEffect(() => {
+        if (!element) return;
+
+        // Coalesced: a batch of cards arriving fires the observer once per change, and each
+        // measurement reads a layout the last one just invalidated.
+        const request = () => {
+            if (frameRef.current === undefined) {
+                frameRef.current = requestAnimationFrame(() => {
+                    frameRef.current = undefined;
+                    measure();
+                });
+            }
+        };
+
+        measure();
+
+        // The box is resized by everything from a window to a pane being dragged; the content grows
+        // and shrinks without either, which no resize reports.
+        const resize = new ResizeObserver(request);
+        resize.observe(element);
+        const mutations = new MutationObserver(request);
+        mutations.observe(element, { childList: true, subtree: true, characterData: true });
+        element.addEventListener("scroll", request, { passive: true });
+
+        return () => {
+            resize.disconnect();
+            mutations.disconnect();
+            element.removeEventListener("scroll", request);
+            if (frameRef.current !== undefined) {
+                cancelAnimationFrame(frameRef.current);
+                frameRef.current = undefined;
+            }
+        };
+    }, [ element, measure ]);
+
+    return {
+        className: clsx("scroll-fade", `scroll-fade-${direction}`, {
+            "scroll-fade-start": fades.start,
+            "scroll-fade-end": fades.end
+        }),
+        style: {
+            ...(size !== undefined && { "--scroll-fade-size": `${size}px` }),
+            ...(duration !== undefined && { "--scroll-fade-duration": `${duration}ms` })
+        } as CSSProperties,
+        overflow,
+        measure
+    };
+}

--- a/apps/client/src/widgets/react/scroll_fade.ts
+++ b/apps/client/src/widgets/react/scroll_fade.ts
@@ -73,8 +73,9 @@ export function useScrollFade(ref: RefObject<HTMLElement>, options: ScrollFadeOp
     useEffect(() => {
         if (!element) return;
 
-        // Coalesced: a batch of cards arriving fires the observer once per change, and each
-        // measurement reads a layout the last one just invalidated.
+        // Coalesced, for the observers alone: a batch of cards arriving fires one per change, and
+        // each measurement reads a layout the last one just invalidated. A scroll is measured as it
+        // happens, so the fade keeps up with the finger rather than trailing it by a frame.
         const request = () => {
             if (frameRef.current === undefined) {
                 frameRef.current = requestAnimationFrame(() => {
@@ -92,12 +93,12 @@ export function useScrollFade(ref: RefObject<HTMLElement>, options: ScrollFadeOp
         resize.observe(element);
         const mutations = new MutationObserver(request);
         mutations.observe(element, { childList: true, subtree: true, characterData: true });
-        element.addEventListener("scroll", request, { passive: true });
+        element.addEventListener("scroll", measure, { passive: true });
 
         return () => {
             resize.disconnect();
             mutations.disconnect();
-            element.removeEventListener("scroll", request);
+            element.removeEventListener("scroll", measure);
             if (frameRef.current !== undefined) {
                 cancelAnimationFrame(frameRef.current);
                 frameRef.current = undefined;

--- a/apps/client/vite.config.mts
+++ b/apps/client/vite.config.mts
@@ -13,9 +13,11 @@ const isDev = process.env.NODE_ENV === "development";
 let plugins: any = [];
 
 if (isDev) {
-    // Add Prefresh for Preact HMR in development
     plugins = [
-        prefresh(),
+        // Prefresh keeps a growing list of vnodes per component type and scans it on every diff, so
+        // a view with thousands of instances of one component slows to a stop. Set TRILIUM_NO_HMR to
+        // work on such a view; components then reload with the page instead of in place.
+        ...(process.env.TRILIUM_NO_HMR ? [] : [ prefresh() ]),
         stripUniverHyphenation()
     ];
 } else {


### PR DESCRIPTION
The Kanban board now moves under your finger. Cards and columns are dragged with a gesture built for touch as well as for a mouse, so they can be rearranged on a phone the same way they always could on the desktop, and the board itself can be panned by dragging its background. Adding cards is quicker too: the "New item" button stays pinned at the foot of every column instead of drifting away as the column fills, the editor stays open so a run of cards can be typed one after another, and each new card scrolls into view and fades in where it landed. Large boards are considerably more responsive, since moving one card no longer redraws every other card on the board.

## Drag and drop

- Replace the HTML5 drag and drop for cards and columns with a pointer-driven gesture, so both can be moved on a touch screen.
- Take hold on touch after the finger has rested for 400ms, so a swipe still scrolls the column it started in.
- Take hold with a mouse after 4px of movement, so a click still opens the card.
- Carry a copy of what is dragged, positioned against the window, so it is not clipped by the column or the board it is carried past.
- Draw the drop placeholder in the card's own place from the moment the drag starts, rather than only after the first movement.
- Draw the drop placeholder past the last column, which never appeared before even though the drop itself landed correctly.
- Ignore the carried copy when measuring the board, and re-measure only for card drags, so the places offered match the columns the board is showing.
- Size the drop placeholder to the carried card's own height and gap, so nothing shifts as it opens.
- Scroll the board sideways and the column vertically when the pointer nears an edge.
- Expand a collapsed column after the pointer has rested on it for 500ms, and leave it open for the rest of the drag.
- Cancel a drag with Escape.
- Cap a carried column's height at 150px instead of forcing it, so a short column keeps the height it has.
- Shrink a carried card to 90% and draw it at 85% opacity.
- Keep the focus outline on the carried copy, and put focus back on the card once it is dropped.
- Carry the tint of the column a card came from, which the drag layer would otherwise leave behind.
- Take the new-item footer and the edit icon out of the carried copy, since nothing on it can be used.
- Open the context menu on a tap, and refuse the compatibility mouse events the browser makes from it.
- Suppress the long-press context menu once a touch drag has begun.
- Suspend scroll snapping and smooth scrolling on mobile while a drag is in progress.
- Contain overscroll on the board and on every column, and suppress the bounce entirely while dragging.
- Draw a dropped card in its new place immediately rather than waiting for the writes to land.
- Bring the target column into view on mobile after a card is dropped into it.

## Creating cards

- Pin the "New item" button to the bottom of the column, outside the scrolling area, so it no longer has to be scrolled to.
- Keep the editor open and focused after Enter, cleared and ready for the next card.
- Focus the editor within the press that opened it, so a phone's keyboard opens straight away.
- Give up what was typed when the editor loses focus instead of creating a card from it, and offer it again the next time the editor is opened.
- Scroll a created card into view and fade it in over 500ms, once per card.
- Take the column to its end for a card added at the end, so it lands clear of the fade over the column's bottom edge.
- Leave a card inserted above or below another one focused once its title editor closes.
- Return focus from a card's editor to that card, rather than to whatever was focused before it opened.
- Write the grouping label together with the note, halving the requests and the board refreshes an insert costs.
- Match the height of the "+ New item" button to the editor it opens into.

## Performance

- Keep one board API object per board, updated in place, so a refresh redraws only the cards whose own props changed.
- Hold back refreshes for a board in a background tab, and catch up once it is shown again.
- Stop `useNoteLabelBoolean` forcing a second render on mount, which drew every one of its 72 consumers twice.
- Subscribe cards to their `color` label, which they previously picked up only because every refresh redrew them.

## Panning and scroll fades

- Pan the board sideways by dragging its background with the mouse, with inertia after the pointer is released.
- Add a reusable scroll fade for containers that scroll on either axis, and apply it to each column's cards.
- Rebuild `ScrollableLabel` on the shared scroll fade instead of its own copy of the same logic.
- Add `useTrackedElement`, which reports a ref's element as state so an effect can wait for it to arrive.
- Use the pointer cursor over cards, the move cursor while one is being dragged, and grab cursors over the board's background.

## Layout fixes

- Space cards and drop placeholders below only, so a placeholder above the first card no longer pushes the column down by a margin.
- Read the placeholder's gap at the card's font size, so the two agree to the pixel.
- Remove the column body's bottom padding, leaving the last card's own gap before the footer.
- Keep the new-item footer's spacing and size steady when its editor opens.

## Development

- Allow Preact fast refresh to be turned off with `TRILIUM_NO_HMR`, since its per-component vnode registry stalls a view holding thousands of instances of one component.
