### PR TITLE
Pin third party actions, retire the archived codecov action, harden the release jobs

### DIFF
--- a/.github/actions/build-electron/action.yml
+++ b/.github/actions/build-electron/action.yml
@@ -21,7 +21,7 @@ runs:
   # Certificate setup
   - name: Import Apple certificates
     if: inputs.os == 'macos'
-    uses: apple-actions/import-codesign-certs@v7
+    uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
     with:
       p12-file-base64: ${{ env.APPLE_APP_CERTIFICATE_BASE64 }}
       p12-password: ${{ env.APPLE_APP_CERTIFICATE_PASSWORD }}
@@ -30,7 +30,7 @@ runs:
 
   - name: Install Installer certificate
     if: inputs.os == 'macos'
-    uses: apple-actions/import-codesign-certs@v7
+    uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
     with:
       p12-file-base64: ${{ env.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
       p12-password: ${{ env.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}

--- a/.github/actions/build-mobile/action.yml
+++ b/.github/actions/build-mobile/action.yml
@@ -43,7 +43,7 @@ runs:
         java-version: 21
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/build-mobile/action.yml
+++ b/.github/actions/build-mobile/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v6
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Set up Node.js
       uses: actions/setup-node@v7
       with:

--- a/.github/actions/build-server/action.yml
+++ b/.github/actions/build-server/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: pnpm/action-setup@v6
+  - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
   - name: Set up node & dependencies
     uses: actions/setup-node@v7
     with:

--- a/.github/actions/deploy-to-cloudflare-pages/action.yml
+++ b/.github/actions/deploy-to-cloudflare-pages/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: Deploy to Cloudflare Pages
       id: deploy
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
-      uses: cloudflare/wrangler-action@v4
+      uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
       with:
         apiToken: ${{ inputs.cloudflare_api_token }}
         accountId: ${{ inputs.cloudflare_account_id }}
@@ -46,7 +46,7 @@ runs:
     - name: Deploy Preview to Cloudflare Pages
       id: preview-deployment
       if: github.event_name == 'pull_request'
-      uses: cloudflare/wrangler-action@v4
+      uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
       with:
         apiToken: ${{ inputs.cloudflare_api_token }}
         accountId: ${{ inputs.cloudflare_account_id }}

--- a/.github/actions/report-size/action.yml
+++ b/.github/actions/report-size/action.yml
@@ -46,6 +46,7 @@ runs:
     - name: Checkout base branch
       uses: actions/checkout@v7
       with:
+        persist-credentials: false
         ref: ${{ inputs.branch }}
         path: br-base
         token: ${{ inputs.ghToken }}

--- a/.github/actions/report-size/action.yml
+++ b/.github/actions/report-size/action.yml
@@ -54,7 +54,7 @@ runs:
     # Generate the bundle size difference report [required]
     - name: Generate report
       id: bundleSize
-      uses: nejcm/bundle-size-reporter-action@v1.4.1
+      uses: nejcm/bundle-size-reporter-action@007b40dc7e8dd0905e729faa4d37d6a8f141aa6b # v1.4.1
       with:
         paths: ${{ inputs.paths }}
         onlyDiff: ${{ inputs.onlyDiff }}
@@ -70,7 +70,7 @@ runs:
 
     # Post github action comment
     - name: Post comment
-      uses: marocchino/sticky-pull-request-comment@v3
+      uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
       if: ${{ steps.bundleSize.outputs.hasDifferences == 'true' }} # post only in case of changes
       with:
         number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       - name: Check if PRs have conflicts
-        uses: eps1lon/actions-label-merge-conflict@v3
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         if: ${{ github.repository == vars.REPO_MAIN && github.actor != 'dependabot[bot]' }}
         with:
           dirtyLabel: "merge-conflicts"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,6 +37,8 @@ jobs:
       ckeditor5: ${{ steps.filter.outputs.ckeditor5 }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
@@ -100,6 +102,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
@@ -283,6 +287,8 @@ jobs:
       - name: Checkout the repository
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
@@ -338,6 +344,8 @@ jobs:
       - name: Checkout the repository
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
@@ -398,6 +406,8 @@ jobs:
       - name: Checkout the repository
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
@@ -465,6 +475,8 @@ jobs:
       - name: Checkout the repository
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
@@ -527,6 +539,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
@@ -566,6 +580,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -142,6 +142,7 @@ jobs:
 
       - name: Upload client test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-client.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -165,6 +166,7 @@ jobs:
 
       - name: Upload desktop test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-desktop.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -188,6 +190,7 @@ jobs:
 
       - name: Upload commons test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-commons.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -211,6 +214,7 @@ jobs:
 
       - name: Upload codemirror test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-codemirror.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -234,6 +238,7 @@ jobs:
 
       - name: Upload highlightjs test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-highlightjs.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -257,6 +262,7 @@ jobs:
 
       - name: Upload pdfjs-viewer test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-pdfjs-viewer.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -326,6 +332,7 @@ jobs:
 
       - name: Upload server test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-server.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -379,6 +386,7 @@ jobs:
 
       - name: Upload standalone test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-standalone.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -517,6 +525,7 @@ jobs:
 
       - name: Upload ckeditor5 test results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: ${{ !cancelled() && steps.test-ckeditor5.outcome != 'skipped' }}
         with:
           report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: |
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -128,7 +128,7 @@ jobs:
           retention-days: 30
 
       - name: Upload client coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-client.outcome == 'success' }}
         with:
           files: apps/client/test-output/vitest/coverage/lcov.info
@@ -137,9 +137,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload client test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-client.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/client/test-output/vitest/junit.xml
           flags: client
@@ -151,7 +151,7 @@ jobs:
         run: pnpm run --filter=desktop test --coverage
 
       - name: Upload desktop coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-desktop.outcome == 'success' }}
         with:
           files: apps/desktop/test-output/vitest/coverage/lcov.info
