### PR TITLE
feat(autocomplete): offer creating a note in the inbox (closes #6817)

### DIFF
--- a/apps/client/src/services/date_notes.ts
+++ b/apps/client/src/services/date_notes.ts
@@ -11,6 +11,13 @@ async function getInboxNote() {
     return await froca.getNote(note.noteId);
 }
 
+/** Resolves the inbox note to a note path, for callers that create notes there. */
+async function getInboxNotePath() {
+    const inboxNote = await getInboxNote();
+
+    return inboxNote?.getBestNotePathString();
+}
+
 async function getTodayNote() {
     return await getDayNote(dayjs().format("YYYY-MM-DD"));
 }
@@ -135,6 +142,7 @@ async function getRecentLlmChats(limit: number = 10): Promise<RecentLlmChat[]> {
 
 export default {
     getInboxNote,
+    getInboxNotePath,
     getTodayNote,
     getDayNote,
     getWeekFirstDayNote,

--- a/apps/client/src/services/date_notes.ts
+++ b/apps/client/src/services/date_notes.ts
@@ -1,4 +1,4 @@
-import { dayjs } from "@triliumnext/commons";
+import { dayjs, type InboxTargetResponse } from "@triliumnext/commons";
 
 import type { FNoteRow } from "../entities/fnote.js";
 import froca from "./froca.js";
@@ -16,6 +16,14 @@ async function getInboxNotePath() {
     const inboxNote = await getInboxNote();
 
     return inboxNote?.getBestNotePathString();
+}
+
+/**
+ * Names where `getInboxNote()` would place a note, without creating the day note it would
+ * otherwise create. Honours the hoisted note, which the server reads from the request.
+ */
+async function getInboxTarget() {
+    return await server.get<InboxTargetResponse>("special-notes/inbox-target");
 }
 
 async function getTodayNote() {
@@ -143,6 +151,7 @@ async function getRecentLlmChats(limit: number = 10): Promise<RecentLlmChat[]> {
 export default {
     getInboxNote,
     getInboxNotePath,
+    getInboxTarget,
     getTodayNote,
     getDayNote,
     getWeekFirstDayNote,

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -280,15 +280,15 @@ describe("autocompleteSource (via dataset)", () => {
         expect(server.get).not.toHaveBeenCalled();
     });
 
-    it("keeps the create-note row above the results and the create-child-note row below them", async () => {
+    it("keeps both creation rows above the results, so neither is scrolled or sliced away", async () => {
         server.get = vi.fn(async () => [{ noteTitle: "Existing", notePath: "root/y" }]) as typeof server.get;
         const { dataset } = initAndGetSource({ allowCreatingNotes: true, allowJumpToSearchNotes: true });
         const rows = await runSource(dataset, "New");
-        expect(rows.map((r) => r.action)).toEqual([ "create-note", undefined, "create-child-note", "search-notes" ]);
+        expect(rows.map((r) => r.action)).toEqual([ "create-note", "create-child-note", undefined, "search-notes" ]);
         // the inbox is resolved on selection, so the row carries no parent
         expect(rows[0].parentNoteId).toBeUndefined();
-        expect(rows[1].noteTitle).toBe("Existing");
-        expect(rows[2].parentNoteId).toBe("activeNote");
+        expect(rows[1].parentNoteId).toBe("activeNote");
+        expect(rows[2].noteTitle).toBe("Existing");
     });
 
     it("uses root as the child-note parent when there is no active note", async () => {

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -280,16 +280,15 @@ describe("autocompleteSource (via dataset)", () => {
         expect(server.get).not.toHaveBeenCalled();
     });
 
-    it("prepends create-note and create-child-note suggestions when allowCreatingNotes and term is non-empty", async () => {
+    it("keeps the create-note row above the results and the create-child-note row below them", async () => {
         server.get = vi.fn(async () => [{ noteTitle: "Existing", notePath: "root/y" }]) as typeof server.get;
-        const { dataset } = initAndGetSource({ allowCreatingNotes: true });
+        const { dataset } = initAndGetSource({ allowCreatingNotes: true, allowJumpToSearchNotes: true });
         const rows = await runSource(dataset, "New");
-        expect(rows[0].action).toBe("create-note");
+        expect(rows.map((r) => r.action)).toEqual([ "create-note", undefined, "create-child-note", "search-notes" ]);
         // the inbox is resolved on selection, so the row carries no parent
         expect(rows[0].parentNoteId).toBeUndefined();
-        expect(rows[1].action).toBe("create-child-note");
-        expect(rows[1].parentNoteId).toBe("activeNote");
-        expect(rows[2].noteTitle).toBe("Existing");
+        expect(rows[1].noteTitle).toBe("Existing");
+        expect(rows[2].parentNoteId).toBe("activeNote");
     });
 
     it("uses root as the child-note parent when there is no active note", async () => {
@@ -297,7 +296,8 @@ describe("autocompleteSource (via dataset)", () => {
         server.get = vi.fn(async () => []) as typeof server.get;
         const { dataset } = initAndGetSource({ allowCreatingNotes: true });
         const rows = await runSource(dataset, "New");
-        expect(rows[1].parentNoteId).toBe("root");
+        const childRow = rows.find((r) => r.action === "create-child-note");
+        expect(childRow?.parentNoteId).toBe("root");
     });
 
     it("appends a search-notes suggestion when allowJumpToSearchNotes", async () => {
@@ -367,7 +367,7 @@ describe("autocompleteSource (via dataset)", () => {
         expect(dataset.templates.suggestion({ action: "create-note", highlightedNotePathTitle: "C" }))
             .toContain("bx bx-plus");
         expect(dataset.templates.suggestion({ action: "create-child-note", highlightedNotePathTitle: "C" }))
-            .toContain("bx bx-plus");
+            .toContain("bx bx-subdirectory-right");
         expect(dataset.templates.suggestion({ action: "external-link", highlightedNotePathTitle: "E" }))
             .toContain("bx bx-link-external");
     });

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -3,14 +3,19 @@ import $ from "jquery";
 
 // --- Mocks (hoisted above imports) ---
 
-const { triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote, getInboxNotePath, getInboxTarget, translate, getAllCommands, searchCommands } = vi.hoisted(() => ({
+const {
+    triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote,
+    getInboxNotePath, getInboxTarget, translate, getAllCommands, searchCommands
+} = vi.hoisted(() => ({
     triggerCommand: vi.fn(),
     getActiveContextNoteId: vi.fn<() => string | null>(() => "activeNote"),
     getActiveContext: vi.fn<() => any>(() => ({ hoistedNoteId: "hoisted" })),
     chooseNoteType: vi.fn(),
     createNote: vi.fn(),
     getInboxNotePath: vi.fn<() => Promise<string | undefined>>(async () => "root/inbox"),
-    getInboxTarget: vi.fn<() => Promise<unknown>>(async () => ({ kind: "inbox", noteId: "inb", title: "Inbox" })),
+    getInboxTarget: vi.fn<() => Promise<unknown>>(
+        async () => ({ kind: "inbox", noteId: "inb", title: "Inbox" })
+    ),
     // i18next is never initialised here, so the real `t` returns undefined. Echoing the key
     // keeps the label assertions about which string is chosen rather than about its English.
     translate: vi.fn((key: string, _opts?: Record<string, unknown>) => key),
@@ -148,8 +153,8 @@ describe("note_autocomplete", () => {
             // only the synthetic creation rows remain; they have no notePathTitle.
             const createRow = result.find((r) => r.action === "create-note");
             expect(createRow).toBeDefined();
-            expect(createRow!.name).toBe("");
-            expect(createRow!.id).toBe("@undefined");
+            expect(createRow?.name).toBe("");
+            expect(createRow?.id).toBe("@undefined");
         });
     });
 });

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -133,6 +133,15 @@ describe("note_autocomplete", () => {
             });
         });
 
+        it("omits the creation rows when the host cannot act on them", async () => {
+            server.get = vi.fn(async () => [
+                { noteTitle: "Foo", notePathTitle: "Root / Foo", notePath: "root/abc" }
+            ]) as typeof server.get;
+
+            const result = (await noteAutocomplete.autocompleteSourceForCKEditor("Foo", false)) as any[];
+            expect(result.map((r) => r.action)).toEqual([ undefined ]);
+        });
+
         it("falls back to empty name when notePathTitle is missing", async () => {
             server.get = vi.fn(async () => []) as typeof server.get;
             const result = (await noteAutocomplete.autocompleteSourceForCKEditor("X")) as any[];

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -322,6 +322,16 @@ describe("autocompleteSource (via dataset)", () => {
         expect(translate).toHaveBeenCalledWith("note_autocomplete.create-note-into", { term: "New", parentTitle: title });
     });
 
+    it("says top level for a database with neither an inbox nor a journal", async () => {
+        getInboxTarget.mockResolvedValueOnce({ kind: "root", noteId: "root", title: "root" });
+        server.get = vi.fn(async () => []) as typeof server.get;
+        const { dataset } = initAndGetSource({ allowCreatingNotes: true });
+        const rows = await runSource(dataset, "New");
+        // The root note's title would be meaningless in the label, so it is not used.
+        expect(rows[0].highlightedNotePathTitle).toBe("note_autocomplete.create-note-into-root");
+        expect(translate).toHaveBeenCalledWith("note_autocomplete.create-note-into-root", { term: "New" });
+    });
+
     it("names the day note, which has no title of its own until it is created", async () => {
         getInboxTarget.mockResolvedValueOnce({ kind: "dayNote" });
         server.get = vi.fn(async () => []) as typeof server.get;

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -3,12 +3,13 @@ import $ from "jquery";
 
 // --- Mocks (hoisted above imports) ---
 
-const { triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote, getAllCommands, searchCommands } = vi.hoisted(() => ({
+const { triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote, getInboxNotePath, getAllCommands, searchCommands } = vi.hoisted(() => ({
     triggerCommand: vi.fn(),
     getActiveContextNoteId: vi.fn<() => string | null>(() => "activeNote"),
     getActiveContext: vi.fn<() => any>(() => ({ hoistedNoteId: "hoisted" })),
     chooseNoteType: vi.fn(),
     createNote: vi.fn(),
+    getInboxNotePath: vi.fn<() => Promise<string | undefined>>(async () => "root/inbox"),
     getAllCommands: vi.fn(() => [] as any[]),
     searchCommands: vi.fn(() => [] as any[])
 }));
@@ -25,6 +26,10 @@ vi.mock("../components/app_context.js", () => ({
 
 vi.mock("./note_create.js", () => ({
     default: { chooseNoteType, createNote }
+}));
+
+vi.mock("./date_notes.js", () => ({
+    default: { getInboxNotePath }
 }));
 
 vi.mock("./command_registry.js", () => ({
@@ -105,7 +110,7 @@ describe("note_autocomplete", () => {
             ]) as typeof server.get;
 
             const result = (await noteAutocomplete.autocompleteSourceForCKEditor("Foo")) as any[];
-            // autocompleteSourceForCKEditor forces allowCreatingNotes -> a create-note row is prepended.
+            // autocompleteSourceForCKEditor forces allowCreatingNotes -> the creation rows are prepended.
             const mapped = result.find((r) => r.notePath === "root/abc");
             expect(mapped).toEqual({
                 action: "search-notes",
@@ -122,7 +127,7 @@ describe("note_autocomplete", () => {
         it("falls back to empty name when notePathTitle is missing", async () => {
             server.get = vi.fn(async () => []) as typeof server.get;
             const result = (await noteAutocomplete.autocompleteSourceForCKEditor("X")) as any[];
-            // only the synthetic create-note row remains; it has no notePathTitle.
+            // only the synthetic creation rows remain; they have no notePathTitle.
             const createRow = result.find((r) => r.action === "create-note");
             expect(createRow).toBeDefined();
             expect(createRow!.name).toBe("");
@@ -275,21 +280,24 @@ describe("autocompleteSource (via dataset)", () => {
         expect(server.get).not.toHaveBeenCalled();
     });
 
-    it("prepends a create-note suggestion when allowCreatingNotes and term is non-empty", async () => {
+    it("prepends create-note and create-child-note suggestions when allowCreatingNotes and term is non-empty", async () => {
         server.get = vi.fn(async () => [{ noteTitle: "Existing", notePath: "root/y" }]) as typeof server.get;
         const { dataset } = initAndGetSource({ allowCreatingNotes: true });
         const rows = await runSource(dataset, "New");
         expect(rows[0].action).toBe("create-note");
-        expect(rows[0].parentNoteId).toBe("activeNote");
-        expect(rows[1].noteTitle).toBe("Existing");
+        // the inbox is resolved on selection, so the row carries no parent
+        expect(rows[0].parentNoteId).toBeUndefined();
+        expect(rows[1].action).toBe("create-child-note");
+        expect(rows[1].parentNoteId).toBe("activeNote");
+        expect(rows[2].noteTitle).toBe("Existing");
     });
 
-    it("uses root as parent when there is no active note", async () => {
+    it("uses root as the child-note parent when there is no active note", async () => {
         getActiveContextNoteId.mockReturnValue(null);
         server.get = vi.fn(async () => []) as typeof server.get;
         const { dataset } = initAndGetSource({ allowCreatingNotes: true });
         const rows = await runSource(dataset, "New");
-        expect(rows[0].parentNoteId).toBe("root");
+        expect(rows[1].parentNoteId).toBe("root");
     });
 
     it("appends a search-notes suggestion when allowJumpToSearchNotes", async () => {
@@ -311,8 +319,9 @@ describe("autocompleteSource (via dataset)", () => {
         server.get = vi.fn(async () => [{ noteTitle: "A", notePath: "root/a" }]) as typeof server.get;
         const { dataset } = initAndGetSource({ allowCreatingNotes: true, allowJumpToSearchNotes: true, allowExternalLinks: true });
         const rows = await runSource(dataset, "   ");
-        // length === 0 so neither create-note nor search-notes nor external-link added
+        // length === 0 so neither creation row nor search-notes nor external-link added
         expect(rows.every((r) => r.action !== "create-note")).toBe(true);
+        expect(rows.every((r) => r.action !== "create-child-note")).toBe(true);
         expect(rows.every((r) => r.action !== "search-notes")).toBe(true);
     });
 
@@ -356,6 +365,8 @@ describe("autocompleteSource (via dataset)", () => {
         expect(dataset.templates.suggestion({ action: "search-notes", highlightedNotePathTitle: "S" }))
             .toContain("bx bx-search");
         expect(dataset.templates.suggestion({ action: "create-note", highlightedNotePathTitle: "C" }))
+            .toContain("bx bx-plus");
+        expect(dataset.templates.suggestion({ action: "create-child-note", highlightedNotePathTitle: "C" }))
             .toContain("bx bx-plus");
         expect(dataset.templates.suggestion({ action: "external-link", highlightedNotePathTitle: "E" }))
             .toContain("bx bx-link-external");
@@ -766,16 +777,33 @@ describe("autocomplete:selected handler", () => {
         expect(triggerCommand).toHaveBeenCalledWith("searchNotes", { searchString: "query" });
     });
 
-    it("creates a note then selects it", async () => {
-        const note = buildNote({ title: "Created" });
+    it("creates a note in the inbox then selects it", async () => {
         chooseNoteType.mockResolvedValue({ success: true, noteType: "text", templateNoteId: undefined, notePath: undefined });
         createNote.mockResolvedValue({ note: { getBestNotePathString: () => "root/created" } });
         const { $el, handlers } = initWithSelected();
-        await fireSelected($el, { action: "create-note", noteTitle: "Created", parentNoteId: "parent" });
+        await fireSelected($el, { action: "create-note", noteTitle: "Created" });
         expect(chooseNoteType).toHaveBeenCalled();
-        expect(createNote).toHaveBeenCalledWith("parent", expect.objectContaining({ title: "Created", type: "text" }));
+        expect(createNote).toHaveBeenCalledWith("root/inbox", expect.objectContaining({ title: "Created", type: "text" }));
         expect(handlers["autocomplete:noteselected"]).toBeDefined();
         expect(handlers["autocomplete:noteselected"].notePath).toBe("root/created");
+    });
+
+    it("creates a child note under the suggested parent", async () => {
+        chooseNoteType.mockResolvedValue({ success: true, noteType: "text", templateNoteId: undefined, notePath: undefined });
+        createNote.mockResolvedValue({ note: { getBestNotePathString: () => "root/created" } });
+        const { $el } = initWithSelected();
+        await fireSelected($el, { action: "create-child-note", noteTitle: "Created", parentNoteId: "parent" });
+        expect(getInboxNotePath).not.toHaveBeenCalled();
+        expect(createNote).toHaveBeenCalledWith("parent", expect.objectContaining({ title: "Created" }));
+    });
+
+    it("aborts when the inbox cannot be resolved", async () => {
+        chooseNoteType.mockResolvedValue({ success: true, noteType: "text" });
+        getInboxNotePath.mockResolvedValueOnce(undefined);
+        const { $el, handlers } = initWithSelected();
+        await fireSelected($el, { action: "create-note", noteTitle: "X" });
+        expect(createNote).not.toHaveBeenCalled();
+        expect(handlers["autocomplete:noteselected"]).toBeUndefined();
     });
 
     it("aborts the create-note flow when the type chooser is cancelled", async () => {

--- a/apps/client/src/services/note_autocomplete.spec.ts
+++ b/apps/client/src/services/note_autocomplete.spec.ts
@@ -3,13 +3,17 @@ import $ from "jquery";
 
 // --- Mocks (hoisted above imports) ---
 
-const { triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote, getInboxNotePath, getAllCommands, searchCommands } = vi.hoisted(() => ({
+const { triggerCommand, getActiveContextNoteId, getActiveContext, chooseNoteType, createNote, getInboxNotePath, getInboxTarget, translate, getAllCommands, searchCommands } = vi.hoisted(() => ({
     triggerCommand: vi.fn(),
     getActiveContextNoteId: vi.fn<() => string | null>(() => "activeNote"),
     getActiveContext: vi.fn<() => any>(() => ({ hoistedNoteId: "hoisted" })),
     chooseNoteType: vi.fn(),
     createNote: vi.fn(),
     getInboxNotePath: vi.fn<() => Promise<string | undefined>>(async () => "root/inbox"),
+    getInboxTarget: vi.fn<() => Promise<unknown>>(async () => ({ kind: "inbox", noteId: "inb", title: "Inbox" })),
+    // i18next is never initialised here, so the real `t` returns undefined. Echoing the key
+    // keeps the label assertions about which string is chosen rather than about its English.
+    translate: vi.fn((key: string, _opts?: Record<string, unknown>) => key),
     getAllCommands: vi.fn(() => [] as any[]),
     searchCommands: vi.fn(() => [] as any[])
 }));
@@ -29,7 +33,12 @@ vi.mock("./note_create.js", () => ({
 }));
 
 vi.mock("./date_notes.js", () => ({
-    default: { getInboxNotePath }
+    default: { getInboxNotePath, getInboxTarget }
+}));
+
+vi.mock("./i18n.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./i18n.js")>()),
+    t: translate
 }));
 
 vi.mock("./command_registry.js", () => ({
@@ -289,6 +298,40 @@ describe("autocompleteSource (via dataset)", () => {
         expect(rows[0].parentNoteId).toBeUndefined();
         expect(rows[1].parentNoteId).toBe("activeNote");
         expect(rows[2].noteTitle).toBe("Existing");
+    });
+
+    it.each([
+        { kind: "inbox", title: "Inbox" },
+        { kind: "workspaceInbox", title: "Work" },
+        { kind: "workspaceRoot", title: "Project" }
+    ])("names the $kind destination in the create-note row", async ({ kind, title }) => {
+        getInboxTarget.mockResolvedValueOnce({ kind, title });
+        server.get = vi.fn(async () => []) as typeof server.get;
+        const { dataset } = initAndGetSource({ allowCreatingNotes: true });
+        const rows = await runSource(dataset, "New");
+        expect(rows[0].highlightedNotePathTitle).toBe("note_autocomplete.create-note-into");
+        expect(translate).toHaveBeenCalledWith("note_autocomplete.create-note-into", { term: "New", parentTitle: title });
+    });
+
+    it("names the day note, which has no title of its own until it is created", async () => {
+        getInboxTarget.mockResolvedValueOnce({ kind: "dayNote" });
+        server.get = vi.fn(async () => []) as typeof server.get;
+        const { dataset } = initAndGetSource({ allowCreatingNotes: true });
+        const rows = await runSource(dataset, "New");
+        expect(rows[0].highlightedNotePathTitle).toBe("note_autocomplete.create-note-into-day-note");
+        expect(translate).toHaveBeenCalledWith("note_autocomplete.create-note-into-day-note", { term: "New" });
+    });
+
+    it.each([
+        { when: "the lookup fails", arrange: () => getInboxTarget.mockRejectedValueOnce(new Error("nope")) },
+        { when: "the destination has no title", arrange: () => getInboxTarget.mockResolvedValueOnce({ kind: "inbox" }) }
+    ])("falls back to an unqualified label when $when", async ({ arrange }) => {
+        arrange();
+        server.get = vi.fn(async () => []) as typeof server.get;
+        const { dataset } = initAndGetSource({ allowCreatingNotes: true });
+        const rows = await runSource(dataset, "New");
+        expect(rows[0].action).toBe("create-note");
+        expect(rows[0].highlightedNotePathTitle).toBe("note_autocomplete.create-note");
     });
 
     it("uses root as the child-note parent when there is no active note", async () => {

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -130,20 +130,23 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
 
     options.fastSearch = true;
 
+    // The inbox row holds the single slot above the results, so their positions are the same as
+    // before it existed; the child-note row sits with the other secondary actions at the bottom.
     if (length >= 1 && options.allowCreatingNotes) {
-        results = [
+        results = ([
             {
                 action: "create-note",
                 noteTitle: term,
                 highlightedNotePathTitle: t("note_autocomplete.create-note", { term })
-            } as Suggestion,
+            }
+        ] as Suggestion[]).concat(results, [
             {
                 action: "create-child-note",
                 noteTitle: term,
                 parentNoteId: activeNoteId || "root",
                 highlightedNotePathTitle: t("note_autocomplete.create-child-note", { term })
             } as Suggestion
-        ].concat(results);
+        ]);
     }
 
     if (length >= 1 && options.allowJumpToSearchNotes) {
@@ -362,8 +365,10 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         let iconClass = suggestion.icon ?? "bx bx-note";
                         if (suggestion.action === "search-notes") {
                             iconClass = "bx bx-search";
-                        } else if (suggestion.action === "create-note" || suggestion.action === "create-child-note") {
+                        } else if (suggestion.action === "create-note") {
                             iconClass = "bx bx-plus";
+                        } else if (suggestion.action === "create-child-note") {
+                            iconClass = "bx bx-subdirectory-right";
                         } else if (suggestion.action === "external-link") {
                             iconClass = "bx bx-link-external";
                         }

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -83,7 +83,12 @@ export interface Options {
     isCommandPalette?: boolean;
 }
 
-async function autocompleteSourceForCKEditor(queryText: string) {
+/**
+ * Feeds a CKEditor mention. Creation entries are offered only where the editor's host component
+ * implements `createNoteForReferenceLink`, which is what `MentionCustomization` calls to act on
+ * them.
+ */
+async function autocompleteSourceForCKEditor(queryText: string, allowCreatingNotes = true) {
     return await new Promise<MentionFeedObjectItem[]>((res, rej) => {
         autocompleteSource(
             queryText,
@@ -104,7 +109,7 @@ async function autocompleteSourceForCKEditor(queryText: string) {
                 );
             },
             {
-                allowCreatingNotes: true
+                allowCreatingNotes
             }
         );
     });

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -32,8 +32,7 @@ async function getInboxTarget() {
     try {
         return await dateNoteService.getInboxTarget();
     } catch (e) {
-        // A destination that cannot be named is not worth failing the dropdown over: the
-        // entry falls back to a label without one.
+        // The entry falls back to a label with no destination rather than failing the dropdown.
         logError(`Unable to resolve the inbox target: ${e}`);
         return null;
     }
@@ -166,8 +165,7 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
     const activeNoteId = appContext.tabManager.getActiveContextNoteId();
     const length = term.trim().length;
 
-    // Started before the search rather than after it, so naming the destination costs a request
-    // but no extra wait.
+    // Runs concurrently with the search, so naming the destination costs a request but no wait.
     const pendingInboxTarget = length >= 1 && options.allowCreatingNotes ? getInboxTarget() : null;
 
     let results = await server.get<Suggestion[]>(`autocomplete?query=${encodeURIComponent(term)}&activeNoteId=${activeNoteId}&fastSearch=${fastSearch}`);

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -1,4 +1,5 @@
 import type { MentionFeedObjectItem } from "@triliumnext/ckeditor5";
+import type { InboxTargetResponse } from "@triliumnext/commons";
 
 import appContext from "../components/app_context.js";
 import commandRegistry from "./command_registry.js";
@@ -8,6 +9,7 @@ import { t } from "./i18n.js";
 import noteCreateService from "./note_create.js";
 import server from "./server.js";
 import { escapeHtml } from "./utils.js";
+import { logError } from "./ws.js";
 
 // this key needs to have this value, so it's hit by the tooltip
 const SELECTED_NOTE_PATH_KEY = "data-note-path";
@@ -25,6 +27,30 @@ function getSearchDelay(notesCount: number): number {
     return delay;
 }
 let searchDelay = getSearchDelay(notesCount);
+
+async function getInboxTarget() {
+    try {
+        return await dateNoteService.getInboxTarget();
+    } catch (e) {
+        // A destination that cannot be named is not worth failing the dropdown over: the
+        // entry falls back to a label without one.
+        logError(`Unable to resolve the inbox target: ${e}`);
+        return null;
+    }
+}
+
+/** Labels the creation entry with the note the capture would land in. */
+function buildCreateNoteTitle(term: string, target: InboxTargetResponse | null) {
+    if (!target || (target.kind !== "dayNote" && !target.title)) {
+        return t("note_autocomplete.create-note", { term });
+    }
+
+    if (target.kind === "dayNote") {
+        return t("note_autocomplete.create-note-into-day-note", { term });
+    }
+
+    return t("note_autocomplete.create-note-into", { term, parentTitle: target.title });
+}
 
 // TODO: Deduplicate with server.
 export interface Suggestion {
@@ -126,18 +152,22 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
     const activeNoteId = appContext.tabManager.getActiveContextNoteId();
     const length = term.trim().length;
 
+    // Started before the search rather than after it, so naming the destination costs a request
+    // but no extra wait.
+    const pendingInboxTarget = length >= 1 && options.allowCreatingNotes ? getInboxTarget() : null;
+
     let results = await server.get<Suggestion[]>(`autocomplete?query=${encodeURIComponent(term)}&activeNoteId=${activeNoteId}&fastSearch=${fastSearch}`);
 
     options.fastSearch = true;
 
     // Both rows stay above the results: the CKEditor mention feed renders only the first
     // `mention.dropdownLimit` items, and the jQuery dropdown scrolls past as many as 200.
-    if (length >= 1 && options.allowCreatingNotes) {
+    if (pendingInboxTarget) {
         results = [
             {
                 action: "create-note",
                 noteTitle: term,
-                highlightedNotePathTitle: t("note_autocomplete.create-note", { term })
+                highlightedNotePathTitle: buildCreateNoteTitle(term, await pendingInboxTarget)
             } as Suggestion,
             {
                 action: "create-child-note",

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -130,23 +130,22 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
 
     options.fastSearch = true;
 
-    // The inbox row holds the single slot above the results, so their positions are the same as
-    // before it existed; the child-note row sits with the other secondary actions at the bottom.
+    // Both rows stay above the results: the CKEditor mention feed renders only the first
+    // `mention.dropdownLimit` items, and the jQuery dropdown scrolls past as many as 200.
     if (length >= 1 && options.allowCreatingNotes) {
-        results = ([
+        results = [
             {
                 action: "create-note",
                 noteTitle: term,
                 highlightedNotePathTitle: t("note_autocomplete.create-note", { term })
-            }
-        ] as Suggestion[]).concat(results, [
+            } as Suggestion,
             {
                 action: "create-child-note",
                 noteTitle: term,
                 parentNoteId: activeNoteId || "root",
                 highlightedNotePathTitle: t("note_autocomplete.create-child-note", { term })
             } as Suggestion
-        ]);
+        ].concat(results);
     }
 
     if (length >= 1 && options.allowJumpToSearchNotes) {

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -2,6 +2,7 @@ import type { MentionFeedObjectItem } from "@triliumnext/ckeditor5";
 
 import appContext from "../components/app_context.js";
 import commandRegistry from "./command_registry.js";
+import dateNoteService from "./date_notes.js";
 import froca from "./froca.js";
 import { t } from "./i18n.js";
 import noteCreateService from "./note_create.js";
@@ -32,7 +33,7 @@ export interface Suggestion {
     notePathTitle?: string;
     notePath?: string;
     highlightedNotePathTitle?: string;
-    action?: string | "create-note" | "search-notes" | "external-link" | "command";
+    action?: string | "create-note" | "create-child-note" | "search-notes" | "external-link" | "command";
     parentNoteId?: string;
     icon?: string;
     commandId?: string;
@@ -134,8 +135,13 @@ async function autocompleteSource(term: string, cb: (rows: Suggestion[]) => void
             {
                 action: "create-note",
                 noteTitle: term,
-                parentNoteId: activeNoteId || "root",
                 highlightedNotePathTitle: t("note_autocomplete.create-note", { term })
+            } as Suggestion,
+            {
+                action: "create-child-note",
+                noteTitle: term,
+                parentNoteId: activeNoteId || "root",
+                highlightedNotePathTitle: t("note_autocomplete.create-child-note", { term })
             } as Suggestion
         ].concat(results);
     }
@@ -356,7 +362,7 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
                         let iconClass = suggestion.icon ?? "bx bx-note";
                         if (suggestion.action === "search-notes") {
                             iconClass = "bx bx-search";
-                        } else if (suggestion.action === "create-note") {
+                        } else if (suggestion.action === "create-note" || suggestion.action === "create-child-note") {
                             iconClass = "bx bx-plus";
                         } else if (suggestion.action === "external-link") {
                             iconClass = "bx bx-link-external";
@@ -405,12 +411,20 @@ function initNoteAutocomplete($el: JQuery<HTMLElement>, options?: Options) {
             return;
         }
 
-        if (suggestion.action === "create-note") {
+        if (suggestion.action === "create-note" || suggestion.action === "create-child-note") {
             const { success, noteType, templateNoteId, notePath, cloneToNoteIds } = await noteCreateService.chooseNoteType();
             if (!success) {
                 return;
             }
-            const { note } = await noteCreateService.createNote( notePath || suggestion.parentNoteId, {
+
+            const parentNotePath = notePath ?? (suggestion.action === "create-note"
+                ? await dateNoteService.getInboxNotePath()
+                : suggestion.parentNoteId);
+            if (!parentNotePath) {
+                return;
+            }
+
+            const { note } = await noteCreateService.createNote(parentNotePath, {
                 title: suggestion.noteTitle,
                 activate: false,
                 type: noteType,

--- a/apps/client/src/services/note_autocomplete.ts
+++ b/apps/client/src/services/note_autocomplete.ts
@@ -41,12 +41,21 @@ async function getInboxTarget() {
 
 /** Labels the creation entry with the note the capture would land in. */
 function buildCreateNoteTitle(term: string, target: InboxTargetResponse | null) {
-    if (!target || (target.kind !== "dayNote" && !target.title)) {
+    if (!target) {
         return t("note_autocomplete.create-note", { term });
     }
 
     if (target.kind === "dayNote") {
         return t("note_autocomplete.create-note-into-day-note", { term });
+    }
+
+    // The root note's own title names nothing the user recognises in the tree.
+    if (target.kind === "root") {
+        return t("note_autocomplete.create-note-into-root", { term });
+    }
+
+    if (!target.title) {
+        return t("note_autocomplete.create-note", { term });
     }
 
     return t("note_autocomplete.create-note-into", { term, parentTitle: target.title });

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2978,6 +2978,8 @@
   "note_autocomplete": {
     "search-for": "Search for \"{{term}}\"",
     "create-note": "Create note \"{{term}}\"",
+    "create-note-into": "Create note \"{{term}}\" in {{parentTitle}}",
+    "create-note-into-day-note": "Create note \"{{term}}\" in today's day note",
     "create-child-note": "Create child note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2977,7 +2977,8 @@
   },
   "note_autocomplete": {
     "search-for": "Search for \"{{term}}\"",
-    "create-note": "Create and link child note \"{{term}}\"",
+    "create-note": "Create note \"{{term}}\"",
+    "create-child-note": "Create child note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",
     "show-recent-notes": "Show recent notes",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -2980,6 +2980,7 @@
     "create-note": "Create note \"{{term}}\"",
     "create-note-into": "Create note \"{{term}}\" in {{parentTitle}}",
     "create-note-into-day-note": "Create note \"{{term}}\" in today's day note",
+    "create-note-into-root": "Create note \"{{term}}\" at the top level",
     "create-child-note": "Create child note \"{{term}}\"",
     "insert-external-link": "Insert external link to \"{{term}}\"",
     "clear-text-field": "Clear text field",

--- a/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
+++ b/apps/client/src/widgets/ribbon/components/AttributeEditor.tsx
@@ -14,6 +14,7 @@ import contextMenu from "../../../menus/context_menu";
 import attribute_parser, { Attribute } from "../../../services/attribute_parser";
 import attribute_renderer from "../../../services/attribute_renderer";
 import attributes, { isBuiltinAttribute } from "../../../services/attributes";
+import dateNoteService from "../../../services/date_notes";
 import froca from "../../../services/froca";
 import { t } from "../../../services/i18n";
 import { ATTRIBUTE_HELP_PAGE } from "../../../services/in_app_help";
@@ -250,14 +251,14 @@ export default function AttributeEditor({ api, note, componentId, notePath, ntxI
 
             $el.text(title);
         },
-        createNoteForReferenceLink: async (title: string) => {
-            let result;
-            if (notePath) {
-                result = await note_create.createNoteWithTypePrompt(notePath, {
-                    activate: false,
-                    title
-                });
-            }
+        createNoteForReferenceLink: async (title: string, intoInbox: boolean) => {
+            const parentNotePath = intoInbox ? await dateNoteService.getInboxNotePath() : notePath;
+            if (!parentNotePath) return;
+
+            const result = await note_create.createNoteWithTypePrompt(parentNotePath, {
+                activate: false,
+                title
+            });
 
             return result?.note?.getBestNotePathString();
         }

--- a/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
+++ b/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
@@ -32,19 +32,13 @@ const READ_ONLY_LOCK = "llm-chat-streaming";
 const mentionFeeds: MentionFeed[] = [
     {
         marker: "@",
-        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText),
+        feed: (queryText) => note_autocomplete.autocompleteSourceForCKEditor(queryText, false),
         itemRenderer: (rawItem) => {
             const item = rawItem as Suggestion;
             const itemElement = document.createElement("button");
 
             const iconElement = document.createElement("span");
-            let iconClass = item.icon ?? "bx bx-note";
-            if (item.action === "create-note") {
-                iconClass = "bx bx-plus";
-            } else if (item.action === "create-child-note") {
-                iconClass = "bx bx-subdirectory-right";
-            }
-            iconElement.className = iconClass;
+            iconElement.className = item.icon ?? "bx bx-note";
 
             itemElement.append(iconElement, document.createTextNode(" "));
             const titleContainer = document.createElement("span");

--- a/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
+++ b/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
@@ -39,7 +39,7 @@ const mentionFeeds: MentionFeed[] = [
 
             const iconElement = document.createElement("span");
             let iconClass = item.icon ?? "bx bx-note";
-            if (item.action === "create-note") {
+            if (item.action === "create-note" || item.action === "create-child-note") {
                 iconClass = "bx bx-plus";
             }
             iconElement.className = iconClass;

--- a/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
+++ b/apps/client/src/widgets/type_widgets/llm_chat/ChatInputBar.tsx
@@ -39,8 +39,10 @@ const mentionFeeds: MentionFeed[] = [
 
             const iconElement = document.createElement("span");
             let iconClass = item.icon ?? "bx bx-note";
-            if (item.action === "create-note" || item.action === "create-child-note") {
+            if (item.action === "create-note") {
                 iconClass = "bx bx-plus";
+            } else if (item.action === "create-child-note") {
+                iconClass = "bx bx-subdirectory-right";
             }
             iconElement.className = iconClass;
 

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import appContext from "../../../components/app_context";
 import { consumeBookmark } from "../../../services/bookmark_jump";
+import dateNoteService from "../../../services/date_notes";
 import dialog from "../../../services/dialog";
 import { t } from "../../../services/i18n";
 import link, { parseNavigationStateFromUrl } from "../../../services/link";
@@ -159,8 +160,8 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
             linkEmbedService.renderMentionPreview(container, metadata, editable);
         },
         // Creating notes in @-completion
-        async createNoteForReferenceLink(title: string) {
-            const notePath = noteContext?.notePath;
+        async createNoteForReferenceLink(title: string, intoInbox: boolean) {
+            const notePath = intoInbox ? await dateNoteService.getInboxNotePath() : noteContext?.notePath;
             if (!notePath) return;
 
             const resp = await note_create.createNoteWithTypePrompt(notePath, {

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -305,7 +305,7 @@ export async function buildConfig(opts: BuildEditorOptions): Promise<EditorConfi
                         const iconElement = document.createElement("span");
                         // Choose appropriate icon based on action
                         let iconClass = suggestion.icon ?? "bx bx-note";
-                        if (suggestion.action === "create-note") {
+                        if (suggestion.action === "create-note" || suggestion.action === "create-child-note") {
                             iconClass = "bx bx-plus";
                         }
                         iconElement.className = iconClass;

--- a/apps/client/src/widgets/type_widgets/text/config.ts
+++ b/apps/client/src/widgets/type_widgets/text/config.ts
@@ -305,8 +305,10 @@ export async function buildConfig(opts: BuildEditorOptions): Promise<EditorConfi
                         const iconElement = document.createElement("span");
                         // Choose appropriate icon based on action
                         let iconClass = suggestion.icon ?? "bx bx-note";
-                        if (suggestion.action === "create-note" || suggestion.action === "create-child-note") {
+                        if (suggestion.action === "create-note") {
                             iconClass = "bx bx-plus";
+                        } else if (suggestion.action === "create-child-note") {
+                            iconClass = "bx bx-subdirectory-right";
                         }
                         iconElement.className = iconClass;
 

--- a/apps/server/internal.openapi.yaml
+++ b/apps/server/internal.openapi.yaml
@@ -3137,6 +3137,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/Note'
                 
+  /api/special-notes/inbox-target:
+    get:
+      tags: [Special Notes]
+      summary: Resolve where an inbox capture would go
+      description: >
+        Reports the destination `/api/special-notes/inbox/{date}` would use, without creating
+        anything. Honours the hoisted note, read from the `trilium-hoisted-note-id` header.
+      operationId: getInboxTarget
+      responses:
+        '200':
+          description: The resolved destination
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [kind]
+                properties:
+                  kind:
+                    type: string
+                    enum: [inbox, workspaceInbox, workspaceRoot, dayNote, root]
+                    description: >
+                      Which rule decided the destination. `dayNote` names no note, because the
+                      day note is created when the capture happens.
+                  noteId:
+                    type: string
+                    description: Absent for `dayNote`.
+                  title:
+                    type: string
+                    description: Absent for `dayNote`.
+
   /api/special-notes/days/{date}:
     get:
       tags: [Special Notes]

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
@@ -76,8 +76,8 @@
 <ul>
   <li>Via <code spellcheck="false">@</code>-completion in a&nbsp;<a class="reference-link"
     href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note</li>
-  <li>Via the <em>Create and link child note</em> option of the note search (new
-    tab or&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>),
+  <li>Via the <em>Create note</em> or <em>Create child note</em> options of the
+    note search (new tab or&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>),
     but only if the default/empty location is set.</li>
 </ul>
 <p>Creating an instance note from the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;context

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
@@ -22,10 +22,17 @@
   <li>Using the keyboard, use the up or down arrow keys to navigate between
     items. Press <kbd>Enter</kbd> to open the desired note.</li>
   <li>If the note doesn't exist, it's possible to create it by typing the desired
-    note title and selecting one of two options: <em>Create note</em> places
-    it in the&nbsp;<a class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>,
-    whereas <em>Create child note</em> places it under the note that is currently
-    open.</li>
+    note title and selecting one of two options:
+    <ul>
+      <li><em>Create note</em> places it in the&nbsp;<a class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>:
+        the note labelled <code spellcheck="false">#inbox</code>, or today's&nbsp;<a class="reference-link"
+        href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if there is none. While
+        hoisted into a&nbsp;<a class="reference-link" href="#root/_help_9sRHySam5fXb">Workspaces</a>,
+        the workspace's own inbox is used, falling back to the workspace root itself.</li>
+      <li><em>Create child note</em> places it under the note that is currently
+        open.</li>
+    </ul>
+  </li>
 </ul>
 <h2>Recent notes</h2>
 <p>Jump to note also has the ability to show the list of recently viewed

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
@@ -22,7 +22,10 @@
   <li>Using the keyboard, use the up or down arrow keys to navigate between
     items. Press <kbd>Enter</kbd> to open the desired note.</li>
   <li>If the note doesn't exist, it's possible to create it by typing the desired
-    note title and selecting the <em>Create and link child note</em> option.</li>
+    note title and selecting one of two options: <em>Create note</em> places
+    it in the&nbsp;<a class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>,
+    whereas <em>Create child note</em> places it under the note that is currently
+    open.</li>
 </ul>
 <h2>Recent notes</h2>
 <p>Jump to note also has the ability to show the list of recently viewed

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
@@ -25,10 +25,12 @@
     note title and selecting one of two options:
     <ul>
       <li><em>Create note</em> places it in the&nbsp;<a class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>:
-        the note labelled <code spellcheck="false">#inbox</code>, or today's&nbsp;<a class="reference-link"
-        href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if there is none. While
-        hoisted into a&nbsp;<a class="reference-link" href="#root/_help_9sRHySam5fXb">Workspaces</a>,
-        the workspace's own inbox is used, falling back to the workspace root itself.</li>
+        the note labelled <code spellcheck="false">#inbox</code>, today's&nbsp;<a class="reference-link"
+        href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if there is none, or the
+        top level if there is no journal either. While hoisted into a&nbsp;<a class="reference-link"
+        href="#root/_help_9sRHySam5fXb">Workspaces</a>, the workspace's own inbox
+        is used, falling back to the workspace root itself. The option names the
+        destination, so it is always visible before the note is created.</li>
       <li><em>Create child note</em> places it under the note that is currently
         open.</li>
     </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
@@ -18,7 +18,8 @@
 <p>Only one note should carry this label. If there are multiple notes, only
   one will be used by the application.</p>
 <aside class="admonition note">
-  <p>If there is no inbox note, Trilium will fall back to today's <a href="#root/_help_l0tKav7yLHGF">day note</a> instead.</p>
+  <p>If there is no inbox note, Trilium will fall back to today's <a href="#root/_help_l0tKav7yLHGF">day note</a> instead,
+    creating it and its calendar ancestors if they do not exist yet.</p>
 </aside>
 <h2>Workspace inboxes</h2>
 <p>Each <a href="#root/_help_9sRHySam5fXb">workspace</a> can have its own inbox,

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
@@ -7,6 +7,9 @@
   <li>The global <em>Create note into inbox</em> shortcut (default <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>).</li>
   <li>The <em>New note</em> action in the <a href="#root/_help_7iwde4lsKc6O">tray icon menu</a>.</li>
   <li>The&nbsp;<a class="reference-link" href="#root/_help_MtPxeAWVAzMg">Web Clipper</a>&nbsp;extension.</li>
+  <li>The <em>Create note</em> option offered when a search finds no match, in&nbsp;<a class="reference-link"
+    href="#root/_help_F1r9QtzQLZqm">Jump to &amp; command palette</a>, in an empty
+    tab and in the <code spellcheck="false">@</code> completion of a text note.</li>
 </ul>
 <h2>Setting a note inbox</h2>
 <p>To create a note inbox, apply the <code spellcheck="false">#inbox</code> 

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
@@ -18,8 +18,10 @@
 <p>Only one note should carry this label. If there are multiple notes, only
   one will be used by the application.</p>
 <aside class="admonition note">
-  <p>If there is no inbox note, Trilium will fall back to today's <a href="#root/_help_l0tKav7yLHGF">day note</a> instead,
-    creating it and its calendar ancestors if they do not exist yet.</p>
+  <p>If there is no inbox note, Trilium will fall back to today's <a href="#root/_help_l0tKav7yLHGF">day note</a>,
+    creating it and its calendar ancestors as needed. If the journal has been
+    removed altogether, the note is created at the top level instead of a new
+    journal being built for it.</p>
 </aside>
 <h2>Workspace inboxes</h2>
 <p>Each <a href="#root/_help_9sRHySam5fXb">workspace</a> can have its own inbox,

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
@@ -12,9 +12,9 @@
   <li>Searching for the title of the desired note to link. It's also possible
     to create new notes from this dialog by typing a non-existing note title
     and selecting either <em>Create note</em>, which places it in the&nbsp;<a class="reference-link"
-    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(today's day note if no
-    inbox is set), or <em>Create child note</em>, which places it under the note
-    being edited.</li>
+    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(today's day note, or the
+    top level, when no inbox is set), or <em>Create child note</em>, which places
+    it under the note being edited.</li>
 </ol>
 <p>There are two link types which you can select when creating the link to
   the note:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
@@ -11,7 +11,9 @@
     width="34" height="16">menu in the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>.</li>
   <li>Searching for the title of the desired note to link. It's also possible
     to create new notes from this dialog by typing a non-existing note title
-    and selecting <em>Create and link child note</em>.</li>
+    and selecting either <em>Create note</em>, which places it in the&nbsp;<a class="reference-link"
+    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>, or <em>Create child note</em>,
+    which places it under the note being edited.</li>
 </ol>
 <p>There are two link types which you can select when creating the link to
   the note:</p>
@@ -39,7 +41,8 @@
   <li>Search for the desired note's title by typing a few characters. Use <kbd>Up</kbd> and <kbd>Down</kbd> to
     select the correct note, and press <kbd>Enter</kbd> or <kbd>Tab</kbd> to create
     the link. It's also possible to create new notes with this method by typing
-    a non-existing note title and selecting <em>Create and link child note</em>.</li>
+    a non-existing note title and selecting <em>Create note</em> or <em>Create child note</em>,
+    as described above.</li>
 </ol>
 <h2>Pasting internal links</h2>
 <p>You can also insert internal links by copying a note from the note tree.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
@@ -12,8 +12,9 @@
   <li>Searching for the title of the desired note to link. It's also possible
     to create new notes from this dialog by typing a non-existing note title
     and selecting either <em>Create note</em>, which places it in the&nbsp;<a class="reference-link"
-    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>, or <em>Create child note</em>,
-    which places it under the note being edited.</li>
+    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(today's day note if no
+    inbox is set), or <em>Create child note</em>, which places it under the note
+    being edited.</li>
 </ol>
 <p>There are two link types which you can select when creating the link to
   the note:</p>

--- a/apps/server/src/assets/etapi.openapi.yaml
+++ b/apps/server/src/assets/etapi.openapi.yaml
@@ -795,7 +795,8 @@ paths:
         get:
             description: >
                 returns an "inbox" note, into which note can be created. Date will be used depending on whether the inbox
-                is a fixed note (identified with #inbox label) or a day note in a journal.
+                is a fixed note (identified with #inbox label) or a day note in a journal. A database with neither
+                returns the root note, and ignores the date, rather than creating a journal to hold a day note.
             operationId: getInboxNote
             parameters:
                 - name: date

--- a/apps/server/src/routes/api/clipper.spec.ts
+++ b/apps/server/src/routes/api/clipper.spec.ts
@@ -1,4 +1,4 @@
-import { becca_easy_mocking, BNote, cls } from "@triliumnext/core";
+import { BBranch, becca, becca_easy_mocking, BNote, cls } from "@triliumnext/core";
 import type { Request } from "express";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -100,6 +100,29 @@ describe("clipper route handlers", () => {
             }
         } as unknown as Request));
         expect(result.noteId).toBeTruthy();
+    });
+
+    it("clips to the top level when there is no clipper inbox and no journal", async () => {
+        const result = await cls.init(() => clipperRoute.createNote({
+            body: { title: "No journal", content: "<p>x</p>", images: [], clipType: "note", pageUrl: "https://example.com/nj" }
+        } as unknown as Request));
+
+        // Without a #calendarRoot the clipping must not have a calendar built around it.
+        const clipped = becca.getNoteOrThrow(result.noteId);
+        expect(clipped.getParentNotes().map((p) => p.noteId)).toEqual([ "root" ]);
+    });
+
+    it("clips into the day note once a journal exists", async () => {
+        const journal = buildNote({ title: "Journal", "#calendarRoot": "" });
+        // The day note is created beneath it, so it needs a path back to the root.
+        new BBranch({ noteId: journal.noteId, parentNoteId: "root", branchId: `root_${journal.noteId}` });
+
+        const result = await cls.init(() => clipperRoute.createNote({
+            body: { title: "With journal", content: "<p>x</p>", images: [], clipType: "note", pageUrl: "https://example.com/wj" }
+        } as unknown as Request));
+
+        const clipped = becca.getNoteOrThrow(result.noteId);
+        expect(clipped.getParentNotes().map((p) => p.noteId)).not.toEqual([ "root" ]);
     });
 
     it("returns a null noteId when no clipping matches the URL", async () => {

--- a/apps/server/src/routes/api/clipper.ts
+++ b/apps/server/src/routes/api/clipper.ts
@@ -1,4 +1,4 @@
-import { app_info as appInfo, attribute_formatter as attributeFormatter, attributes as attributeService, type BNote, cloning as cloneService, date_notes as dateNoteService, date_utils as dateUtils, note_service as noteService, sanitize, ValidationError, ws } from "@triliumnext/core";
+import { app_info as appInfo, attribute_formatter as attributeFormatter, attributes as attributeService, becca, type BNote, cloning as cloneService, date_notes as dateNoteService, date_utils as dateUtils, note_service as noteService, sanitize, ValidationError, ws } from "@triliumnext/core";
 import type { Request } from "express";
 import { parse } from "node-html-parser";
 import path from "path";
@@ -77,13 +77,18 @@ function findClippingNote(clipperInboxNote: BNote, pageUrl: string, clipType: st
 }
 
 async function getClipperInboxNote() {
-    let clipperInbox = attributeService.getNoteWithLabel("clipperInbox");
-
-    if (!clipperInbox) {
-        clipperInbox = await dateNoteService.getDayNote(dateUtils.localNowDate());
+    const clipperInbox = attributeService.getNoteWithLabel("clipperInbox");
+    if (clipperInbox) {
+        return clipperInbox;
     }
 
-    return clipperInbox;
+    // Clipping a page is not a request for a journal, so a database without one keeps the
+    // clipping at the top level rather than having a calendar built around it (#11034).
+    if (!dateNoteService.hasCalendarRoot()) {
+        return becca.getNoteOrThrow("root");
+    }
+
+    return await dateNoteService.getDayNote(dateUtils.localNowDate());
 }
 
 async function createNote(req: Request) {

--- a/docs/User Guide/User Guide/Advanced Usage/Templates.md
+++ b/docs/User Guide/User Guide/Advanced Usage/Templates.md
@@ -42,7 +42,7 @@ Adding the relation several times places the new note in every target, as <a cl
 The default parent is used whenever a note is created from the template through the _Choose note type_ dialog:
 
 *   Via `@`\-completion in a <a class="reference-link" href="../Note%20Types/Text.md">Text</a> note
-*   Via the _Create and link child note_ option of the note search (new tab or <a class="reference-link" href="../Note%20Types/Text/Links/Internal%20(reference)%20links.md">Internal (reference) links</a>), but only if the default/empty location is set.
+*   Via the _Create note_ or _Create child note_ options of the note search (new tab or <a class="reference-link" href="../Note%20Types/Text/Links/Internal%20(reference)%20links.md">Internal (reference) links</a>), but only if the default/empty location is set.
 
 Creating an instance note from the <a class="reference-link" href="../Basic%20Concepts%20and%20Features/UI%20Elements/Note%20Tree.md">Note Tree</a> context menu (_Insert child note_, _Insert note after_) still creates it at the chosen place.
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
@@ -16,7 +16,9 @@ In addition to searching for notes, it is also possible to search for commands. 
 
 *   By default, when there is no text entered it will display the most recent notes.
 *   Using the keyboard, use the up or down arrow keys to navigate between items. Press <kbd>Enter</kbd> to open the desired note.
-*   If the note doesn't exist, it's possible to create it by typing the desired note title and selecting one of two options: _Create note_ places it in the <a class="reference-link" href="../Notes/Note%20Inbox.md">Note Inbox</a>, whereas _Create child note_ places it under the note that is currently open.
+*   If the note doesn't exist, it's possible to create it by typing the desired note title and selecting one of two options:
+    *   _Create note_ places it in the <a class="reference-link" href="../Notes/Note%20Inbox.md">Note Inbox</a>: the note labelled `#inbox`, or today's <a class="reference-link" href="../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md">Day Notes</a> if there is none. While hoisted into a <a class="reference-link" href="Workspaces.md">Workspaces</a>, the workspace's own inbox is used, falling back to the workspace root itself.
+    *   _Create child note_ places it under the note that is currently open.
 
 ## Recent notes
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
@@ -17,7 +17,7 @@ In addition to searching for notes, it is also possible to search for commands. 
 *   By default, when there is no text entered it will display the most recent notes.
 *   Using the keyboard, use the up or down arrow keys to navigate between items. Press <kbd>Enter</kbd> to open the desired note.
 *   If the note doesn't exist, it's possible to create it by typing the desired note title and selecting one of two options:
-    *   _Create note_ places it in the <a class="reference-link" href="../Notes/Note%20Inbox.md">Note Inbox</a>: the note labelled `#inbox`, or today's <a class="reference-link" href="../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md">Day Notes</a> if there is none. While hoisted into a <a class="reference-link" href="Workspaces.md">Workspaces</a>, the workspace's own inbox is used, falling back to the workspace root itself.
+    *   _Create note_ places it in the <a class="reference-link" href="../Notes/Note%20Inbox.md">Note Inbox</a>: the note labelled `#inbox`, today's <a class="reference-link" href="../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md">Day Notes</a> if there is none, or the top level if there is no journal either. While hoisted into a <a class="reference-link" href="Workspaces.md">Workspaces</a>, the workspace's own inbox is used, falling back to the workspace root itself. The option names the destination, so it is always visible before the note is created.
     *   _Create child note_ places it under the note that is currently open.
 
 ## Recent notes

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.md
@@ -16,7 +16,7 @@ In addition to searching for notes, it is also possible to search for commands. 
 
 *   By default, when there is no text entered it will display the most recent notes.
 *   Using the keyboard, use the up or down arrow keys to navigate between items. Press <kbd>Enter</kbd> to open the desired note.
-*   If the note doesn't exist, it's possible to create it by typing the desired note title and selecting the _Create and link child note_ option.
+*   If the note doesn't exist, it's possible to create it by typing the desired note title and selecting one of two options: _Create note_ places it in the <a class="reference-link" href="../Notes/Note%20Inbox.md">Note Inbox</a>, whereas _Create child note_ places it under the note that is currently open.
 
 ## Recent notes
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
@@ -16,7 +16,7 @@ To create a note inbox, apply the `#inbox` [label](../../Advanced%20Usage/Attrib
 Only one note should carry this label. If there are multiple notes, only one will be used by the application.
 
 > [!NOTE]
-> If there is no inbox note, Trilium will fall back to today's [day note](../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md) instead, creating it and its calendar ancestors if they do not exist yet.
+> If there is no inbox note, Trilium will fall back to today's [day note](../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md), creating it and its calendar ancestors as needed. If the journal has been removed altogether, the note is created at the top level instead of a new journal being built for it.
 
 ## Workspace inboxes
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
@@ -7,6 +7,7 @@ The inbox is the default destination for quickly captured notes. When a note is 
 *   The global _Create note into inbox_ shortcut (default <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>).
 *   The _New note_ action in the [tray icon menu](../../Installation%20%26%20Setup/Desktop%20Installation/Tray%20icon%20%26%20automatic%20startup.md).
 *   The <a class="reference-link" href="../../Installation%20%26%20Setup/Web%20Clipper.md">Web Clipper</a> extension.
+*   The _Create note_ option offered when a search finds no match, in <a class="reference-link" href="../Navigation/Jump%20to%20%26%20command%20palette.md">Jump to & command palette</a>, in an empty tab and in the `@` completion of a text note.
 
 ## Setting a note inbox
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
@@ -16,7 +16,7 @@ To create a note inbox, apply the `#inbox` [label](../../Advanced%20Usage/Attrib
 Only one note should carry this label. If there are multiple notes, only one will be used by the application.
 
 > [!NOTE]
-> If there is no inbox note, Trilium will fall back to today's [day note](../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md) instead.
+> If there is no inbox note, Trilium will fall back to today's [day note](../../Advanced%20Usage/Advanced%20Showcases/Day%20Notes.md) instead, creating it and its calendar ancestors if they do not exist yet.
 
 ## Workspace inboxes
 

--- a/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
@@ -8,7 +8,7 @@ You can open an internal link by clicking it. You can also see a read-only previ
 Internal links can be created at the current position in a text note by:
 
 1.  Pressing <kbd>Ctrl</kbd> + <kbd>L</kbd> or the <img src="Internal (reference) links_image.png" width="20" height="17"> button underneath the <img src="1_Internal (reference) links_image.png" width="34" height="16"> menu in the <a class="reference-link" href="../Formatting%20toolbar.md">Formatting toolbar</a>.
-2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting either _Create note_, which places it in the <a class="reference-link" href="../../../Basic%20Concepts%20and%20Features/Notes/Note%20Inbox.md">Note Inbox</a>, or _Create child note_, which places it under the note being edited.
+2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting either _Create note_, which places it in the <a class="reference-link" href="../../../Basic%20Concepts%20and%20Features/Notes/Note%20Inbox.md">Note Inbox</a> (today's day note if no inbox is set), or _Create child note_, which places it under the note being edited.
 
 There are two link types which you can select when creating the link to the note:
 

--- a/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
@@ -8,7 +8,7 @@ You can open an internal link by clicking it. You can also see a read-only previ
 Internal links can be created at the current position in a text note by:
 
 1.  Pressing <kbd>Ctrl</kbd> + <kbd>L</kbd> or the <img src="Internal (reference) links_image.png" width="20" height="17"> button underneath the <img src="1_Internal (reference) links_image.png" width="34" height="16"> menu in the <a class="reference-link" href="../Formatting%20toolbar.md">Formatting toolbar</a>.
-2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting either _Create note_, which places it in the <a class="reference-link" href="../../../Basic%20Concepts%20and%20Features/Notes/Note%20Inbox.md">Note Inbox</a> (today's day note if no inbox is set), or _Create child note_, which places it under the note being edited.
+2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting either _Create note_, which places it in the <a class="reference-link" href="../../../Basic%20Concepts%20and%20Features/Notes/Note%20Inbox.md">Note Inbox</a> (today's day note, or the top level, when no inbox is set), or _Create child note_, which places it under the note being edited.
 
 There are two link types which you can select when creating the link to the note:
 

--- a/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
+++ b/docs/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.md
@@ -8,7 +8,7 @@ You can open an internal link by clicking it. You can also see a read-only previ
 Internal links can be created at the current position in a text note by:
 
 1.  Pressing <kbd>Ctrl</kbd> + <kbd>L</kbd> or the <img src="Internal (reference) links_image.png" width="20" height="17"> button underneath the <img src="1_Internal (reference) links_image.png" width="34" height="16"> menu in the <a class="reference-link" href="../Formatting%20toolbar.md">Formatting toolbar</a>.
-2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting _Create and link child note_.
+2.  Searching for the title of the desired note to link. It's also possible to create new notes from this dialog by typing a non-existing note title and selecting either _Create note_, which places it in the <a class="reference-link" href="../../../Basic%20Concepts%20and%20Features/Notes/Note%20Inbox.md">Note Inbox</a>, or _Create child note_, which places it under the note being edited.
 
 There are two link types which you can select when creating the link to the note:
 
@@ -24,7 +24,7 @@ There are two link types which you can select when creating the link to the note
 You can also insert internal links “inline” by using the `@` symbol:
 
 1.  Type `@` in a text note, which will open the note search menu.
-2.  Search for the desired note's title by typing a few characters. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select the correct note, and press <kbd>Enter</kbd> or <kbd>Tab</kbd> to create the link. It's also possible to create new notes with this method by typing a non-existing note title and selecting _Create and link child note_.
+2.  Search for the desired note's title by typing a few characters. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select the correct note, and press <kbd>Enter</kbd> or <kbd>Tab</kbd> to create the link. It's also possible to create new notes with this method by typing a non-existing note title and selecting _Create note_ or _Create child note_, as described above.
 
 ## Pasting internal links
 

--- a/packages/ckeditor5/src/augmentation.ts
+++ b/packages/ckeditor5/src/augmentation.ts
@@ -24,7 +24,7 @@ declare global {
 
     interface EditorComponent extends Component {
         loadReferenceLinkTitle($el: JQuery<HTMLElement>, href: string): Promise<void>;
-        createNoteForReferenceLink(title: string): Promise<string>;
+        createNoteForReferenceLink(title: string, intoInbox: boolean): Promise<string | undefined>;
         loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>, boxSize?: string): void;
         /**
          * Reads a page's preview metadata through the host. Never rejects: any failure — network

--- a/packages/ckeditor5/src/plugins/mention_customization.spec.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.spec.ts
@@ -80,15 +80,18 @@ describe("MentionCustomization", () => {
         expect(getModelData(editor.model)).toContain("noteAbc");
     });
 
-    it("creates a note then inserts the reference link for a create-note mention", async () => {
+    it.each([
+        { action: "create-note", intoInbox: true },
+        { action: "create-child-note", intoInbox: false }
+    ])("creates a note then inserts the reference link for a $action mention", async ({ action, intoInbox }) => {
         setModelData(editor.model, "<paragraph>foo[]bar</paragraph>");
 
         editor.execute("mention", {
-            mention: { id: "@Brand new note", action: "create-note", noteTitle: "Brand new note" },
+            mention: { id: "@Brand new note", action, noteTitle: "Brand new note" },
             marker: "@"
         });
 
-        expect(createNoteForReferenceLink).toHaveBeenCalledWith("Brand new note");
+        expect(createNoteForReferenceLink).toHaveBeenCalledWith("Brand new note", intoInbox);
 
         // Wait for the createNoteForReferenceLink promise (and the chained
         // getReferenceLinkTitle promise from the referenceLink command) to resolve.

--- a/packages/ckeditor5/src/plugins/mention_customization.ts
+++ b/packages/ckeditor5/src/plugins/mention_customization.ts
@@ -38,7 +38,7 @@ interface MentionOpts {
 
 interface MentionAttribute {
     id: string;
-    action?: "create-note";
+    action?: "create-note" | "create-child-note";
     noteTitle: string;
     notePath: string;
 }
@@ -58,12 +58,15 @@ class CustomMentionCommand extends Command {
 				model.insertContent( writer.createText( mention.id, {} ), range );
 			});
 		}
-		else if (mention.action === 'create-note') {
+		else if (mention.action === 'create-note' || mention.action === 'create-child-note') {
 			const editorEl = this.editor.editing.view.getDomRoot();
 			const component = glob.getComponentByEl<EditorComponent>(editorEl);
+			const intoInbox = mention.action === 'create-note';
 
-			component.createNoteForReferenceLink(mention.noteTitle).then(notePath => {
-				this.insertReference(range, notePath);
+			component.createNoteForReferenceLink(mention.noteTitle, intoInbox).then(notePath => {
+				if (notePath) {
+					this.insertReference(range, notePath);
+				}
 			});
 		}
 		else {

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -794,8 +794,8 @@ export type SimilarNoteResponse = SimilarNote[];
 export type SaveSearchNoteResponse = CloneResponse;
 
 /**
- * Which rule decided where a quickly captured note goes. `dayNote` is the only one that
- * names no note, because the day note is created when the capture happens.
+ * Which rule decided where a quickly captured note goes. `dayNote` carries no note ID, because
+ * the day note is created at capture time.
  */
 export type InboxTargetKind = "inbox" | "workspaceInbox" | "workspaceRoot" | "dayNote" | "root";
 

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -793,6 +793,19 @@ export type SimilarNoteResponse = SimilarNote[];
 
 export type SaveSearchNoteResponse = CloneResponse;
 
+/**
+ * Which rule decided where a quickly captured note goes. `dayNote` is the only one that
+ * names no note, because the day note is created when the capture happens.
+ */
+export type InboxTargetKind = "inbox" | "workspaceInbox" | "workspaceRoot" | "dayNote";
+
+/** Where `POST /api/notes/:id/children` would put a note captured into the inbox. */
+export interface InboxTargetResponse {
+    kind: InboxTargetKind;
+    noteId?: string;
+    title?: string;
+}
+
 /** A font file note carrying `#customFont`, as the font picker in the options lists it. */
 export interface UserFont {
     noteId: string;

--- a/packages/commons/src/lib/server_api.ts
+++ b/packages/commons/src/lib/server_api.ts
@@ -797,7 +797,7 @@ export type SaveSearchNoteResponse = CloneResponse;
  * Which rule decided where a quickly captured note goes. `dayNote` is the only one that
  * names no note, because the day note is created when the capture happens.
  */
-export type InboxTargetKind = "inbox" | "workspaceInbox" | "workspaceRoot" | "dayNote";
+export type InboxTargetKind = "inbox" | "workspaceInbox" | "workspaceRoot" | "dayNote" | "root";
 
 /** Where `POST /api/notes/:id/children` would put a note captured into the inbox. */
 export interface InboxTargetResponse {

--- a/packages/trilium-core/src/routes/api/special_notes.ts
+++ b/packages/trilium-core/src/routes/api/special_notes.ts
@@ -10,6 +10,10 @@ function getInboxNote(req: Request<{ date: string }>) {
     return specialNotesService.getInboxNote(req.params.date);
 }
 
+function getInboxTarget() {
+    return specialNotesService.getInboxTarget();
+}
+
 function getDayNote(req: Request<{ date: string }>) {
     const calendarRootId = req.query.calendarRootId;
     const calendarRoot = typeof calendarRootId === "string" ? becca.getNoteOrThrow(calendarRootId) : null;
@@ -132,6 +136,7 @@ function saveLlmChat(req: Request<{ llmChatNoteId: string }>) {
 
 export default {
     getInboxNote,
+    getInboxTarget,
     getDayNote,
     getWeekFirstDayNote,
     getWeekNote,

--- a/packages/trilium-core/src/routes/index.ts
+++ b/packages/trilium-core/src/routes/index.ts
@@ -257,6 +257,7 @@ export function buildSharedApiRoutes({ route, asyncRoute, asyncRouteWithoutTrans
     apiRoute(PUT, "/api/notes/:noteId/clone-after/:afterBranchId", cloningApiRoute.cloneNoteAfter);
 
     asyncApiRoute(GET, "/api/special-notes/inbox/:date", specialNotesRoute.getInboxNote);
+    apiRoute(GET, "/api/special-notes/inbox-target", specialNotesRoute.getInboxTarget);
     asyncApiRoute(GET, "/api/special-notes/days/:date", specialNotesRoute.getDayNote);
     asyncApiRoute(GET, "/api/special-notes/week-first-day/:date", specialNotesRoute.getWeekFirstDayNote);
     asyncApiRoute(GET, "/api/special-notes/weeks/:week", specialNotesRoute.getWeekNote);

--- a/packages/trilium-core/src/services/date_notes.ts
+++ b/packages/trilium-core/src/services/date_notes.ts
@@ -434,8 +434,18 @@ function getTodayNote(rootNote: BNote | null = null) {
     return getDayNote(dayjs().format("YYYY-MM-DD"), rootNote);
 }
 
+/**
+ * Whether a journal exists. `getRootCalendarNote()` builds one when it finds none, which is
+ * what asking for a day note means; callers that are only capturing a note check this first so
+ * that a deleted journal stays deleted.
+ */
+function hasCalendarRoot() {
+    return !!attributeService.getNoteWithLabel(CALENDAR_ROOT_LABEL);
+}
+
 export default {
     getRootCalendarNote,
+    hasCalendarRoot,
     getYearNote,
     getQuarterNote,
     getMonthNote,

--- a/packages/trilium-core/src/services/special_notes.spec.ts
+++ b/packages/trilium-core/src/services/special_notes.spec.ts
@@ -189,6 +189,58 @@ describe("special_notes (core, real DB)", () => {
         });
     });
 
+    describe("getInboxTarget", () => {
+        it("names the #inbox note at the root workspace", () => {
+            const inbox = becca.getNoteOrThrow("root").getChildNotes()[0];
+            vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(inbox);
+
+            expect(specialNotes.getInboxTarget()).toEqual({
+                kind: "inbox",
+                noteId: inbox.noteId,
+                title: inbox.getTitleOrProtected()
+            });
+        });
+
+        it("reports the day note without creating it", () => {
+            vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(null);
+            const noteCountBefore = Object.keys(becca.notes).length;
+
+            // No CLS context: reaching getDayNote() would need one, so this also proves it is
+            // never called.
+            expect(specialNotes.getInboxTarget()).toEqual({ kind: "dayNote", noteId: undefined, title: undefined });
+            expect(Object.keys(becca.notes).length).toBe(noteCountBefore);
+        });
+
+        it("still reports the day note when the journal has been deleted, because the capture recreates it", () => {
+            // Nulls both labels this path consults, #inbox and #calendarRoot.
+            vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(null);
+
+            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "dayNote" });
+
+            // Not root: getInboxNote() rebuilds the calendar rather than falling back to it.
+            const created = getContext().init(() => specialNotes.getInboxNote("2026-05-29"));
+            expect(created.noteId).not.toBe("root");
+            expect(created.getParentNotes().some((p) => p.noteId === "root")).toBe(false);
+        });
+
+        it("distinguishes the workspace inbox, a plain inbox and the workspace root", () => {
+            const workspaceInbox = becca.getNoteOrThrow("root").getChildNotes()[0];
+            const plainInbox = becca.getNoteOrThrow("root").getChildNotes()[1];
+
+            const withBoth = makeWorkspaceStub({ "#workspaceInbox": workspaceInbox, "#inbox": plainInbox });
+            vi.spyOn(hoistedNoteService, "getWorkspaceNote").mockReturnValue(withBoth as any);
+            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "workspaceInbox", noteId: workspaceInbox.noteId });
+
+            const withPlainOnly = makeWorkspaceStub({ "#inbox": plainInbox });
+            vi.spyOn(hoistedNoteService, "getWorkspaceNote").mockReturnValue(withPlainOnly as any);
+            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "inbox", noteId: plainInbox.noteId });
+
+            const withNeither = makeWorkspaceStub({});
+            vi.spyOn(hoistedNoteService, "getWorkspaceNote").mockReturnValue(withNeither as any);
+            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "workspaceRoot", noteId: withNeither.noteId });
+        });
+    });
+
     describe("createLauncher", () => {
         it("creates a note launcher with the note-launcher template", () => {
             const { success, note } = getContext().init(() =>

--- a/packages/trilium-core/src/services/special_notes.spec.ts
+++ b/packages/trilium-core/src/services/special_notes.spec.ts
@@ -158,7 +158,9 @@ describe("special_notes (core, real DB)", () => {
         });
 
         it("falls back to the day note when no #inbox label exists at the root", () => {
-            vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(null);
+            // A journal has to exist, or the capture stays at the top level instead.
+            vi.spyOn(attributeService, "getNoteWithLabel").mockImplementation((name: string) =>
+                name === "calendarRoot" ? becca.getNoteOrThrow("root").getChildNotes()[0] : null);
 
             // getDayNote may create the day note, so it needs a CLS context.
             const result = getContext().init(() => specialNotes.getInboxNote("2026-05-29"));
@@ -202,7 +204,8 @@ describe("special_notes (core, real DB)", () => {
         });
 
         it("reports the day note without creating it", () => {
-            vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(null);
+            vi.spyOn(attributeService, "getNoteWithLabel").mockImplementation((name: string) =>
+                name === "calendarRoot" ? becca.getNoteOrThrow("root").getChildNotes()[0] : null);
             const noteCountBefore = Object.keys(becca.notes).length;
 
             // No CLS context: reaching getDayNote() would need one, so this also proves it is
@@ -211,16 +214,15 @@ describe("special_notes (core, real DB)", () => {
             expect(Object.keys(becca.notes).length).toBe(noteCountBefore);
         });
 
-        it("still reports the day note when the journal has been deleted, because the capture recreates it", () => {
+        it("keeps a capture at the top level when the journal has been deleted, rather than rebuilding it", () => {
             // Nulls both labels this path consults, #inbox and #calendarRoot.
             vi.spyOn(attributeService, "getNoteWithLabel").mockReturnValue(null);
+            const noteCountBefore = Object.keys(becca.notes).length;
 
-            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "dayNote" });
-
-            // Not root: getInboxNote() rebuilds the calendar rather than falling back to it.
-            const created = getContext().init(() => specialNotes.getInboxNote("2026-05-29"));
-            expect(created.noteId).not.toBe("root");
-            expect(created.getParentNotes().some((p) => p.noteId === "root")).toBe(false);
+            expect(specialNotes.getInboxTarget()).toMatchObject({ kind: "root", noteId: "root" });
+            expect(specialNotes.getInboxNote("2026-05-29").noteId).toBe("root");
+            // No calendar was built on the way.
+            expect(Object.keys(becca.notes).length).toBe(noteCountBefore);
         });
 
         it("distinguishes the workspace inbox, a plain inbox and the workspace root", () => {

--- a/packages/trilium-core/src/services/special_notes.ts
+++ b/packages/trilium-core/src/services/special_notes.ts
@@ -10,7 +10,10 @@ import SearchContext from "./search/search_context.js";
 import { LBTPL_NOTE_LAUNCHER, LBTPL_CUSTOM_WIDGET, LBTPL_SPACER, LBTPL_SCRIPT } from "./hidden_subtree.js";
 import { t } from "i18next";
 import BNote from '../becca/entities/bnote.js';
-import { InboxTargetKind, InboxTargetResponse, SaveLlmChatResponse, SaveSearchNoteResponse, SaveSqlConsoleResponse } from "@triliumnext/commons";
+import {
+    InboxTargetKind, InboxTargetResponse, SaveLlmChatResponse, SaveSearchNoteResponse,
+    SaveSqlConsoleResponse
+} from "@triliumnext/commons";
 
 function getInboxNote(date: string) {
     const { note } = resolveInboxTarget();
@@ -19,9 +22,8 @@ function getInboxNote(date: string) {
 }
 
 /**
- * Decides where a quickly captured note goes, without creating anything. `getInboxNote()`
- * creates the day note it falls back to, so callers that only want to name the destination —
- * the note autocomplete labels its creation entry with it — go through this instead.
+ * Decides where a quickly captured note goes. Creates nothing, unlike `getInboxNote()`, which
+ * creates the day note it falls back to. Use this to name the destination without capturing.
  */
 function resolveInboxTarget(): { kind: InboxTargetKind; note?: BNote } {
     const workspaceNote = hoistedNoteService.getWorkspaceNote();

--- a/packages/trilium-core/src/services/special_notes.ts
+++ b/packages/trilium-core/src/services/special_notes.ts
@@ -48,7 +48,13 @@ function resolveInboxTarget(): { kind: InboxTargetKind; note?: BNote } {
         return { kind: "inbox", note: inbox };
     }
 
-    return { kind: "dayNote" };
+    // Capturing a note is not a request for a journal, so a database without one keeps the note
+    // at the top level rather than having a calendar built around it (#11034).
+    if (dateNoteService.hasCalendarRoot()) {
+        return { kind: "dayNote" };
+    }
+
+    return { kind: "root", note: workspaceNote };
 }
 
 function getInboxTarget(): InboxTargetResponse {

--- a/packages/trilium-core/src/services/special_notes.ts
+++ b/packages/trilium-core/src/services/special_notes.ts
@@ -10,31 +10,51 @@ import SearchContext from "./search/search_context.js";
 import { LBTPL_NOTE_LAUNCHER, LBTPL_CUSTOM_WIDGET, LBTPL_SPACER, LBTPL_SCRIPT } from "./hidden_subtree.js";
 import { t } from "i18next";
 import BNote from '../becca/entities/bnote.js';
-import { SaveLlmChatResponse, SaveSearchNoteResponse, SaveSqlConsoleResponse } from "@triliumnext/commons";
+import { InboxTargetKind, InboxTargetResponse, SaveLlmChatResponse, SaveSearchNoteResponse, SaveSqlConsoleResponse } from "@triliumnext/commons";
 
 function getInboxNote(date: string) {
+    const { note } = resolveInboxTarget();
+
+    return note ?? dateNoteService.getDayNote(date);
+}
+
+/**
+ * Decides where a quickly captured note goes, without creating anything. `getInboxNote()`
+ * creates the day note it falls back to, so callers that only want to name the destination —
+ * the note autocomplete labels its creation entry with it — go through this instead.
+ */
+function resolveInboxTarget(): { kind: InboxTargetKind; note?: BNote } {
     const workspaceNote = hoistedNoteService.getWorkspaceNote();
     if (!workspaceNote) {
         throw new Error("Unable to find workspace note");
     }
 
-    let inbox: BNote;
-
     if (!workspaceNote.isRoot()) {
-        inbox = workspaceNote.searchNoteInSubtree("#workspaceInbox");
-
-        if (!inbox) {
-            inbox = workspaceNote.searchNoteInSubtree("#inbox");
+        const workspaceInbox = workspaceNote.searchNoteInSubtree("#workspaceInbox");
+        if (workspaceInbox) {
+            return { kind: "workspaceInbox", note: workspaceInbox };
         }
 
-        if (!inbox) {
-            inbox = workspaceNote;
+        const inbox = workspaceNote.searchNoteInSubtree("#inbox");
+        if (inbox) {
+            return { kind: "inbox", note: inbox };
         }
-    } else {
-        inbox = attributeService.getNoteWithLabel("inbox") || dateNoteService.getDayNote(date);
+
+        return { kind: "workspaceRoot", note: workspaceNote };
     }
 
-    return inbox;
+    const inbox = attributeService.getNoteWithLabel("inbox");
+    if (inbox) {
+        return { kind: "inbox", note: inbox };
+    }
+
+    return { kind: "dayNote" };
+}
+
+function getInboxTarget(): InboxTargetResponse {
+    const { kind, note } = resolveInboxTarget();
+
+    return { kind, noteId: note?.noteId, title: note?.getTitleOrProtected() };
 }
 
 function createSqlConsole() {
@@ -389,6 +409,7 @@ function saveLlmChat(llmChatNoteId: string | null) {
 
 export default {
     getInboxNote,
+    getInboxTarget,
     createSqlConsole,
     saveSqlConsole,
     createSearchNote,

--- a/packages/trilium-e2e/src/support/app.ts
+++ b/packages/trilium-e2e/src/support/app.ts
@@ -107,13 +107,13 @@ export default class App {
         await autocomplete.clear();
         await autocomplete.pressSequentially(noteTitle);
 
-        // The best candidate follows the two creation suggestions ("Create note" and
-        // "Create child note"). Asserting on the suggestion itself (instead of the parent
+        // The second suggestion is the best candidate; the first is "Create
+        // note". Asserting on the suggestion itself (instead of the parent
         // `.note-detail-empty-results`, which also contains the recent-notes
         // list) ensures the dropdown actually opened.
         const suggestionSelector = this.currentNoteSplit
             .locator(".note-detail-empty-results .aa-suggestion")
-            .nth(2);
+            .nth(1);
         await expect(suggestionSelector).toContainText(noteTitle);
         await suggestionSelector.click();
     }

--- a/packages/trilium-e2e/src/support/app.ts
+++ b/packages/trilium-e2e/src/support/app.ts
@@ -107,13 +107,13 @@ export default class App {
         await autocomplete.clear();
         await autocomplete.pressSequentially(noteTitle);
 
-        // The second suggestion is the best candidate; the first is "Create
-        // note". Asserting on the suggestion itself (instead of the parent
+        // The best candidate follows the two creation suggestions ("Create note" and
+        // "Create child note"). Asserting on the suggestion itself (instead of the parent
         // `.note-detail-empty-results`, which also contains the recent-notes
         // list) ensures the dropdown actually opened.
         const suggestionSelector = this.currentNoteSplit
             .locator(".note-detail-empty-results .aa-suggestion")
-            .nth(1);
+            .nth(2);
         await expect(suggestionSelector).toContainText(noteTitle);
         await suggestionSelector.click();
     }

--- a/packages/trilium-e2e/src/support/app.ts
+++ b/packages/trilium-e2e/src/support/app.ts
@@ -107,13 +107,13 @@ export default class App {
         await autocomplete.clear();
         await autocomplete.pressSequentially(noteTitle);
 
-        // The second suggestion is the best candidate; the first is "Create a
-        // new note". Asserting on the suggestion itself (instead of the parent
+        // The best candidate follows the two creation suggestions ("Create note" and
+        // "Create child note"). Asserting on the suggestion itself (instead of the parent
         // `.note-detail-empty-results`, which also contains the recent-notes
         // list) ensures the dropdown actually opened.
         const suggestionSelector = this.currentNoteSplit
             .locator(".note-detail-empty-results .aa-suggestion")
-            .nth(1);
+            .nth(2);
         await expect(suggestionSelector).toContainText(noteTitle);
         await suggestionSelector.click();
     }


### PR DESCRIPTION
Typing a title that matches nothing offered a single creation option, and it put the note under the note you were on. In *Jump to* that is the wrong parent by construction: the dialog exists to navigate away from the current note, so the note being left behind has no claim on what gets captured.

Every surface that sets `allowCreatingNotes` now offers two, and each says where the note lands:

```
🔍  meet
──────────────────────────────────────────
➕  Create note "meet" in Inbox
↳   Create child note "meet"
📄  Meeting notes
📄  Meeting 2024-03
🔎  Search for "meet"              Ctrl+⏎
```

## Where the note goes, and saying so

The destination is decided by several rules, so "Create note" on its own asked the user to know their own configuration in order to predict it. The row now names it.

`getInboxNote()` cannot answer the question, because it creates the day note it falls back to as it answers. The decision is split out into `resolveInboxTarget()`, which reads becca and creates nothing; `getInboxNote()` materialises the day note only when the resolver says that is the destination. Both go through the same function, so a label and the capture it describes cannot disagree.

`GET /api/special-notes/inbox-target` exposes the resolved kind, note ID and title. Hoisting needs no argument — the client already sends `trilium-hoisted-note-id` on every request, which is what the resolver reads through `hoistedNoteService`:

| | destination | label |
|---|---|---|
| not hoisted | the `#inbox` note | *in `<title>`* |
| not hoisted, no `#inbox`, journal exists | today's day note | *in today's day note* |
| not hoisted, no `#inbox`, no journal | the top level | *at the top level* |
| hoisted | `#workspaceInbox`, else `#inbox` in the subtree | *in `<title>`* |
| hoisted, neither | the workspace note itself | *in `<title>`* |

The three that name a real note share one string with a `{{parentTitle}}`. The day note gets its own, having no title until the capture creates it, and so does the top level, whose note is called `root` and would name nothing the user recognises in the tree. A further string covers a failed lookup, and `{{parentTitle}}` interpolates escaped because the label is injected as raw HTML into the suggestion template.

The lookup is issued before the autocomplete search and awaited after it, so naming the destination costs a request but no extra wait. It is deliberately not cached: a cache goes stale exactly when someone labels a note `#inbox` or hoists into a workspace, which is when the label matters most.

## Not rebuilding a deleted journal

Writing the labels turned up that deleting the journal did not stop notes being date-nested — the next capture recreated the calendar, the year, the month and the day. That is [#11034](https://github.com/TriliumNext/Trilium/issues/11034), where the New button is described as impossible to escape.

`getRootCalendarNote()` treats a missing journal as one to build, which is right for the callers that ask for a day note — the calendar widget, "open today's note" — and wrong for the ones that only need somewhere to put a note. `hasCalendarRoot()` distinguishes them without building anything, and the two capture paths consult it first:

- `resolveInboxTarget()`, reaching the New button in the launcher bar, <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>, the tray entry, the sender API, ETAPI's `/inbox/{date}` and this dropdown.
- `getClipperInboxNote()`, which had the same shape — no `#clipperInbox`, so ask for a day note, so build a calendar. Leaving it alone would have meant a deleted journal held everywhere except the Web Clipper.

A capture with no inbox now goes to the top level unless a journal already exists, so a deleted journal stays deleted. Nothing changes where one exists, which is every installation that kept the demo data: `demo.zip` labels its Journal `#calendarRoot`. Deliberate day-note navigation is untouched and still builds the calendar it is asking for.

This is the behaviour half of #11034; the setting its reporter asked for is not here, since `#inbox` already answers "put my notes somewhere specific".

## Row order

Both creation rows sit above the search results. Putting the child-note row below them looked better — search results would keep the indices they have today, so a habitual "type, Down, Enter" would still open the note it always opened — but past a handful of results that row is not reachable in either dropdown:

- `TriliumMentionUI` renders `items.slice(0, limit)` and the `@` note feed sets no `dropdownLimit`, so the default of 10 drops a trailing row once the search returns nine or more notes. It is not scrolled past, it is never built.
- In the jQuery dropdown the row survives but sits below as many as 200 results inside a 500px scroller.

So both rows stay on top, and the spec pins the whole row order rather than the first two entries. The cost is that search results shift down by one: "type, Down, Enter" now lands on *Create child note*. The note type chooser opens before anything is written, so a mis-<kbd>Down</kbd> is a cancellable dialog rather than a stray note.

## Reach

`@`-completion takes the same pair. `createNoteForReferenceLink` gains an `intoInbox` argument rather than the action string, since the two implementations only need to choose between the inbox and a note path they already hold — `noteContext.notePath` in the text editor, `notePath` in the attribute editor. The child row takes `bx bx-subdirectory-right`, which the board and table context menus already use for their child-note actions.

The LLM chat box is the exception. `autocompleteSourceForCKEditor` forced `allowCreatingNotes`, so `@` there offered creation entries that threw: the chat editor is an `AttributeEditor`, so it carries `MentionCustomization`, but `ChatInputBar` registers only `loadReferenceLinkTitle`. The feed now takes a flag and the chat passes it, rather than the box growing a creation callback it has no use for — the marker is there to point the model at notes that exist.

## Documentation

Four User Guide pages named the old option by its label, "Create and link child note". Each now describes both options and says where each note lands, including the top-level case. *Note Inbox* — which enumerates the routes into the inbox — gains this one, and its note on the day-note fallback now says a deleted journal is not rebuilt.

Both representations were edited by hand and kept in sync: the Markdown under `docs/`, and the in-app HTML under `apps/server/src/assets/doc_notes/`. Worth a look in the app before merging.

## Testing

- `apps/client` — 91 across `note_autocomplete`, `date_notes` and `AttributeEditor`, covering one case per destination kind, both label fallbacks and the full row order.
- `apps/server` — 76 across `special_notes` and `clipper`, plus 10 for the doc notes.
- `packages/trilium-core` — its specs run under **both** the `apps/server` and `apps/standalone` suites.
- `packages/ckeditor5` — 121 across the mention specs.
- `pnpm typecheck` clean.

Three guarantees were checked by mutation rather than assumed:

- making `getInboxTarget()` resolve the day note eagerly fails *"reports the day note without creating it"* with `No context available. cls.init() must be called first.`
- dropping the `resolveInboxTarget()` guard fails *"keeps a capture at the top level when the journal has been deleted"*.
- dropping the clipper guard fails *"clips to the top level when there is no clipper inbox and no journal"*, with the day-note ID in place of `root`.

## Two things to know before merging

`note_autocomplete.create-note` keeps its key and changed its English text. The 39 locales Weblate holds still carry the old "Create and link child note" translation under it, and the new sibling keys are untranslated, so those rows fall back to English until the next sync.

ETAPI's `/inbox/{date}` changes behaviour for a database with neither an inbox nor a journal, returning the root note rather than creating a day note. Its own description reads "a fixed note (identified with `#inbox` label) or a day note in a journal", so no journal, no day note — but it is API-visible and worth a release note.

Closes #6817.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
