### PR TITLE
Board: search / filtering support

### DIFF
--- a/apps/client/src/services/search.spec.ts
+++ b/apps/client/src/services/search.spec.ts
@@ -32,6 +32,18 @@ describe("search service", () => {
         expect(notes.map((n) => n.noteId)).toEqual([noteA.noteId, noteB.noteId]);
     });
 
+    it("searchInSubtree scopes the query to the ancestor and asks for tokens", async () => {
+        const response = { searchResultNoteIds: ["id1"], highlightedTokens: [], error: null };
+        const get = vi.fn(async () => response);
+        server.get = get as typeof server.get;
+
+        const result = await searchService.searchInSubtree("#done & task", "board1");
+
+        expect(get).toHaveBeenCalledWith(
+            `search/${encodeURIComponent("#done & task")}?ancestorNoteId=board1&includeTokens=true`);
+        expect(result).toBe(response);
+    });
+
     it("searchForNotes returns an empty array when no ids match", async () => {
         server.get = vi.fn(async () => []) as typeof server.get;
 

--- a/apps/client/src/services/search.ts
+++ b/apps/client/src/services/search.ts
@@ -1,3 +1,5 @@
+import type { SearchWithTokensResponse } from "@triliumnext/commons";
+
 import server from "./server.js";
 import froca from "./froca.js";
 
@@ -11,7 +13,18 @@ async function searchForNotes(searchString: string) {
     return await froca.getNotes(noteIds);
 }
 
+/**
+ * Runs a search restricted to one subtree and returns the matching note ids together with the
+ * tokens to highlight and any parse error, for filtering a collection down to the matches.
+ */
+async function searchInSubtree(searchString: string, ancestorNoteId: string) {
+    return await server.get<SearchWithTokensResponse>(
+        `search/${encodeURIComponent(searchString)}`
+        + `?ancestorNoteId=${encodeURIComponent(ancestorNoteId)}&includeTokens=true`);
+}
+
 export default {
     searchForNoteIds,
-    searchForNotes
+    searchForNotes,
+    searchInSubtree
 };

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3493,7 +3493,8 @@
       "move_column": "Move the column left / right",
       "move_column_to_edge": "Move the column to the far left / right"
     },
-    "status-alias": "Status"
+    "status-alias": "Status",
+    "filter-placeholder": "Filter board..."
   },
   "dashboard_view": {
     "refresh-widget": "Refresh",
@@ -4195,8 +4196,9 @@
   },
   "collection_filter": {
     "placeholder": "Filter...",
-    "tooltip": "Narrows the collection to the notes matching a search query. Press Enter to apply; clear the box to show everything again.",
+    "tooltip": "Narrows the collection to the notes matching a search query. Press Enter or the search button to apply; clear the box to show everything again.",
     "clear": "Clear the filter",
-    "fetch-error": "The filter could not be run."
+    "fetch-error": "The filter could not be run.",
+    "submit": "Apply the filter"
   }
 }

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3494,7 +3494,8 @@
       "move_column_to_edge": "Move the column to the far left / right"
     },
     "status-alias": "Status",
-    "filter-placeholder": "Filter board..."
+    "filter-placeholder": "Filter board...",
+    "card-outside-filter": "This card is outside of the current filtering scope"
   },
   "dashboard_view": {
     "refresh-widget": "Refresh",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -4192,5 +4192,11 @@
       "invalid-symbol": "the markdown symbol should be one character, excepting \"[\", \" \", \"X\", and \"]\"",
       "duplicate-symbol": "duplicate markdown symbol"
     }