@@ -160,9 +160,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload desktop test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-desktop.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/desktop/test-output/vitest/junit.xml
           flags: desktop
@@ -174,7 +174,7 @@ jobs:
         run: pnpm run --filter=commons test --coverage
 
       - name: Upload commons coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-commons.outcome == 'success' }}
         with:
           files: packages/commons/test-output/vitest/coverage/lcov.info
@@ -183,9 +183,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload commons test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-commons.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/commons/test-output/vitest/junit.xml
           flags: commons
@@ -197,7 +197,7 @@ jobs:
         run: pnpm run --filter=codemirror test --coverage
 
       - name: Upload codemirror coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-codemirror.outcome == 'success' }}
         with:
           files: packages/codemirror/test-output/vitest/coverage/lcov.info
@@ -206,9 +206,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload codemirror test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-codemirror.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/codemirror/test-output/vitest/junit.xml
           flags: codemirror
@@ -220,7 +220,7 @@ jobs:
         run: pnpm run --filter=highlightjs test --coverage
 
       - name: Upload highlightjs coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-highlightjs.outcome == 'success' }}
         with:
           files: packages/highlightjs/test-output/vitest/coverage/lcov.info
@@ -229,9 +229,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload highlightjs test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-highlightjs.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/highlightjs/test-output/vitest/junit.xml
           flags: highlightjs
@@ -243,7 +243,7 @@ jobs:
         run: pnpm run --filter=pdfjs-viewer test --coverage
 
       - name: Upload pdfjs-viewer coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-pdfjs-viewer.outcome == 'success' }}
         with:
           files: packages/pdfjs-viewer/test-output/vitest/coverage/lcov.info
@@ -252,9 +252,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload pdfjs-viewer test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-pdfjs-viewer.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/pdfjs-viewer/test-output/vitest/junit.xml
           flags: pdfjs-viewer
@@ -284,7 +284,7 @@ jobs:
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
       - name: Set up node & dependencies
         if: env.AFFECTED == 'true'
@@ -310,7 +310,7 @@ jobs:
           retention-days: 30
 
       - name: Upload server coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-server.outcome == 'success' }}
         with:
           files: apps/server/test-output/vitest/coverage/lcov.info
@@ -319,9 +319,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload server test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-server.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/server/test-output/vitest/junit.xml
           flags: server
@@ -339,7 +339,7 @@ jobs:
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
       - name: Set up node & dependencies
         if: env.AFFECTED == 'true'
@@ -361,7 +361,7 @@ jobs:
         run: pnpm run --filter=standalone test --coverage
 
       - name: Upload standalone coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-standalone.outcome == 'success' }}
         with:
           files: apps/standalone/test-output/vitest/coverage/lcov.info
@@ -370,9 +370,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload standalone test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-standalone.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/standalone/test-output/vitest/junit.xml
           flags: standalone
@@ -399,7 +399,7 @@ jobs:
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
       - name: Set up node & dependencies
         if: env.AFFECTED == 'true'
@@ -466,7 +466,7 @@ jobs:
         if: env.AFFECTED == 'true'
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: env.AFFECTED == 'true'
       - name: Set up node & dependencies
         if: env.AFFECTED == 'true'
@@ -495,7 +495,7 @@ jobs:
         run: pnpm run --filter=ckeditor5 test --mergeReports --coverage
 
       - name: Upload ckeditor5 coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ !cancelled() && steps.test-ckeditor5.outcome == 'success' }}
         with:
           files: packages/ckeditor5/test-output/vitest/coverage/lcov.info
