### PR TITLE
Markdown: register slash commands as completion sources instead of a second autocompletion extension

### DIFF
--- a/apps/client/src/widgets/type_widgets/markdown/completions.spec.ts
+++ b/apps/client/src/widgets/type_widgets/markdown/completions.spec.ts
@@ -2,11 +2,23 @@ import type { CompletionContext } from "@codemirror/autocomplete";
 import { markdown } from "@codemirror/lang-markdown";
 import { ensureSyntaxTree } from "@codemirror/language";
 import { EditorState } from "@codemirror/state";
+import type VanillaCodeMirror from "@triliumnext/codemirror";
 import type { MimeType } from "@triliumnext/commons";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { h, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type FNote from "../../../entities/fnote";
 import mime_types from "../../../services/mime_types.js";
-import { buildCodeFenceOptions, buildTaskItemInsert, codeFenceCompletionSource, isClosingFence, parseCodeFencePrefix } from "./completions.js";
+import type { TypeWidgetProps } from "../type_widget";
+import { buildCodeFenceOptions, buildTaskItemInsert, codeFenceCompletionSource, isClosingFence, parseCodeFencePrefix, useSlashCommands } from "./completions.js";
+
+// The hook's two asynchronous sources of menu entries, stubbed so mounting it needs no server.
+vi.mock("../code/snippets", async (importOriginal) => ({
+    ...await importOriginal<typeof import("../code/snippets")>(),
+    useCodeSnippets: () => ({ current: [] })
+}));
+vi.mock("../../../services/task_states", () => ({ getTaskStateDefinitions: () => Promise.resolve([]) }));
 
 describe("buildTaskItemInsert", () => {
     it("prepends a bullet when not already in a list item", () => {
@@ -135,5 +147,49 @@ describe("codeFenceCompletionSource", () => {
     it("returns null on a valid opener when no languages are enabled", () => {
         withLanguages(); // none enabled → no options
         expect(codeFenceCompletionSource(context("```", 3))).toBeNull();
+    });
+});
+
+describe("useSlashCommands", () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+    });
+
+    /** Mounts the hook against an editor that only records what it is asked to register. */
+    function mount() {
+        const setCompletionSource = vi.fn();
+        const editorView = { setCompletionSource } as unknown as VanillaCodeMirror;
+
+        function Probe() {
+            useSlashCommands({} as TypeWidgetProps["parentComponent"], editorView, {} as FNote);
+            return null;
+        }
+
+        act(() => render(h(Probe, {}), container));
+        return setCompletionSource;
+    }
+
+    it("contributes both sources to the editor's shared aggregate", () => {
+        const setCompletionSource = mount();
+
+        expect(setCompletionSource.mock.calls.map(([ name ]) => name)).toEqual([ "slashCommands", "markdownCodeFence" ]);
+        for (const [ , source ] of setCompletionSource.mock.calls) expect(source).toBeTypeOf("function");
+    });
+
+    it("withdraws both sources on unmount, so a later editor does not inherit them", () => {
+        const setCompletionSource = mount();
+        setCompletionSource.mockClear();
+
+        act(() => render(null, container));
+
+        expect(setCompletionSource.mock.calls).toEqual([ [ "slashCommands", null ], [ "markdownCodeFence", null ] ]);
     });
 });

--- a/apps/client/src/widgets/type_widgets/markdown/completions.ts
+++ b/apps/client/src/widgets/type_widgets/markdown/completions.ts
@@ -41,9 +41,7 @@ export function useSlashCommands(parentComponent: TypeWidgetProps["parentCompone
     useEffect(() => {
         if (!editorView) return;
 
-        // CodeMirror allows one `override` config per editor, so sources go through
-        // `setCompletionSource` instead of each adding its own `autocompletion()`.
-        editorView.setCompletionSource("slashCommands", (ctx) => {
+        const slashCommands = (ctx: CompletionContext): CompletionResult | null => {
             // `:` and `-` are allowed so `/todo:<state>` (e.g. `/todo:in-progress`) matches as one token.
             const match = ctx.matchBefore(SLASH_COMMAND_REGEX);
             if (!match) return null;
@@ -241,8 +239,14 @@ export function useSlashCommands(parentComponent: TypeWidgetProps["parentCompone
                     ...buildSnippetCompletions(snippetsRef.current.filter((snippet) => snippet.noteId !== noteRef.current.noteId))
                 ]
             };
-        });
-        editorView.setCompletionSource("markdownCodeFence", codeFenceCompletionSource);
+        };
+
+        // CodeMirror allows one `override` config per editor, so sources go through
+        // `setCompletionSource` instead of each adding its own `autocompletion()`.
+        // Bridges the codemirror package's own @codemirror/autocomplete identity, as code/snippets.ts does.
+        type CmCompletionSource = Parameters<VanillaCodeMirror["setCompletionSource"]>[1];
+        editorView.setCompletionSource("slashCommands", slashCommands as unknown as CmCompletionSource);
+        editorView.setCompletionSource("markdownCodeFence", codeFenceCompletionSource as unknown as CmCompletionSource);
 
         return () => {
             editorView.setCompletionSource("slashCommands", null);

--- a/apps/client/src/widgets/type_widgets/markdown/completions.ts
+++ b/apps/client/src/widgets/type_widgets/markdown/completions.ts
@@ -41,12 +41,8 @@ export function useSlashCommands(parentComponent: TypeWidgetProps["parentCompone
     useEffect(() => {
         if (!editorView) return;
 
-        // Registered as completion *sources* rather than as a whole
-        // `autocompletion()` extension: CodeMirror allows a single `override`
-        // config per editor, and the editor already aggregates every source into
-        // one extension. Adding a second one here collided with that aggregate
-        // once any other source was registered (e.g. by `setMimeType`), throwing
-        // "Config merge conflict for field override".
+        // CodeMirror allows one `override` config per editor, so sources go through
+        // `setCompletionSource` instead of each adding its own `autocompletion()`.
         editorView.setCompletionSource("slashCommands", (ctx) => {
             // `:` and `-` are allowed so `/todo:<state>` (e.g. `/todo:in-progress`) matches as one token.
             const match = ctx.matchBefore(SLASH_COMMAND_REGEX);

--- a/apps/client/src/widgets/type_widgets/markdown/completions.ts
+++ b/apps/client/src/widgets/type_widgets/markdown/completions.ts
@@ -1,4 +1,4 @@
-import { autocompletion, type Completion, type CompletionContext, type CompletionResult } from "@codemirror/autocomplete";
+import type { Completion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
 import { syntaxTree } from "@codemirror/language";
 import type { EditorState } from "@codemirror/state";
 import type { SyntaxNode } from "@lezer/common";
@@ -41,210 +41,217 @@ export function useSlashCommands(parentComponent: TypeWidgetProps["parentCompone
     useEffect(() => {
         if (!editorView) return;
 
-        const ext = autocompletion({
-            override: [(ctx) => {
-                // `:` and `-` are allowed so `/todo:<state>` (e.g. `/todo:in-progress`) matches as one token.
-                const match = ctx.matchBefore(SLASH_COMMAND_REGEX);
-                if (!match) return null;
+        // Registered as completion *sources* rather than as a whole
+        // `autocompletion()` extension: CodeMirror allows a single `override`
+        // config per editor, and the editor already aggregates every source into
+        // one extension. Adding a second one here collided with that aggregate
+        // once any other source was registered (e.g. by `setMimeType`), throwing
+        // "Config merge conflict for field override".
+        editorView.setCompletionSource("slashCommands", (ctx) => {
+            // `:` and `-` are allowed so `/todo:<state>` (e.g. `/todo:in-progress`) matches as one token.
+            const match = ctx.matchBefore(SLASH_COMMAND_REGEX);
+            if (!match) return null;
 
-                // Suppress slash menu inside fenced/indented code blocks and inline code spans —
-                // a leading `/` there is part of the code, not a command trigger.
-                for (let node: SyntaxNode | null = syntaxTree(ctx.state).resolveInner(ctx.pos, -1); node; node = node.parent) {
-                    if (node.name.includes("Code")) return null;
-                }
+            // Suppress slash menu inside fenced/indented code blocks and inline code spans —
+            // a leading `/` there is part of the code, not a command trigger.
+            for (let node: SyntaxNode | null = syntaxTree(ctx.state).resolveInner(ctx.pos, -1); node; node = node.parent) {
+                if (node.name.includes("Code")) return null;
+            }
 
-                return {
-                    from: match.from,
-                    options: [
-                        {
-                            label: "/date",
-                            detail: t("markdown_slash_commands.date"),
-                            apply(view, _completion, from, to) {
-                                view.dispatch({ changes: { from, to } });
-                                parentRef.current?.triggerCommand("insertDateTimeToText");
+            return {
+                from: match.from,
+                options: [
+                    {
+                        label: "/date",
+                        detail: t("markdown_slash_commands.date"),
+                        apply(view, _completion, from, to) {
+                            view.dispatch({ changes: { from, to } });
+                            parentRef.current?.triggerCommand("insertDateTimeToText");
+                        }
+                    },
+                    {
+                        label: "/include",
+                        detail: t("markdown_slash_commands.include"),
+                        apply(view, _completion, from, to) {
+                            view.dispatch({ changes: { from, to } });
+                            parentRef.current?.triggerCommand("addIncludeNoteToText");
+                        }
+                    },
+                    {
+                        label: "/image",
+                        detail: t("markdown_slash_commands.image"),
+                        apply(view, _completion, from, to) {
+                            view.dispatch({ changes: { from, to } });
+                            const input = document.createElement("input");
+                            input.type = "file";
+                            input.accept = "image/*";
+                            input.addEventListener("change", () => {
+                                const file = input.files?.[0];
+                                if (file) uploadImageAndInsert(editorView, noteRef.current, file);
+                            });
+                            input.click();
+                        }
+                    },
+                    {
+                        label: "/link",
+                        detail: t("markdown_slash_commands.link"),
+                        apply(view, _completion, from, to) {
+                            view.dispatch({ changes: { from, to } });
+                            parentRef.current?.triggerCommand("addLinkToText");
+                        }
+                    },
+                    {
+                        label: "/math",
+                        detail: t("markdown_slash_commands.math"),
+                        apply(view, _completion, from, to) {
+                            const placeholder = `\\text{${t("markdown_slash_commands.placeholders.math")}}`;
+                            const template = `$$\n${placeholder}\n$$`;
+                            view.dispatch({
+                                changes: { from, to, insert: template },
+                                selection: { anchor: from + 3, head: from + 3 + placeholder.length }
+                            });
+                        }
+                    },
+                    {
+                        label: "/footnote",
+                        detail: t("markdown_slash_commands.footnote"),
+                        apply(view, _completion, from, to) {
+                            const doc = view.state.doc.toString();
+                            let maxFootnote = 0;
+                            for (const m of doc.matchAll(/\[\^(\d+)\]/g)) {
+                                maxFootnote = Math.max(maxFootnote, parseInt(m[1], 10));
                             }
-                        },
-                        {
-                            label: "/include",
-                            detail: t("markdown_slash_commands.include"),
-                            apply(view, _completion, from, to) {
-                                view.dispatch({ changes: { from, to } });
-                                parentRef.current?.triggerCommand("addIncludeNoteToText");
-                            }
-                        },
-                        {
-                            label: "/image",
-                            detail: t("markdown_slash_commands.image"),
-                            apply(view, _completion, from, to) {
-                                view.dispatch({ changes: { from, to } });
-                                const input = document.createElement("input");
-                                input.type = "file";
-                                input.accept = "image/*";
-                                input.addEventListener("change", () => {
-                                    const file = input.files?.[0];
-                                    if (file) uploadImageAndInsert(editorView, noteRef.current, file);
-                                });
-                                input.click();
-                            }
-                        },
-                        {
-                            label: "/link",
-                            detail: t("markdown_slash_commands.link"),
-                            apply(view, _completion, from, to) {
-                                view.dispatch({ changes: { from, to } });
-                                parentRef.current?.triggerCommand("addLinkToText");
-                            }
-                        },
-                        {
-                            label: "/math",
-                            detail: t("markdown_slash_commands.math"),
-                            apply(view, _completion, from, to) {
-                                const placeholder = `\\text{${t("markdown_slash_commands.placeholders.math")}}`;
-                                const template = `$$\n${placeholder}\n$$`;
-                                view.dispatch({
-                                    changes: { from, to, insert: template },
-                                    selection: { anchor: from + 3, head: from + 3 + placeholder.length }
-                                });
-                            }
-                        },
-                        {
-                            label: "/footnote",
-                            detail: t("markdown_slash_commands.footnote"),
-                            apply(view, _completion, from, to) {
-                                const doc = view.state.doc.toString();
-                                let maxFootnote = 0;
-                                for (const m of doc.matchAll(/\[\^(\d+)\]/g)) {
-                                    maxFootnote = Math.max(maxFootnote, parseInt(m[1], 10));
+                            const n = maxFootnote + 1;
+                            const ref = `[^${n}]`;
+                            const def = `\n\n[^${n}]: `;
+                            const docEnd = view.state.doc.length;
+                            const newDocEnd = docEnd - (to - from) + ref.length + def.length;
+                            view.dispatch({
+                                changes: [
+                                    { from, to, insert: ref },
+                                    { from: docEnd, insert: def }
+                                ],
+                                selection: { anchor: newDocEnd }
+                            });
+                        }
+                    },
+                    {
+                        label: "/mermaid",
+                        detail: t("markdown_slash_commands.mermaid"),
+                        apply(view, _completion, from, to) {
+                            const placeholder = "graph TD\n    A --> B";
+                            const template = `\`\`\`mermaid\n${placeholder}\n\`\`\``;
+                            view.dispatch({
+                                changes: { from, to, insert: template },
+                                selection: { anchor: from + 11, head: from + 11 + placeholder.length }
+                            });
+                        }
+                    },
+                    // One `/mermaid:<type>` per sample diagram (e.g. `/mermaid:flowchart`),
+                    // pre-filling the fenced block with that template's source.
+                    ...SAMPLE_DIAGRAMS.map((sample) => ({
+                        label: `/mermaid:${sample.name.toLowerCase().replace(/\s+/g, "-")}`,
+                        detail: t("markdown_slash_commands.mermaid_template", { name: sample.name }),
+                        apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
+                            const template = `\`\`\`mermaid\n${sample.content.trimEnd()}\n\`\`\``;
+                            view.dispatch({
+                                changes: { from, to, insert: template },
+                                selection: { anchor: from + 11 }
+                            });
+                        }
+                    })),
+                    {
+                        label: "/collapsible",
+                        detail: t("markdown_slash_commands.collapsible"),
+                        apply(view, _completion, from, to) {
+                            // No native markdown syntax — round-trips through the
+                            // importer as raw <details>/<summary> HTML (see markdown.ts).
+                            const placeholder = t("markdown_slash_commands.placeholders.collapsible_summary");
+                            const open = `<details class="trilium-collapsible">\n<summary>`;
+                            const close = `</summary>\n\n${t("markdown_slash_commands.placeholders.collapsible_details")}\n\n</details>`;
+                            const anchor = from + open.length;
+                            view.dispatch({
+                                changes: { from, to, insert: open + placeholder + close },
+                                selection: { anchor, head: anchor + placeholder.length }
+                            });
+                        }
+                    },
+                    {
+                        label: "/page-break",
+                        detail: t("markdown_slash_commands.page_break"),
+                        apply(view, _completion, from, to) {
+                            // No native markdown syntax — round-trips through the
+                            // importer as raw HTML and drives the print/PDF page break (see print.css).
+                            // The trailing blank line terminates the raw-HTML block; without it the
+                            // text on the next line is swallowed into the <div> and never rendered.
+                            const insert = `<div class="page-break"></div>\n\n`;
+                            view.dispatch({
+                                changes: { from, to, insert },
+                                selection: { anchor: from + insert.length }
+                            });
+                        }
+                    },
+                    {
+                        label: "/table",
+                        detail: t("markdown_slash_commands.table"),
+                        apply(view, _completion, from, to) {
+                            // GFM table skeleton. The trailing blank line terminates the table block
+                            // so following text isn't absorbed into it (see page break above).
+                            const header = t("markdown_slash_commands.placeholders.table_column", { number: 1 });
+                            const table = [
+                                `| ${header} | ${t("markdown_slash_commands.placeholders.table_column", { number: 2 })} |`,
+                                `| -------- | -------- |`,
+                                `|          |          |`
+                            ].join("\n");
+                            // Select the first header cell so the user can type the first column name.
+                            const anchor = from + 2; // skip the leading "| "
+                            view.dispatch({
+                                changes: { from, to, insert: `${table}\n\n` },
+                                selection: { anchor, head: anchor + header.length }
+                            });
+                        }
+                    },
+                    ...["note", "tip", "important", "caution", "warning"].map((admonitionType) => ({
+                        label: `/${admonitionType}`,
+                        detail: t("markdown_slash_commands.admonition", { type: admonitionType }),
+                        apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
+                            const template = `> [!${admonitionType.toUpperCase()}]\n> `;
+                            view.dispatch({
+                                changes: { from, to, insert: template },
+                                selection: { anchor: from + template.length }
+                            });
+                        }
+                    })),
+                    // One `/todo:<state>` per configured task state that has a markdown marker —
+                    // the ` ` (unchecked) and `x` (checked) anchors are markers too, so both are covered.
+                    ...taskStatesRef.current
+                        .filter((state) => state.markdownSymbol)
+                        .map((state) => {
+                            // Anchors (`none`/`done`) are the standard `[ ]`/`[x]`; custom states
+                            // use non-standard markers (e.g. `[/]`), so flag those in the description.
+                            const detailKey = isAnchorState(state.name)
+                                ? "markdown_slash_commands.todo"
+                                : "markdown_slash_commands.todo_nonstandard";
+                            return {
+                                label: `/todo:${state.name}`,
+                                detail: t(detailKey, { title: state.title }),
+                                apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
+                                    const precededByBullet = from >= 2 && view.state.doc.sliceString(from - 2, from) === "- ";
+                                    const insert = buildTaskItemInsert(state.markdownSymbol, precededByBullet);
+                                    view.dispatch({ changes: { from, to, insert } });
                                 }
-                                const n = maxFootnote + 1;
-                                const ref = `[^${n}]`;
-                                const def = `\n\n[^${n}]: `;
-                                const docEnd = view.state.doc.length;
-                                const newDocEnd = docEnd - (to - from) + ref.length + def.length;
-                                view.dispatch({
-                                    changes: [
-                                        { from, to, insert: ref },
-                                        { from: docEnd, insert: def }
-                                    ],
-                                    selection: { anchor: newDocEnd }
-                                });
-                            }
-                        },
-                        {
-                            label: "/mermaid",
-                            detail: t("markdown_slash_commands.mermaid"),
-                            apply(view, _completion, from, to) {
-                                const placeholder = "graph TD\n    A --> B";
-                                const template = `\`\`\`mermaid\n${placeholder}\n\`\`\``;
-                                view.dispatch({
-                                    changes: { from, to, insert: template },
-                                    selection: { anchor: from + 11, head: from + 11 + placeholder.length }
-                                });
-                            }
-                        },
-                        // One `/mermaid:<type>` per sample diagram (e.g. `/mermaid:flowchart`),
-                        // pre-filling the fenced block with that template's source.
-                        ...SAMPLE_DIAGRAMS.map((sample) => ({
-                            label: `/mermaid:${sample.name.toLowerCase().replace(/\s+/g, "-")}`,
-                            detail: t("markdown_slash_commands.mermaid_template", { name: sample.name }),
-                            apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
-                                const template = `\`\`\`mermaid\n${sample.content.trimEnd()}\n\`\`\``;
-                                view.dispatch({
-                                    changes: { from, to, insert: template },
-                                    selection: { anchor: from + 11 }
-                                });
-                            }
-                        })),
-                        {
-                            label: "/collapsible",
-                            detail: t("markdown_slash_commands.collapsible"),
-                            apply(view, _completion, from, to) {
-                                // No native markdown syntax — round-trips through the
-                                // importer as raw <details>/<summary> HTML (see markdown.ts).
-                                const placeholder = t("markdown_slash_commands.placeholders.collapsible_summary");
-                                const open = `<details class="trilium-collapsible">\n<summary>`;
-                                const close = `</summary>\n\n${t("markdown_slash_commands.placeholders.collapsible_details")}\n\n</details>`;
-                                const anchor = from + open.length;
-                                view.dispatch({
-                                    changes: { from, to, insert: open + placeholder + close },
-                                    selection: { anchor, head: anchor + placeholder.length }
-                                });
-                            }
-                        },
-                        {
-                            label: "/page-break",
-                            detail: t("markdown_slash_commands.page_break"),
-                            apply(view, _completion, from, to) {
-                                // No native markdown syntax — round-trips through the
-                                // importer as raw HTML and drives the print/PDF page break (see print.css).
-                                // The trailing blank line terminates the raw-HTML block; without it the
-                                // text on the next line is swallowed into the <div> and never rendered.
-                                const insert = `<div class="page-break"></div>\n\n`;
-                                view.dispatch({
-                                    changes: { from, to, insert },
-                                    selection: { anchor: from + insert.length }
-                                });
-                            }
-                        },
-                        {
-                            label: "/table",
-                            detail: t("markdown_slash_commands.table"),
-                            apply(view, _completion, from, to) {
-                                // GFM table skeleton. The trailing blank line terminates the table block
-                                // so following text isn't absorbed into it (see page break above).
-                                const header = t("markdown_slash_commands.placeholders.table_column", { number: 1 });
-                                const table = [
-                                    `| ${header} | ${t("markdown_slash_commands.placeholders.table_column", { number: 2 })} |`,
-                                    `| -------- | -------- |`,
-                                    `|          |          |`
-                                ].join("\n");
-                                // Select the first header cell so the user can type the first column name.
-                                const anchor = from + 2; // skip the leading "| "
-                                view.dispatch({
-                                    changes: { from, to, insert: `${table}\n\n` },
-                                    selection: { anchor, head: anchor + header.length }
-                                });
-                            }
-                        },
-                        ...["note", "tip", "important", "caution", "warning"].map((admonitionType) => ({
-                            label: `/${admonitionType}`,
-                            detail: t("markdown_slash_commands.admonition", { type: admonitionType }),
-                            apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
-                                const template = `> [!${admonitionType.toUpperCase()}]\n> `;
-                                view.dispatch({
-                                    changes: { from, to, insert: template },
-                                    selection: { anchor: from + template.length }
-                                });
-                            }
-                        })),
-                        // One `/todo:<state>` per configured task state that has a markdown marker —
-                        // the ` ` (unchecked) and `x` (checked) anchors are markers too, so both are covered.
-                        ...taskStatesRef.current
-                            .filter((state) => state.markdownSymbol)
-                            .map((state) => {
-                                // Anchors (`none`/`done`) are the standard `[ ]`/`[x]`; custom states
-                                // use non-standard markers (e.g. `[/]`), so flag those in the description.
-                                const detailKey = isAnchorState(state.name)
-                                    ? "markdown_slash_commands.todo"
-                                    : "markdown_slash_commands.todo_nonstandard";
-                                return {
-                                    label: `/todo:${state.name}`,
-                                    detail: t(detailKey, { title: state.title }),
-                                    apply(view: import("@codemirror/view").EditorView, _c: unknown, from: number, to: number) {
-                                        const precededByBullet = from >= 2 && view.state.doc.sliceString(from - 2, from) === "- ";
-                                        const insert = buildTaskItemInsert(state.markdownSymbol, precededByBullet);
-                                        view.dispatch({ changes: { from, to, insert } });
-                                    }
-                                };
-                            }),
-                        ...buildSnippetCompletions(snippetsRef.current.filter((snippet) => snippet.noteId !== noteRef.current.noteId))
-                    ]
-                };
-            }, codeFenceCompletionSource],
-            activateOnTyping: true
+                            };
+                        }),
+                    ...buildSnippetCompletions(snippetsRef.current.filter((snippet) => snippet.noteId !== noteRef.current.noteId))
+                ]
+            };
         });
+        editorView.setCompletionSource("markdownCodeFence", codeFenceCompletionSource);
 
-        editorView.setNamedExtension("slashCommands", ext);
+        return () => {
+            editorView.setCompletionSource("slashCommands", null);
+            editorView.setCompletionSource("markdownCodeFence", null);
+        };
     }, [editorView]);
 }
 


### PR DESCRIPTION
Fixes #11367

## The problem

Switching a note to Markdown and back to Text throws an uncaught exception, and the UI stops updating until the page is reloaded:

```
Uncaught Error: Config merge conflict for field override
```

It comes from CodeMirror's `combineConfig` in `@codemirror/state`, which refuses to merge two extensions that give different values to the same config field when no combiner is defined for it.

## Cause

`useSlashCommands` installed the markdown slash commands with `setNamedExtension("slashCommands", autocompletion({ override: [...] }))`, that is, as a whole second `autocompletion()` extension. The editor already aggregates every completion source into a single `autocompletion()` inside `completionSourceCompartment`, and the comment on `setCompletionSource` says why: "CodeMirror permits only one `override` config per editor, so features (snippets, the TypeScript language service, …) contribute sources here rather than each adding their own autocompletion."

That is exactly the invariant this hook was breaking. It only surfaced on the way back, because the aggregate has to be non-empty for the conflict to exist: leaving Markdown calls `setMimeType`, which reaches `setCompletionSource("typescript", ...)` through `#updateTypeCompletion`, and at that moment two `autocompletion()` extensions with different `override` values are live. The hook also never removed its extension, since the effect had no cleanup.

## The change

Register the two sources through `setCompletionSource` and drop them on unmount, which is what `code/snippets.ts` already does for its own source. `activateOnTyping: true` is preserved by the aggregate, so behaviour is unchanged. The sources are cast at the call site, again as in `code/snippets.ts`: the method types its argument through the codemirror package's own copy of `@codemirror/autocomplete`, a separate type identity from the client's under project references. The diff is mostly re-indentation from unwrapping the source out of the `override` array, so it reads better with whitespace hidden.

## Verification

Built from this branch and driven through the reported steps automatically, counting uncaught errors at each stage:

| | before | after |
|---|---|---|
| load | 0 | 0 |
| text to markdown | 0 | 0 |
| markdown back to text | 6 | 0 |

Same tree, same dev server, the only difference being whether the patch is applied. Unit tests pass: 18 in `markdown/completions.spec.ts` and 37 in `packages/codemirror/src/index.spec.ts`. Two of those 18 are new and mount the hook against an editor that records what it is asked to register: both sources go in on mount and come back out on unmount. They fail against the hook as it stood, on `setNamedExtension is not a function`. `tsc -b apps/client/tsconfig.app.json` is clean, and ESLint on the file reports the same 5 warnings and 0 errors as before.

What I could not verify: I was unable to open the slash menu in an automated browser at all, with or without this change, so I have no positive end-to-end confirmation that the menu still appears. The unit tests and the parity above are the evidence I do have, and that path is worth a manual check before merging.

Reported by @vlna in #11367, and confirmed by @march-7th-mini in https://github.com/orgs/TriliumNext/discussions/11352, where the exception was first traced.