+  },
+  "collection_filter": {
+    "placeholder": "Filter...",
+    "tooltip": "Narrows the collection to the notes matching a search query. Press Enter to apply; clear the box to show everything again.",
+    "clear": "Clear the filter",
+    "fetch-error": "The filter could not be run."
   }
 }

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -4197,7 +4197,6 @@
   },
   "collection_filter": {
     "placeholder": "Filter...",
-    "tooltip": "Narrows the collection to the notes matching a search query. Press Enter or the search button to apply; clear the box to show everything again.",
     "clear": "Clear the filter",
     "fetch-error": "The filter could not be run.",
     "submit": "Apply the filter"

--- a/apps/client/src/widgets/attribute_widgets/UserAttributesList.spec.tsx
+++ b/apps/client/src/widgets/attribute_widgets/UserAttributesList.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from "preact";
+import { ComponentChildren, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -53,6 +53,16 @@ describe("UserAttributesDisplay", () => {
         expect(container.querySelector(".user-attributes")).toBeNull();
     });
 
+    it("draws a caller's badges before the attributes, and without them", () => {
+        draw({ shownAttributes: [ "stage" ], badges: <span className="marker">!</span> });
+        expect([ ...(container.querySelector(".user-attributes")?.children ?? []) ]
+            .map(child => child.className)).toEqual([ "marker", "user-attribute type-label text" ]);
+
+        // The row is what carries a badge, so it stands even where no attribute would raise it.
+        draw({ shownAttributes: [], badges: <span className="marker">!</span> });
+        expect(container.querySelector(".user-attributes .marker")).not.toBeNull();
+    });
+
     /** The values of one attribute belong together wherever the attribute is placed. */
     it("keeps the values of one attribute together", () => {
         const note = noteWith({ tag: [ "red", "green" ], owner: [ "Ada" ] });
@@ -78,8 +88,9 @@ describe("UserAttributesDisplay", () => {
         expect(values()).toEqual([ "Doing", "Ada" ]);
     });
 
-    function draw({ note = NOTE, ignoredAttributes, shownAttributes }: {
-        note?: FNote, ignoredAttributes?: string[], shownAttributes?: string[]
+    function draw({ note = NOTE, ignoredAttributes, shownAttributes, badges }: {
+        note?: FNote, ignoredAttributes?: string[], shownAttributes?: string[],
+        badges?: ComponentChildren
     } = {}) {
         act(() => {
             render(
@@ -87,6 +98,7 @@ describe("UserAttributesDisplay", () => {
                     note={note}
                     ignoredAttributes={ignoredAttributes}
                     shownAttributes={shownAttributes}
+                    badges={badges}
                 />,
                 container);
         });

--- a/apps/client/src/widgets/attribute_widgets/UserAttributesList.tsx
+++ b/apps/client/src/widgets/attribute_widgets/UserAttributesList.tsx
@@ -20,6 +20,8 @@ interface UserAttributesListProps {
      * carrying a definition is drawn, in the order the definitions stand in.
      */
     shownAttributes?: string[];
+    /** Drawn before the attributes, for what a caller marks a note with in the same row. */
+    badges?: ComponentChildren;
 }
 
 interface AttributeWithDefinitions {
@@ -31,11 +33,12 @@ interface AttributeWithDefinitions {
 }
 
 export default function UserAttributesDisplay({
-    note, ignoredAttributes, shownAttributes
+    note, ignoredAttributes, shownAttributes, badges
 }: UserAttributesListProps) {
     const userAttributes = useNoteAttributesWithDefinitions(note, ignoredAttributes, shownAttributes);
-    return userAttributes?.length > 0 && (
+    return (userAttributes?.length > 0 || !!badges) && (
         <div className="user-attributes">
+            {badges}
             {userAttributes?.map(attr => buildUserAttribute(attr))}
         </div>
     );

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -69,7 +69,8 @@ function createApi(
     parentNote?: FNote,
     statusAttribute = "status",
     byColumn: ColumnMap = new Map(),
-    allByColumn?: ColumnMap
+    allByColumn?: ColumnMap,
+    keepNote?: (noteId: string) => void
 ) {
     const board = parentNote ?? buildNote({ title: "Board" });
     const saved: BoardViewData[] = [];
@@ -86,7 +87,8 @@ function createApi(
         (branchId) => editing.push(branchId),
         pending,
         getStatusDefinition(board, statusAttribute),
-        allByColumn
+        allByColumn,
+        keepNote
     );
     return { api, board, saved, editing, pendingRenames: pending.renames };
 }
@@ -621,13 +623,49 @@ describe("BoardApi card operations", () => {
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[0].branch.branchId);
     });
 
-    it("sends a card to the true end of a column a filter narrows", async () => {
+    it("sends a card after the last one drawn in a column a filter narrows", async () => {
         const { api, done, spare } = createBoardWithSpareCard((all) => [ all[0] ]);
 
         await api.moveToColumnEnd(spare.note.noteId, spare.branch.branchId, "Done");
 
         expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[0].branch.branchId);
+    });
+
+    it("sends a card past the cards a filter hides when it draws none of them", async () => {
+        const { api, done, spare } = createBoardWithSpareCard(() => []);
+
+        await api.moveToColumnEnd(spare.note.noteId, spare.branch.branchId, "Done");
+
+        expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
+    });
+
+    /**
+     * A card is rarely made to match the query in force, so one made here is drawn anyway rather
+     * than the board answering an addition by showing nothing at all.
+     */
+    it("reports every card it gains, so a filter does not swallow it", async () => {
+        const kept: string[] = [];
+        const { api } = createApi(
+            {}, [ "Done" ], undefined, "status", new Map(), undefined,
+            (noteId) => kept.push(noteId));
+        vi.mocked(note_create.createNote).mockResolvedValue(
+            { note: { noteId: "made" } } as never);
+
+        await api.createNewItem("Done", "Made now");
+
+        expect(kept).toEqual([ "made" ]);
+    });
+
+    it("makes a card at the head of a column above the first one drawn", async () => {
+        const { api, done } = createBoardWithSpareCard((all) => [ all[1] ]);
+
+        await api.createNewItem("Done", "Newest", "top");
+
+        expect(note_create.createNote).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ target: "before", targetBranchId: done[1].branch.branchId }));
     });
 
     it("reorders within a column, and places past the last card after it", async () => {

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -68,7 +68,8 @@ function createApi(
     columns: string[],
     parentNote?: FNote,
     statusAttribute = "status",
-    byColumn: ColumnMap = new Map()
+    byColumn: ColumnMap = new Map(),
+    allByColumn?: ColumnMap
 ) {
     const board = parentNote ?? buildNote({ title: "Board" });
     const saved: BoardViewData[] = [];
@@ -84,10 +85,61 @@ function createApi(
         (newConfig) => saved.push(newConfig),
         (branchId) => editing.push(branchId),
         pending,
-        getStatusDefinition(board, statusAttribute)
+        getStatusDefinition(board, statusAttribute),
+        allByColumn
     );
     return { api, board, saved, editing, pendingRenames: pending.renames };
 }
+
+describe("BoardApi filtering", () => {
+    /** Cards named by their note id, which is all the operations under test read them for. */
+    function cards(columns: Record<string, string[]>): ColumnMap {
+        return new Map(Object.entries(columns).map(([ column, ids ]) => [
+            column,
+            ids.map((noteId) => ({ note: { noteId }, branch: { branchId: `b_${noteId}` } }))
+        ])) as unknown as ColumnMap;
+    }
+
+    it("stores a submitted filter query and clears it for an empty one", () => {
+        const { api, saved } = createApi({ filterQuery: undefined }, []);
+
+        api.setFilterQuery("#done");
+        expect(saved.at(-1)?.filterQuery).toBe("#done");
+
+        api.setFilterQuery("#done");
+        expect(saved).toHaveLength(1);
+
+        api.setFilterQuery("");
+        expect(saved).toHaveLength(2);
+        expect(saved.at(-1)?.filterQuery).toBeUndefined();
+    });
+
+    it("does not save for a cleared filter that was never set", () => {
+        const { api, saved } = createApi({}, []);
+
+        api.setFilterQuery("");
+        expect(saved).toHaveLength(0);
+    });
+
+    it("removes a column's value from the cards the filter is not showing too", async () => {
+        const { api } = createApi(
+            { columns: [ { value: "To Do" } ] },
+            [ "To Do" ],
+            undefined,
+            "status",
+            cards({ "To Do": [ "visible" ] }),
+            cards({ "To Do": [ "visible", "hidden" ] })
+        );
+
+        await api.removeColumn("To Do");
+
+        expect(executeBulkActions).toHaveBeenCalledWith(
+            [ "visible", "hidden" ],
+            [ { name: "deleteLabel", labelName: "status" } ],
+            { silent: true }
+        );
+    });
+});
 
 describe("BoardApi column mutations", () => {
     /**

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -15,7 +15,7 @@ import ws from "../../../services/ws";
 import { buildNote } from "../../../test/easy-froca";
 import { BoardViewData } from ".";
 import BoardApi, { getPendingWrites, PendingColumnWrites } from "./api";
-import { ColumnMap } from "./data";
+import { ColumnItem, ColumnMap } from "./data";
 import { BOARD_TEMPLATE_ID, DEFAULT_COLUMN_ICON, getStatusDefinition, INBOX_COLUMN } from "./columns";
 import { DEFAULT_CARD_TEMPLATES } from "./card_templates";
 
@@ -554,10 +554,80 @@ describe("BoardApi card operations", () => {
         // The target column is empty, so there is nothing to place it against.
         await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 1, "Done", "To Do");
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+        expect(branches.moveAfterBranch).not.toHaveBeenCalled();
 
         await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 1, "To Do", "Done");
         expect(branches.moveBeforeBranch)
             .toHaveBeenCalledWith([ first.branch.branchId ], items[1].branch.branchId);
+    });
+
+    /** A board whose "Done" column holds three cards, with a fourth waiting in "To Do". */
+    function createBoardWithSpareCard(shownInDone?: (done: ColumnItem[]) => ColumnItem[]) {
+        const board = buildNote({
+            title: "Board",
+            children: [
+                { title: "First", "#status": "Done" },
+                { title: "Second", "#status": "Done" },
+                { title: "Third", "#status": "Done" },
+                { title: "Spare", "#status": "To Do" }
+            ]
+        });
+
+        const items = board.getChildBranches().flatMap(branch => {
+            const note = froca.getNoteFromCache(branch.noteId);
+            return note ? [ { branch, note } ] : [];
+        });
+        const done = items.slice(0, 3);
+        const spare = items[3];
+        const allByColumn: ColumnMap = new Map([ [ "To Do", [ spare ] ], [ "Done", done ] ]);
+        const byColumn: ColumnMap = shownInDone
+            ? new Map([ [ "To Do", [ spare ] ], [ "Done", shownInDone(done) ] ])
+            : allByColumn;
+
+        const created = createApi(
+            {}, [ "To Do", "Done" ], board, "status", byColumn, allByColumn);
+        return { ...created, done, spare };
+    }
+
+    /**
+     * Crossing columns writes a placement too. Left with the tree position it came with, the card
+     * would rank among the target's cards by wherever it happened to sit before the drop.
+     */
+    it("files a card dropped past the last card of another column after it", async () => {
+        const { api, done, spare } = createBoardWithSpareCard();
+
+        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 3, "To Do", "Done");
+
+        expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+        expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
+    });
+
+    it("files a card dropped into a column a filter empties after the cards it hides", async () => {
+        const { api, done, spare } = createBoardWithSpareCard(() => []);
+
+        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 0, "To Do", "Done");
+
+        expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
+    });
+
+    it("files a card dropped past the last card shown after that one, not the hidden", async () => {
+        const { api, done, spare } = createBoardWithSpareCard((all) => [ all[0] ]);
+
+        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 1, "To Do", "Done");
+
+        expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[0].branch.branchId);
+    });
+
+    it("sends a card to the true end of a column a filter narrows", async () => {
+        const { api, done, spare } = createBoardWithSpareCard((all) => [ all[0] ]);
+
+        await api.moveToColumnEnd(spare.note.noteId, spare.branch.branchId, "Done");
+
+        expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
     });
 
     it("reorders within a column, and places past the last card after it", async () => {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -123,7 +123,9 @@ export default class BoardApi {
          * Every card, when `byColumn` is narrowed by a filter. Bulk operations read this one, so a
          * column operation reaches the cards the filter leaves out too.
          */
-        private allByColumn?: ColumnMap
+        private allByColumn?: ColumnMap,
+        /** Draws a card the active filter does not match. See {@link keepInView}. */
+        private keepNote?: (noteId: string) => void
     ) {
         this.viewConfigSource = viewConfig;
         this.viewConfig = viewConfig ?? {};
@@ -150,7 +152,8 @@ export default class BoardApi {
         saveConfig: (newConfig: BoardViewData) => void,
         setBranchIdToEdit: (branchId: string | undefined) => void,
         statusDefinition?: BoardStatusDefinition,
-        allByColumn?: ColumnMap
+        allByColumn?: ColumnMap,
+        keepNote?: (noteId: string) => void
     ) {
         // What was sent to the end of a column stands in for what the map does not show yet, so it
         // is given up with the map it stands in for. Kept across a refresh, it would name a branch
@@ -161,6 +164,7 @@ export default class BoardApi {
 
         this.byColumn = byColumn;
         this.allByColumn = allByColumn;
+        this.keepNote = keepNote;
         this.columns = columns;
         this.parentNote = parentNote;
         // Only a config the board has actually replaced, since `storeColumns` moves this one ahead
@@ -187,9 +191,7 @@ export default class BoardApi {
         column: string, title: string, placement: CardPlacement = "bottom", icon?: string,
         template: NoteTypeOption | undefined = this.getCurrentCardTemplate()
     ) {
-        const first = placement === "top"
-            ? this.byColumn?.get(column)?.[0]?.branch.branchId
-            : undefined;
+        const first = placement === "top" ? this.firstInColumn(column) : undefined;
 
         try {
             const { note } = await note_create.createNote(this.parentNote.noteId, {
@@ -201,6 +203,7 @@ export default class BoardApi {
                 ...(first ? { target: "before", targetBranchId: first } : {})
             });
 
+            this.keepInView(note?.noteId);
             return note?.noteId;
         } catch (error) {
             console.error("Failed to create new item:", error);
@@ -224,6 +227,19 @@ export default class BoardApi {
         const { note } = await this.insertRowAtPosition(
             column, beforeBranchId, "before", title, icon, template);
         return note.noteId;
+    }
+
+    /**
+     * Keeps a card the board has just gained on screen while the board is narrowed by a filter.
+     *
+     * A card is rarely made to match the query in force, so the board would otherwise answer every
+     * addition by drawing nothing at all. It is marked as standing outside the filter, and the
+     * next query decides on it like any other card.
+     */
+    private keepInView(noteId: string | undefined) {
+        if (noteId) {
+            this.keepNote?.(noteId);
+        }
     }
 
     /** What a new card carries besides its title: the column it lands in, and its icon. */
@@ -298,6 +314,7 @@ export default class BoardApi {
             await this.moveIntoPlace(noteId, beforeBranchId);
         }
 
+        this.keepInView(noteId);
         return true;
     }
 
@@ -1058,6 +1075,7 @@ export default class BoardApi {
             throw new Error("Failed to create note");
         }
 
+        this.keepInView(note.noteId);
         return { note, branch };
     }
 
@@ -1086,9 +1104,11 @@ export default class BoardApi {
      * named by the server and has to be in froca before it can be placed.
      */
     async duplicateItem(noteId: string, branchId: string) {
-        const { branch } = await server.post<{ branch: { branchId: string } }>(
-            `notes/${noteId}/duplicate/${this.parentNote.noteId}`);
+        const { note, branch } = await server.post<
+            { note: { noteId: string }, branch: { branchId: string } }>(
+                `notes/${noteId}/duplicate/${this.parentNote.noteId}`);
 
+        this.keepInView(note?.noteId);
         await ws.waitForMaxKnownEntityChangeId();
         await branches.moveAfterBranch([ branch.branchId ], branchId);
     }
@@ -1134,11 +1154,9 @@ export default class BoardApi {
         // to redraw between two keystrokes, so the column map still shows the target as it was
         // before the card the last press sent. Anything sent since is remembered here instead, and
         // the memory lasts exactly as long as the map it stands in for, both being rebuilt by the
-        // refresh that catches up. Read off the unfiltered map, since the end of a column is behind
-        // the cards a filter is not showing.
-        const columnItems = (this.allByColumn ?? this.byColumn)?.get(targetColumn) ?? [];
+        // refresh that catches up.
         const last = this.sentToColumnEnd.get(targetColumn)
-            ?? columnItems.at(-1)?.branch.branchId;
+            ?? this.lastInColumn(targetColumn);
 
         await this.changeColumn(noteId, targetColumn);
         if (last && last !== branchId) {
@@ -1151,6 +1169,27 @@ export default class BoardApi {
     /** Whether a card stands at the head of its column, with nowhere left to be moved up to. */
     isFirstInColumn(branchId: string, column: string) {
         return this.byColumn?.get(column)?.[0]?.branch.branchId === branchId;
+    }
+
+    /**
+     * The card a new or arriving one is placed after: the last one drawn, or the last one the
+     * column holds when a filter is drawing none of them.
+     *
+     * Placement is relative to the cards on screen, so the unfiltered map is read only where that
+     * rule has nothing to say. Left unplaced, a card would rank among the ones it cannot see by
+     * wherever it happened to sit before.
+     */
+    private lastInColumn(column: string) {
+        const shown = this.byColumn?.get(column) ?? [];
+        const items = shown.length ? shown : this.allByColumn?.get(column) ?? [];
+        return items.at(-1)?.branch.branchId;
+    }
+
+    /** The counterpart of {@link lastInColumn}, for a card made at the head of a column. */
+    private firstInColumn(column: string) {
+        const shown = this.byColumn?.get(column) ?? [];
+        const items = shown.length ? shown : this.allByColumn?.get(column) ?? [];
+        return items[0]?.branch.branchId;
     }
 
     /**
@@ -1171,11 +1210,9 @@ export default class BoardApi {
 
     async moveWithinBoard(noteId: string, sourceBranchId: string, sourceIndex: number, targetIndex: number, sourceColumn: string, targetColumn: string) {
         const targetItems = this.byColumn?.get(targetColumn) ?? [];
-        // What a card dropped past the last one drawn is placed after: the last card shown, or the
-        // last one the column holds when a filter is showing none of them. Read before the writes
-        // below, since a redraw between them hands this instance the map with the card moved.
-        const lastInTarget = (targetItems.at(-1)
-            ?? this.allByColumn?.get(targetColumn)?.at(-1))?.branch.branchId;
+        // Read before the writes below, since a redraw between them hands this instance the map
+        // with the card already moved.
+        const lastInTarget = this.lastInColumn(targetColumn);
 
         const note = froca.getNoteFromCache(noteId);
         if (!note) return;

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -230,11 +230,8 @@ export default class BoardApi {
     }
 
     /**
-     * Keeps a card the board has just gained on screen while the board is narrowed by a filter.
-     *
-     * A card is rarely made to match the query in force, so the board would otherwise answer every
-     * addition by drawing nothing at all. It is marked as standing outside the filter, and the
-     * next query decides on it like any other card.
+     * Reports a card the board has just gained, which `useCollectionFilter` draws and marks even
+     * when the query misses it. Without this, adding a card to a filtered board shows nothing.
      */
     private keepInView(noteId: string | undefined) {
         if (noteId) {
@@ -1172,12 +1169,8 @@ export default class BoardApi {
     }
 
     /**
-     * The card a new or arriving one is placed after: the last one drawn, or the last one the
-     * column holds when a filter is drawing none of them.
-     *
-     * Placement is relative to the cards on screen, so the unfiltered map is read only where that
-     * rule has nothing to say. Left unplaced, a card would rank among the ones it cannot see by
-     * wherever it happened to sit before.
+     * The card a new or arriving one is placed after: the last one drawn, or `allByColumn`'s last
+     * where a filter draws none. Placement follows the cards on screen wherever there are any.
      */
     private lastInColumn(column: string) {
         const shown = this.byColumn?.get(column) ?? [];

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1140,12 +1140,7 @@ export default class BoardApi {
         return attributes.removeOwnedLabelByName(note, this.statusAttribute);
     }
 
-    /**
-     * Moves a card to the end of another column, where a new one would go.
-     *
-     * A card sent across by the keyboard is aimed at no card in particular, unlike a drop, so it
-     * goes where the reader would look for it.
-     */
+    /** Moves a card to the end of another column, where a card sent by the keyboard belongs. */
     async moveToColumnEnd(noteId: string, branchId: string, targetColumn: string) {
         // What is already at the end, as far as this instance can know: nothing waits for the board
         // to redraw between two keystrokes, so the column map still shows the target as it was

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -118,7 +118,12 @@ export default class BoardApi {
         private setBranchIdToEdit: (branchId: string | undefined) => void,
         private pending: PendingColumnWrites =
             { renames: new Map(), claims: new Map(), inFlight: 0 },
-        private statusDefinition?: BoardStatusDefinition
+        private statusDefinition?: BoardStatusDefinition,
+        /**
+         * Every card, when `byColumn` is narrowed by a filter. Bulk operations read this one, so a
+         * column operation reaches the cards the filter leaves out too.
+         */
+        private allByColumn?: ColumnMap
     ) {
         this.viewConfigSource = viewConfig;
         this.viewConfig = viewConfig ?? {};
@@ -144,7 +149,8 @@ export default class BoardApi {
         viewConfig: BoardViewData | undefined,
         saveConfig: (newConfig: BoardViewData) => void,
         setBranchIdToEdit: (branchId: string | undefined) => void,
-        statusDefinition?: BoardStatusDefinition
+        statusDefinition?: BoardStatusDefinition,
+        allByColumn?: ColumnMap
     ) {
         // What was sent to the end of a column stands in for what the map does not show yet, so it
         // is given up with the map it stands in for. Kept across a refresh, it would name a branch
@@ -154,6 +160,7 @@ export default class BoardApi {
         }
 
         this.byColumn = byColumn;
+        this.allByColumn = allByColumn;
         this.columns = columns;
         this.parentNote = parentNote;
         // Only a config the board has actually replaced, since `storeColumns` moves this one ahead
@@ -448,8 +455,10 @@ export default class BoardApi {
     }
 
     async removeColumn(column: string) {
-        // Remove the value from the notes.
-        const noteIds = this.byColumn?.get(column)?.map(item => item.note.noteId) || [];
+        // Remove the value from the notes. Read off the unfiltered map where there is one, so the
+        // value also comes off the cards an active filter is not showing.
+        const items = (this.allByColumn ?? this.byColumn)?.get(column);
+        const noteIds = items?.map(item => item.note.noteId) || [];
 
         const action: BulkAction = this.isRelationMode
             ? { name: "deleteRelation", relationName: this.statusAttribute }
@@ -674,6 +683,15 @@ export default class BoardApi {
         }
 
         this.storeConfig({ templates });
+    }
+
+    /** Stores the query the board is narrowed to, or clears it when given an empty one. */
+    setFilterQuery(query: string) {
+        if ((query || undefined) === this.viewConfig?.filterQuery) {
+            return;
+        }
+
+        this.storeConfig({ filterQuery: query || undefined });
     }
 
     /** Remembers what the last card was made from, so the next one is made from it too. */

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1126,18 +1126,19 @@ export default class BoardApi {
     /**
      * Moves a card to the end of another column, where a new one would go.
      *
-     * {@link moveWithinBoard} leaves a card crossing columns where the tree already had it, which
-     * is where a drop between two cards wants it. A card sent across by the keyboard is aimed at no
-     * card in particular, so it goes where the reader would look for it.
+     * A card sent across by the keyboard is aimed at no card in particular, unlike a drop, so it
+     * goes where the reader would look for it.
      */
     async moveToColumnEnd(noteId: string, branchId: string, targetColumn: string) {
         // What is already at the end, as far as this instance can know: nothing waits for the board
         // to redraw between two keystrokes, so the column map still shows the target as it was
         // before the card the last press sent. Anything sent since is remembered here instead, and
         // the memory lasts exactly as long as the map it stands in for, both being rebuilt by the
-        // refresh that catches up.
+        // refresh that catches up. Read off the unfiltered map, since the end of a column is behind
+        // the cards a filter is not showing.
+        const columnItems = (this.allByColumn ?? this.byColumn)?.get(targetColumn) ?? [];
         const last = this.sentToColumnEnd.get(targetColumn)
-            ?? (this.byColumn?.get(targetColumn) ?? []).at(-1)?.branch.branchId;
+            ?? columnItems.at(-1)?.branch.branchId;
 
         await this.changeColumn(noteId, targetColumn);
         if (last && last !== branchId) {
@@ -1170,6 +1171,11 @@ export default class BoardApi {
 
     async moveWithinBoard(noteId: string, sourceBranchId: string, sourceIndex: number, targetIndex: number, sourceColumn: string, targetColumn: string) {
         const targetItems = this.byColumn?.get(targetColumn) ?? [];
+        // What a card dropped past the last one drawn is placed after: the last card shown, or the
+        // last one the column holds when a filter is showing none of them. Read before the writes
+        // below, since a redraw between them hands this instance the map with the card moved.
+        const lastInTarget = (targetItems.at(-1)
+            ?? this.allByColumn?.get(targetColumn)?.at(-1))?.branch.branchId;
 
         const note = froca.getNoteFromCache(noteId);
         if (!note) return;
@@ -1178,10 +1184,11 @@ export default class BoardApi {
             // Moving to a different column
             await this.changeColumn(noteId, targetColumn);
 
-            // If there are items in the target column, reorder
-            if (targetItems.length > 0 && targetIndex < targetItems.length) {
+            if (targetIndex < targetItems.length) {
                 const targetBranch = targetItems[targetIndex].branch;
                 await branches.moveBeforeBranch([ sourceBranchId ], targetBranch.branchId);
+            } else if (lastInTarget && lastInTarget !== sourceBranchId) {
+                await branches.moveAfterBranch([ sourceBranchId ], lastInTarget);
             }
         } else if (sourceIndex !== targetIndex) {
             // Reordering within the same column

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -385,10 +385,7 @@ describe("Board card", () => {
     const cardIcon = (noteId: string) => card(noteId).querySelector(".title .icon")?.className ?? "";
 });
 
-/**
- * The clock a card carries while it is drawn although the filter misses it. The tooltip reaches
- * only a reader who points at it, so the name has to be on the element as well.
- */
+/** `TooltipIcon` opens its tooltip on hover, so the name has to be an attribute as well. */
 describe("OutsideFilterBadge", () => {
     it("names itself for assistive technology", () => {
         const container = document.body.appendChild(document.createElement("div"));

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -20,10 +20,20 @@ import { buildNote } from "../../../test/easy-froca";
 import { ParentComponent } from "../../react/react_utils";
 import BoardApi from "./api";
 import BoardView from ".";
+import { OutsideFilterBadge } from "./card";
 
 // The card menu opens with the shared link items, which reach for the active note context.
 vi.mock("../../../menus/link_context_menu", () => ({
     default: { getItems: () => [], handleLinkContextMenuItem: () => {} }
+}));
+
+// i18next is never initialised under test, so every label would read as undefined. The awaited
+// promise is what `command_registry` imports from here, which the board pulls in through the
+// autocomplete field.
+vi.mock("../../../services/i18n", () => ({
+    t: (key: string) => key,
+    translationsInitializedPromise: Promise.resolve(),
+    getCurrentLanguage: () => "en"
 }));
 
 /** Counts how often each card has drawn, which is what the memo boundary around it decides. */
@@ -373,6 +383,26 @@ describe("Board card", () => {
 
     const cardClasses = (noteId: string) => card(noteId).className;
     const cardIcon = (noteId: string) => card(noteId).querySelector(".title .icon")?.className ?? "";
+});
+
+/**
+ * The clock a card carries while it is drawn although the filter misses it. The tooltip reaches
+ * only a reader who points at it, so the name has to be on the element as well.
+ */
+describe("OutsideFilterBadge", () => {
+    it("names itself for assistive technology", () => {
+        const container = document.body.appendChild(document.createElement("div"));
+        try {
+            act(() => render(<OutsideFilterBadge />, container));
+
+            const badge = container.querySelector(".board-note-outside-filter");
+            expect(badge?.getAttribute("role")).toBe("img");
+            expect(badge?.getAttribute("aria-label")).toBe("board_view.card-outside-filter");
+        } finally {
+            render(null, container);
+            container.remove();
+        }
+    });
 });
 
 /** Drains the async chain inside the board's `refresh()` plus any re-render it queues. */

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -236,10 +236,8 @@ function Card({
 }
 
 /**
- * Marks a card drawn although the filter does not match it, which one just made here is.
- *
- * `role="img"` is what carries the label to a reader: a bare span has no role that a name can be
- * given to, and the tooltip alone reaches nobody who is not pointing at it.
+ * Marks a card the filter does not match, drawn because it was just made here.
+ * `role="img"` is what lets `aria-label` name it: a span on its own cannot be named.
  */
 export function OutsideFilterBadge() {
     return (

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -1,4 +1,3 @@
-import type { Tooltip } from "bootstrap";
 import { memo } from "preact/compat";
 import {
     useCallback, useContext, useEffect, useLayoutEffect, useRef, useState
@@ -18,9 +17,9 @@ import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
 import { parseNavigationStateFromUrl } from "../../../services/link";
 import { FLIP_SETTLE_MS } from "../../react/flip";
 import {
-    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useStaticTooltip,
-    useTriliumEvent
+    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useTriliumEvent
 } from "../../react/hooks";
+import { TooltipIcon } from "../../react/Icon";
 import { HighlightedText } from "../../react/RawHtml";
 
 function Card({
@@ -236,19 +235,24 @@ function Card({
     )
 }
 
-/** Marks a card drawn although the filter does not match it, which one just made here is. */
-function OutsideFilterBadge() {
-    const badgeRef = useRef<HTMLSpanElement>(null);
-    useStaticTooltip(badgeRef, OUTSIDE_FILTER_TOOLTIP);
-
-    return <span ref={badgeRef} className="board-note-outside-filter icon bx bx-time-five" />;
+/**
+ * Marks a card drawn although the filter does not match it, which one just made here is.
+ *
+ * `role="img"` is what carries the label to a reader: a bare span has no role that a name can be
+ * given to, and the tooltip alone reaches nobody who is not pointing at it.
+ */
+export function OutsideFilterBadge() {
+    return (
+        <TooltipIcon
+            className="board-note-outside-filter"
+            icon="bx bx-time-five"
+            tooltip={t("board_view.card-outside-filter")}
+            tooltipPosition="bottom"
+            role="img"
+            aria-label={t("board_view.card-outside-filter")}
+        />
+    );
 }
-
-const OUTSIDE_FILTER_TOOLTIP: Partial<Tooltip.Options> = {
-    title: t("board_view.card-outside-filter"),
-    placement: "bottom",
-    animation: false
-};
 
 /**
  * Memoized because a board holds hundreds of these and most redraws change none of them: a drag

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -5,7 +5,9 @@ import {
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
 import BoardApi from "./api";
-import { BoardActionsContext, BoardPromotedAttributesContext, TitleEditor } from ".";
+import {
+    BoardActionsContext, BoardHighlightTokensContext, BoardPromotedAttributesContext, TitleEditor
+} from ".";
 import { ContextMenuEvent } from "../../../menus/context_menu";
 import { openNoteContextMenu } from "./context_menu";
 import { t } from "../../../services/i18n";
@@ -15,6 +17,7 @@ import { FLIP_SETTLE_MS } from "../../react/flip";
 import {
     useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useTriliumEvent
 } from "../../react/hooks";
+import { HighlightedText } from "../../react/RawHtml";
 
 function Card({
     api,
@@ -60,6 +63,7 @@ function Card({
 }) {
     const { setBranchIdToEdit } = useContext(BoardActionsContext);
     const shownAttributes = useContext(BoardPromotedAttributesContext);
+    const highlightedTokens = useContext(BoardHighlightTokensContext);
     // Tracks the `color` label, which the board does not redraw a card for.
     const colorClass = useNoteColorClass(note) || "";
     const editorRef = useRef<HTMLInputElement>(null);
@@ -192,7 +196,7 @@ function Card({
                 <>
                     <span className="title">
                         <span class={`icon ${icon}`} />
-                        {title}
+                        <HighlightedText text={title} highlightedTokens={highlightedTokens} />
                     </span>
                     <span
                         className="edit-icon icon bx bx-edit"

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -1,12 +1,15 @@
+import type { Tooltip } from "bootstrap";
 import { memo } from "preact/compat";
 import {
     useCallback, useContext, useEffect, useLayoutEffect, useRef, useState
 } from "preact/hooks";
+
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
 import BoardApi from "./api";
 import {
-    BoardActionsContext, BoardHighlightTokensContext, BoardPromotedAttributesContext, TitleEditor
+    BoardActionsContext, BoardHighlightTokensContext, BoardKeptCardsContext,
+    BoardPromotedAttributesContext, TitleEditor
 } from ".";
 import { ContextMenuEvent } from "../../../menus/context_menu";
 import { openNoteContextMenu } from "./context_menu";
@@ -15,7 +18,8 @@ import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
 import { parseNavigationStateFromUrl } from "../../../services/link";
 import { FLIP_SETTLE_MS } from "../../react/flip";
 import {
-    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useTriliumEvent
+    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useStaticTooltip,
+    useTriliumEvent
 } from "../../react/hooks";
 import { HighlightedText } from "../../react/RawHtml";
 
@@ -64,6 +68,7 @@ function Card({
     const { setBranchIdToEdit } = useContext(BoardActionsContext);
     const shownAttributes = useContext(BoardPromotedAttributesContext);
     const highlightedTokens = useContext(BoardHighlightTokensContext);
+    const isOutsideFilter = useContext(BoardKeptCardsContext).has(note.noteId);
     // Tracks the `color` label, which the board does not redraw a card for.
     const colorClass = useNoteColorClass(note) || "";
     const editorRef = useRef<HTMLInputElement>(null);
@@ -207,6 +212,7 @@ function Card({
                         note={note}
                         ignoredAttributes={[statusAttribute]}
                         shownAttributes={shownAttributes}
+                        badges={isOutsideFilter && <OutsideFilterBadge />}
                     />
                 </>
             ) : (
@@ -229,6 +235,20 @@ function Card({
         </div>
     )
 }
+
+/** Marks a card drawn although the filter does not match it, which one just made here is. */
+function OutsideFilterBadge() {
+    const badgeRef = useRef<HTMLSpanElement>(null);
+    useStaticTooltip(badgeRef, OUTSIDE_FILTER_TOOLTIP);
+
+    return <span ref={badgeRef} className="board-note-outside-filter icon bx bx-time-five" />;
+}
+
+const OUTSIDE_FILTER_TOOLTIP: Partial<Tooltip.Options> = {
+    title: t("board_view.card-outside-filter"),
+    placement: "bottom",
+    animation: false
+};
 
 /**
  * Memoized because a board holds hundreds of these and most redraws change none of them: a drag

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -61,6 +61,7 @@ export default function Column({
     nested,
     limit,
     columnItems,
+    totalCount,
     isNew,
     cardTemplates,
     api,
@@ -88,6 +89,11 @@ export default function Column({
     nested?: boolean,
     /** The note limit, absent if disabled. */
     limit?: number,
+    /**
+     * How many cards the column really holds, when an active filter leaves `columnItems` with
+     * fewer. The badge counts what is shown; the limit is about the real column.
+     */
+    totalCount?: number,
     api: BoardApi,
     parentNote: FNote,
     isInRelationMode: boolean,
@@ -160,7 +166,7 @@ export default function Column({
         : undefined;
 
     // Read here rather than in the badge: the column body shows an outline as well.
-    const isOverLimit = limit !== undefined && (columnItems?.length ?? 0) > limit;
+    const isOverLimit = limit !== undefined && (totalCount ?? columnItems?.length ?? 0) > limit;
     const isCollapsed = !!collapsed && !isActive && !isPeeked;
     // A column opened to take a dragged card takes its width at once, and its cards with it.
     const opensAtOnce = !!draggedCard || dropTarget === column;

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import FBranch from "../../../entities/fbranch";
 import froca from "../../../services/froca";
 import { buildNote } from "../../../test/easy-froca";
-import { applyCardMove, type ColumnMap, filterColumnMap, getBoardData } from "./data";
+import {
+    applyCardMove, type ColumnMap, filterColumnMap, getBoardData, unfilteredCardIndex
+} from "./data";
 
 describe("applyCardMove", () => {
     /** Cards named by their note id, which is all this reads them for. */
@@ -81,6 +83,41 @@ describe("applyCardMove", () => {
             const start = board({ A: [ "a1" ] });
 
             expect(filterColumnMap(start, null)).toBe(start);
+        });
+    });
+
+    describe("unfilteredCardIndex", () => {
+        const items = (ids: string[]) => board({ A: ids }).get("A") ?? [];
+
+        it("puts the card where the card it was dropped before stands", () => {
+            const all = items([ "hidden1", "hidden2", "a1", "hidden3", "a2" ]);
+            const shown = items([ "a1", "a2" ]);
+
+            // Before the first card on screen, which stands after two hidden ones.
+            expect(unfilteredCardIndex(shown, all, 0)).toBe(2);
+            // Between the two on screen, which is where `a2` stands rather than where `hidden3` does.
+            expect(unfilteredCardIndex(shown, all, 1)).toBe(4);
+        });
+
+        it("puts a card dropped past the last one on screen right after it", () => {
+            const all = items([ "a1", "hidden1", "hidden2" ]);
+            const shown = items([ "a1" ]);
+
+            expect(unfilteredCardIndex(shown, all, 1)).toBe(1);
+        });
+
+        it("counts against the column itself when nothing is filtered out", () => {
+            const all = items([ "a1", "a2", "a3" ]);
+
+            for (const index of [ 0, 1, 2 ]) {
+                expect(unfilteredCardIndex(all, all, index)).toBe(index);
+            }
+            expect(unfilteredCardIndex(all, all, 3)).toBe(3);
+        });
+
+        it("puts the card at the end of a column showing none of its own", () => {
+            expect(unfilteredCardIndex([], items([ "hidden1" ]), 0)).toBe(1);
+            expect(unfilteredCardIndex([], [], 0)).toBe(0);
         });
     });
 });

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import FBranch from "../../../entities/fbranch";
 import froca from "../../../services/froca";
 import { buildNote } from "../../../test/easy-froca";
-import { applyCardMove, type ColumnMap, getBoardData } from "./data";
+import { applyCardMove, type ColumnMap, filterColumnMap, getBoardData } from "./data";
 
 describe("applyCardMove", () => {
     /** Cards named by their note id, which is all this reads them for. */
@@ -57,6 +57,31 @@ describe("applyCardMove", () => {
         const start = board({ A: [ "a1" ], B: [] });
 
         expect(applyCardMove(start, "nope", "A", "B", 0)).toBe(start);
+    });
+
+    describe("filterColumnMap", () => {
+        it("keeps only the matched cards, in the order the column holds them", () => {
+            // The set is built in reversed order to prove it carries membership, not order.
+            const matched = new Set([ "a4", "a2", "a1" ]);
+            const filtered = filterColumnMap(
+                board({ A: [ "a1", "a2", "a3", "a4" ], B: [ "b1" ] }), matched);
+
+            expect(names(filtered, "A")).toEqual([ "a1", "a2", "a4" ]);
+            expect(names(filtered, "B")).toEqual([]);
+        });
+
+        it("keeps every column, emptied ones included", () => {
+            const filtered = filterColumnMap(board({ A: [ "a1" ], B: [] }), new Set([ "nothing" ]));
+
+            expect([ ...filtered.keys() ]).toEqual([ "A", "B" ]);
+            expect(names(filtered, "A")).toEqual([]);
+        });
+
+        it("hands the map back untouched while no filter is active", () => {
+            const start = board({ A: [ "a1" ] });
+
+            expect(filterColumnMap(start, null)).toBe(start);
+        });
     });
 });
 

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -3,10 +3,12 @@ import FNote from "../../../entities/fnote";
 import { INBOX_COLUMN, resolveBoardColumns } from "./columns";
 import { BoardColumnData, BoardViewData } from "./index";
 
-export type ColumnMap = Map<string, {
+export interface ColumnItem {
     branch: FBranch;
     note: FNote;
-}[]>;
+}
+
+export type ColumnMap = Map<string, ColumnItem[]>;
 
 /**
  * The columns as they stand once a card has moved, for drawing the outcome before the writes land.
@@ -59,6 +61,33 @@ export function filterColumnMap(
         filtered.set(column, items.filter(item => matchedNoteIds.has(item.note.noteId)));
     }
     return filtered;
+}
+
+/**
+ * Where a card dropped among the cards on screen goes in the full column.
+ *
+ * A drop is measured against the cards a filter leaves showing, and the move is written against the
+ * visible card it was dropped before. That card decides the place in the full column too, so the
+ * cards a filter hides keep their order around it.
+ *
+ * @param shown the target column as it is drawn, counting the moved card where it stays in place.
+ * @param all the same column with every card it holds.
+ * @param index where the card goes among the ones drawn.
+ */
+export function unfilteredCardIndex(shown: ColumnItem[], all: ColumnItem[], index: number) {
+    const placeOf = (item: ColumnItem | undefined) => (item
+        ? all.findIndex(other => other.branch.branchId === item.branch.branchId)
+        : -1);
+
+    const before = placeOf(shown[index]);
+    if (before >= 0) {
+        return before;
+    }
+
+    // Dropped past the last card on screen, which is what the move is written against; a hidden
+    // card below it stays below.
+    const after = placeOf(shown.at(-1));
+    return after >= 0 ? after + 1 : all.length;
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -44,10 +44,7 @@ export function applyCardMove(
 
 /**
  * The columns with only the cards in `matchedNoteIds`, keeping their order relative to each other.
- *
- * A filter narrows what is drawn, nothing else: every column stays, and the full map is what column
- * discovery, the config write-back and bulk operations keep reading, so filtering cannot rewrite
- * the board's columns or reach fewer cards than an operation means to.
+ * Every column is kept, since a filter narrows what is drawn and nothing else.
  */
 export function filterColumnMap(
     byColumn: ColumnMap, matchedNoteIds: Set<string> | null
@@ -65,10 +62,6 @@ export function filterColumnMap(
 
 /**
  * Where a card dropped among the cards on screen goes in the full column.
- *
- * A drop is measured against the cards a filter leaves showing, and the move is written against the
- * visible card it was dropped before. That card decides the place in the full column too, so the
- * cards a filter hides keep their order around it.
  *
  * @param shown the target column as it is drawn, counting the moved card where it stays in place.
  * @param all the same column with every card it holds.

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -43,19 +43,19 @@ export function applyCardMove(
 }
 
 /**
- * The columns with only the cards in `matchedNoteIds`, keeping their order relative to each other.
+ * The columns with only the cards in `shownNoteIds`, keeping their order relative to each other.
  * Every column is kept, since a filter narrows what is drawn and nothing else.
  */
 export function filterColumnMap(
-    byColumn: ColumnMap, matchedNoteIds: Set<string> | null
+    byColumn: ColumnMap, shownNoteIds: Set<string> | null
 ): ColumnMap {
-    if (!matchedNoteIds) {
+    if (!shownNoteIds) {
         return byColumn;
     }
 
     const filtered: ColumnMap = new Map();
     for (const [ column, items ] of byColumn) {
-        filtered.set(column, items.filter(item => matchedNoteIds.has(item.note.noteId)));
+        filtered.set(column, items.filter(item => shownNoteIds.has(item.note.noteId)));
     }
     return filtered;
 }

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -47,7 +47,9 @@ export function applyCardMove(
  * discovery, the config write-back and bulk operations keep reading, so filtering cannot rewrite
  * the board's columns or reach fewer cards than an operation means to.
  */
-export function filterColumnMap(byColumn: ColumnMap, matchedNoteIds: Set<string> | null): ColumnMap {
+export function filterColumnMap(
+    byColumn: ColumnMap, matchedNoteIds: Set<string> | null
+): ColumnMap {
     if (!matchedNoteIds) {
         return byColumn;
     }

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -41,6 +41,25 @@ export function applyCardMove(
 }
 
 /**
+ * The columns with only the cards in `matchedNoteIds`, keeping their order relative to each other.
+ *
+ * A filter narrows what is drawn, nothing else: every column stays, and the full map is what column
+ * discovery, the config write-back and bulk operations keep reading, so filtering cannot rewrite
+ * the board's columns or reach fewer cards than an operation means to.
+ */
+export function filterColumnMap(byColumn: ColumnMap, matchedNoteIds: Set<string> | null): ColumnMap {
+    if (!matchedNoteIds) {
+        return byColumn;
+    }
+
+    const filtered: ColumnMap = new Map();
+    for (const [ column, items ] of byColumn) {
+        filtered.set(column, items.filter(item => matchedNoteIds.has(item.note.noteId)));
+    }
+    return filtered;
+}
+
+/**
  * @param definitionOptions the choices the board's group-by definition offers, empty when it has no
  *                          select definition of its own to lead the column order.
  * @param pendingRenames the columns the board is in the middle of renaming or deleting. Read

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -405,6 +405,15 @@ body.mobile .board-view-container .board-add-column {
     var(--card-title-inset) - var(--card-icon-inset) - var(--card-icon-size));
 }
 
+/* The mark.js spans the filter's matched tokens are wrapped in, styled as the search cards
+   style theirs. */
+.board-view-container .board-note > .title .ck-find-result {
+  background: var(--note-list-view-search-result-highlight-background);
+  color: var(--note-list-view-search-result-highlight-color);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .board-view-container .board-note > .edit-icon {
   position: absolute;
   top: 8px;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -405,8 +405,7 @@ body.mobile .board-view-container .board-add-column {
     var(--card-title-inset) - var(--card-icon-inset) - var(--card-icon-size));
 }
 
-/* The mark.js spans the filter's matched tokens are wrapped in, styled as the search cards
-   style theirs. */
+/* The spans mark.js wraps a filter's matched tokens in. Matches the search result cards. */
 .board-view-container .board-note > .title .ck-find-result {
   background: var(--note-list-view-search-result-highlight-background);
   color: var(--note-list-view-search-result-highlight-color);

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -370,6 +370,13 @@ body.mobile .board-view-container .board-add-column {
      above it takes that place and moves the card down by it. */
   margin-block: 0 0.65em;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.15s ease;
+
+  .board-note-outside-filter {
+    color: var(--muted-text-color);
+    font-size: 1.1em;
+    line-height: 1;
+    cursor: default;
+  }
 }
 
 .board-view-container .board-column.board-column-archived {
@@ -399,13 +406,6 @@ body.mobile .board-view-container .board-add-column {
     font-weight: 600;
     text-decoration: underline;
   }
-}
-
-.board-view-container .board-note .board-note-outside-filter {
-  color: var(--muted-text-color);
-  font-size: 1.1em;
-  line-height: 1;
-  cursor: default;
 }
 
 .board-view-container .board-note > .title > .icon {

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -401,6 +401,13 @@ body.mobile .board-view-container .board-add-column {
   }
 }
 
+.board-view-container .board-note .board-note-outside-filter {
+  color: var(--muted-text-color);
+  font-size: 1.1em;
+  line-height: 1;
+  cursor: default;
+}
+
 .board-view-container .board-note > .title > .icon {
   flex: none;
   display: flex;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -391,6 +391,14 @@ body.mobile .board-view-container .board-add-column {
 .board-view-container .board-note > .title {
   display: flex;
   align-items: flex-start;
+
+  /* The spans mark.js wraps a filter's matched tokens in. Matches the search result cards. */
+  .ck-find-result {
+    background: var(--note-list-view-search-result-highlight-background);
+    color: var(--note-list-view-search-result-highlight-color);
+    font-weight: 600;
+    text-decoration: underline;
+  }
 }
 
 .board-view-container .board-note > .title > .icon {
@@ -403,14 +411,6 @@ body.mobile .board-view-container .board-add-column {
   margin-inline-start: calc(var(--card-icon-inset) - var(--card-padding));
   margin-inline-end: calc(
     var(--card-title-inset) - var(--card-icon-inset) - var(--card-icon-size));
-}
-
-/* The spans mark.js wraps a filter's matched tokens in. Matches the search result cards. */
-.board-view-container .board-note > .title .ck-find-result {
-  background: var(--note-list-view-search-result-highlight-background);
-  color: var(--note-list-view-search-result-highlight-color);
-  font-weight: 600;
-  text-decoration: underline;
 }
 
 .board-view-container .board-note > .edit-icon {

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3331,10 +3331,10 @@ describe("Board filtering", () => {
             "#collection": "",
             "#viewType": "board",
             children: [
-                { id: "card1", title: "First", "#status": "To Do" },
-                { id: "card2", title: "Second", "#status": "To Do" },
-                { id: "card3", title: "Third", "#status": "To Do" },
-                { id: "card4", title: "Fourth", "#status": "Done" }
+                { id: "filtered1", title: "First", "#status": "To Do" },
+                { id: "filtered2", title: "Second", "#status": "To Do" },
+                { id: "filtered3", title: "Third", "#status": "To Do" },
+                { id: "filtered4", title: "Fourth", "#status": "Done" }
             ]
         });
 
@@ -3369,11 +3369,8 @@ describe("Board filtering", () => {
 
     it("shows only the matched cards, in their own order, keeping every column", async () => {
         // The matches arrive in score order; the board must keep branch order regardless.
-        const note = await setup({ matched: [ "card3", "card1" ] });
+        const note = await setup({ matched: [ "filtered3", "filtered1" ] });
 
-        console.log("CALLS", searchInSubtree.mock.calls.length,
-            JSON.stringify(searchInSubtree.mock.calls));
-        console.log("COL0", [ ...container.querySelectorAll(".board-column") ][0]?.innerHTML);
         expect(searchInSubtree).toHaveBeenCalledWith("#urgent", note.noteId);
         expect(cardTitles(0)).toEqual([ "First", "Third" ]);
         expect(cardTitles(1)).toEqual([]);
@@ -3381,7 +3378,7 @@ describe("Board filtering", () => {
     });
 
     it("counts the visible cards in the badge while the limit reads the real column", async () => {
-        await setup({ matched: [ "card1" ], limit: 2 });
+        await setup({ matched: [ "filtered1" ], limit: 2 });
 
         const column = container.querySelector(".board-column");
         // One of three cards is shown, and three stand against the limit of two.
@@ -3391,7 +3388,7 @@ describe("Board filtering", () => {
 
     it("marks the matched tokens in the card titles", async () => {
         await setup({
-            matched: [ "card1" ],
+            matched: [ "filtered1" ],
             tokens: [ { token: "First", type: "plain" } ]
         });
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -20,6 +20,7 @@ import froca from "../../../services/froca";
 import attributes from "../../../services/attributes";
 import { executeBulkActions } from "../../../services/bulk_action";
 import LoadResults from "../../../services/load_results";
+import searchService from "../../../services/search";
 import { buildNote } from "../../../test/easy-froca";
 import { ParentComponent } from "../../react/react_utils";
 import BoardView, { BoardViewData } from ".";
@@ -106,6 +107,16 @@ vi.mock("../../../services/bulk_action", () => ({
         }
     })
 }));
+
+vi.mock("../../../services/search", () => ({
+    default: {
+        searchInSubtree: vi.fn(),
+        searchForNoteIds: vi.fn(async () => []),
+        searchForNotes: vi.fn(async () => [])
+    }
+}));
+
+const searchInSubtree = vi.mocked(searchService.searchInSubtree);
 
 /** What a card is made from until another template is picked: the first the board offers. */
 function textTemplate() {
@@ -3291,4 +3302,100 @@ describe("the promoted attributes a card shows", () => {
         return [ ...container.querySelectorAll(".board-note .user-attribute") ]
             .map(element => element.textContent);
     }
+});
+
+describe("Board filtering", () => {
+    let container: HTMLElement;
+
+    afterEach(() => {
+        saved.length = 0;
+        render(null, container);
+        container.remove();
+    });
+
+    /** A board of four cards over two columns, opened with a stored filter query. */
+    async function setup({ matched, tokens = [], limit }: {
+        matched: string[];
+        tokens?: { token: string; type: "plain" }[];
+        limit?: number;
+    }) {
+        searchInSubtree.mockReset();
+        searchInSubtree.mockResolvedValue({
+            searchResultNoteIds: matched,
+            highlightedTokens: tokens,
+            error: null
+        });
+
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "card1", title: "First", "#status": "To Do" },
+                { id: "card2", title: "Second", "#status": "To Do" },
+                { id: "card3", title: "Third", "#status": "To Do" },
+                { id: "card4", title: "Fourth", "#status": "Done" }
+            ]
+        });
+
+        container = document.body.appendChild(document.createElement("div"));
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={new Component()}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={{
+                            columns: [ { value: "To Do", ...(limit ? { limit } : {}) },
+                                { value: "Done" } ],
+                            filterQuery: "#urgent"
+                        }}
+                    />
+                </ParentComponent.Provider>,
+                container
+            );
+        });
+        await act(async () => { await flush(); });
+        await act(async () => { await flush(); });
+
+        return note;
+    }
+
+    function cardTitles(column: number) {
+        const columns = [ ...container.querySelectorAll(".board-column") ];
+        return [ ...columns[column].querySelectorAll(".board-note .title") ]
+            .map(el => el.textContent);
+    }
+
+    it("shows only the matched cards, in their own order, keeping every column", async () => {
+        // The matches arrive in score order; the board must keep branch order regardless.
+        const note = await setup({ matched: [ "card3", "card1" ] });
+
+        console.log("CALLS", searchInSubtree.mock.calls.length,
+            JSON.stringify(searchInSubtree.mock.calls));
+        console.log("COL0", [ ...container.querySelectorAll(".board-column") ][0]?.innerHTML);
+        expect(searchInSubtree).toHaveBeenCalledWith("#urgent", note.noteId);
+        expect(cardTitles(0)).toEqual([ "First", "Third" ]);
+        expect(cardTitles(1)).toEqual([]);
+        expect(container.querySelectorAll(".board-column")).toHaveLength(2);
+    });
+
+    it("counts the visible cards in the badge while the limit reads the real column", async () => {
+        await setup({ matched: [ "card1" ], limit: 2 });
+
+        const column = container.querySelector(".board-column");
+        // One of three cards is shown, and three stand against the limit of two.
+        expect(column?.querySelector(".counter-badge")?.textContent).toBe("1/2");
+        expect(column?.classList.contains("over-limit")).toBe(true);
+    });
+
+    it("marks the matched tokens in the card titles", async () => {
+        await setup({
+            matched: [ "card1" ],
+            tokens: [ { token: "First", type: "plain" } ]
+        });
+
+        const marks = [ ...container.querySelectorAll(".board-note .title .ck-find-result") ];
+        expect(marks.map(el => el.textContent)).toEqual([ "First" ]);
+    });
 });

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3306,8 +3306,10 @@ describe("the promoted attributes a card shows", () => {
 
 describe("Board filtering", () => {
     let container: HTMLElement;
+    let host: Component;
 
     afterEach(() => {
+        vi.useRealTimers();
         saved.length = 0;
         render(null, container);
         container.remove();
@@ -3338,10 +3340,11 @@ describe("Board filtering", () => {
             ]
         });
 
+        host = new Component();
         container = document.body.appendChild(document.createElement("div"));
         await act(async () => {
             render(
-                <ParentComponent.Provider value={new Component()}>
+                <ParentComponent.Provider value={host}>
                     <Harness
                         note={note}
                         noteIds={[ ...note.getChildNoteIds() ]}
@@ -3367,6 +3370,17 @@ describe("Board filtering", () => {
             .map(el => el.textContent);
     }
 
+    /** A branch change under the board, which is what re-runs an active filter. */
+    function branchChange(parentNoteId: string, noteId: string) {
+        const results = new LoadResults([ {
+            entityName: "branches",
+            entityId: "branch1",
+            entity: { branchId: "branch1", parentNoteId, noteId }
+        } as never ]);
+        results.addBranch("branch1", "other");
+        return results;
+    }
+
     it("shows only the matched cards, in their own order, keeping every column", async () => {
         // The matches arrive in score order; the board must keep branch order regardless.
         const note = await setup({ matched: [ "filtered3", "filtered1" ] });
@@ -3384,6 +3398,32 @@ describe("Board filtering", () => {
         // One of three cards is shown, and three stand against the limit of two.
         expect(column?.querySelector(".counter-badge")?.textContent).toBe("1/2");
         expect(column?.classList.contains("over-limit")).toBe(true);
+    });
+
+    /**
+     * The cards drawn are derived from what the filter matches rather than held beside it, so a
+     * re-run's answer cannot be left unapplied by whatever else the board is doing at the time.
+     */
+    it("draws what a re-run matches", async () => {
+        const note = await setup({ matched: [ "filtered1" ] });
+        expect(cardTitles(0)).toEqual([ "First" ]);
+
+        searchInSubtree.mockResolvedValue({
+            searchResultNoteIds: [ "filtered2", "filtered3" ],
+            highlightedTokens: [],
+            error: null
+        });
+
+        // A change under the board re-runs the filter, after the wait that collects a run of them.
+        vi.useFakeTimers();
+        await act(async () => {
+            await host.handleEvent("entitiesReloaded", {
+                loadResults: branchChange(note.noteId, "filtered2")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+
+        expect(cardTitles(0)).toEqual([ "Second", "Third" ]);
     });
 
     it("marks the matched tokens in the card titles", async () => {

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3426,6 +3426,62 @@ describe("Board filtering", () => {
         expect(cardTitles(0)).toEqual([ "Second", "Third" ]);
     });
 
+    /**
+     * A board opened onto a stored query draws nothing until the query has said what it matches,
+     * rather than drawing every card and then taking most of them away.
+     */
+    it("draws no cards until the stored query has resolved", async () => {
+        let resolveSearch: (response: unknown) => void = () => {};
+        searchInSubtree.mockReset();
+        searchInSubtree.mockReturnValue(
+            new Promise(resolve => { resolveSearch = resolve; }) as never);
+
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "held1", title: "First", "#status": "To Do" },
+                { id: "held2", title: "Second", "#status": "To Do" }
+            ]
+        });
+
+        host = new Component();
+        container = document.body.appendChild(document.createElement("div"));
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={host}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={{
+                            columns: [ { value: "To Do" } ],
+                            filterQuery: "#urgent"
+                        }}
+                    />
+                </ParentComponent.Provider>,
+                container
+            );
+        });
+        await act(async () => { await flush(); });
+        await act(async () => { await flush(); });
+
+        expect(container.querySelectorAll(".board-column")).toHaveLength(0);
+        expect(container.querySelectorAll(".board-note")).toHaveLength(0);
+
+        await act(async () => {
+            resolveSearch({
+                searchResultNoteIds: [ "held2" ],
+                highlightedTokens: [],
+                error: null
+            });
+            await flush();
+        });
+        await act(async () => { await flush(); });
+
+        expect(cardTitles(0)).toEqual([ "Second" ]);
+    });
+
     it("marks the matched tokens in the card titles", async () => {
         await setup({
             matched: [ "filtered1" ],

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -749,7 +749,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         <div className="board-view">
             <CollectionProperties
                 note={parentNote}
-                centerChildren={<CollectionFilterInput filter={filter} />}
+                rightChildren={<CollectionFilterInput
+                    filter={filter}
+                    placeholder={t("board_view.filter-placeholder")}
+                />}
             />
             <BoardActionsContext.Provider value={boardActions}>
                 <BoardPromotedAttributesContext.Provider value={shownAttributes}>

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -9,6 +9,8 @@ import {
     Dispatch, StateUpdater, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState
 } from "preact/hooks";
 
+import type { HighlightedTokenInfo } from "@triliumnext/commons";
+
 import FNote from "../../../entities/fnote";
 import { t } from "../../../services/i18n";
 import type LoadResults from "../../../services/load_results";
@@ -34,6 +36,7 @@ import ActionButton from "../../react/ActionButton";
 import { IconPickerButton } from "../../react/IconPicker";
 import { useDragPan } from "../../react/drag_pan";
 import { FLIP_SETTLE_MS, useFlip } from "../../react/flip";
+import { CollectionFilterInput, useCollectionFilter } from "../collection_filter";
 import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
 import { useBoardDrag } from "./board_drag";
@@ -45,7 +48,7 @@ import { currentCardTemplate, DEFAULT_CARD_TEMPLATES } from "./card_templates";
 import ColumnLimitDialog from "./column_limit";
 import BoardProperties from "./properties";
 import { openBoardContextMenu, openCreateColumnMenu } from "./context_menu";
-import { applyCardMove, ColumnMap, getBoardData } from "./data";
+import { applyCardMove, ColumnMap, filterColumnMap, getBoardData } from "./data";
 import { useBoardKeyboard } from "./keyboard";
 
 /**
@@ -73,6 +76,8 @@ export interface BoardViewData {
      * name is shown after the ones it does; see {@link resolvePromotedAttributes}.
      */
     promotedAttributes?: PromotedAttributeSetting[];
+    /** The search query the board is narrowed to, absent while no filter is active. */
+    filterQuery?: string;
 }
 
 export interface BoardColumnData {
@@ -194,6 +199,13 @@ export const BoardDragStateContext = createContext<BoardDragState>({
 });
 
 /**
+ * The tokens the active filter matched by, which the cards highlight in their titles. Null while
+ * no filter is active. A context for the same reason the promoted attributes use one: a card is
+ * memoized, and the tokens change only when a query is submitted.
+ */
+export const BoardHighlightTokensContext = createContext<HighlightedTokenInfo[] | null>(null);
+
+/**
  * What the board answers with when asked for contextual keyboard help. Every entry is a key the
  * board handles itself (see `keyboard.ts` and the card and column handlers), none of them
  * rebindable, so each is listed literally rather than through a registered action.
@@ -256,6 +268,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const [ includeArchived ] = useNoteLabelBoolean(parentNote, "includeArchived");
     const [ inboxEnabled ] = useNoteLabelBoolean(parentNote, "enableInboxColumn");
     const [ byColumn, setByColumn ] = useState<ColumnMap>();
+    /** Every card, while `byColumn` holds only what the active filter matches. */
+    const [ allByColumn, setAllByColumn ] = useState<ColumnMap>();
     const [ columns, setColumns ] = useState<string[]>();
     const [ isInRelationMode, setIsRelationMode ] = useState(false);
     const [ draggedCard, setDraggedCard ] = useState<CardDrag | null>(null);
@@ -333,14 +347,26 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             board: boardIdentity,
             api: new Api(
                 byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
-                saveConfig, setBranchIdToEdit, pendingRenamesRef.current.writes, statusDefinition)
+                saveConfig, setBranchIdToEdit, pendingRenamesRef.current.writes, statusDefinition,
+                allByColumn)
         };
     } else {
         apiRef.current.api.update(
             byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
-            saveConfig, setBranchIdToEdit, statusDefinition);
+            saveConfig, setBranchIdToEdit, statusDefinition, allByColumn);
     }
     const api = apiRef.current.api;
+
+    const persistFilterQuery = useCallback(
+        (query: string) => apiRef.current?.api.setFilterQuery(query), []);
+    const filter = useCollectionFilter(parentNote, {
+        persistedQuery: viewConfig?.filterQuery,
+        onQueryChanged: persistFilterQuery,
+        collectionNoteIds: noteIds
+    });
+    // Read through a ref by `refresh`, whose result can land after the filter has moved on.
+    const matchedNoteIdsRef = useRef(filter.matchedNoteIds);
+    matchedNoteIdsRef.current = filter.matchedNoteIds;
     // Every member is one of useState's own setters, so this value is built once and never changes
     // identity -- a drag cannot reach anything that reads only this.
     const openBoardMenu = useCallback((event: ContextMenuEvent) => {
@@ -470,7 +496,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                     settleColumn(pendingRenamesRef.current.writes, settled);
                 }
 
-                setByColumn(byColumn);
+                setAllByColumn(byColumn);
+                setByColumn(filterColumnMap(byColumn, matchedNoteIdsRef.current));
                 setIsRelationMode(isInRelationMode);
                 setColumns(columns);
 
@@ -657,6 +684,15 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         parentNote, noteIds, viewConfig, statusAttributeWithPrefix, statusDefinition, inboxEnabled
     ]);
 
+    // Redraws for a change in what the filter matches; a change in the cards themselves goes
+    // through `refresh`. Skipped while a move is being written, exactly as a refresh would be:
+    // the board has already been drawn as the move will leave it, and the maps are older.
+    useEffect(() => {
+        if (allByColumn && !movesInFlight.current) {
+            setByColumn(filterColumnMap(allByColumn, filter.matchedNoteIds));
+        }
+    }, [ filter.matchedNoteIds ]);
+
     // The drag reports where the column landed among the ones on screen, which is not where it
     // landed among them all once some are archived and hidden. Translated here so a reorder leaves
     // every hidden column where it was rather than herding them to the end.
@@ -710,9 +746,13 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
 
     return (
         <div className="board-view">
-            <CollectionProperties note={parentNote} />
+            <CollectionProperties
+                note={parentNote}
+                centerChildren={<CollectionFilterInput filter={filter} />}
+            />
             <BoardActionsContext.Provider value={boardActions}>
                 <BoardPromotedAttributesContext.Provider value={shownAttributes}>
+                <BoardHighlightTokensContext.Provider value={filter.highlightedTokens}>
                 <BoardDragStateContext.Provider value={boardDragState}>
                     {byColumn && columns && <div
                         ref={containerRef}
@@ -764,6 +804,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                                     onFocusColumn={focusColumn}
                                     onFocusCard={focusCard}
                                     columnItems={byColumn.get(column)}
+                                    totalCount={allByColumn?.get(column)?.length}
                                     isNew={column === createdColumn}
                                 />
                             </Fragment>
@@ -811,6 +852,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                         )}
                     </div>}
                 </BoardDragStateContext.Provider>
+                </BoardHighlightTokensContext.Provider>
                 </BoardPromotedAttributesContext.Provider>
             </BoardActionsContext.Provider>
         </div>

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -352,9 +352,13 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     });
     // The cards as drawn. Derived rather than held, so that what is shown cannot fall behind what
     // the filter matches: a card move and a search resolving in the same moment both land here.
+    // Withheld until a query stored in `board.json` has said what it matches, so a filtered board
+    // is not drawn whole and then narrowed.
     const byColumn = useMemo(
-        () => allByColumn && filterColumnMap(allByColumn, filter.matchedNoteIds),
-        [ allByColumn, filter.matchedNoteIds ]);
+        () => (allByColumn && !filter.isResolvingStoredQuery
+            ? filterColumnMap(allByColumn, filter.matchedNoteIds)
+            : undefined),
+        [ allByColumn, filter.matchedNoteIds, filter.isResolvingStoredQuery ]);
 
     if (!apiRef.current || apiRef.current.board !== boardIdentity) {
         apiRef.current = {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -201,9 +201,8 @@ export const BoardDragStateContext = createContext<BoardDragState>({
 });
 
 /**
- * The tokens the active filter matched by, which the cards highlight in their titles. Null while
- * no filter is active. A context for the same reason the promoted attributes use one: a card is
- * memoized, and the tokens change only when a query is submitted.
+ * The tokens the active filter matched by, which the cards highlight in their titles. A context
+ * rather than a prop, so a memoized card is not redrawn for it during a drag.
  */
 export const BoardHighlightTokensContext = createContext<HighlightedTokenInfo[] | null>(null);
 
@@ -350,10 +349,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         onQueryChanged: persistFilterQuery,
         collectionNoteIds: noteIds
     });
-    // The cards as drawn. Derived rather than held, so that what is shown cannot fall behind what
-    // the filter matches: a card move and a search resolving in the same moment both land here.
-    // Withheld until a query stored in `board.json` has said what it matches, so a filtered board
-    // is not drawn whole and then narrowed.
+    // The cards as drawn. Derived rather than held, so what is shown cannot fall behind what the
+    // filter matches, and withheld until a query stored in `board.json` has said what it matches.
     const byColumn = useMemo(
         () => (allByColumn && !filter.isResolvingStoredQuery
             ? filterColumnMap(allByColumn, filter.matchedNoteIds)

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -573,10 +573,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         onCardEnd: (card, position) => {
             const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
             if (position && branchId && byColumn && allByColumn) {
-                // Drawn where it landed at once, and held there until both writes are in: each of
-                // them lands a redraw, and the first would show the card at the top of the column.
-                // Written into the full column, which is what the cards are drawn from, at the
-                // place the move is written against rather than the one it was dropped at.
+                // Drawn at once, into `allByColumn` since that is what `byColumn` derives from, at
+                // the index `unfilteredCardIndex` translates rather than the visible drop index.
                 setAllByColumn(applyCardMove(
                     allByColumn, card.noteId, card.fromColumn, position.column,
                     unfilteredCardIndex(

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -48,7 +48,9 @@ import { currentCardTemplate, DEFAULT_CARD_TEMPLATES } from "./card_templates";
 import ColumnLimitDialog from "./column_limit";
 import BoardProperties from "./properties";
 import { openBoardContextMenu, openCreateColumnMenu } from "./context_menu";
-import { applyCardMove, ColumnMap, filterColumnMap, getBoardData } from "./data";
+import {
+    applyCardMove, ColumnMap, filterColumnMap, getBoardData, unfilteredCardIndex
+} from "./data";
 import { useBoardKeyboard } from "./keyboard";
 
 /**
@@ -267,8 +269,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const [ statusAttributeWithPrefix ] = useNoteLabelWithDefault(parentNote, "board:groupBy", DEFAULT_GROUP_BY);
     const [ includeArchived ] = useNoteLabelBoolean(parentNote, "includeArchived");
     const [ inboxEnabled ] = useNoteLabelBoolean(parentNote, "enableInboxColumn");
-    const [ byColumn, setByColumn ] = useState<ColumnMap>();
-    /** Every card, while `byColumn` holds only what the active filter matches. */
+    /** Every card the board holds, which an active filter narrows before the cards are drawn. */
     const [ allByColumn, setAllByColumn ] = useState<ColumnMap>();
     const [ columns, setColumns ] = useState<string[]>();
     const [ isInRelationMode, setIsRelationMode ] = useState(false);
@@ -342,6 +343,19 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // them for a move that touched one. Another board takes a new one, since this instance is
     // reused across boards and the api holds that board's record of the writes in flight.
     const apiRef = useRef<{ board: string, api: Api }>();
+    const persistFilterQuery = useCallback(
+        (query: string) => apiRef.current?.api.setFilterQuery(query), []);
+    const filter = useCollectionFilter(parentNote, {
+        persistedQuery: viewConfig?.filterQuery,
+        onQueryChanged: persistFilterQuery,
+        collectionNoteIds: noteIds
+    });
+    // The cards as drawn. Derived rather than held, so that what is shown cannot fall behind what
+    // the filter matches: a card move and a search resolving in the same moment both land here.
+    const byColumn = useMemo(
+        () => allByColumn && filterColumnMap(allByColumn, filter.matchedNoteIds),
+        [ allByColumn, filter.matchedNoteIds ]);
+
     if (!apiRef.current || apiRef.current.board !== boardIdentity) {
         apiRef.current = {
             board: boardIdentity,
@@ -356,17 +370,6 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             saveConfig, setBranchIdToEdit, statusDefinition, allByColumn);
     }
     const api = apiRef.current.api;
-
-    const persistFilterQuery = useCallback(
-        (query: string) => apiRef.current?.api.setFilterQuery(query), []);
-    const filter = useCollectionFilter(parentNote, {
-        persistedQuery: viewConfig?.filterQuery,
-        onQueryChanged: persistFilterQuery,
-        collectionNoteIds: noteIds
-    });
-    // Read through a ref by `refresh`, whose result can land after the filter has moved on.
-    const matchedNoteIdsRef = useRef(filter.matchedNoteIds);
-    matchedNoteIdsRef.current = filter.matchedNoteIds;
     // Every member is one of useState's own setters, so this value is built once and never changes
     // identity -- a drag cannot reach anything that reads only this.
     const openBoardMenu = useCallback((event: ContextMenuEvent) => {
@@ -487,7 +490,9 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         getBoardData(
             parentNote, statusAttributeWithPrefix, viewConfig ?? {}, includeArchived,
             statusDefinition?.options ?? [], pendingRenamesRef.current.writes.renames, inboxEnabled)
-            .then(({ byColumn, columns, newPersistedData, isInRelationMode, settledRenames }) => {
+            .then(({
+                byColumn: allCards, columns, newPersistedData, isInRelationMode, settledRenames
+            }) => {
                 if (refreshId !== refreshSeqRef.current) {
                     return;
                 }
@@ -496,8 +501,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                     settleColumn(pendingRenamesRef.current.writes, settled);
                 }
 
-                setAllByColumn(byColumn);
-                setByColumn(filterColumnMap(byColumn, matchedNoteIdsRef.current));
+                setAllByColumn(allCards);
                 setIsRelationMode(isInRelationMode);
                 setColumns(columns);
 
@@ -564,11 +568,17 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         },
         onCardEnd: (card, position) => {
             const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
-            if (position && branchId && byColumn) {
+            if (position && branchId && byColumn && allByColumn) {
                 // Drawn where it landed at once, and held there until both writes are in: each of
                 // them lands a redraw, and the first would show the card at the top of the column.
-                setByColumn(applyCardMove(
-                    byColumn, card.noteId, card.fromColumn, position.column, position.index));
+                // Written into the full column, which is what the cards are drawn from, at the
+                // place the move is written against rather than the one it was dropped at.
+                setAllByColumn(applyCardMove(
+                    allByColumn, card.noteId, card.fromColumn, position.column,
+                    unfilteredCardIndex(
+                        byColumn.get(position.column) ?? [],
+                        allByColumn.get(position.column) ?? [],
+                        position.index)));
                 movesInFlight.current++;
                 // Any refresh already on its way is about the board as it stood before the drop,
                 // and would put the card back where it came from as it resolves.
@@ -683,15 +693,6 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     useEffect(refresh, [
         parentNote, noteIds, viewConfig, statusAttributeWithPrefix, statusDefinition, inboxEnabled
     ]);
-
-    // Redraws for a change in what the filter matches; a change in the cards themselves goes
-    // through `refresh`. Skipped while a move is being written, exactly as a refresh would be:
-    // the board has already been drawn as the move will leave it, and the maps are older.
-    useEffect(() => {
-        if (allByColumn && !movesInFlight.current) {
-            setByColumn(filterColumnMap(allByColumn, filter.matchedNoteIds));
-        }
-    }, [ filter.matchedNoteIds ]);
 
     // The drag reports where the column landed among the ones on screen, which is not where it
     // landed among them all once some are archived and hidden. Translated here so a reorder leaves

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -206,6 +206,9 @@ export const BoardDragStateContext = createContext<BoardDragState>({
  */
 export const BoardHighlightTokensContext = createContext<HighlightedTokenInfo[] | null>(null);
 
+/** The cards drawn although the filter does not match them, which say as much on their face. */
+export const BoardKeptCardsContext = createContext<Set<string>>(new Set());
+
 /**
  * What the board answers with when asked for contextual keyboard help. Every entry is a key the
  * board handles itself (see `keyboard.ts` and the card and column handlers), none of them
@@ -353,9 +356,9 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // filter matches, and withheld until a query stored in `board.json` has said what it matches.
     const byColumn = useMemo(
         () => (allByColumn && !filter.isResolvingStoredQuery
-            ? filterColumnMap(allByColumn, filter.matchedNoteIds)
+            ? filterColumnMap(allByColumn, filter.shownNoteIds)
             : undefined),
-        [ allByColumn, filter.matchedNoteIds, filter.isResolvingStoredQuery ]);
+        [ allByColumn, filter.shownNoteIds, filter.isResolvingStoredQuery ]);
 
     if (!apiRef.current || apiRef.current.board !== boardIdentity) {
         apiRef.current = {
@@ -363,12 +366,12 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             api: new Api(
                 byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
                 saveConfig, setBranchIdToEdit, pendingRenamesRef.current.writes, statusDefinition,
-                allByColumn)
+                allByColumn, filter.keepNote)
         };
     } else {
         apiRef.current.api.update(
             byColumn, usableColumns, parentNote, statusAttributeWithPrefix, viewConfig,
-            saveConfig, setBranchIdToEdit, statusDefinition, allByColumn);
+            saveConfig, setBranchIdToEdit, statusDefinition, allByColumn, filter.keepNote);
     }
     const api = apiRef.current.api;
     // Every member is one of useState's own setters, so this value is built once and never changes
@@ -758,6 +761,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             <BoardActionsContext.Provider value={boardActions}>
                 <BoardPromotedAttributesContext.Provider value={shownAttributes}>
                 <BoardHighlightTokensContext.Provider value={filter.highlightedTokens}>
+                <BoardKeptCardsContext.Provider value={filter.keptNoteIds}>
                 <BoardDragStateContext.Provider value={boardDragState}>
                     {byColumn && columns && <div
                         ref={containerRef}
@@ -857,6 +861,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                         )}
                     </div>}
                 </BoardDragStateContext.Provider>
+                </BoardKeptCardsContext.Provider>
                 </BoardHighlightTokensContext.Provider>
                 </BoardPromotedAttributesContext.Provider>
             </BoardActionsContext.Provider>

--- a/apps/client/src/widgets/collections/collection_filter.css
+++ b/apps/client/src/widgets/collections/collection_filter.css
@@ -1,0 +1,41 @@
+:where(:root) {
+    --collection-filter-active-border-color: var(--main-text-color);
+    --collection-filter-error-color: #c73a35;
+    --collection-filter-error-background: var(--main-background-color);
+    --collection-filter-error-border-color: var(--main-border-color);
+}
+
+.collection-filter {
+    display: inline-flex;
+    position: relative;
+    align-items: center;
+    gap: 0.25em;
+
+    > input.form-control {
+        width: clamp(120px, 30vw, 260px);
+        padding: 2px 8px;
+        font-size: inherit;
+    }
+
+    &.active > input.form-control {
+        border-color: var(--collection-filter-active-border-color);
+    }
+
+    .collection-filter-error {
+        display: block;
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        z-index: 100;
+        max-width: 60vw;
+        border: 1px solid var(--collection-filter-error-border-color);
+        border-radius: 4px;
+        padding: 2px 8px;
+        background: var(--collection-filter-error-background);
+        color: var(--collection-filter-error-color);
+        font-size: 0.9em;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/apps/client/src/widgets/collections/collection_filter.css
+++ b/apps/client/src/widgets/collections/collection_filter.css
@@ -1,4 +1,25 @@
+/* Painted from the quick search box's own variables, so the two boxes stay in step under a theme
+   that styles it; the fallbacks cover the themes that define none of them. */
 :where(:root) {
+    --collection-filter-color:
+        var(--quick-search-color, var(--muted-text-color));
+    --collection-filter-background:
+        var(--quick-search-background, var(--accented-background-color));
+    --collection-filter-hover-background:
+        var(--quick-search-hover-background, var(--accented-background-color));
+    --collection-filter-focus-color:
+        var(--quick-search-focus-color, var(--main-text-color));
+    --collection-filter-focus-background:
+        var(--quick-search-focus-background, var(--main-background-color));
+    --collection-filter-focus-border-color:
+        var(--quick-search-focus-border, var(--main-border-color));
+    --collection-filter-button-hover-background:
+        var(--left-pane-item-action-button-hover-background, var(--main-border-color));
+    --collection-filter-clear-background:
+        var(--dropdown-item-icon-destructive-color, #de4027);
+    --collection-filter-clear-hover-background: color-mix(
+        in srgb, var(--collection-filter-clear-background) 85%, black);
+    --collection-filter-clear-color: white;
     --collection-filter-active-border-color: var(--main-text-color);
     --collection-filter-error-color: #c73a35;
     --collection-filter-error-background: var(--main-background-color);
@@ -6,26 +27,111 @@
 }
 
 .collection-filter {
-    display: inline-flex;
-    position: relative;
-    align-items: center;
-    gap: 0.25em;
+    /* The buttons sit over the trailing end of the box, so the input reserves room for them in its
+       own padding rather than standing beside them. */
+    --collection-filter-button-size: 22px;
+    --collection-filter-button-inset: 4px;
+    --collection-filter-button-gap: 2px;
 
-    > input.form-control {
-        width: clamp(120px, 30vw, 260px);
-        padding: 2px 8px;
-        font-size: inherit;
+    display: inline-block;
+    position: relative;
+    width: clamp(110px, 16vw, 200px);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: var(--collection-filter-background);
+    color: var(--collection-filter-color);
+    transition: background-color 200ms ease-in;
+
+    &:hover {
+        background: var(--collection-filter-hover-background);
+        transition: background-color 75ms ease-out;
     }
 
-    &.active > input.form-control {
+    &:focus-within {
+        border-color: var(--collection-filter-focus-border-color);
+        background: var(--collection-filter-focus-background);
+        color: var(--collection-filter-focus-color);
+        transition: background-color 100ms ease-out;
+    }
+
+    &.active {
         border-color: var(--collection-filter-active-border-color);
+    }
+
+    > input.form-control {
+        width: 100%;
+        box-shadow: none;
+        border: 0;
+        padding: 6px 10px;
+        padding-inline-end: calc(
+            var(--collection-filter-button-size) + 2 * var(--collection-filter-button-inset));
+        background: transparent;
+        color: inherit;
+        font-size: inherit;
+
+        &::placeholder {
+            color: var(--collection-filter-color);
+        }
+    }
+
+    &:has(.collection-filter-clear) > input.form-control {
+        padding-inline-end: calc(
+            2 * var(--collection-filter-button-size) + 2 * var(--collection-filter-button-inset)
+            + var(--collection-filter-button-gap));
+    }
+
+    .collection-filter-buttons {
+        display: flex;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        inset-inline-end: var(--collection-filter-button-inset);
+        gap: var(--collection-filter-button-gap);
+        align-items: center;
+    }
+
+    button {
+        display: flex;
+        flex: none;
+        align-items: center;
+        justify-content: center;
+        width: var(--collection-filter-button-size);
+        height: var(--collection-filter-button-size);
+        border: 0;
+        border-radius: 50%;
+        padding: 0;
+        background: transparent;
+        color: inherit;
+        font-size: 1.1em;
+        line-height: 1;
+        transition: background-color 100ms ease-out;
+
+        /* The colour is restated because Bootstrap's own `.btn:hover` would otherwise take it. */
+        &:hover {
+            background: var(--collection-filter-button-hover-background);
+            color: inherit;
+        }
+
+        &:active {
+            transform: scale(0.85);
+        }
+    }
+
+    .collection-filter-clear {
+        background: var(--collection-filter-clear-background);
+        color: var(--collection-filter-clear-color);
+
+        &:hover {
+            background: var(--collection-filter-clear-hover-background);
+            color: var(--collection-filter-clear-color);
+        }
     }
 
     .collection-filter-error {
         display: block;
         position: absolute;
         top: calc(100% + 4px);
-        left: 0;
+        inset-inline-end: 0;
         z-index: 100;
         max-width: 60vw;
         border: 1px solid var(--collection-filter-error-border-color);

--- a/apps/client/src/widgets/collections/collection_filter.css
+++ b/apps/client/src/widgets/collections/collection_filter.css
@@ -35,7 +35,7 @@
 
     display: inline-block;
     position: relative;
-    width: clamp(110px, 16vw, 200px);
+    width: clamp(138px, 20vw, 250px);
     border: 1px solid transparent;
     border-radius: 6px;
     background: var(--collection-filter-background);

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -160,6 +160,47 @@ describe("useCollectionFilter", () => {
         expect(currentFilter?.matchedNoteIds?.has("n1")).toBe(true);
     });
 
+    it("holds while a stored query resolves, and not for one submitted afterwards", async () => {
+        const stored = deferred<ReturnType<typeof matchResponse>>();
+        searchInSubtree.mockReturnValueOnce(stored);
+        await mount({ persistedQuery: "#done" });
+
+        // Nothing may be drawn yet: the matches the board would narrow to are still unknown.
+        expect(currentFilter?.isResolvingStoredQuery).toBe(true);
+
+        await act(async () => {
+            stored.resolve(matchResponse([ "n1" ]));
+            await flushMicrotasks();
+        });
+        expect(currentFilter?.isResolvingStoredQuery).toBe(false);
+
+        // A later submit narrows a board already on screen, which must not be taken away.
+        const submitted = deferred<ReturnType<typeof matchResponse>>();
+        searchInSubtree.mockReturnValueOnce(submitted);
+        await act(async () => { currentFilter?.setQuery("#other"); });
+
+        expect(currentFilter?.isResolvingStoredQuery).toBe(false);
+        await act(async () => {
+            submitted.resolve(matchResponse([ "n2" ]));
+            await flushMicrotasks();
+        });
+    });
+
+    it("stops holding when a stored query cannot be run", async () => {
+        searchInSubtree.mockRejectedValueOnce(new Error("offline"));
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        await mount({ persistedQuery: "#done" });
+        await settle();
+
+        expect(currentFilter?.isResolvingStoredQuery).toBe(false);
+        expect(currentFilter?.error).toBe("collection_filter.fetch-error");
+    });
+
+    it("does not hold when nothing was stored", async () => {
+        await mount({});
+        expect(currentFilter?.isResolvingStoredQuery).toBe(false);
+    });
+
     it("keeps the previous matches when a query comes back with an error", async () => {
         searchInSubtree.mockResolvedValueOnce(matchResponse([ "n1" ]));
         await mount({});
@@ -280,6 +321,7 @@ describe("CollectionFilterInput", () => {
             matchedNoteIds: null,
             highlightedTokens: null,
             error: null,
+            isResolvingStoredQuery: false,
             setQuery: vi.fn(),
             ...overrides
         };

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -1,0 +1,347 @@
+import { deferred } from "@triliumnext/commons";
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Component from "../../components/component";
+import type FNote from "../../entities/fnote";
+import type { EntityChange } from "../../server_types";
+import LoadResults from "../../services/load_results";
+import searchService from "../../services/search";
+import { buildNote } from "../../test/easy-froca";
+import { ParentComponent } from "../react/react_utils";
+import {
+    type CollectionFilter, CollectionFilterInput, useCollectionFilter
+} from "./collection_filter";
+
+vi.mock("../../services/i18n", () => ({
+    t: (key: string) => key
+}));
+
+vi.mock("../../services/search", () => ({
+    default: { searchInSubtree: vi.fn() }
+}));
+
+const searchInSubtree = vi.mocked(searchService.searchInSubtree);
+
+let currentFilter: CollectionFilter | undefined;
+
+function Harness({ note, persistedQuery, onQueryChanged, collectionNoteIds }: {
+    note: FNote;
+    persistedQuery?: string;
+    onQueryChanged?: (query: string) => void;
+    collectionNoteIds?: string[];
+}) {
+    currentFilter = useCollectionFilter(note, {
+        persistedQuery,
+        onQueryChanged: onQueryChanged ?? (() => {}),
+        collectionNoteIds: collectionNoteIds ?? []
+    });
+    return null;
+}
+
+function matchResponse(noteIds: string[], error: string | null = null) {
+    return {
+        searchResultNoteIds: noteIds,
+        highlightedTokens: [ { token: "match", type: "plain" as const } ],
+        error
+    };
+}
+
+function branchEntitiesReloaded(parentNoteId: string, childNoteId: string) {
+    const branchId = `br-${childNoteId}`;
+    const loadResults = new LoadResults([
+        {
+            entityName: "branches",
+            entityId: branchId,
+            entity: { branchId, parentNoteId, noteId: childNoteId },
+            componentId: "comp-1"
+        } as unknown as EntityChange
+    ]);
+    loadResults.addBranch(branchId, "comp-1");
+    return loadResults;
+}
+
+async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+/**
+ * Flushes the work a mutation leaves behind: the effect run at the end of the previous `act` starts
+ * the search, whose resolution then has to land inside an `act` of its own to be drawn.
+ */
+async function settle() {
+    await act(async () => {
+        await flushMicrotasks();
+    });
+}
+
+describe("useCollectionFilter", () => {
+    let container: HTMLElement | undefined;
+    let parent: Component;
+
+    beforeEach(() => {
+        currentFilter = undefined;
+        searchInSubtree.mockReset();
+        parent = new Component();
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    async function mount(props: Omit<Parameters<typeof Harness>[0], "note"> & { note?: FNote }) {
+        const note = props.note ?? buildNote({ title: "Board" });
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={parent}>
+                    <Harness {...props} note={note} />
+                </ParentComponent.Provider>,
+                container ?? document.body
+            );
+            await flushMicrotasks();
+        });
+        return note;
+    }
+
+    it("stays inactive without a query and resolves matches on submit", async () => {
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1", "n2" ]));
+        const note = await mount({});
+
+        expect(currentFilter?.matchedNoteIds).toBeNull();
+        expect(searchInSubtree).not.toHaveBeenCalled();
+
+        await act(async () => {
+            currentFilter?.setQuery("#done");
+            await flushMicrotasks();
+        });
+        await settle();
+
+        expect(searchInSubtree).toHaveBeenCalledWith("#done", note.noteId);
+        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n1", "n2" ]);
+        expect(currentFilter?.highlightedTokens).toEqual([ { token: "match", type: "plain" } ]);
+
+        await act(async () => {
+            currentFilter?.setQuery("");
+            await flushMicrotasks();
+        });
+
+        expect(currentFilter?.matchedNoteIds).toBeNull();
+        expect(currentFilter?.highlightedTokens).toBeNull();
+    });
+
+    it("reports a submitted query for persistence, trimmed", async () => {
+        searchInSubtree.mockResolvedValue(matchResponse([]));
+        const onQueryChanged = vi.fn();
+        await mount({ onQueryChanged });
+
+        await act(async () => {
+            currentFilter?.setQuery("  #done  ");
+            await flushMicrotasks();
+        });
+
+        expect(onQueryChanged).toHaveBeenCalledWith("#done");
+        expect(currentFilter?.query).toBe("#done");
+    });
+
+    it("resolves a persisted query on mount", async () => {
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1" ]));
+        const note = await mount({ persistedQuery: "#done" });
+
+        expect(searchInSubtree).toHaveBeenCalledWith("#done", note.noteId);
+        expect(currentFilter?.matchedNoteIds?.has("n1")).toBe(true);
+    });
+
+    it("keeps the previous matches when a query comes back with an error", async () => {
+        searchInSubtree.mockResolvedValueOnce(matchResponse([ "n1" ]));
+        await mount({});
+
+        await act(async () => {
+            currentFilter?.setQuery("#done");
+            await flushMicrotasks();
+        });
+        await settle();
+
+        searchInSubtree.mockResolvedValueOnce(matchResponse([ "other" ], "broken query"));
+        await act(async () => {
+            currentFilter?.setQuery("#done ==");
+            await flushMicrotasks();
+        });
+        await settle();
+
+        expect(currentFilter?.error).toBe("broken query");
+        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n1" ]);
+
+        // A good query clears the error and takes over.
+        searchInSubtree.mockResolvedValueOnce(matchResponse([ "n2" ]));
+        await act(async () => {
+            currentFilter?.setQuery("#other");
+            await flushMicrotasks();
+        });
+        await settle();
+
+        expect(currentFilter?.error).toBeNull();
+        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n2" ]);
+    });
+
+    it("lets only the newest run set the result when runs resolve out of order", async () => {
+        const first = deferred<ReturnType<typeof matchResponse>>();
+        const second = deferred<ReturnType<typeof matchResponse>>();
+        searchInSubtree.mockReturnValueOnce(first).mockReturnValueOnce(second);
+        await mount({});
+
+        await act(async () => { currentFilter?.setQuery("#first"); });
+        await act(async () => { currentFilter?.setQuery("#second"); });
+
+        await act(async () => {
+            second.resolve(matchResponse([ "newer" ]));
+            await flushMicrotasks();
+        });
+        await act(async () => {
+            first.resolve(matchResponse([ "older" ]));
+            await flushMicrotasks();
+        });
+
+        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "newer" ]);
+    });
+
+    it("re-runs an active filter, debounced, when a change touches the collection", async () => {
+        vi.useFakeTimers();
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1" ]));
+        const note = await mount({ collectionNoteIds: [ "n1", "n2" ] });
+
+        await act(async () => {
+            currentFilter?.setQuery("#done");
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(searchInSubtree).toHaveBeenCalledTimes(1);
+
+        // Two changes inside the debounce window collapse into one re-run.
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "added")
+            });
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded("n2", "nested")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+        expect(searchInSubtree).toHaveBeenCalledTimes(2);
+
+        // A change elsewhere re-runs nothing.
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded("unrelated", "elsewhere")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+        expect(searchInSubtree).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not re-run while no filter is active", async () => {
+        const note = await mount({ collectionNoteIds: [ "n1" ] });
+        vi.useFakeTimers();
+
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "added")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+
+        expect(searchInSubtree).not.toHaveBeenCalled();
+    });
+});
+
+describe("CollectionFilterInput", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+    });
+
+    function mountInput(overrides: Partial<CollectionFilter> = {}) {
+        const filter: CollectionFilter = {
+            query: "",
+            matchedNoteIds: null,
+            highlightedTokens: null,
+            error: null,
+            setQuery: vi.fn(),
+            ...overrides
+        };
+        // Rendered inside act so the mount effects run now, not queued into the next act where
+        // they would clobber what a test has typed in the meantime.
+        act(() => render(<CollectionFilterInput filter={filter} />, container));
+        const input = container.querySelector("input");
+        expect(input).not.toBeNull();
+        return { filter, input: input as HTMLInputElement };
+    }
+
+    function type(input: HTMLInputElement, value: string) {
+        input.value = value;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+
+    it("submits what is typed on Enter", async () => {
+        const { filter, input } = mountInput();
+
+        // Typed first and submitted in a pass of its own, so the keydown runs against the
+        // re-rendered handler that has seen the typing.
+        await act(async () => type(input, "#done"));
+        await act(async () => {
+            input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+        });
+
+        expect(filter.setQuery).toHaveBeenCalledWith("#done");
+    });
+
+    it("clears the filter through the button and refocuses the box", async () => {
+        const { filter } = mountInput({ query: "#done" });
+
+        const clear = container.querySelector<HTMLElement>(".collection-filter-clear");
+        expect(clear).not.toBeNull();
+        await act(async () => clear?.click());
+
+        expect(filter.setQuery).toHaveBeenCalledWith("");
+    });
+
+    it("shows the box as active and offers no clear button while empty and inactive", () => {
+        mountInput();
+        expect(container.querySelector(".collection-filter")?.classList.contains("active")).toBe(false);
+        expect(container.querySelector(".collection-filter-clear")).toBeNull();
+
+        mountInput({ query: "#done" });
+        expect(container.querySelector(".collection-filter")?.classList.contains("active")).toBe(true);
+    });
+
+    it("shows the query error under the box", () => {
+        mountInput({ error: "broken" });
+        expect(container.querySelector(".collection-filter-error")?.textContent).toBe("broken");
+    });
+
+    it("gives up unsubmitted typing on Escape without touching the filter", async () => {
+        const { filter, input } = mountInput({ query: "#kept" });
+
+        await act(async () => type(input, "#typed"));
+        await act(async () => {
+            input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+        });
+
+        expect(input.value).toBe("#kept");
+        expect(filter.setQuery).not.toHaveBeenCalled();
+    });
+});

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -165,7 +165,7 @@ describe("useCollectionFilter", () => {
         searchInSubtree.mockReturnValueOnce(stored);
         await mount({ persistedQuery: "#done" });
 
-        // Nothing may be drawn yet: the matches the board would narrow to are still unknown.
+        // Nothing must be drawn yet: the matches the board would narrow to are still unknown.
         expect(currentFilter?.isResolvingStoredQuery).toBe(true);
 
         await act(async () => {

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -309,6 +309,29 @@ describe("CollectionFilterInput", () => {
         expect(filter.setQuery).toHaveBeenCalledWith("#done");
     });
 
+    it("submits what is typed through the search button", async () => {
+        const { filter, input } = mountInput();
+
+        await act(async () => type(input, "#done"));
+        const submit = container.querySelector<HTMLElement>(".collection-filter-submit");
+        expect(submit).not.toBeNull();
+        await act(async () => submit?.click());
+
+        expect(filter.setQuery).toHaveBeenCalledWith("#done");
+    });
+
+    it("puts the clear button before the search button", async () => {
+        const { input } = mountInput();
+
+        await act(async () => type(input, "#done"));
+        const buttons = [ ...container.querySelectorAll("button") ].map(button => button.className);
+        const clear = buttons.findIndex(name => name.includes("collection-filter-clear"));
+        const submit = buttons.findIndex(name => name.includes("collection-filter-submit"));
+
+        expect(clear).toBeGreaterThanOrEqual(0);
+        expect(submit).toBe(clear + 1);
+    });
+
     it("clears the filter through the button and refocuses the box", async () => {
         const { filter } = mountInput({ query: "#done" });
 

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -116,7 +116,7 @@ describe("useCollectionFilter", () => {
         searchInSubtree.mockResolvedValue(matchResponse([ "n1", "n2" ]));
         const note = await mount({});
 
-        expect(currentFilter?.matchedNoteIds).toBeNull();
+        expect(currentFilter?.shownNoteIds).toBeNull();
         expect(searchInSubtree).not.toHaveBeenCalled();
 
         await act(async () => {
@@ -126,7 +126,7 @@ describe("useCollectionFilter", () => {
         await settle();
 
         expect(searchInSubtree).toHaveBeenCalledWith("#done", note.noteId);
-        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n1", "n2" ]);
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "n1", "n2" ]);
         expect(currentFilter?.highlightedTokens).toEqual([ { token: "match", type: "plain" } ]);
 
         await act(async () => {
@@ -134,7 +134,7 @@ describe("useCollectionFilter", () => {
             await flushMicrotasks();
         });
 
-        expect(currentFilter?.matchedNoteIds).toBeNull();
+        expect(currentFilter?.shownNoteIds).toBeNull();
         expect(currentFilter?.highlightedTokens).toBeNull();
     });
 
@@ -157,7 +157,7 @@ describe("useCollectionFilter", () => {
         const note = await mount({ persistedQuery: "#done" });
 
         expect(searchInSubtree).toHaveBeenCalledWith("#done", note.noteId);
-        expect(currentFilter?.matchedNoteIds?.has("n1")).toBe(true);
+        expect(currentFilter?.shownNoteIds?.has("n1")).toBe(true);
     });
 
     it("holds while a stored query resolves, and not for one submitted afterwards", async () => {
@@ -201,6 +201,77 @@ describe("useCollectionFilter", () => {
         expect(currentFilter?.isResolvingStoredQuery).toBe(false);
     });
 
+    // Nothing stands outside a filter that is not there, so a note reported while the collection
+    // is whole must not come back marked.
+    it("keeps nothing while no filter is active", async () => {
+        await mount({});
+
+        await act(async () => { currentFilter?.keepNote("made"); });
+
+        expect(currentFilter?.keptNoteIds.size).toBe(0);
+        expect(currentFilter?.shownNoteIds).toBeNull();
+    });
+
+    /** A note made in a narrowed collection is drawn although the query misses it. */
+    it("draws a kept note the query misses, and marks it, until the query changes", async () => {
+        vi.useFakeTimers();
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1" ]));
+        const note = await mount({ collectionNoteIds: [ "n1" ] });
+
+        await act(async () => {
+            currentFilter?.setQuery("#done");
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        await act(async () => { currentFilter?.keepNote("made"); });
+
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "n1", "made" ]);
+        expect([ ...(currentFilter?.keptNoteIds ?? []) ]).toEqual([ "made" ]);
+
+        // A re-run that still misses it leaves it drawn: it was made here, on this query.
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "made")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+        expect(currentFilter?.shownNoteIds?.has("made")).toBe(true);
+
+        // Another query is asked afresh which notes belong.
+        searchInSubtree.mockResolvedValue(matchResponse([ "n2" ]));
+        await act(async () => {
+            currentFilter?.setQuery("#other");
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        await settle();
+
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "n2" ]);
+        expect(currentFilter?.keptNoteIds.size).toBe(0);
+    });
+
+    it("stops marking a kept note once the query comes to match it", async () => {
+        vi.useFakeTimers();
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1" ]));
+        const note = await mount({ collectionNoteIds: [ "n1" ] });
+
+        await act(async () => {
+            currentFilter?.setQuery("#done");
+            await vi.advanceTimersByTimeAsync(0);
+        });
+        await act(async () => { currentFilter?.keepNote("made"); });
+        expect(currentFilter?.keptNoteIds.has("made")).toBe(true);
+
+        searchInSubtree.mockResolvedValue(matchResponse([ "n1", "made" ]));
+        await act(async () => {
+            await parent.handleEvent("entitiesReloaded", {
+                loadResults: branchEntitiesReloaded(note.noteId, "made")
+            });
+            await vi.advanceTimersByTimeAsync(400);
+        });
+
+        expect(currentFilter?.shownNoteIds?.has("made")).toBe(true);
+        expect(currentFilter?.keptNoteIds.has("made")).toBe(false);
+    });
+
     it("keeps the previous matches when a query comes back with an error", async () => {
         searchInSubtree.mockResolvedValueOnce(matchResponse([ "n1" ]));
         await mount({});
@@ -219,7 +290,7 @@ describe("useCollectionFilter", () => {
         await settle();
 
         expect(currentFilter?.error).toBe("broken query");
-        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n1" ]);
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "n1" ]);
 
         // A good query clears the error and takes over.
         searchInSubtree.mockResolvedValueOnce(matchResponse([ "n2" ]));
@@ -230,7 +301,7 @@ describe("useCollectionFilter", () => {
         await settle();
 
         expect(currentFilter?.error).toBeNull();
-        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "n2" ]);
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "n2" ]);
     });
 
     it("lets only the newest run set the result when runs resolve out of order", async () => {
@@ -251,7 +322,7 @@ describe("useCollectionFilter", () => {
             await flushMicrotasks();
         });
 
-        expect([ ...(currentFilter?.matchedNoteIds ?? []) ]).toEqual([ "newer" ]);
+        expect([ ...(currentFilter?.shownNoteIds ?? []) ]).toEqual([ "newer" ]);
     });
 
     it("re-runs an active filter, debounced, when a change touches the collection", async () => {
@@ -318,10 +389,12 @@ describe("CollectionFilterInput", () => {
     function mountInput(overrides: Partial<CollectionFilter> = {}) {
         const filter: CollectionFilter = {
             query: "",
-            matchedNoteIds: null,
+            shownNoteIds: null,
+            keptNoteIds: new Set<string>(),
             highlightedTokens: null,
             error: null,
             isResolvingStoredQuery: false,
+            keepNote: vi.fn(),
             setQuery: vi.fn(),
             ...overrides
         };

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -435,10 +435,9 @@ describe("CollectionFilterInput", () => {
         expect(filter.setQuery).toHaveBeenCalledWith("#done");
     });
 
-    it("puts the clear button before the search button", async () => {
-        const { input } = mountInput();
+    it("puts the clear button before the search button", () => {
+        mountInput({ query: "#done" });
 
-        await act(async () => type(input, "#done"));
         const buttons = [ ...container.querySelectorAll("button") ].map(button => button.className);
         const clear = buttons.findIndex(name => name.includes("collection-filter-clear"));
         const submit = buttons.findIndex(name => name.includes("collection-filter-submit"));
@@ -457,16 +456,22 @@ describe("CollectionFilterInput", () => {
         expect(filter.setQuery).toHaveBeenCalledWith("");
     });
 
-    it("shows the box as active and offers no clear button while empty and inactive", () => {
-        mountInput();
-        expect(container.querySelector(".collection-filter")?.classList.contains("active")).toBe(false);
+    it("offers no clear button until a filter is in force, whatever is typed", async () => {
+        const { input } = mountInput();
+        const box = () => container.querySelector(".collection-filter");
+        expect(box()?.classList.contains("active")).toBe(false);
+        expect(container.querySelector(".collection-filter-clear")).toBeNull();
+
+        // Typing is not yet a filter, so there is nothing for the button to take away.
+        await act(async () => type(input, "#done"));
         expect(container.querySelector(".collection-filter-clear")).toBeNull();
 
         mountInput({ query: "#done" });
-        expect(container.querySelector(".collection-filter")?.classList.contains("active")).toBe(true);
+        expect(box()?.classList.contains("active")).toBe(true);
+        expect(container.querySelector(".collection-filter-clear")).not.toBeNull();
     });
 
-    // The tooltip opens on hover alone, so the name has to be on the element itself.
+    // The box carries no tooltip, and a placeholder is gone as soon as something is typed.
     it("names the box for assistive technology", () => {
         const { input } = mountInput();
         expect(input.getAttribute("aria-label")).toBe("collection_filter.placeholder");

--- a/apps/client/src/widgets/collections/collection_filter.spec.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.spec.tsx
@@ -393,6 +393,12 @@ describe("CollectionFilterInput", () => {
         expect(container.querySelector(".collection-filter")?.classList.contains("active")).toBe(true);
     });
 
+    // The tooltip opens on hover alone, so the name has to be on the element itself.
+    it("names the box for assistive technology", () => {
+        const { input } = mountInput();
+        expect(input.getAttribute("aria-label")).toBe("collection_filter.placeholder");
+    });
+
     it("shows the query error under the box", () => {
         mountInput({ error: "broken" });
         expect(container.querySelector(".collection-filter-error")?.textContent).toBe("broken");

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -12,7 +12,7 @@ import ActionButton from "../react/ActionButton";
 import FormTextBox from "../react/FormTextBox";
 import { useTriliumEvent } from "../react/hooks";
 
-/** How long changes are left to settle before the active filter is re-run over them. */
+/** How long to wait after a change before re-running the active filter. */
 const RERUN_DEBOUNCE_MS = 300;
 
 export interface CollectionFilter {
@@ -37,10 +37,9 @@ const NO_MATCHES: FilterMatches = { matchedNoteIds: null, highlightedTokens: nul
 /**
  * Narrows a collection to the notes matching a search query, using the full search syntax.
  *
- * The query runs server-side, scoped to the collection's subtree, and the result is a membership
- * set: the view keeps its own enumeration and order and only leaves out the notes not in the set.
- * Search results are a snapshot, so while a filter is active it is re-run (debounced) whenever an
- * entity change touches the collection.
+ * The result is a membership set, not an order: a view keeps its own enumeration and leaves out
+ * the notes the set does not name. A search result is a snapshot, so an active filter re-runs
+ * when an entity change touches the collection.
  */
 export function useCollectionFilter(note: FNote, {
     persistedQuery, onQueryChanged, collectionNoteIds
@@ -55,8 +54,8 @@ export function useCollectionFilter(note: FNote, {
     const [ query, setQuery ] = useState(persistedQuery ?? "");
     const [ matches, setMatches ] = useState<FilterMatches>(NO_MATCHES);
     const [ error, setError ] = useState<string | null>(null);
-    // Runs resolve on the server, so an older one can land after a newer one; only the latest run
-    // is allowed to set the result.
+    // A run resolves on the server, so an older one can land after a newer one. Only the latest
+    // run sets the result.
     const runSeqRef = useRef(0);
     const rerunTimerRef = useRef<number>();
     const collectionSet = useMemo(() => new Set(collectionNoteIds), [ collectionNoteIds ]);
@@ -111,7 +110,8 @@ export function useCollectionFilter(note: FNote, {
     }, [ note.noteId, query ]);
 
     useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
-        if (!query.trim() || !touchesCollection(loadResults, collectionSetRef.current, note.noteId)) {
+        const collection = collectionSetRef.current;
+        if (!query.trim() || !touchesCollection(loadResults, collection, note.noteId)) {
             return;
         }
         window.clearTimeout(rerunTimerRef.current);
@@ -133,9 +133,10 @@ export function useCollectionFilter(note: FNote, {
 }
 
 /**
- * The filter box a collection header shows: Enter submits what is typed, the button or an emptied
- * box clears the filter, and a query error is shown under the box. What is typed but not submitted
- * is local to the box, so an unrelated redraw does not apply a half-typed query.
+ * The filter box for a collection header. Enter submits what is typed and the button clears it.
+ *
+ * What is typed is held here until it is submitted, so an unrelated redraw cannot apply a
+ * half-typed query.
  */
 export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) {
     const [ typed, setTyped ] = useState(filter.query);
@@ -159,8 +160,8 @@ export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) 
                         e.preventDefault();
                         filter.setQuery(typed);
                     } else if (e.key === "Escape" && typed !== filter.query) {
-                        // Give up what was typed, keeping the submitted query; a second Escape is
-                        // left for whatever the view does with it.
+                        // Drops what was typed and keeps the submitted query. A second Escape
+                        // reaches the view, which handles it as usual.
                         e.stopPropagation();
                         setTyped(filter.query);
                     }

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -1,6 +1,7 @@
 import "./collection_filter.css";
 
 import type { HighlightedTokenInfo } from "@triliumnext/commons";
+import type { Tooltip } from "bootstrap";
 import clsx from "clsx";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 
@@ -10,10 +11,19 @@ import type LoadResults from "../../services/load_results";
 import searchService from "../../services/search";
 import ActionButton from "../react/ActionButton";
 import FormTextBox from "../react/FormTextBox";
-import { useTriliumEvent } from "../react/hooks";
+import { useStaticTooltip, useTriliumEvent } from "../react/hooks";
 
 /** How long to wait after a change before re-running the active filter. */
 const RERUN_DEBOUNCE_MS = 300;
+
+// Hover only: the box is typed into, and a tooltip opened by the focus would sit over the header
+// for as long as the query is being written.
+const TOOLTIP_CONFIG: Partial<Tooltip.Options> = {
+    title: t("collection_filter.tooltip"),
+    placement: "bottom",
+    trigger: "hover",
+    animation: false
+};
 
 export interface CollectionFilter {
     /** The submitted query, empty while no filter is active. */
@@ -133,14 +143,20 @@ export function useCollectionFilter(note: FNote, {
 }
 
 /**
- * The filter box for a collection header. Enter submits what is typed and the button clears it.
+ * The filter box for a collection header, styled after the quick search box. Enter or the search
+ * button submits what is typed, and the clear button beside it drops the filter.
  *
  * What is typed is held here until it is submitted, so an unrelated redraw cannot apply a
  * half-typed query.
  */
-export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) {
+export function CollectionFilterInput({ filter, placeholder }: {
+    filter: CollectionFilter;
+    /** Names the collection being filtered, for a view that has a word for what it holds. */
+    placeholder?: string;
+}) {
     const [ typed, setTyped ] = useState(filter.query);
     const inputRef = useRef<HTMLInputElement>(null);
+    useStaticTooltip(inputRef, TOOLTIP_CONFIG);
 
     // Adopt a query submitted elsewhere, or the stored one arriving on mount.
     useEffect(() => setTyped(filter.query), [ filter.query ]);
@@ -152,8 +168,7 @@ export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) 
             <FormTextBox
                 inputRef={inputRef}
                 currentValue={typed}
-                placeholder={t("collection_filter.placeholder")}
-                title={t("collection_filter.tooltip")}
+                placeholder={placeholder ?? t("collection_filter.placeholder")}
                 onChange={setTyped}
                 onKeyDown={(e: KeyboardEvent) => {
                     if (e.key === "Enter") {
@@ -167,18 +182,28 @@ export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) 
                     }
                 }}
             />
-            {(!!typed || isActive) && (
+            <div className="collection-filter-buttons">
+                {(!!typed || isActive) && (
+                    <ActionButton
+                        className="collection-filter-clear"
+                        noIconActionClass
+                        icon="bx bx-x"
+                        text={t("collection_filter.clear")}
+                        onClick={() => {
+                            setTyped("");
+                            filter.setQuery("");
+                            inputRef.current?.focus();
+                        }}
+                    />
+                )}
                 <ActionButton
-                    className="collection-filter-clear"
-                    icon="bx bx-x"
-                    text={t("collection_filter.clear")}
-                    onClick={() => {
-                        setTyped("");
-                        filter.setQuery("");
-                        inputRef.current?.focus();
-                    }}
+                    className="collection-filter-submit"
+                    noIconActionClass
+                    icon="bx bx-search"
+                    text={t("collection_filter.submit")}
+                    onClick={() => filter.setQuery(typed)}
                 />
-            )}
+            </div>
             {filter.error && <span className="collection-filter-error">{filter.error}</span>}
         </div>
     );

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -1,0 +1,197 @@
+import "./collection_filter.css";
+
+import type { HighlightedTokenInfo } from "@triliumnext/commons";
+import clsx from "clsx";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+
+import FNote from "../../entities/fnote";
+import { t } from "../../services/i18n";
+import type LoadResults from "../../services/load_results";
+import searchService from "../../services/search";
+import ActionButton from "../react/ActionButton";
+import FormTextBox from "../react/FormTextBox";
+import { useTriliumEvent } from "../react/hooks";
+
+/** How long changes are left to settle before the active filter is re-run over them. */
+const RERUN_DEBOUNCE_MS = 300;
+
+export interface CollectionFilter {
+    /** The submitted query, empty while no filter is active. */
+    query: string;
+    /** The notes the query matches, or null while no filter is active. */
+    matchedNoteIds: Set<string> | null;
+    /** The tokens the matches were found by, for highlighting them where the notes are drawn. */
+    highlightedTokens: HighlightedTokenInfo[] | null;
+    /** What is wrong with the query, or null. An erroneous query keeps the previous matches. */
+    error: string | null;
+    setQuery: (query: string) => void;
+}
+
+interface FilterMatches {
+    matchedNoteIds: Set<string> | null;
+    highlightedTokens: HighlightedTokenInfo[] | null;
+}
+
+const NO_MATCHES: FilterMatches = { matchedNoteIds: null, highlightedTokens: null };
+
+/**
+ * Narrows a collection to the notes matching a search query, using the full search syntax.
+ *
+ * The query runs server-side, scoped to the collection's subtree, and the result is a membership
+ * set: the view keeps its own enumeration and order and only leaves out the notes not in the set.
+ * Search results are a snapshot, so while a filter is active it is re-run (debounced) whenever an
+ * entity change touches the collection.
+ */
+export function useCollectionFilter(note: FNote, {
+    persistedQuery, onQueryChanged, collectionNoteIds
+}: {
+    /** The stored query the filter starts from, so it survives reopening the collection. */
+    persistedQuery: string | undefined;
+    /** Reports a submitted query, for the view to persist. Called with "" when cleared. */
+    onQueryChanged: (query: string) => void;
+    /** The notes the collection shows, deciding which entity changes re-run the filter. */
+    collectionNoteIds: string[];
+}): CollectionFilter {
+    const [ query, setQuery ] = useState(persistedQuery ?? "");
+    const [ matches, setMatches ] = useState<FilterMatches>(NO_MATCHES);
+    const [ error, setError ] = useState<string | null>(null);
+    // Runs resolve on the server, so an older one can land after a newer one; only the latest run
+    // is allowed to set the result.
+    const runSeqRef = useRef(0);
+    const rerunTimerRef = useRef<number>();
+    const collectionSet = useMemo(() => new Set(collectionNoteIds), [ collectionNoteIds ]);
+    const collectionSetRef = useRef(collectionSet);
+    collectionSetRef.current = collectionSet;
+
+    async function run(activeQuery: string) {
+        const seq = ++runSeqRef.current;
+        let response;
+        try {
+            response = await searchService.searchInSubtree(activeQuery, note.noteId);
+        } catch (e) {
+            console.error("Failed to run the collection filter:", e);
+            if (seq === runSeqRef.current) {
+                setError(t("collection_filter.fetch-error"));
+            }
+            return;
+        }
+
+        if (seq !== runSeqRef.current) {
+            return;
+        }
+
+        if (response.error) {
+            // The previous matches stay shown: a broken query must not blank the collection.
+            setError(response.error);
+            return;
+        }
+
+        setError(null);
+        setMatches({
+            matchedNoteIds: new Set(response.searchResultNoteIds),
+            highlightedTokens: response.highlightedTokens
+        });
+    }
+
+    // Adopt a query stored elsewhere: the persisted one on mount, or one another view submitted.
+    useEffect(() => {
+        setQuery(persistedQuery ?? "");
+    }, [ note.noteId, persistedQuery ]);
+
+    // Resolve the submitted query, or drop the filter when it is cleared.
+    useEffect(() => {
+        window.clearTimeout(rerunTimerRef.current);
+        if (!query.trim()) {
+            runSeqRef.current++;
+            setError(null);
+            setMatches(NO_MATCHES);
+            return;
+        }
+        run(query);
+    }, [ note.noteId, query ]);
+
+    useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
+        if (!query.trim() || !touchesCollection(loadResults, collectionSetRef.current, note.noteId)) {
+            return;
+        }
+        window.clearTimeout(rerunTimerRef.current);
+        rerunTimerRef.current = window.setTimeout(() => run(query), RERUN_DEBOUNCE_MS);
+    });
+
+    useEffect(() => () => window.clearTimeout(rerunTimerRef.current), []);
+
+    return {
+        query,
+        ...matches,
+        error,
+        setQuery: (newQuery: string) => {
+            const trimmed = newQuery.trim();
+            setQuery(trimmed);
+            onQueryChanged(trimmed);
+        }
+    };
+}
+
+/**
+ * The filter box a collection header shows: Enter submits what is typed, the button or an emptied
+ * box clears the filter, and a query error is shown under the box. What is typed but not submitted
+ * is local to the box, so an unrelated redraw does not apply a half-typed query.
+ */
+export function CollectionFilterInput({ filter }: { filter: CollectionFilter }) {
+    const [ typed, setTyped ] = useState(filter.query);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // Adopt a query submitted elsewhere, or the stored one arriving on mount.
+    useEffect(() => setTyped(filter.query), [ filter.query ]);
+
+    const isActive = !!filter.query;
+
+    return (
+        <div className={clsx("collection-filter", { active: isActive })}>
+            <FormTextBox
+                inputRef={inputRef}
+                currentValue={typed}
+                placeholder={t("collection_filter.placeholder")}
+                title={t("collection_filter.tooltip")}
+                onChange={setTyped}
+                onKeyDown={(e: KeyboardEvent) => {
+                    if (e.key === "Enter") {
+                        e.preventDefault();
+                        filter.setQuery(typed);
+                    } else if (e.key === "Escape" && typed !== filter.query) {
+                        // Give up what was typed, keeping the submitted query; a second Escape is
+                        // left for whatever the view does with it.
+                        e.stopPropagation();
+                        setTyped(filter.query);
+                    }
+                }}
+            />
+            {(!!typed || isActive) && (
+                <ActionButton
+                    className="collection-filter-clear"
+                    icon="bx bx-x"
+                    text={t("collection_filter.clear")}
+                    onClick={() => {
+                        setTyped("");
+                        filter.setQuery("");
+                        inputRef.current?.focus();
+                    }}
+                />
+            )}
+            {filter.error && <span className="collection-filter-error">{filter.error}</span>}
+        </div>
+    );
+}
+
+/** Whether any changed note, attribute or branch belongs to the collection's subtree. */
+function touchesCollection(
+    loadResults: LoadResults, collectionNoteIds: Set<string>, collectionNoteId: string
+) {
+    const inCollection = (noteId: string | null | undefined) =>
+        !!noteId && (noteId === collectionNoteId || collectionNoteIds.has(noteId));
+
+    return loadResults.getNoteIds().some(inCollection)
+        || loadResults.getAttributeRows().some(attr => inCollection(attr.noteId))
+        || loadResults.getBranchRows().some(branch =>
+            inCollection(branch.noteId) || inCollection(branch.parentNoteId));
+}

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -34,6 +34,11 @@ export interface CollectionFilter {
     highlightedTokens: HighlightedTokenInfo[] | null;
     /** What is wrong with the query, or null. An erroneous query keeps the previous matches. */
     error: string | null;
+    /**
+     * Whether a stored query is still being resolved, for the view to hold its first draw on. Only
+     * a stored one: a query submitted later narrows a collection that is already on screen.
+     */
+    isResolvingStoredQuery: boolean;
     setQuery: (query: string) => void;
 }
 
@@ -64,10 +69,15 @@ export function useCollectionFilter(note: FNote, {
     const [ query, setQuery ] = useState(persistedQuery ?? "");
     const [ matches, setMatches ] = useState<FilterMatches>(NO_MATCHES);
     const [ error, setError ] = useState<string | null>(null);
+    // Set before anything is drawn, so a collection opened onto a stored query waits for its
+    // matches instead of drawing every note and then taking most of them away.
+    const [ isResolvingStoredQuery, setIsResolvingStoredQuery ] =
+        useState(() => !!persistedQuery?.trim());
     // A run resolves on the server, so an older one can land after a newer one. Only the latest
     // run sets the result.
     const runSeqRef = useRef(0);
     const rerunTimerRef = useRef<number>();
+    const previousNoteIdRef = useRef(note.noteId);
     const collectionSet = useMemo(() => new Set(collectionNoteIds), [ collectionNoteIds ]);
     const collectionSetRef = useRef(collectionSet);
     collectionSetRef.current = collectionSet;
@@ -81,6 +91,7 @@ export function useCollectionFilter(note: FNote, {
             console.error("Failed to run the collection filter:", e);
             if (seq === runSeqRef.current) {
                 setError(t("collection_filter.fetch-error"));
+                setIsResolvingStoredQuery(false);
             }
             return;
         }
@@ -88,6 +99,10 @@ export function useCollectionFilter(note: FNote, {
         if (seq !== runSeqRef.current) {
             return;
         }
+
+        // The wait is over whatever the run came back with: a stored query that cannot be run must
+        // not hold the collection back from being drawn.
+        setIsResolvingStoredQuery(false);
 
         if (response.error) {
             // The previous matches stay shown: a broken query must not blank the collection.
@@ -105,6 +120,14 @@ export function useCollectionFilter(note: FNote, {
     // Adopt a query stored elsewhere: the persisted one on mount, or one another view submitted.
     useEffect(() => {
         setQuery(persistedQuery ?? "");
+
+        // Another collection brings its own stored query, and this instance is reused across them,
+        // so the wait is armed again here rather than only at mount. Not for a query submitted in
+        // this collection, which also arrives as a new `persistedQuery`.
+        if (previousNoteIdRef.current !== note.noteId) {
+            previousNoteIdRef.current = note.noteId;
+            setIsResolvingStoredQuery(!!persistedQuery?.trim());
+        }
     }, [ note.noteId, persistedQuery ]);
 
     // Resolve the submitted query, or drop the filter when it is cleared.
@@ -114,6 +137,7 @@ export function useCollectionFilter(note: FNote, {
             runSeqRef.current++;
             setError(null);
             setMatches(NO_MATCHES);
+            setIsResolvingStoredQuery(false);
             return;
         }
         run(query);
@@ -134,6 +158,7 @@ export function useCollectionFilter(note: FNote, {
         query,
         ...matches,
         error,
+        isResolvingStoredQuery,
         setQuery: (newQuery: string) => {
             const trimmed = newQuery.trim();
             setQuery(trimmed);

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -28,8 +28,10 @@ const TOOLTIP_CONFIG: Partial<Tooltip.Options> = {
 export interface CollectionFilter {
     /** The submitted query, empty while no filter is active. */
     query: string;
-    /** The notes the query matches, or null while no filter is active. */
-    matchedNoteIds: Set<string> | null;
+    /** The notes to draw, or null while no filter is active. Matches plus {@link keptNoteIds}. */
+    shownNoteIds: Set<string> | null;
+    /** Of those, the ones the query does not match, drawn because they were just made here. */
+    keptNoteIds: Set<string>;
     /** The tokens the matches were found by, for highlighting them where the notes are drawn. */
     highlightedTokens: HighlightedTokenInfo[] | null;
     /** What is wrong with the query, or null. An erroneous query keeps the previous matches. */
@@ -39,6 +41,8 @@ export interface CollectionFilter {
      * a stored one: a query submitted later narrows a collection that is already on screen.
      */
     isResolvingStoredQuery: boolean;
+    /** Draws a note the query does not match, until the query is changed. */
+    keepNote: (noteId: string) => void;
     setQuery: (query: string) => void;
 }
 
@@ -48,6 +52,7 @@ interface FilterMatches {
 }
 
 const NO_MATCHES: FilterMatches = { matchedNoteIds: null, highlightedTokens: null };
+const NOTHING_KEPT: Set<string> = new Set();
 
 /**
  * Narrows a collection to the notes matching a search query, using the full search syntax.
@@ -70,6 +75,9 @@ export function useCollectionFilter(note: FNote, {
     // matches instead of drawing every note and then taking most of them away.
     const [ isResolvingStoredQuery, setIsResolvingStoredQuery ] =
         useState(() => !!persistedQuery?.trim());
+    // Notes made in the collection while it is narrowed, drawn until the query changes. A re-run
+    // does not take them away: a note made here and not shown would look like nothing happened.
+    const [ keptNoteIds, setKeptNoteIds ] = useState(NOTHING_KEPT);
     // A run resolves on the server, so an older one can land after a newer one. Only the latest
     // run sets the result.
     const runSeqRef = useRef(0);
@@ -126,9 +134,11 @@ export function useCollectionFilter(note: FNote, {
         }
     }, [ note.noteId, persistedQuery ]);
 
-    // Resolve the submitted query, or drop the filter when it is cleared.
+    // Resolve the submitted query, or drop the filter when it is cleared. What was kept goes with
+    // the query it was kept against: a new one is asked afresh which notes belong.
     useEffect(() => {
         window.clearTimeout(rerunTimerRef.current);
+        setKeptNoteIds(NOTHING_KEPT);
         if (!query.trim()) {
             runSeqRef.current++;
             setError(null);
@@ -150,11 +160,30 @@ export function useCollectionFilter(note: FNote, {
 
     useEffect(() => () => window.clearTimeout(rerunTimerRef.current), []);
 
+    // Only what the query does not match, so a note that comes to match it on a later run stops
+    // being drawn on sufferance and is no longer marked as outside the filter. Nothing stands
+    // outside a filter that is not there, whatever the collection has reported in the meantime.
+    const stillKept = useMemo(
+        () => (matches.matchedNoteIds
+            ? new Set([ ...keptNoteIds ].filter(id => !matches.matchedNoteIds?.has(id)))
+            : NOTHING_KEPT),
+        [ keptNoteIds, matches.matchedNoteIds ]);
+    const shownNoteIds = useMemo(
+        () => (matches.matchedNoteIds
+            ? new Set([ ...matches.matchedNoteIds, ...stillKept ])
+            : null),
+        [ matches.matchedNoteIds, stillKept ]);
+
     return {
         query,
-        ...matches,
+        shownNoteIds,
+        keptNoteIds: stillKept,
+        highlightedTokens: matches.highlightedTokens,
         error,
         isResolvingStoredQuery,
+        keepNote: (noteId: string) => setKeptNoteIds(kept => (!query.trim() || kept.has(noteId)
+            ? kept
+            : new Set(kept).add(noteId))),
         setQuery: (newQuery: string) => {
             const trimmed = newQuery.trim();
             setQuery(trimmed);

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -1,7 +1,6 @@
 import "./collection_filter.css";
 
 import type { HighlightedTokenInfo } from "@triliumnext/commons";
-import type { Tooltip } from "bootstrap";
 import clsx from "clsx";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 
@@ -11,19 +10,10 @@ import type LoadResults from "../../services/load_results";
 import searchService from "../../services/search";
 import ActionButton from "../react/ActionButton";
 import FormTextBox from "../react/FormTextBox";
-import { useStaticTooltip, useTriliumEvent } from "../react/hooks";
+import { useTriliumEvent } from "../react/hooks";
 
 /** How long to wait after a change before re-running the active filter. */
 const RERUN_DEBOUNCE_MS = 300;
-
-// Hover only: the box is typed into, and a tooltip opened by the focus would sit over the header
-// for as long as the query is being written.
-const TOOLTIP_CONFIG: Partial<Tooltip.Options> = {
-    title: t("collection_filter.tooltip"),
-    placement: "bottom",
-    trigger: "hover",
-    animation: false
-};
 
 export interface CollectionFilter {
     /** The submitted query, empty while no filter is active. */
@@ -194,7 +184,8 @@ export function useCollectionFilter(note: FNote, {
 
 /**
  * The filter box for a collection header. Enter or the search button submits what is typed, which
- * is held here until then so an unrelated redraw cannot apply a half-typed query.
+ * is held here until then so an unrelated redraw cannot apply a half-typed query. The clear button
+ * stands only while a filter is in force, since that is what it takes away.
  */
 export function CollectionFilterInput({ filter, placeholder }: {
     filter: CollectionFilter;
@@ -203,7 +194,6 @@ export function CollectionFilterInput({ filter, placeholder }: {
 }) {
     const [ typed, setTyped ] = useState(filter.query);
     const inputRef = useRef<HTMLInputElement>(null);
-    useStaticTooltip(inputRef, TOOLTIP_CONFIG);
 
     // Adopt a query submitted elsewhere, or the stored one arriving on mount.
     useEffect(() => setTyped(filter.query), [ filter.query ]);
@@ -216,8 +206,7 @@ export function CollectionFilterInput({ filter, placeholder }: {
                 inputRef={inputRef}
                 currentValue={typed}
                 placeholder={placeholder ?? t("collection_filter.placeholder")}
-                // The tooltip opens on hover alone, so it cannot carry the name to a reader who
-                // arrives by keyboard.
+                // A placeholder names the box only until something is typed into it.
                 aria-label={placeholder ?? t("collection_filter.placeholder")}
                 onChange={setTyped}
                 onKeyDown={(e: KeyboardEvent) => {
@@ -233,7 +222,7 @@ export function CollectionFilterInput({ filter, placeholder }: {
                 }}
             />
             <div className="collection-filter-buttons">
-                {(!!typed || isActive) && (
+                {isActive && (
                     <ActionButton
                         className="collection-filter-clear"
                         noIconActionClass

--- a/apps/client/src/widgets/collections/collection_filter.tsx
+++ b/apps/client/src/widgets/collections/collection_filter.tsx
@@ -51,10 +51,7 @@ const NO_MATCHES: FilterMatches = { matchedNoteIds: null, highlightedTokens: nul
 
 /**
  * Narrows a collection to the notes matching a search query, using the full search syntax.
- *
- * The result is a membership set, not an order: a view keeps its own enumeration and leaves out
- * the notes the set does not name. A search result is a snapshot, so an active filter re-runs
- * when an entity change touches the collection.
+ * The result is a membership set, not an order: a view keeps its own enumeration.
  */
 export function useCollectionFilter(note: FNote, {
     persistedQuery, onQueryChanged, collectionNoteIds
@@ -121,9 +118,8 @@ export function useCollectionFilter(note: FNote, {
     useEffect(() => {
         setQuery(persistedQuery ?? "");
 
-        // Another collection brings its own stored query, and this instance is reused across them,
-        // so the wait is armed again here rather than only at mount. Not for a query submitted in
-        // this collection, which also arrives as a new `persistedQuery`.
+        // A different collection brings its own stored query, so the wait is armed again for it.
+        // Not for a query submitted here, which also arrives as a new `persistedQuery`.
         if (previousNoteIdRef.current !== note.noteId) {
             previousNoteIdRef.current = note.noteId;
             setIsResolvingStoredQuery(!!persistedQuery?.trim());
@@ -168,11 +164,8 @@ export function useCollectionFilter(note: FNote, {
 }
 
 /**
- * The filter box for a collection header, styled after the quick search box. Enter or the search
- * button submits what is typed, and the clear button beside it drops the filter.
- *
- * What is typed is held here until it is submitted, so an unrelated redraw cannot apply a
- * half-typed query.
+ * The filter box for a collection header. Enter or the search button submits what is typed, which
+ * is held here until then so an unrelated redraw cannot apply a half-typed query.
  */
 export function CollectionFilterInput({ filter, placeholder }: {
     filter: CollectionFilter;
@@ -194,6 +187,9 @@ export function CollectionFilterInput({ filter, placeholder }: {
                 inputRef={inputRef}
                 currentValue={typed}
                 placeholder={placeholder ?? t("collection_filter.placeholder")}
+                // The tooltip opens on hover alone, so it cannot carry the name to a reader who
+                // arrives by keyboard.
+                aria-label={placeholder ?? t("collection_filter.placeholder")}
                 onChange={setTyped}
                 onKeyDown={(e: KeyboardEvent) => {
                     if (e.key === "Enter") {

--- a/apps/client/src/widgets/collections/search/SearchResultCard.tsx
+++ b/apps/client/src/widgets/collections/search/SearchResultCard.tsx
@@ -1,12 +1,11 @@
 import type { HighlightedTokenInfo, SearchResultDetails } from "@triliumnext/commons";
-import { useEffect, useRef } from "preact/hooks";
 
 import { t } from "../../../services/i18n";
 import { calculateHash, type ViewScope } from "../../../services/link";
 import { Badge } from "../../react/Badge";
-import { useImperativeSearchHighlighlighting, useNote, useNoteTitle } from "../../react/hooks";
+import { useNote, useNoteTitle } from "../../react/hooks";
 import Icon from "../../react/Icon";
-import RawHtml, { RawHtmlBlock } from "../../react/RawHtml";
+import RawHtml, { HighlightedText, RawHtmlBlock } from "../../react/RawHtml";
 
 interface SearchResultCardProps {
     noteId: string;
@@ -33,26 +32,15 @@ export default function SearchResultCard({ noteId, details, loading, highlighted
     const viewScope: ViewScope = { searchTerms };
     const href = calculateHash({ notePath: noteId, viewScope });
 
-    // Set the title text imperatively so mark.js, which injects `.ck-find-result` spans into the
-    // DOM, does not fight Preact's reconciliation of a controlled text child. NoteLink renders its
-    // title imperatively for the same reason.
-    const titleRef = useRef<HTMLSpanElement>(null);
-    const highlightTitle = useImperativeSearchHighlighlighting(highlightedTokens);
-    useEffect(() => {
-        if (titleRef.current) {
-            titleRef.current.textContent = title;
-            highlightTitle(titleRef.current);
-        }
-        // highlightTitle is a fresh closure each render; keying on the token list (as the legacy
-        // cards do) avoids re-running on every render.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [ title, highlightedTokens ]);
-
     return (
         <a className="search-result-card" href={href}>
             <div className="search-result-card-header">
                 <Icon className="search-result-card-icon" icon={icon} />
-                <span className="search-result-card-title" ref={titleRef} />
+                <HighlightedText
+                    className="search-result-card-title"
+                    text={title}
+                    highlightedTokens={highlightedTokens}
+                />
                 {breadcrumb && <span className="search-result-card-path">{breadcrumb}</span>}
             </div>
             <SearchResultSnippet details={details} loading={loading} />

--- a/apps/client/src/widgets/react/Icon.tsx
+++ b/apps/client/src/widgets/react/Icon.tsx
@@ -5,7 +5,8 @@ import { useRef } from "preact/hooks";
 import { isMobile } from "../../services/utils";
 import { useStaticTooltip } from "./hooks";
 
-interface IconProps extends Pick<HTMLAttributes<HTMLSpanElement>, "className" | "onClick" | "title" | "style"> {
+interface IconProps extends Pick<HTMLAttributes<HTMLSpanElement>,
+    "className" | "onClick" | "title" | "style" | "role" | "aria-label"> {
     icon?: string;
     className?: string;
 }

--- a/apps/client/src/widgets/react/RawHtml.spec.tsx
+++ b/apps/client/src/widgets/react/RawHtml.spec.tsx
@@ -1,7 +1,8 @@
 import { render } from "preact";
+import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import RawHtml, { RawHtmlBlock } from "./RawHtml";
+import RawHtml, { HighlightedText, RawHtmlBlock } from "./RawHtml";
 
 let container: HTMLDivElement;
 
@@ -45,5 +46,49 @@ describe("RawHtml", () => {
         expect(el?.innerHTML).toBe("<b>hi</b>");
         expect(el?.hasAttribute("dir")).toBe(false);
         expect(el?.hasAttribute("tabindex")).toBe(false);
+    });
+});
+
+describe("HighlightedText", () => {
+    it("renders the text as text, never as markup", () => {
+        act(() => render(
+            <HighlightedText className="title" text="a <b>literal</b> title" highlightedTokens={null} />,
+            container
+        ));
+
+        const el = container.querySelector("span.title");
+        expect(el?.textContent).toBe("a <b>literal</b> title");
+        expect(el?.querySelector("b")).toBeNull();
+    });
+
+    it("marks the matched tokens and clears them when the tokens go away", () => {
+        act(() => render(
+            <HighlightedText text="the matched word" highlightedTokens={[ "matched" ]} />,
+            container
+        ));
+
+        const marks = () => [ ...container.querySelectorAll(".ck-find-result") ];
+        expect(marks().map((mark) => mark.textContent)).toEqual([ "matched" ]);
+
+        act(() => render(
+            <HighlightedText text="the matched word" highlightedTokens={null} />,
+            container
+        ));
+        expect(marks()).toEqual([]);
+        expect(container.textContent).toBe("the matched word");
+    });
+
+    it("re-applies the marks when the text changes under the same tokens", () => {
+        act(() => render(
+            <HighlightedText text="one match" highlightedTokens={[ "match" ]} />,
+            container
+        ));
+        act(() => render(
+            <HighlightedText text="another match here" highlightedTokens={[ "match" ]} />,
+            container
+        ));
+
+        expect(container.textContent).toBe("another match here");
+        expect(container.querySelectorAll(".ck-find-result")).toHaveLength(1);
     });
 });

--- a/apps/client/src/widgets/react/RawHtml.tsx
+++ b/apps/client/src/widgets/react/RawHtml.tsx
@@ -1,7 +1,7 @@
 import type { HighlightedTokenInfo } from "@triliumnext/commons";
 import DOMPurify from "dompurify";
 import type { CSSProperties, HTMLProps, RefObject } from "preact/compat";
-import { useEffect, useRef } from "preact/hooks";
+import { useLayoutEffect, useRef } from "preact/hooks";
 
 import { useImperativeSearchHighlighlighting } from "./hooks";
 
@@ -60,9 +60,10 @@ export function HighlightedText({ className, text, highlightedTokens }: {
     const ref = useRef<HTMLSpanElement>(null);
     const highlight = useImperativeSearchHighlighlighting(highlightedTokens);
 
-    // `highlight` is a fresh closure each render, so the effect keys on the token list instead.
+    // Before the paint, so the span is not drawn empty for a frame first. `highlight` is a fresh
+    // closure each render, so the effect keys on the token list instead.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    useEffect(() => {
+    useLayoutEffect(() => {
         if (!ref.current) return;
         ref.current.textContent = text;
         highlight(ref.current);

--- a/apps/client/src/widgets/react/RawHtml.tsx
+++ b/apps/client/src/widgets/react/RawHtml.tsx
@@ -1,5 +1,9 @@
+import type { HighlightedTokenInfo } from "@triliumnext/commons";
 import DOMPurify from "dompurify";
 import type { CSSProperties, HTMLProps, RefObject } from "preact/compat";
+import { useEffect, useRef } from "preact/hooks";
+
+import { useImperativeSearchHighlighlighting } from "./hooks";
 
 type HTMLElementLike = string | HTMLElement | JQuery<HTMLElement>;
 
@@ -41,6 +45,30 @@ export function getHtml(html: string | HTMLElement | JQuery<HTMLElement>) {
     return {
         __html: html as string
     };
+}
+
+/**
+ * Renders plain text with search-match highlighting. The text is set imperatively so mark.js,
+ * which injects `.ck-find-result` spans around matches, does not fight Preact's reconciliation
+ * of a controlled text child.
+ */
+export function HighlightedText({ className, text, highlightedTokens }: {
+    className?: string;
+    text: string;
+    highlightedTokens: (string | HighlightedTokenInfo)[] | null | undefined;
+}) {
+    const ref = useRef<HTMLSpanElement>(null);
+    const highlight = useImperativeSearchHighlighlighting(highlightedTokens);
+
+    // `highlight` is a fresh closure each render, so the effect keys on the token list instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => {
+        if (!ref.current) return;
+        ref.current.textContent = text;
+        highlight(ref.current);
+    }, [ text, highlightedTokens ]);
+
+    return <span className={className} ref={ref} />;
 }
 
 /**

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -349,6 +349,13 @@ export interface HighlightedTokenInfo {
     type: "plain" | "regex" | "fuzzy";
 }
 
+/** Response for `GET /api/search/:searchString?includeTokens=true`. */
+export interface SearchWithTokensResponse {
+    searchResultNoteIds: string[];
+    highlightedTokens: HighlightedTokenInfo[];
+    error: string | null;
+}
+
 /** Request body for `POST /api/search-note/:noteId/result-details` (max 100 noteIds). */
 export interface SearchResultDetailsRequest {
     noteIds: string[];

--- a/packages/trilium-core/src/routes/api/search.spec.ts
+++ b/packages/trilium-core/src/routes/api/search.spec.ts
@@ -1,4 +1,4 @@
-import { dayjs, type SearchResultDetailsResponse, type TemplatesResponse } from "@triliumnext/commons";
+import { dayjs, type SearchResultDetailsResponse, type SearchWithTokensResponse, type TemplatesResponse } from "@triliumnext/commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { createTextNote } from "../../test/api_fixtures";
@@ -28,6 +28,46 @@ describe("Search API (core)", () => {
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body)).toBe(true);
         expect(res.body).toContain(createdNoteId);
+    });
+
+    it("restricts a full search to the given ancestor's subtree", async () => {
+        const token = "ZzScopedSearchQwerty";
+        const board = await createTextNote(api, { title: "Board" });
+        const inside = await createTextNote(api, { parentNoteId: board.noteId, title: `${token} inside` });
+        const outside = await createTextNote(api, { title: `${token} outside` });
+
+        const scoped = await api.get<string[]>(`/api/search/${token}`, {
+            query: { ancestorNoteId: board.noteId }
+        });
+        expect(scoped.status).toBe(200);
+        expect(scoped.body).toContain(inside.noteId);
+        expect(scoped.body).not.toContain(outside.noteId);
+
+        const unscoped = await api.get<string[]>(`/api/search/${token}`);
+        expect(unscoped.body).toContain(inside.noteId);
+        expect(unscoped.body).toContain(outside.noteId);
+    });
+
+    it("returns note ids with token infos and the error when includeTokens is set", async () => {
+        const withTokens = await api.get<SearchWithTokensResponse>(`/api/search/${UNIQUE_TOKEN}`, {
+            query: { includeTokens: "true" }
+        });
+        expect(withTokens.status).toBe(200);
+        expect(withTokens.body.searchResultNoteIds).toContain(createdNoteId);
+        expect(withTokens.body.highlightedTokens).toContainEqual({
+            token: UNIQUE_TOKEN.toLowerCase(),
+            type: "plain"
+        });
+        expect(withTokens.body.error).toBeNull();
+
+        // A query the parser rejects still answers 200, with the parse error in the body for the
+        // client to show inline.
+        const broken = await api.get<SearchWithTokensResponse>(
+            `/api/search/${encodeURIComponent("#label = ")}`,
+            { query: { includeTokens: "true" } }
+        );
+        expect(broken.status).toBe(200);
+        expect(broken.body.error).toBeTruthy();
     });
 
     it("returns structured quick-search results with snippets", async () => {

--- a/packages/trilium-core/src/routes/api/search.ts
+++ b/packages/trilium-core/src/routes/api/search.ts
@@ -1,4 +1,7 @@
-import { dayjs, type SearchResultDetails, type SearchResultDetailsRequest, type SearchResultDetailsResponse, type SearchWithTokensResponse, type TemplatesResponse } from "@triliumnext/commons";
+import {
+    dayjs, type SearchResultDetails, type SearchResultDetailsRequest,
+    type SearchResultDetailsResponse, type SearchWithTokensResponse, type TemplatesResponse
+} from "@triliumnext/commons";
 import type { Request } from "express";
 
 import becca from "../../becca/becca.js";
@@ -146,12 +149,13 @@ function search(
         includeArchivedNotes: true,
         fuzzyAttributeSearch: false,
         ignoreHoistedNote: true,
-        // Restricts the results to one subtree, for callers that filter a collection rather than
-        // search the whole tree.
-        ancestorNoteId: typeof ancestorNoteId === "string" && ancestorNoteId ? ancestorNoteId : undefined
+        // Restricts the results to one subtree, for callers that filter a collection rather
+        // than search the whole tree.
+        ancestorNoteId: ancestorNoteId || undefined
     });
 
-    const noteIds = searchService.findResultsWithQuery(searchString, searchContext).map((sr) => sr.noteId);
+    const noteIds = searchService.findResultsWithQuery(searchString, searchContext)
+        .map((sr) => sr.noteId);
 
     if (includeTokens !== "true") {
         return noteIds;

--- a/packages/trilium-core/src/routes/api/search.ts
+++ b/packages/trilium-core/src/routes/api/search.ts
@@ -1,4 +1,4 @@
-import { dayjs, type SearchResultDetails, type SearchResultDetailsRequest, type SearchResultDetailsResponse, type TemplatesResponse } from "@triliumnext/commons";
+import { dayjs, type SearchResultDetails, type SearchResultDetailsRequest, type SearchResultDetailsResponse, type SearchWithTokensResponse, type TemplatesResponse } from "@triliumnext/commons";
 import type { Request } from "express";
 
 import becca from "../../becca/becca.js";
@@ -134,17 +134,34 @@ function quickSearch(req: Request<{ searchString: string }>) {
     };
 }
 
-function search(req: Request<{ searchString: string }>) {
+function search(
+    req: Request<{ searchString: string }, unknown, unknown,
+        { ancestorNoteId?: string, includeTokens?: string }>
+): string[] | SearchWithTokensResponse {
     const { searchString } = req.params;
+    const { ancestorNoteId, includeTokens } = req.query;
 
     const searchContext = new SearchContext({
         fastSearch: false,
         includeArchivedNotes: true,
         fuzzyAttributeSearch: false,
-        ignoreHoistedNote: true
+        ignoreHoistedNote: true,
+        // Restricts the results to one subtree, for callers that filter a collection rather than
+        // search the whole tree.
+        ancestorNoteId: typeof ancestorNoteId === "string" && ancestorNoteId ? ancestorNoteId : undefined
     });
 
-    return searchService.findResultsWithQuery(searchString, searchContext).map((sr) => sr.noteId);
+    const noteIds = searchService.findResultsWithQuery(searchString, searchContext).map((sr) => sr.noteId);
+
+    if (includeTokens !== "true") {
+        return noteIds;
+    }
+
+    return {
+        searchResultNoteIds: noteIds,
+        highlightedTokens: searchContext.getHighlightedTokenInfos(),
+        error: searchContext.getError()
+    };
 }
 
 function getRelatedNotes(req: Request) {


### PR DESCRIPTION
Large Kanban boards become hard to work with once they hold more cards than fit on a screen. This pull request adds a search box to the board header that narrows the board to the cards matching a query. It uses Trilium's full search syntax rather than a simple title match, so cards can be selected by label, relation, date, content, or any combination of these. Every column stays in place while a filter is active, the surviving cards keep the order they had, and the board remains fully operable: cards can still be dragged between and within columns, created, renamed and edited. The query is stored with the board, so a board that was left filtered reopens the same way.

## Board filtering

- Add a search box to the Kanban board's collection header, submitted with Enter or with its search button.
- Narrow the board to the notes matching the query, using the full Trilium search syntax including attribute operators, relations, content search and fulltext.
- Scope every query to the board's own subtree.
- Keep every column while a filter is active, including the ones the filter empties.
- Preserve the cards' order relative to each other by treating a search result as a membership set rather than as an ordering.
- Persist the submitted query as `filterQuery` in the board's `board.json` attachment.
- Withhold the board's first draw until a query stored in the configuration has resolved.
- Show a query's parse error beneath the box while keeping the previous results on screen.
- Re-run an active filter, debounced at 300 ms, when an entity change touches the board.
- Style the box after the launcher pane's quick search box, with the clear button before the search button and both overlaid on the field's trailing edge.
- Offer the clear button only once there is a query or unsubmitted text to clear.
- Discard unsubmitted text on Escape while leaving the submitted query in force.
- Attach the explanatory labels as Bootstrap tooltips, the field's opening on hover alone.
- Wire the box into the Kanban board only, leaving the other collection views unchanged.
- Add the `collection_filter.*` and `board_view.filter-placeholder` English strings.

## Working on a filtered board

- Place a dropped card relative to the cards on screen, translating the visible drop index into a position in the full column.
- Apply a card move's optimistic redraw to the unfiltered column map.
- Derive the drawn column map during render instead of holding it in state, closing the window in which a filter update could be dropped while a card move was in flight.
- Count the visible cards in a column's badge while testing the column's limit against the number of cards it actually holds.
- Strip a deleted column's grouping value from every card it holds, including the ones an active filter is hiding.
- Apply the filter after column discovery and after the configuration write-back, keeping a filtered view from rewriting the board's stored columns.

## Search API

- Add an optional `ancestorNoteId` query parameter to `GET /api/search/:searchString`, restricting results to one subtree through `SearchContext`'s native support rather than by appending a clause to the user's query.
- Add an optional `includeTokens=true` query parameter, returning the matched note ids together with the highlight tokens and any parse error instead of a bare array of ids.
- Answer a query the parser rejects with `200` and the message in `error` rather than with an HTTP error.
- Keep both parameters optional, leaving existing callers of the route unaffected.
- Add the `SearchWithTokensResponse` type to `@triliumnext/commons`.
- Add `searchService.searchInSubtree` to the client.

## The reusable collection filter

- Add `useCollectionFilter`, a view-agnostic hook reporting the matched note ids, the highlight tokens, any error, and whether a stored query is still resolving.
- Add `CollectionFilterInput`, which holds unsubmitted text locally rather than in the filter state.
- Guard against out-of-order resolution with a monotonic sequence counter, so a slow earlier run cannot overwrite a newer one's result.
- Re-arm the stored-query wait when the hook is handed a different collection, since the view instance is reused across collections.
- Skip all work, including re-runs, while no filter is active.
- Accept an optional placeholder, defaulting to a view-agnostic one.
- Add `filterColumnMap` and `unfilteredCardIndex`, the only board-specific part of the feature.

## Match highlighting

- Highlight the matched tokens in card titles, in the style the search result cards use.
- Extract `HighlightedText` into `RawHtml.tsx` and refactor `SearchResultCard` onto it, removing the duplicated imperative highlighting.
- Pass the tokens to the cards through a context rather than a prop, keeping memoized cards off the render path during a drag.

## Tests

- Cover the route's subtree scoping and token response shape in `packages/trilium-core`, which runs under both the server and standalone suites.
- Cover the hook's submit, clear, stored query on mount, error retention, out-of-order runs, debounced re-run, idle behaviour and stored-query hold.
- Cover the input's Enter and search-button submission, button order, clearing, Escape and error display.
- Cover `filterColumnMap`'s order preservation and column retention, and `unfilteredCardIndex`'s index translation.
- Cover the rendered board's filtered cards, badge against limit, title highlighting, live re-run, and the hold on a stored query.