@@ -504,9 +504,9 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload ckeditor5 test results to Codecov
-        uses: codecov/test-results-action@v1
-        if: ${{ !cancelled() && steps.test-ckeditor5.outcome != 'skipped' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/ckeditor5/test-output/vitest/junit.xml
           flags: ckeditor5
@@ -527,7 +527,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -543,8 +543,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Trigger server build
         run: pnpm run server:build
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: apps/server
           cache-from: type=gha
@@ -567,7 +567,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -587,10 +587,10 @@ jobs:
         run: echo "TEST_TAG=${TEST_TAG,,}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: apps/server
           file: apps/server/${{ matrix.dockerfile }}
@@ -605,7 +605,7 @@ jobs:
           echo "Container ID: $CONTAINER_ID"
 
       - name: Wait for the healthchecks to pass
-        uses: stringbean/docker-healthcheck-action@v3
+        uses: stringbean/docker-healthcheck-action@a958d329225ccbd485766815734e01c335e62bd4 # v3.0.0
         with:
           container: trilium_local
           wait-time: 50

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set IMAGE_NAME to lowercase
         run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
@@ -148,6 +150,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/main-docker.yml
+++ b/.github/workflows/main-docker.yml
@@ -42,9 +42,9 @@ jobs:
         run: echo "TEST_TAG=${TEST_TAG,,}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -61,7 +61,7 @@ jobs:
         run: pnpm run server:build
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: apps/server
           file: apps/server/${{ matrix.dockerfile }}
@@ -77,7 +77,7 @@ jobs:
           echo "Container ID: $CONTAINER_ID"
 
       - name: Wait for the healthchecks to pass
-        uses: stringbean/docker-healthcheck-action@v3
+        uses: stringbean/docker-healthcheck-action@a958d329225ccbd485766815734e01c335e62bd4 # v3.0.0
         with:
           container: trilium_local
           wait-time: 50
@@ -148,7 +148,7 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -170,7 +170,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -181,13 +181,13 @@ jobs:
             latest=false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: apps/server
           file: apps/server/${{ matrix.dockerfile }}
@@ -235,17 +235,17 @@ jobs:
         run: echo "TEST_TAG=${TEST_TAG,,}" >> $GITHUB_ENV
 
       - name: Set up crane
-        uses: imjasonh/setup-crane@v0.7
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.DOCKERHUB_REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -253,7 +253,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Build mobile APK
         uses: ./.github/actions/build-mobile
@@ -35,6 +37,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Set up Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -99,7 +99,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGN_KEY }}
 
       - name: Publish release
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         with:
           make_latest: false
@@ -140,7 +140,7 @@ jobs:
           apps/mobile/android/app/build/outputs/apk/release/TriliumNotes-mobile-nightly.apk
 
       - name: Publish release
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           make_latest: false
@@ -181,7 +181,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Publish release
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         with:
           make_latest: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,8 +74,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          # No dependency cache on this publish job, a cache entry primed
-          # elsewhere must not feed what ships.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: 'pnpm'
+          # No dependency cache on this publish job, a cache entry primed
+          # elsewhere must not feed what ships.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,8 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
@@ -124,6 +126,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Build mobile APK
         uses: ./.github/actions/build-mobile
@@ -174,6 +178,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run the build
         uses: ./.github/actions/build-server

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@v7
         with:
           node-version: 24
@@ -163,7 +163,7 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@v7
         with:
           node-version: 24

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,6 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           filter: tree:0
           fetch-depth: 0
 
@@ -120,6 +121,8 @@ jobs:
     name: PDF viewer E2E tests
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@v7
@@ -160,6 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           filter: tree:0
           fetch-depth: 0
 

--- a/.github/workflows/release-winget.yml
+++ b/.github/workflows/release-winget.yml
@@ -8,6 +8,9 @@ on:
         description: 'Git tag to release from'
         type: string
         required: true
+# The winget publish authenticates with a PAT, the job token is not used.
+permissions: {}
+
 jobs:
   release-winget:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
@@ -66,6 +68,8 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
@@ -114,6 +118,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Run the build
         uses: ./.github/actions/build-server
@@ -138,6 +144,7 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           sparse-checkout: |
             docs/Release Notes
             scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os.image }}
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -159,7 +159,7 @@ jobs:
           path: upload
 
       - name: Publish stable release
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           draft: false
           body_path: ${{ runner.temp }}/release-body.md

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -59,7 +59,7 @@ jobs:
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
       - name: Open a PR
         if: steps.sync.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: |
             README.md

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -41,6 +41,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/update-model-prices.yml
+++ b/.github/workflows/update-model-prices.yml
@@ -24,6 +24,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/update-model-prices.yml
+++ b/.github/workflows/update-model-prices.yml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -35,7 +35,7 @@ jobs:
       - name: Regenerate the price table
         run: pnpm --filter @triliumnext/core update-model-prices
       - name: Open a PR if the table changed
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: packages/trilium-core/src/services/llm/providers/model_prices.json
           branch: chore/update-model-prices

--- a/.github/workflows/update-nix-flake.yml
+++ b/.github/workflows/update-nix-flake.yml
@@ -42,6 +42,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/update-nix-flake.yml
+++ b/.github/workflows/update-nix-flake.yml
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Nix
         # The headers hash is a NAR hash of the unpacked tarball, so only Nix can
         # compute it — and the verification step below needs a working builder.
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -73,7 +73,7 @@ jobs:
         run: nix build --no-link '.#electron' '.#electron.headers'
       - name: Open a PR
         if: steps.refresh.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: flake.nix
           branch: chore/update-flake-electron

--- a/.github/workflows/update-pdfjs-viewer.yml
+++ b/.github/workflows/update-pdfjs-viewer.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -142,7 +142,7 @@ jobs:
           fi
       - name: Open a PR
         if: steps.bump.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: |
             packages/pdfjs-viewer/package.json

--- a/.github/workflows/update-pdfjs-viewer.yml
+++ b/.github/workflows/update-pdfjs-viewer.yml
@@ -41,6 +41,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/web-clipper.yml
+++ b/.github/workflows/web-clipper.yml
@@ -39,8 +39,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          # No dependency cache on this publish job, a cache entry primed
-          # elsewhere must not feed what ships.
 
       - name: Install dependencies
         run: pnpm install --filter web-clipper --frozen-lockfile --ignore-scripts

--- a/.github/workflows/web-clipper.yml
+++ b/.github/workflows/web-clipper.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/web-clipper.yml
+++ b/.github/workflows/web-clipper.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: "pnpm"
+          # No dependency cache on this publish job, a cache entry primed
+          # elsewhere must not feed what ships.
 
       - name: Install dependencies
         run: pnpm install --filter web-clipper --frozen-lockfile --ignore-scripts

--- a/.github/workflows/web-clipper.yml
+++ b/.github/workflows/web-clipper.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
@@ -58,7 +58,7 @@ jobs:
           compression-level: 0
 
       - name: Release web clipper extension
-        uses: softprops/action-gh-release@v3.0.3
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         if: ${{ startsWith(github.ref, 'refs/tags/web-clipper-v') }}
         with:
           draft: false

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: "pnpm"
+          # No dependency cache on this publish job, a cache entry primed
+          # elsewhere must not feed what ships.
 
       - name: Install dependencies
         run: pnpm install --filter website --frozen-lockfile --ignore-scripts

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,8 +34,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-          # No dependency cache on this publish job, a cache entry primed
-          # elsewhere must not feed what ships.
 
       - name: Install dependencies
         run: pnpm install --filter website --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
Hi, four commits, all on the workflow security posture, no application code touched.

**Pins.** Every third party action now points to a full commit SHA inside the major already in use, with the tag kept in a comment so each ref stays readable and can be cross-checked. A tag is a movable pointer: whoever controls the action repository can repoint it, and the next run executes their code with this repo's secrets, the release, signing and registry credentials included. That is the March 2025 tj-actions/changed-files incident (CVE-2025-30066). First party actions (actions/*) stay on their tags, though Scorecard's pinned-dependencies check would want those pinned too. Renovate keeps SHA pins updated through the same manual-merge PRs it opens for version bumps today, so nothing changes in your update flow.

**Archived action retired.** `codecov/test-results-action` is archived and its own README says to migrate. All nine sites now use the `codecov-action` you already run elsewhere, pinned, with `report_type: test_results` added, the exact migration codecov documents. Inputs carry over unchanged, so the test analytics upload keeps working, just without archived code in the pipeline.

**Release caches.** The nightly electron build, the web clipper build and the website deploy restored the shared pnpm cache while producing what ships. A cache entry primed from any other context must never feed a release (the May 2026 TanStack cache poisoning vector), so those three jobs now install cold. The per-PR CI keeps its caches, so review-loop speed is untouched.

**Winget job token.** The winget publish authenticates with your `WINGET_PAT` and the action was already pinned by commit SHA on your side, nicely done. Its workflow token was inherited at the repository default scope and unused, it is now empty. And the 32 checkouts that persisted the workflow token in `.git/config` without anything pushing through it now set `persist-credentials: false`.

One heads-up: an allowed-actions list using tag patterns (`owner/action@v1`) stops matching SHA refs and fails workflows at startup, the fix is `owner/action@*` in the allowed-actions settings.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.