### PR TITLE
Board: performance improvements

### DIFF
--- a/apps/client/src/stylesheets/style.css
+++ b/apps/client/src/stylesheets/style.css
@@ -1096,10 +1096,6 @@ table.promoted-attributes-in-tooltip th {
     color: orange;
 }
 
-.multiplicity {
-    font-size: 1.3em;
-}
-
 /* this is because bootstrap (?) sets code color to red for some reason */
 code {
     color: inherit !important;

--- a/apps/client/src/stylesheets/theme-next/shell.css
+++ b/apps/client/src/stylesheets/theme-next/shell.css
@@ -1539,8 +1539,7 @@ div.promoted-attribute-cell {
 }
 
 /* A promoted attribute card (boolean attribute) */
-div.promoted-attribute-cell:has(input[type="checkbox"]):not(:has(.multiplicity > span)) {
-    /* Checbox attribute, without multiplicity */
+div.promoted-attribute-cell:has(input[type="checkbox"]) {
     padding-inline-end: var(--pa-card-padding-inline-start);
 }
 
@@ -1612,22 +1611,6 @@ div.promoted-attribute-cell .tn-checkbox > input[type="checkbox"] {
 
 div.promoted-attribute-cell.promoted-attribute-label-boolean > div:first-of-type {
     margin-inline-end: 0.5em;
-}
-
-/* The element containing the "new attribute" and "remove this attribute button" */
-div.promoted-attribute-cell .multiplicity:has(span) {
-    --icon-button-size: 24px;
-
-    margin-inline-start: 8px;
-    margin-inline-end: calc(var(--pa-card-padding-inline-start) - var(--pa-card-padding-inline-end));
-    font-size: 0; /* Prevent whitespaces creating a gap between buttons */
-    display: flex;
-}
-
-div.promoted-attribute-cell .multiplicity:has(span) span {
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 div.promoted-attribute-cell.promoted-attribute-label-color {

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -362,25 +362,7 @@ export function useBoardDrag(
             }
         };
 
-        /**
- * Where the columns stood before the carried one was taken out of the row, which is what the board
- * places the gap and the columns that step aside for it against.
- */
-function row(held: Gesture & { kind: "column" }) {
-    const boxes = held.measurement?.columns ?? [];
-    const last = boxes[boxes.length - 1];
-    // Read off the row rather than from the stylesheet: what stands between two columns is the
-    // same everywhere, and one pair is enough to say how much.
-    const gap = boxes.length > 1 ? boxes[1].left - (boxes[0].left + boxes[0].width) : 0;
-    const lefts = boxes.map(({ left }) => left);
-    if (last) {
-        lefts.push(last.left + last.width + gap);
-    }
-
-    return { lefts, stride: (boxes[held.index]?.width ?? 0) + gap };
-}
-
-/** Set between a tap and the `touchend` the browser would make mouse events from. */
+        /** Set between a tap and the `touchend` the browser would make mouse events from. */
         let justTapped = false;
 
         const onTouchEnd = (event: TouchEvent) => {
@@ -469,6 +451,24 @@ function row(held: Gesture & { kind: "column" }) {
     }, [ container ]);
 
     return { isDragging, remeasure };
+}
+
+/**
+ * Where the columns stood before the carried one was taken out of the row, which is what the board
+ * places the gap and the columns that step aside for it against.
+ */
+function row(held: Gesture & { kind: "column" }) {
+    const boxes = held.measurement?.columns ?? [];
+    const last = boxes[boxes.length - 1];
+    // Read off the row rather than from the stylesheet: what stands between two columns is the
+    // same everywhere, and one pair is enough to say how much.
+    const gap = boxes.length > 1 ? boxes[1].left - (boxes[0].left + boxes[0].width) : 0;
+    const lefts = boxes.map(({ left }) => left);
+    if (last) {
+        lefts.push(last.left + last.width + gap);
+    }
+
+    return { lefts, stride: (boxes[held.index]?.width ?? 0) + gap };
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -66,8 +66,13 @@ export interface BoardDragCallbacks {
      * A column has been taken hold of by its heading.
      *
      * @param size what it measures, so the gap held open for it is the size it will land in.
+     * @param row where the columns stood before it was taken out of the row, and how much room it
+     * takes out of one, which is what the board moves the gap and the other columns against.
      */
-    onColumnStart(column: string, index: number, size: { width: number, height: number }): void;
+    onColumnStart(
+        column: string, index: number, size: { width: number, height: number },
+        row: { lefts: number[], stride: number }
+    ): void;
     /** Which place among the columns it would take, counting them as they stand. */
     onColumnMove(index: number | null): void;
     /** As {@link onCardEnd}, for a column: a place means let go, nothing means called off. */
@@ -175,7 +180,7 @@ export function useBoardDrag(
             if (held.kind === "card") {
                 latest.current.onCardStart(held.card);
             } else {
-                latest.current.onColumnStart(held.column, held.index, lifted.size);
+                latest.current.onColumnStart(held.column, held.index, lifted.size, row(held));
             }
             resolve(held);
         };
@@ -357,7 +362,25 @@ export function useBoardDrag(
             }
         };
 
-        /** Set between a tap and the `touchend` the browser would make mouse events from. */
+        /**
+ * Where the columns stood before the carried one was taken out of the row, which is what the board
+ * places the gap and the columns that step aside for it against.
+ */
+function row(held: Gesture & { kind: "column" }) {
+    const boxes = held.measurement?.columns ?? [];
+    const last = boxes[boxes.length - 1];
+    // Read off the row rather than from the stylesheet: what stands between two columns is the
+    // same everywhere, and one pair is enough to say how much.
+    const gap = boxes.length > 1 ? boxes[1].left - (boxes[0].left + boxes[0].width) : 0;
+    const lefts = boxes.map(({ left }) => left);
+    if (last) {
+        lefts.push(last.left + last.width + gap);
+    }
+
+    return { lefts, stride: (boxes[held.index]?.width ?? 0) + gap };
+}
+
+/** Set between a tap and the `touchend` the browser would make mouse events from. */
         let justTapped = false;
 
         const onTouchEnd = (event: TouchEvent) => {

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -147,8 +147,9 @@ export function useBoardDrag(
 
             held.active = true;
             // Measured before what is carried is taken out of the flow, so the places it can land
-            // are the ones the board is showing.
-            held.measurement = measureBoard(container);
+            // are the ones the board is showing. A column is placed among the columns alone, so
+            // the cards are left unmeasured for one.
+            held.measurement = measureBoard(container, held.kind === "card");
             // Held from here on, so the gesture keeps the pointer wherever it goes. Taken at the
             // press instead, it would carry the click away from what was pressed.
             container.setPointerCapture?.(held.pointerId);
@@ -428,7 +429,7 @@ export function useBoardDrag(
             return;
         }
 
-        const measurement = measureBoard(container);
+        const measurement = measureBoard(container, held.kind === "card");
         // A column that was measured with cards keeps them. The board now holds the gap where the
         // carried card was, which stands every card below it one place lower, so reading them again
         // would take the drag's own doing for a move of its own and the places would creep away

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -11,6 +11,7 @@ import {
     BoardPromotedAttributesContext, TitleEditor
 } from ".";
 import { ContextMenuEvent } from "../../../menus/context_menu";
+import { cardFollows } from "./columns";
 import { openNoteContextMenu } from "./context_menu";
 import { t } from "../../../services/i18n";
 import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
@@ -164,7 +165,7 @@ function Card({
         }
 
         const bring = () => {
-            if (!card.nextElementSibling) {
+            if (!cardFollows(card)) {
                 content.scrollTop = content.scrollHeight;
             } else if (!card.previousElementSibling) {
                 content.scrollTop = 0;

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -26,7 +26,7 @@ import { useScrollFade } from "../../react/scroll_fade";
 const HAND_OVER_MS = 2000;
 
 /** How long an open takes. Matches `--board-expand-duration` in the board's own rules. */
-const EXPAND_MS = 200;
+export const EXPAND_MS = 200;
 import NoteLink from "../../react/NoteLink";
 import { BoardActionsContext, BoardDragStateContext, TitleEditor } from ".";
 import BoardApi from "./api";
@@ -59,6 +59,7 @@ export default function Column({
     keepCollapsed,
     isActive,
     isPeeked,
+    isResizing,
     nested,
     limit,
     columnItems,
@@ -84,6 +85,8 @@ export default function Column({
     isActive?: boolean,
     /** Whether the board is showing every collapsed column at once, which opens this one too. */
     isPeeked?: boolean,
+    /** Whether a column is still taking its new width, during which no column's cards move. */
+    isResizing?: boolean,
     /** What a new card is made from, and how the reader picks something else. */
     cardTemplates: CardTemplates,
     /** Whether the inbox also collects notes deeper than the board's direct children. */
@@ -145,7 +148,8 @@ export default function Column({
     const [ isRevealed, setIsRevealed ] = useState(false);
     const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn } =
         useContext(BoardActionsContext);
-    const { branchIdToEdit, columnNameToEdit, draggedCard } = useContext(BoardDragStateContext);
+    const { branchIdToEdit, columnNameToEdit, draggedCard, draggedColumn } =
+        useContext(BoardDragStateContext);
     // Asked about this column alone: where the gap stands changes on every step of a drag, and a
     // column that the answer does not concern is left as it is rather than drawn again.
     const dropIndex = useDropIndex(column);
@@ -163,6 +167,9 @@ export default function Column({
     // of any column the gap has stood in. The rest are left unmeasured, measuring one costing a
     // layout of the whole board; paused rather than switched off, so a column the gap reaches in
     // one step still knows where its cards stood and slides them from there.
+    //
+    // A column being carried, and a column changing width, move no card inside any column, so
+    // every column is left unmeasured for the length of either.
     const heldGap = useRef(false);
     if (!draggedCard) {
         heldGap.current = false;
@@ -171,7 +178,9 @@ export default function Column({
     }
     useFlip(contentRef, {
         selector: ".board-note",
-        paused: !!draggedCard && column !== draggedCard.fromColumn && !heldGap.current
+        paused: draggedCard
+            ? column !== draggedCard.fromColumn && !heldGap.current
+            : !!draggedColumn || !!isResizing
     });
     const { handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -29,12 +29,11 @@ const HAND_OVER_MS = 2000;
 const STOCK_GAP_HEIGHT = 40;
 
 /**
- * How many cards below the gap are told to stand aside for it.
+ * The least a card can stand, which is one line of its title with the padding and gap around it.
  *
- * Only the ones the reader can see have to move, and a column shows a handful at a time. Telling
- * every card below the gap instead is thousands of them on a long column, and each one costs.
+ * Says how many cards a column can show at once, which is how many below the gap have to move.
  */
-const CARDS_ASIDE = 30;
+const MIN_CARD_HEIGHT = 32;
 
 /** How long an open takes. Matches `--board-expand-duration` in the board's own rules. */
 export const EXPAND_MS = 200;
@@ -103,9 +102,8 @@ export default function Column({
     /**
      * How far the column stands aside for one being carried, in pixels.
      *
-     * Written as a transform rather than drawn by putting the carried column's place among the
-     * others: the row is left as it stands for the length of the gesture, so a step of it costs
-     * the browser a transform apiece instead of laying out every card on the board again.
+     * The row keeps its order for the length of the gesture, so a step costs a transform per
+     * column rather than a fresh layout of every card on the board.
      */
     standsAside?: number,
     /** What a new card is made from, and how the reader picks something else. */
@@ -180,25 +178,9 @@ export default function Column({
     const headerRef = useRef<HTMLHeadingElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const scrollFade = useScrollFade(contentRef);
-    // Cards slide to follow the drop gap opening and closing. No card opens out of nothing: one
-    // made in the footer is shown by the scroll to the end and by its fade, and one made among the
-    // others takes the place its field was standing in.
-    //
-    // While a card is carried, the cards that move are those of the column it came from, the one
-    // the gap stands in, and the one it has just left, whose cards close up behind it. Every other
-    // column is left unmeasured, measuring one costing a layout of the whole board; paused rather
-    // than switched off, so a column the gap reaches in one step still knows where its cards stood
-    // and slides them from there.
-    //
-    // Just left, rather than ever held: a column keeps whatever it last measured, so one the gap
-    // passed through earlier has nothing more to say. Kept on, a column of thousands measures
-    // again every time anything redraws the board for the rest of the gesture.
-    //
-    // A column being carried, and a column changing width, move no card inside any column, so
-    // every column is left unmeasured for the length of either.
-    // Measured only when the column's own cards have changed, which is the only thing that moves
-    // them. Anything else that redraws the board, scrolling it sideways above all, would otherwise
-    // have every column read a position for every card it holds.
+    // Cards slide to follow the drop gap opening and closing. Measured only when the column's own
+    // cards have changed: reading one position costs a layout of the whole board, and anything
+    // else that redraws it would have every column read one per card.
     const measured = useRef<unknown>();
     const cardsChanged = measured.current !== columnItems;
     measured.current = columnItems;
@@ -206,19 +188,13 @@ export default function Column({
         selector: ".board-note",
         // Paused where nothing has moved the cards, so the places it knows are still good.
         paused: !cardsChanged,
-        // Switched off outright for the length of a gesture, which is what makes the commit that
-        // ends one record where the cards landed rather than slide them there: the places it knew
-        // are from before the drag, and a card let go has already been carried to its own.
+        // Off for the length of a gesture, so the commit that ends one records where the cards
+        // landed rather than sliding them there.
         disabled: !!draggedCard || !!draggedColumn || !!isResizing
     });
 
-    // The gap is opened without touching what the column holds. Putting an element among the
-    // cards, taking one out, or carrying one to another place all cost the same: the board
-    // restyles every element it holds, which on a large one is most of a second. Changing the
-    // size of an element that stays put, and moving one that stands outside the flow, cost
-    // nothing, so the gap is a standing element that slides and the cards beside it are
-    // transformed. The cards carry a transform transition already, so the sliding is the
-    // browser's to do.
+    // The gap is a standing element that slides, and the cards beside it are transformed: putting
+    // one among the cards, or taking one out, restyles every element the board holds.
     const gapRef = useRef<HTMLDivElement>(null);
     const roomRef = useRef<HTMLDivElement>(null);
     /** Whether a card was being carried at the previous commit. */
@@ -226,9 +202,8 @@ export default function Column({
     /** Which cards were last told to stand aside, so only what changed is written. */
     const aside = useRef({ from: 0, until: 0, room: 0 });
     useLayoutEffect(() => {
-        // The two commits a drag opens and closes on. A card is drawn in either one in the place
-        // its own transform already had it, so easing would slide it from somewhere it never
-        // stood; every commit in between moves the cards for real and eases as usual.
+        // The commits a drag opens and closes on, where a card is already standing where it is
+        // being drawn. Every commit in between moves the cards for real and eases as usual.
         const atOnce = carried.current !== !!draggedCard;
         carried.current = !!draggedCard;
 
@@ -239,6 +214,9 @@ export default function Column({
         const cards = area.querySelectorAll<HTMLElement>(".board-note");
         const height = draggedCard?.height ?? STOCK_GAP_HEIGHT;
         const room = dropIndex === null ? 0 : height + cardSpacing();
+        // Read with the places below, before anything is written: every card the column can show
+        // moves, and the ones past its foot are left alone whatever it holds.
+        const reach = Math.ceil(area.clientHeight / MIN_CARD_HEIGHT) + 1;
 
         // Read before anything is written, and `offsetTop` is no business of a transform anyway.
         if (dropIndex !== null) {
@@ -266,7 +244,7 @@ export default function Column({
         }
 
         const from = dropIndex;
-        const until = Math.min(cards.length, from + CARDS_ASIDE);
+        const until = Math.min(cards.length, from + reach);
         const last = aside.current;
         // A step of a drag moves the gap by a card, so only the few cards it passed change what
         // they are told; the rest of the window is already standing where it should.
@@ -309,9 +287,8 @@ export default function Column({
     /**
      * Whether the cards have been drawn, which they stay once they have been.
      *
-     * A column collapsed when the board opens draws none of them, so a reader who keeps a long one
-     * closed pays nothing for it. Past the first open they are held in the page and hidden rather
-     * than taken out, closing costing a fraction of what building them again does.
+     * A column collapsed when the board opens draws none of them; past the first open they are
+     * hidden rather than taken out, which is what makes closing one cheap.
      */
     const [ isDrawn, setIsDrawn ] = useState(!isCollapsed);
     if (!isDrawn && !isCollapsed) {
@@ -673,12 +650,11 @@ export default function Column({
 /**
  * Puts a card where a transform says, easing it there unless the board is drawing a still frame.
  *
- * A still frame is one the board draws an element in the place its own transform already had it,
- * which is what a drag's lift and its drop both are. The transition is suppressed on the card
- * rather than by a rule under the board's own class: such a rule matches every card on the board,
- * and Chrome restyles all of them for the few that move.
+ * Suppressed on the card rather than by a rule under the board's own class, which would match
+ * every card on it.
  *
  * @param transform what to write, or `null` to put the card back where the column draws it.
+ * @param atOnce whether the card is already standing where it is being put, as at a lift or a drop.
  */
 export function placeCard(card: HTMLElement, transform: string | null, atOnce: boolean) {
     if (atOnce) {
@@ -692,19 +668,27 @@ export function placeCard(card: HTMLElement, transform: string | null, atOnce: b
         card.style.transform = transform;
     }
 
-    if (!atOnce || restoring !== undefined) {
+    if (!atOnce) {
         return;
+    }
+
+    // Started afresh on every call: a lift and the drop that follows it a frame later would
+    // otherwise be put back on the first one's schedule, before the drop has been drawn.
+    if (restoring !== undefined) {
+        cancelAnimationFrame(restoring);
     }
 
     // Put back a frame later than the one that draws them, since a frame's callbacks run before
     // the styles it paints are worked out.
-    restoring = requestAnimationFrame(() => requestAnimationFrame(() => {
-        restoring = undefined;
-        for (const held of settling) {
-            held.style.removeProperty("transition");
-        }
-        settling.clear();
-    }));
+    restoring = requestAnimationFrame(() => {
+        restoring = requestAnimationFrame(() => {
+            restoring = undefined;
+            for (const held of settling) {
+                held.style.removeProperty("transition");
+            }
+            settling.clear();
+        });
+    });
 }
 
 /** The cards whose transition is suppressed, waiting for the frame that puts it back. */

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -691,18 +691,27 @@ export function placeCard(card: HTMLElement, transform: string | null, atOnce: b
     });
 }
 
-/** Puts every suppressed transition back at once, for a board leaving the page. */
-export function settleCards() {
-    if (restoring !== undefined) {
+/**
+ * Puts back at once the suppressed transitions of the cards one board holds, for a board leaving
+ * the page.
+ *
+ * Its own cards alone, and whatever has already left the page: another board can be part-way
+ * through a gesture, and the frame that would put its cards back is the same one.
+ */
+export function settleCards(container: HTMLElement | null) {
+    for (const held of settling) {
+        if (held.isConnected && !container?.contains(held)) {
+            continue;
+        }
+
+        held.style.removeProperty("transition");
+        settling.delete(held);
+    }
+
+    if (!settling.size && restoring !== undefined) {
         cancelAnimationFrame(restoring);
         restoring = undefined;
     }
-
-    for (const held of settling) {
-        held.style.removeProperty("transition");
-    }
-
-    settling.clear();
 }
 
 /** The cards whose transition is suppressed, waiting for the frame that puts it back. */

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -221,9 +221,17 @@ export default function Column({
     // browser's to do.
     const gapRef = useRef<HTMLDivElement>(null);
     const roomRef = useRef<HTMLDivElement>(null);
+    /** Whether a card was being carried at the previous commit. */
+    const carried = useRef(false);
     /** Which cards were last told to stand aside, so only what changed is written. */
     const aside = useRef({ from: 0, until: 0, room: 0 });
     useLayoutEffect(() => {
+        // The two commits a drag opens and closes on. A card is drawn in either one in the place
+        // its own transform already had it, so easing would slide it from somewhere it never
+        // stood; every commit in between moves the cards for real and eases as usual.
+        const atOnce = carried.current !== !!draggedCard;
+        carried.current = !!draggedCard;
+
         const area = contentRef.current;
         const gap = gapRef.current;
         if (!area || !gap) return;
@@ -250,7 +258,7 @@ export default function Column({
         if (dropIndex === null) {
             for (const card of cards) {
                 if (card.style.transform) {
-                    card.style.removeProperty("transform");
+                    placeCard(card, null, atOnce);
                 }
             }
             aside.current = { from: 0, until: 0, room: 0 };
@@ -265,16 +273,19 @@ export default function Column({
         const afresh = last.room !== room;
         for (let index = last.from; index < last.until; index++) {
             if (afresh || index < from || index >= until) {
-                cards[index]?.style.removeProperty("transform");
+                const card = cards[index];
+                if (card) {
+                    placeCard(card, null, atOnce);
+                }
             }
         }
         for (let index = from; index < until; index++) {
             if (afresh || index < last.from || index >= last.until) {
-                cards[index].style.transform = `translateY(${room}px)`;
+                placeCard(cards[index], `translateY(${room}px)`, atOnce);
             }
         }
         aside.current = { from, until, room };
-    }, [ dropIndex, draggedCard?.height, columnItems ]);
+    }, [ dropIndex, draggedCard, columnItems ]);
     const { handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote
     });
@@ -646,6 +657,47 @@ export default function Column({
         </div>
     );
 }
+
+/**
+ * Puts a card where a transform says, easing it there unless the board is drawing a still frame.
+ *
+ * A still frame is one the board draws an element in the place its own transform already had it,
+ * which is what a drag's lift and its drop both are. The transition is suppressed on the card
+ * rather than by a rule under the board's own class: such a rule matches every card on the board,
+ * and Chrome restyles all of them for the few that move.
+ *
+ * @param transform what to write, or `null` to put the card back where the column draws it.
+ */
+export function placeCard(card: HTMLElement, transform: string | null, atOnce: boolean) {
+    if (atOnce) {
+        card.style.transition = "none";
+        settling.add(card);
+    }
+
+    if (transform === null) {
+        card.style.removeProperty("transform");
+    } else {
+        card.style.transform = transform;
+    }
+
+    if (!atOnce || restoring !== undefined) {
+        return;
+    }
+
+    // Put back a frame later than the one that draws them, since a frame's callbacks run before
+    // the styles it paints are worked out.
+    restoring = requestAnimationFrame(() => requestAnimationFrame(() => {
+        restoring = undefined;
+        for (const held of settling) {
+            held.style.removeProperty("transition");
+        }
+        settling.clear();
+    }));
+}
+
+/** The cards whose transition is suppressed, waiting for the frame that puts it back. */
+const settling = new Set<HTMLElement>();
+let restoring: number | undefined;
 
 /**
  * The editor a new card is named in, standing below the column or between two of its cards.

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -306,6 +306,18 @@ export default function Column({
      * Unpainted rather than undrawn: the board focuses the card a keyboard open steps onto, and a
      * card that is not there yet is one it cannot hand focus to.
      */
+    /**
+     * Whether the cards have been drawn, which they stay once they have been.
+     *
+     * A column collapsed when the board opens draws none of them, so a reader who keeps a long one
+     * closed pays nothing for it. Past the first open they are held in the page and hidden rather
+     * than taken out, closing costing a fraction of what building them again does.
+     */
+    const [ isDrawn, setIsDrawn ] = useState(!isCollapsed);
+    if (!isDrawn && !isCollapsed) {
+        setIsDrawn(true);
+    }
+
     const [ isExpanding, setIsExpanding ] = useState(false);
     const [ wasCollapsed, setWasCollapsed ] = useState(isCollapsed);
     if (wasCollapsed !== isCollapsed) {
@@ -614,7 +626,7 @@ export default function Column({
                 </>)}
             </h3>
 
-            {!isCollapsed && <div
+            {isDrawn && <div
                 ref={contentRef}
                 className={clsx("board-column-content", scrollFade.className)}
                 style={scrollFade.style}

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -691,6 +691,20 @@ export function placeCard(card: HTMLElement, transform: string | null, atOnce: b
     });
 }
 
+/** Puts every suppressed transition back at once, for a board leaving the page. */
+export function settleCards() {
+    if (restoring !== undefined) {
+        cancelAnimationFrame(restoring);
+        restoring = undefined;
+    }
+
+    for (const held of settling) {
+        held.style.removeProperty("transition");
+    }
+
+    settling.clear();
+}
+
 /** The cards whose transition is suppressed, waiting for the frame that puts it back. */
 const settling = new Set<HTMLElement>();
 let restoring: number | undefined;

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import { Fragment } from "preact";
 import { flushSync } from "preact/compat";
 import {
-    useCallback, useContext, useEffect, useMemo, useRef, useState
+    useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState
 } from "preact/hooks";
 import { JSX } from "preact/jsx-runtime";
 
@@ -25,6 +25,17 @@ import { useScrollFade } from "../../react/scroll_fade";
 /** How long a field waits for the card it made, after which it is taken down regardless. */
 const HAND_OVER_MS = 2000;
 
+/** What a gap stands at when nothing carried says otherwise. Matches `.board-drop-placeholder`. */
+const STOCK_GAP_HEIGHT = 40;
+
+/**
+ * How many cards below the gap are told to stand aside for it.
+ *
+ * Only the ones the reader can see have to move, and a column shows a handful at a time. Telling
+ * every card below the gap instead is thousands of them on a long column, and each one costs.
+ */
+const CARDS_ASIDE = 30;
+
 /** How long an open takes. Matches `--board-expand-duration` in the board's own rules. */
 export const EXPAND_MS = 200;
 import NoteLink from "../../react/NoteLink";
@@ -35,6 +46,7 @@ import CardTemplatePill from "./card_template_pill";
 import { type CardTemplates } from "./card_templates";
 import { DEFAULT_CARD_ICON, DEFAULT_COLUMN_ICON, INBOX_COLUMN } from "./columns";
 import { openColumnContextMenu, openCreateCardMenu } from "./context_menu";
+import { cardSpacing } from "./drag_measure";
 import { BoardDropStateContext, useDropIndex, useIsDropTarget } from "./drop_state";
 
 interface DragContext {
@@ -184,26 +196,88 @@ export default function Column({
     //
     // A column being carried, and a column changing width, move no card inside any column, so
     // every column is left unmeasured for the length of either.
-    const heldGap = useRef(false);
-    const holdsGap = dropIndex !== null;
-    const justLeftGap = heldGap.current && !holdsGap;
-    heldGap.current = holdsGap;
+    // Measured only when the column's own cards have changed, which is the only thing that moves
+    // them. Anything else that redraws the board, scrolling it sideways above all, would otherwise
+    // have every column read a position for every card it holds.
+    const measured = useRef<unknown>();
+    const cardsChanged = measured.current !== columnItems;
+    measured.current = columnItems;
     useFlip(contentRef, {
         selector: ".board-note",
-        paused: draggedCard
-            ? column !== draggedCard.fromColumn && !holdsGap && !justLeftGap
-            : !!draggedColumn || !!isResizing
+        // Paused where nothing has moved the cards, so the places it knows are still good.
+        paused: !cardsChanged,
+        // Switched off outright for the length of a gesture, which is what makes the commit that
+        // ends one record where the cards landed rather than slide them there: the places it knew
+        // are from before the drag, and a card let go has already been carried to its own.
+        disabled: !!draggedCard || !!draggedColumn || !!isResizing
     });
+
+    // The gap is opened without touching what the column holds. Putting an element among the
+    // cards, taking one out, or carrying one to another place all cost the same: the board
+    // restyles every element it holds, which on a large one is most of a second. Changing the
+    // size of an element that stays put, and moving one that stands outside the flow, cost
+    // nothing, so the gap is a standing element that slides and the cards beside it are
+    // transformed. The cards carry a transform transition already, so the sliding is the
+    // browser's to do.
+    const gapRef = useRef<HTMLDivElement>(null);
+    const roomRef = useRef<HTMLDivElement>(null);
+    /** Which cards were last told to stand aside, so only what changed is written. */
+    const aside = useRef({ from: 0, until: 0, room: 0 });
+    useLayoutEffect(() => {
+        const area = contentRef.current;
+        const gap = gapRef.current;
+        if (!area || !gap) return;
+
+        const cards = area.querySelectorAll<HTMLElement>(".board-note");
+        const height = draggedCard?.height ?? STOCK_GAP_HEIGHT;
+        const room = dropIndex === null ? 0 : height + cardSpacing();
+
+        // Read before anything is written, and `offsetTop` is no business of a transform anyway.
+        if (dropIndex !== null) {
+            const standing = cards[dropIndex];
+            const last = cards[cards.length - 1];
+            const top = standing
+                ? standing.offsetTop
+                : (last ? last.offsetTop + last.offsetHeight + cardSpacing() : 0);
+            gap.style.transform = `translateY(${top}px)`;
+            gap.style.height = `${height}px`;
+        }
+        gap.classList.toggle("show", dropIndex !== null);
+        roomRef.current?.style.setProperty("height", `${room}px`);
+
+        // Once the gap is gone, every card is put back, whichever ones they now are: a drop
+        // reorders the column, so the places that stood aside no longer name the same cards.
+        if (dropIndex === null) {
+            for (const card of cards) {
+                if (card.style.transform) {
+                    card.style.removeProperty("transform");
+                }
+            }
+            aside.current = { from: 0, until: 0, room: 0 };
+            return;
+        }
+
+        const from = dropIndex;
+        const until = Math.min(cards.length, from + CARDS_ASIDE);
+        const last = aside.current;
+        // A step of a drag moves the gap by a card, so only the few cards it passed change what
+        // they are told; the rest of the window is already standing where it should.
+        const afresh = last.room !== room;
+        for (let index = last.from; index < last.until; index++) {
+            if (afresh || index < from || index >= until) {
+                cards[index]?.style.removeProperty("transform");
+            }
+        }
+        for (let index = from; index < until; index++) {
+            if (afresh || index < last.from || index >= last.until) {
+                cards[index].style.transform = `translateY(${room}px)`;
+            }
+        }
+        aside.current = { from, until, room };
+    }, [ dropIndex, draggedCard?.height, columnItems ]);
     const { handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote
     });
-
-    // Measured rather than styled: the gap stands for the card being carried, which is whatever
-    // height its own content gave it. A drag from the note tree carries no card, so the stock
-    // height stands.
-    const gapStyle = draggedCard?.height
-        ? { height: `${draggedCard.height}px` }
-        : undefined;
 
     // Read here rather than in the badge: the column body shows an outline as well.
     const isOverLimit = limit !== undefined && (totalCount ?? columnItems?.length ?? 0) > limit;
@@ -537,9 +611,6 @@ export default function Column({
             >
                 {(columnItems ?? []).map(({ note, branch }, index) => (
                     <Fragment key={note.noteId}>
-                        {dropIndex === index && (
-                            <div className="board-drop-placeholder show" style={gapStyle} />
-                        )}
                         {insertBefore?.branchId === branch.branchId && insertField}
                         <Card
                             api={api}
@@ -558,9 +629,10 @@ export default function Column({
                     </Fragment>
                 ))}
                 {insertBefore && !insertBefore.branchId && insertField}
-                {dropIndex === (columnItems?.length ?? 0) && (
-                    <div className="board-drop-placeholder show" style={gapStyle} />
-                )}
+                {/* Both stand here for the length of the board's life: an element appearing
+                    among the cards, or leaving them, is what a drag cannot afford. */}
+                <div ref={gapRef} className="board-drop-placeholder" />
+                <div ref={roomRef} className="board-drop-room" />
             </div>}
 
             {!isCollapsed && <AddNewItem

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -172,23 +172,26 @@ export default function Column({
     // made in the footer is shown by the scroll to the end and by its fade, and one made among the
     // others takes the place its field was standing in.
     //
-    // While a card is carried, the cards that move are those of the column it came from and those
-    // of any column the gap has stood in. The rest are left unmeasured, measuring one costing a
-    // layout of the whole board; paused rather than switched off, so a column the gap reaches in
-    // one step still knows where its cards stood and slides them from there.
+    // While a card is carried, the cards that move are those of the column it came from, the one
+    // the gap stands in, and the one it has just left, whose cards close up behind it. Every other
+    // column is left unmeasured, measuring one costing a layout of the whole board; paused rather
+    // than switched off, so a column the gap reaches in one step still knows where its cards stood
+    // and slides them from there.
+    //
+    // Just left, rather than ever held: a column keeps whatever it last measured, so one the gap
+    // passed through earlier has nothing more to say. Kept on, a column of thousands measures
+    // again every time anything redraws the board for the rest of the gesture.
     //
     // A column being carried, and a column changing width, move no card inside any column, so
     // every column is left unmeasured for the length of either.
     const heldGap = useRef(false);
-    if (!draggedCard) {
-        heldGap.current = false;
-    } else if (dropIndex !== null) {
-        heldGap.current = true;
-    }
+    const holdsGap = dropIndex !== null;
+    const justLeftGap = heldGap.current && !holdsGap;
+    heldGap.current = holdsGap;
     useFlip(contentRef, {
         selector: ".board-note",
         paused: draggedCard
-            ? column !== draggedCard.fromColumn && !heldGap.current
+            ? column !== draggedCard.fromColumn && !holdsGap && !justLeftGap
             : !!draggedColumn || !!isResizing
     });
     const { handleDragOver, handleDragLeave, handleDrop } = useDragging({

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -535,35 +535,28 @@ export default function Column({
                 style={scrollFade.style}
                 onWheel={handleScroll}
             >
-                {(columnItems ?? []).map(({ note, branch }, index) => {
-                    // The card being carried is out of the flow, so the gap stands in its own
-                    // place too: held still, which a touch does before it moves, that is where it
-                    // was picked up from.
-                    const showIndicatorBefore = dropIndex === index;
-
-                    return (
-                        <Fragment key={note.noteId}>
-                            {showIndicatorBefore && (
-                                <div className="board-drop-placeholder show" style={gapStyle} />
-                            )}
-                            {insertBefore?.branchId === branch.branchId && insertField}
-                            <Card
-                                api={api}
-                                note={note}
-                                branch={branch}
-                                column={column}
-                                index={index}
-                                statusAttribute={api.statusAttribute}
-                                isNew={note.noteId === createdNoteId}
-                                focusOnArrival={note.noteId === insertedNoteId}
-                                isDragging={draggedCard?.noteId === note.noteId}
-                                isEditing={branch.branchId === branchIdToEdit}
-                                onFocusCard={onFocusCard}
-                                onInsert={beginInsert}
-                            />
-                        </Fragment>
-                    );
-                })}
+                {(columnItems ?? []).map(({ note, branch }, index) => (
+                    <Fragment key={note.noteId}>
+                        {dropIndex === index && (
+                            <div className="board-drop-placeholder show" style={gapStyle} />
+                        )}
+                        {insertBefore?.branchId === branch.branchId && insertField}
+                        <Card
+                            api={api}
+                            note={note}
+                            branch={branch}
+                            column={column}
+                            index={index}
+                            statusAttribute={api.statusAttribute}
+                            isNew={note.noteId === createdNoteId}
+                            focusOnArrival={note.noteId === insertedNoteId}
+                            isDragging={draggedCard?.noteId === note.noteId}
+                            isEditing={branch.branchId === branchIdToEdit}
+                            onFocusCard={onFocusCard}
+                            onInsert={beginInsert}
+                        />
+                    </Fragment>
+                ))}
                 {insertBefore && !insertBefore.branchId && insertField}
                 {dropIndex === (columnItems?.length ?? 0) && (
                     <div className="board-drop-placeholder show" style={gapStyle} />

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -60,6 +60,7 @@ export default function Column({
     isActive,
     isPeeked,
     isResizing,
+    standsAside,
     nested,
     limit,
     columnItems,
@@ -87,6 +88,14 @@ export default function Column({
     isPeeked?: boolean,
     /** Whether a column is still taking its new width, during which no column's cards move. */
     isResizing?: boolean,
+    /**
+     * How far the column stands aside for one being carried, in pixels.
+     *
+     * Written as a transform rather than drawn by putting the carried column's place among the
+     * others: the row is left as it stands for the length of the gesture, so a step of it costs
+     * the browser a transform apiece instead of laying out every card on the board again.
+     */
+    standsAside?: number,
     /** What a new card is made from, and how the reader picks something else. */
     cardTemplates: CardTemplates,
     /** Whether the inbox also collects notes deeper than the board's direct children. */
@@ -421,7 +430,10 @@ export default function Column({
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
-            style={{ "--board-column-custom-hue": hue }}
+            style={{
+                "--board-column-custom-hue": hue,
+                transform: standsAside ? `translateX(${standsAside}px)` : undefined
+            }}
         >
             <h3
                 ref={headerRef}

--- a/apps/client/src/widgets/collections/board/columns.ts
+++ b/apps/client/src/widgets/collections/board/columns.ts
@@ -171,3 +171,20 @@ export function resolveBoardColumns(
 function named(value: string) {
     return value.trim() !== INBOX_COLUMN;
 }
+
+/**
+ * Whether the column holds another card below this one.
+ *
+ * Asked rather than read off `nextElementSibling`: the gap a drag opens, and the room it takes,
+ * stand below the cards for the length of the board's life, so the last card is never the last
+ * thing in its column.
+ */
+export function cardFollows(card: Element) {
+    for (let next = card.nextElementSibling; next; next = next.nextElementSibling) {
+        if (next.classList.contains("board-note")) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -14,6 +14,7 @@ import { buildNote } from "../../../test/easy-froca";
 import { TREE_CLIPBOARD_TYPE } from "../../note_tree";
 import { ParentComponent } from "../../react/react_utils";
 import BoardView, { BoardViewData } from ".";
+import { placeCard, settleCards } from "./column";
 
 vi.mock("../../../services/branches", () => ({
     default: {
@@ -870,6 +871,50 @@ describe("Board column reordering", () => {
 
     function settle() {
         return new Promise((resolve) => setTimeout(resolve));
+    }
+});
+
+describe("a board leaving the page", () => {
+    /**
+     * Boards stay mounted across tabs and splits, and the frame that puts a suppressed transition
+     * back is one they share. A board being taken off the page settles its own cards alone.
+     */
+    it("puts back only the cards it holds, leaving another board's gesture alone", () => {
+        const [ leaving, staying ] = [ board(), board() ];
+
+        placeCard(leaving.card, "translateY(10px)", true);
+        placeCard(staying.card, "translateY(10px)", true);
+        expect([ leaving.card.style.transition, staying.card.style.transition ])
+            .toEqual([ "none", "none" ]);
+
+        settleCards(leaving.container);
+
+        expect(leaving.card.style.transition).toBe("");
+        expect(staying.card.style.transition).toBe("none");
+
+        settleCards(staying.container);
+        expect(staying.card.style.transition).toBe("");
+        for (const { container } of [ leaving, staying ]) container.remove();
+    });
+
+    /** A card taken off the page with its board has nothing left to animate. */
+    it("puts back a card that has already left the page, whichever board held it", () => {
+        const gone = board();
+        placeCard(gone.card, "translateY(10px)", true);
+        gone.container.remove();
+
+        settleCards(document.createElement("div"));
+
+        expect(gone.card.style.transition).toBe("");
+    });
+
+    function board() {
+        const container = document.createElement("div");
+        const card = document.createElement("div");
+        card.className = "board-note";
+        container.appendChild(card);
+        document.body.appendChild(container);
+        return { container, card };
     }
 });
 

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -61,25 +61,33 @@ describe("Board drag and drop", () => {
         }
     });
 
+    /**
+     * The gap stands outside the column's flow and the cards below it stand aside for it. Carried
+     * among them instead, it changes what the column holds, and the board restyles every element
+     * it holds for that, on every step of a drag.
+     */
     it("marks the card a drop would land before, from where the pointer is", async () => {
         const { columns } = await renderBoard();
 
         // Above the middle of the second card, so the drop lands between the two.
         await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 120);
 
-        const placeholders = [ ...columns[0].querySelectorAll(".board-column-content > *") ]
-            .map(child => child.className);
-        expect(placeholders[1]).toContain("board-drop-placeholder");
+        expect(columns[0].querySelector(".board-drop-placeholder.show")).toBeTruthy();
+        expect([ ...columns[0].querySelectorAll<HTMLElement>(".board-note") ]
+            .map(card => card.style.transform !== "")).toEqual([ false, true ]);
     });
 
     it("clears the mark once the pointer leaves the column altogether", async () => {
         const { columns } = await renderBoard();
 
         await drag(columns[0], "dragover", { types: [ TREE_CLIPBOARD_TYPE ] }, 120);
-        expect(columns[0].querySelector(".board-drop-placeholder")).toBeTruthy();
+        expect(columns[0].querySelector(".board-drop-placeholder.show")).toBeTruthy();
 
+        // The gap itself stays where it stands; it is shown and hidden rather than made and
+        // unmade, which is what keeps a drag off the board's own contents.
         await drag(columns[0], "dragleave", { types: [] });
-        expect(columns[0].querySelector(".board-drop-placeholder")).toBeNull();
+        expect(columns[0].querySelector(".board-drop-placeholder.show")).toBeNull();
+        expect(columns[0].querySelector(".board-drop-placeholder")).toBeTruthy();
     });
 
     it("ignores a drag carrying something the board has no use for", async () => {
@@ -87,7 +95,7 @@ describe("Board drag and drop", () => {
 
         await drag(columns[0], "dragover", { types: [ "text/uri-list" ] }, 120);
 
-        expect(columns[0].querySelector(".board-drop-placeholder")).toBeNull();
+        expect(columns[0].querySelector(".board-drop-placeholder.show")).toBeNull();
     });
 
     it("clones a note dragged in from the tree, which the board does not hold", async () => {

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -309,6 +309,45 @@ describe("Board drag and drop", () => {
         expect(gap?.style.height).toBe("100px");
     });
 
+    /**
+     * The card leaves the flow as it is lifted, and the gap opens in its place by pushing the cards
+     * below it down again. Under their transition that reads as the column closing up and then
+     * sliding back open, where nothing has actually moved.
+     */
+    it("opens the gap without a transition as a card is lifted", async () => {
+        const { columns, board } = await renderBoard();
+        await act(async () => { await settle(); });
+        const second = columns[0].querySelectorAll<HTMLElement>(".board-note")[1];
+
+        // Watched rather than read afterwards: the frame that puts the transitions back has run by
+        // the time the gesture returns.
+        expect(await classesWhile(board, async () => {
+            await pointer(second, "pointerdown", 50, 150);
+            await pointer(columns[0], "pointermove", 50, 60);
+        })).toContain("board-still");
+    });
+
+    /**
+     * Cards below the gap carry a `translateY` that the drop replaces with the layout the reorder
+     * gives them. Cleared under their transition they slide up from a place they never stood in,
+     * which reads as the column settling after the card has landed.
+     */
+    it("takes the transforms off without a transition once a card has landed", async () => {
+        const { columns, board } = await renderBoard();
+        await act(async () => { await settle(); });
+        const second = columns[0].querySelectorAll<HTMLElement>(".board-note")[1];
+
+        await pointer(second, "pointerdown", 50, 150);
+        await pointer(columns[0], "pointermove", 50, 60);
+        await act(async () => { await frames(); });
+        // The lift suppresses transitions too, so the release is watched on its own: left running,
+        // this would pass on what the lift did.
+        expect(board.classList.contains("board-still")).toBe(false);
+
+        expect(await classesWhile(board, () => pointer(columns[0], "pointerup", 50, 60)))
+            .toContain("board-still");
+    });
+
     function place(
         element: HTMLElement | null,
         box: { left: number, top: number, width: number, height: number }
@@ -392,7 +431,9 @@ describe("Board drag and drop", () => {
         const cards = note.getChildBranches()
             .map(branch => ({ noteId: branch.noteId, branchId: branch.branchId }));
 
-        return { note, columns, cards };
+        if (!board) throw new Error("expected the board container");
+
+        return { note, columns, cards, board };
     }
 
     /** Dispatches one of the drag events, with the clipboard the board reads its payload from. */
@@ -430,6 +471,12 @@ describe("Board drag and drop", () => {
 
     function settle() {
         return new Promise((resolve) => setTimeout(resolve));
+    }
+
+    /** Waits out the two frames a suppressed transition is put back after. */
+    function frames() {
+        return new Promise<void>(resolve => requestAnimationFrame(
+            () => requestAnimationFrame(() => setTimeout(resolve))));
     }
 });
 
@@ -529,7 +576,7 @@ describe("Board column reordering", () => {
         // Watched rather than read afterwards: the frame that puts the transition back has run by
         // the time the gesture returns.
         expect(await classesWhile(board, () => carryColumn(columns[0], 280)))
-            .toContain("board-landing");
+            .toContain("board-still");
     });
 
     it("eases the columns back where the drag is called off, having moved nothing", async () => {
@@ -538,7 +585,7 @@ describe("Board column reordering", () => {
         // Let go where it started, which places the column back where it came from: the columns
         // that stepped aside slide back, so the transition has to stay on.
         expect(await classesWhile(board, () => carryColumn(columns[0], 20)))
-            .not.toContain("board-landing");
+            .not.toContain("board-still");
     });
 
     it("puts the columns back once the gesture is over", async () => {
@@ -659,20 +706,6 @@ describe("Board column reordering", () => {
     });
 
     /** Takes hold of a column by its heading, carries it to `clientX` and lets it go there. */
-    /** Every class the element wears at any point while `run` is going on. */
-    async function classesWhile(element: HTMLElement, run: () => Promise<void>) {
-        const seen = new Set<string>();
-        const watch = new MutationObserver(() => {
-            for (const name of element.classList) {
-                seen.add(name);
-            }
-        });
-        watch.observe(element, { attributes: true, attributeFilter: [ "class" ] });
-        await run();
-        watch.disconnect();
-        return [ ...seen ];
-    }
-
     async function carryColumn(
         column: HTMLElement,
         clientX: number,
@@ -812,3 +845,17 @@ describe("Board column reordering", () => {
         return new Promise((resolve) => setTimeout(resolve));
     }
 });
+
+/** Every class the element wears at any point while `run` is going on. */
+async function classesWhile(element: HTMLElement, run: () => Promise<void>) {
+    const seen = new Set<string>();
+    const watch = new MutationObserver(() => {
+        for (const name of element.classList) {
+            seen.add(name);
+        }
+    });
+    watch.observe(element, { attributes: true, attributeFilter: [ "class" ] });
+    await run();
+    watch.disconnect();
+    return [ ...seen ];
+}

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -317,14 +317,21 @@ describe("Board drag and drop", () => {
     it("opens the gap without a transition as a card is lifted", async () => {
         const { columns, board } = await renderBoard();
         await act(async () => { await settle(); });
-        const second = columns[0].querySelectorAll<HTMLElement>(".board-note")[1];
+        const [ first, second ] = columns[0].querySelectorAll<HTMLElement>(".board-note");
 
         // Watched rather than read afterwards: the frame that puts the transitions back has run by
         // the time the gesture returns.
-        expect(await classesWhile(board, async () => {
-            await pointer(second, "pointerdown", 50, 150);
-            await pointer(columns[0], "pointermove", 50, 60);
-        })).toContain("board-still");
+        const eased = await transitionsWhile(first, async () => {
+            expect(await classesWhile(board, async () => {
+                await pointer(second, "pointerdown", 50, 150);
+                await pointer(columns[0], "pointermove", 50, 60);
+            })).toContain("board-still");
+        });
+
+        // The card that steps aside carries the suppression itself: a rule under the board's class
+        // would reach every card on it.
+        expect(first.style.transform).toBe("translateY(100px)");
+        expect(eased).toContain("none");
     });
 
     /**
@@ -335,7 +342,7 @@ describe("Board drag and drop", () => {
     it("takes the transforms off without a transition once a card has landed", async () => {
         const { columns, board } = await renderBoard();
         await act(async () => { await settle(); });
-        const second = columns[0].querySelectorAll<HTMLElement>(".board-note")[1];
+        const [ first, second ] = columns[0].querySelectorAll<HTMLElement>(".board-note");
 
         await pointer(second, "pointerdown", 50, 150);
         await pointer(columns[0], "pointermove", 50, 60);
@@ -343,10 +350,30 @@ describe("Board drag and drop", () => {
         // The lift suppresses transitions too, so the release is watched on its own: left running,
         // this would pass on what the lift did.
         expect(board.classList.contains("board-still")).toBe(false);
+        expect(first.style.transform).toBe("translateY(100px)");
 
-        expect(await classesWhile(board, () => pointer(columns[0], "pointerup", 50, 60)))
-            .toContain("board-still");
+        const eased = await transitionsWhile(first, async () => {
+            expect(await classesWhile(board, () => pointer(columns[0], "pointerup", 50, 60)))
+                .toContain("board-still");
+        });
+
+        // Put back where the column draws it, and without easing its way there.
+        expect(first.style.transform).toBe("");
+        expect(eased).toContain("none");
     });
+
+    it("puts the suppressed transitions back once the frame that moved the cards has passed",
+        async () => {
+            const { columns } = await renderBoard();
+            await act(async () => { await settle(); });
+            const [ first, second ] = columns[0].querySelectorAll<HTMLElement>(".board-note");
+
+            await pointer(second, "pointerdown", 50, 150);
+            await pointer(columns[0], "pointermove", 50, 60);
+            await act(async () => { await frames(); });
+
+            expect(first.style.transition).toBe("");
+        });
 
     function place(
         element: HTMLElement | null,
@@ -847,14 +874,31 @@ describe("Board column reordering", () => {
 });
 
 /** Every class the element wears at any point while `run` is going on. */
-async function classesWhile(element: HTMLElement, run: () => Promise<void>) {
+function classesWhile(element: HTMLElement, run: () => Promise<void>) {
+    return seenWhile(element, "class", () => element.classList, run);
+}
+
+/** Every inline `transition` the element carries at any point while `run` is going on. */
+function transitionsWhile(element: HTMLElement, run: () => Promise<void>) {
+    return seenWhile(element, "style", () => [ element.style.transition ], run);
+}
+
+/**
+ * What `read` returns each time the watched attribute changes, gathered while `run` goes on.
+ *
+ * Read as it happens rather than afterwards: what a still frame writes is taken back a frame or
+ * two later, so by the time the gesture returns there is nothing left to find.
+ */
+async function seenWhile(
+    element: HTMLElement, attribute: string, read: () => Iterable<string>, run: () => Promise<void>
+) {
     const seen = new Set<string>();
     const watch = new MutationObserver(() => {
-        for (const name of element.classList) {
-            seen.add(name);
+        for (const value of read()) {
+            seen.add(value);
         }
     });
-    watch.observe(element, { attributes: true, attributeFilter: [ "class" ] });
+    watch.observe(element, { attributes: true, attributeFilter: [ attribute ] });
     await run();
     watch.disconnect();
     return [ ...seen ];

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -521,7 +521,7 @@ describe("Board column reordering", () => {
         // Watched rather than read afterwards: the frame that puts the transition back has run by
         // the time the gesture returns.
         expect(await classesWhile(board, () => carryColumn(columns[0], 280)))
-            .toContain("board-columns-landing");
+            .toContain("board-landing");
     });
 
     it("eases the columns back where the drag is called off, having moved nothing", async () => {
@@ -530,7 +530,7 @@ describe("Board column reordering", () => {
         // Let go where it started, which places the column back where it came from: the columns
         // that stepped aside slide back, so the transition has to stay on.
         expect(await classesWhile(board, () => carryColumn(columns[0], 20)))
-            .not.toContain("board-columns-landing");
+            .not.toContain("board-landing");
     });
 
     it("puts the columns back once the gesture is over", async () => {

--- a/apps/client/src/widgets/collections/board/drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/drag.spec.tsx
@@ -487,6 +487,61 @@ describe("Board column reordering", () => {
         expect(placeholder?.style.width).toBe("");
     });
 
+    /**
+     * The row is left as it stands for the length of the gesture: the carried column's place is
+     * held open where it was lifted from, and the columns it is carried past step aside by a
+     * transform. Reordering the elements per step would lay out every card on the board again.
+     */
+    it("holds the gap where the column was lifted from and steps the others aside", async () => {
+        const { columns, board } = await renderColumns();
+
+        // Carried over the third column, which spans 200 to 300, past its middle.
+        await carryColumn(columns[0], 280, { release: false });
+
+        // The copy being carried is a column too, and it follows the pointer rather than the row.
+        const drawn = [ ...board.querySelectorAll<HTMLElement>(
+            ".board-column:not(.board-drag-preview)") ];
+        const placeholder = board.querySelector<HTMLElement>(".column-drop-placeholder");
+        // Still the first thing in the row, where the column it stands for was picked up.
+        expect(placeholder?.previousElementSibling).toBeNull();
+        // The two it passes close up by what it takes out of the row, which is its own 100px:
+        // happy-dom computes no styles, so the gap between columns reads as nothing here.
+        expect(drawn.map(column => column.style.transform))
+            .toEqual([ "", "translateX(-100px)", "translateX(-100px)" ]);
+    });
+
+    /**
+     * The transforms come off in the same frame the row is drawn in its new order, where every
+     * column already stands where that order puts it. Eased to nothing they would each carry a
+     * column's width from a place it never stood in, which reads as the row sliding after the drop.
+     */
+    it("takes the transforms off without a transition once a column has landed", async () => {
+        const { columns, board } = await renderColumns();
+
+        // Watched rather than read afterwards: the frame that puts the transition back has run by
+        // the time the gesture returns.
+        expect(await classesWhile(board, () => carryColumn(columns[0], 280)))
+            .toContain("board-columns-landing");
+    });
+
+    it("eases the columns back where the drag is called off, having moved nothing", async () => {
+        const { columns, board } = await renderColumns();
+
+        // Let go where it started, which places the column back where it came from: the columns
+        // that stepped aside slide back, so the transition has to stay on.
+        expect(await classesWhile(board, () => carryColumn(columns[0], 20)))
+            .not.toContain("board-columns-landing");
+    });
+
+    it("puts the columns back once the gesture is over", async () => {
+        const { columns, board } = await renderColumns();
+
+        await carryColumn(columns[0], 280);
+
+        expect([ ...board.querySelectorAll<HTMLElement>(".board-column") ]
+            .map(column => column.style.transform)).toEqual([ "", "", "" ]);
+    });
+
     /** A copy of it is carried, capped so a tall column does not cover the board it is placed on. */
     it("carries a copy, hiding the column until it is let go", async () => {
         const { columns, board } = await renderColumns();
@@ -596,6 +651,20 @@ describe("Board column reordering", () => {
     });
 
     /** Takes hold of a column by its heading, carries it to `clientX` and lets it go there. */
+    /** Every class the element wears at any point while `run` is going on. */
+    async function classesWhile(element: HTMLElement, run: () => Promise<void>) {
+        const seen = new Set<string>();
+        const watch = new MutationObserver(() => {
+            for (const name of element.classList) {
+                seen.add(name);
+            }
+        });
+        watch.observe(element, { attributes: true, attributeFilter: [ "class" ] });
+        await run();
+        watch.disconnect();
+        return [ ...seen ];
+    }
+
     async function carryColumn(
         column: HTMLElement,
         clientX: number,

--- a/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
     type CardBox, cardInsertionIndex, columnAt, type ColumnBox, columnCovers,
-    columnInsertionIndex, movesColumn
+    columnInsertionIndex, columnStandsAside, movesColumn
 } from "./drag_geometry";
 
 /** Three 100px columns with a 20px gap, standing 400 tall from the top of the page. */
@@ -170,5 +170,35 @@ describe("movesColumn", () => {
         expect(movesColumn(0, 0)).toBe(false);
         expect(movesColumn(0, 1)).toBe(false);
         expect(movesColumn(0, 2)).toBe(true);
+    });
+});
+
+describe("columnStandsAside", () => {
+    // Six columns, the third one carried, each standing 266px wide with the gap after it.
+    const aside = (index: number, to: number | null) => columnStandsAside(index, 2, to, 266);
+
+    it("moves the columns between where it left and where it lands, and no others", () => {
+        // Carried to the right: the ones it passes close up behind it.
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, 5)))
+            .toEqual([ 0, 0, 0, -266, -266, 0 ]);
+
+        // Carried to the left: the ones it passes stand aside for it.
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, 0)))
+            .toEqual([ 266, 266, 0, 0, 0, 0 ]);
+    });
+
+    it("holds everything still where the column would land back in its own place", () => {
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, 2))).toEqual([ 0, 0, 0, 0, 0, 0 ]);
+        // The place just after its own is the same place: it is the only column out of the row.
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, 3))).toEqual([ 0, 0, 0, 0, 0, 0 ]);
+    });
+
+    it("holds everything still while the column is over nowhere it could land", () => {
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, null))).toEqual([ 0, 0, 0, 0, 0, 0 ]);
+    });
+
+    it("counts the place past the last column as the end of the row", () => {
+        expect([ 0, 1, 2, 3, 4, 5 ].map(index => aside(index, 6)))
+            .toEqual([ 0, 0, 0, -266, -266, -266 ]);
     });
 });

--- a/apps/client/src/widgets/collections/board/drag_geometry.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.ts
@@ -132,3 +132,55 @@ export function columnInsertionIndex(columns: ColumnBox[], x: number): number {
 export function movesColumn(from: number, to: number): boolean {
     return to !== from && to !== from + 1;
 }
+
+/**
+ * How far a column stands aside while another is carried past it, in pixels.
+ *
+ * The board is not reordered as the reader drags: the carried column's place is held open where it
+ * was lifted from, and the columns between there and where it would land step aside by its width
+ * instead. A step of the gesture then costs each of them a transform, where reordering the elements
+ * costs a fresh layout of every card on the board.
+ *
+ * @param index which column is being asked about.
+ * @param from where the carried column was lifted from.
+ * @param to the place it would take, counting the columns as they stand, or nothing while it is
+ * over nowhere it could land.
+ * @param width what it takes up, its own width and the gap after it.
+ */
+export function columnStandsAside(
+    index: number, from: number, to: number | null, width: number
+): number {
+    if (to === null || index === from) {
+        return 0;
+    }
+
+    // Landing further along: everything between the place it left and the place it takes closes up
+    // behind it. Landing at the place just after its own leaves it where it is.
+    if (to > from) {
+        return index > from && index < to ? -width : 0;
+    }
+
+    return index >= to && index < from ? width : 0;
+}
+
+/**
+ * How far the gap held open for a carried column stands from where that column was lifted, in
+ * pixels.
+ *
+ * The gap is drawn where the column was picked up and carried to where it would land, the columns
+ * it passes having stepped aside to leave the room. Read against `lefts`, which holds where each
+ * column stood before the drag began and, last of all, where a column added at the end would.
+ */
+export function columnGapStandsAside(
+    from: number, to: number | null, lefts: number[], stride: number
+): number {
+    const origin = lefts[from];
+    if (to === null || origin === undefined) {
+        return 0;
+    }
+
+    const at = lefts[Math.min(to, lefts.length - 1)];
+    // Landing further along, the gap opens after the column it is carried past rather than before
+    // it, which is that column's own place less the room the gap takes.
+    return (to > from ? at - stride : at) - origin;
+}

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -109,20 +109,44 @@ describe("measureBoard", () => {
         expect(measureBoard(buildBoard({ areaScrollTop: 90 })).columns[0].cards).toEqual(expected);
     });
 
-    it("reads one card per column once it knows what the rest of them measure", () => {
+    it("reads the ends of a column once it knows what the cards between them measure", () => {
         const board = buildBoard({ cardCounts: [ 3, 2 ] });
         const expected = measureBoard(board).columns.map((column) => column.cards);
 
-        let reads = 0;
-        for (const note of board.querySelectorAll<HTMLElement>(".board-note")) {
-            const box = note.getBoundingClientRect.bind(note);
-            note.getBoundingClientRect = () => { reads++; return box(); };
-        }
+        const count = () => {
+            let reads = 0;
+            for (const note of board.querySelectorAll<HTMLElement>(".board-note")) {
+                const box = note.getBoundingClientRect.bind(note);
+                note.getBoundingClientRect = () => { reads++; return box(); };
+            }
 
-        // Where a column's cards begin is still its own to say, so the first of them is read.
-        // The four under it are placed by counting up from it instead.
+            return () => reads;
+        };
+
+        // Where a column's cards begin is still its own to say, so the first of them is read, and
+        // the last says whether counting up from it still lands where the column does. The one
+        // between them is placed by the count alone.
+        let reads = count();
         expect(measureBoard(board).columns.map((column) => column.cards)).toEqual(expected);
-        expect(reads).toBe(2);
+        expect(reads()).toBe(4);
+    });
+
+    /**
+     * Nothing announces that a card stands taller than it did: a title can grow a line and an
+     * attribute can be promoted onto it while the board is open.
+     */
+    it("reads every card again once what it remembers no longer lands where the column does", () => {
+        const board = buildBoard({ cardCounts: [ 3 ] });
+        measureBoard(board);
+
+        // The middle card grows, which moves the one under it. Counting up from the first would
+        // put both of them 20px short, the height it remembers for the middle one being the old.
+        const cards = board.querySelectorAll<HTMLElement>(".board-note");
+        place(cards[1], { left: 0, top: 90, width: 100, height: 80 });
+        place(cards[2], { left: 0, top: 180, width: 100, height: 50 });
+
+        expect(measureBoard(board).columns[0].cards)
+            .toEqual([ { top: 10, height: 50 }, { top: 70, height: 80 }, { top: 160, height: 50 } ]);
     });
 
     it("hands back each column's card area, and counts a column holding none", () => {

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -1,9 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { cardInsertionIndex, columnAt } from "./drag_geometry";
-import { measureBoard, toAreaY, toBoardX } from "./drag_measure";
+import { forgetCardHeights, measureBoard, toAreaY, toBoardX } from "./drag_measure";
 
 let container: HTMLElement | undefined;
+
+// What has been measured outlives one board, which is the point of it, so each test starts with
+// nothing remembered.
+beforeEach(forgetCardHeights);
 
 afterEach(() => {
     container?.remove();
@@ -38,6 +42,7 @@ function buildBoard({ scrollLeft = 200, areaScrollTop = 20, cardCounts = [ 2, 1 
         for (let card = 0; card < cards; card++) {
             const note = document.createElement("div");
             note.className = "board-note";
+            note.dataset.noteId = `note-${index}-${card}`;
             area.appendChild(note);
             // Stated where the card stands in the area's content, then drawn where that leaves it
             // on screen once the area has been scrolled.
@@ -102,6 +107,22 @@ describe("measureBoard", () => {
         expect(measureBoard(buildBoard({ areaScrollTop: 0 })).columns[0].cards).toEqual(expected);
         container?.remove();
         expect(measureBoard(buildBoard({ areaScrollTop: 90 })).columns[0].cards).toEqual(expected);
+    });
+
+    it("reads one card per column once it knows what the rest of them measure", () => {
+        const board = buildBoard({ cardCounts: [ 3, 2 ] });
+        const expected = measureBoard(board).columns.map((column) => column.cards);
+
+        let reads = 0;
+        for (const note of board.querySelectorAll<HTMLElement>(".board-note")) {
+            const box = note.getBoundingClientRect.bind(note);
+            note.getBoundingClientRect = () => { reads++; return box(); };
+        }
+
+        // Where a column's cards begin is still its own to say, so the first of them is read.
+        // The four under it are placed by counting up from it instead.
+        expect(measureBoard(board).columns.map((column) => column.cards)).toEqual(expected);
+        expect(reads).toBe(2);
     });
 
     it("hands back each column's card area, and counts a column holding none", () => {

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -134,7 +134,22 @@ describe("measureBoard", () => {
         expect(areas.get("To Do")).toBe(board.querySelector(".board-column-content"));
     });
 
-    /** A collapsed column draws no card area at all. */
+    /**
+     * A strip holds its cards in the page without drawing any of them, so there is nothing in it
+     * to place a card against and a card carried over one goes to the front of what it holds.
+     */
+    it("counts a collapsed column as holding no cards, whatever it holds", () => {
+        const board = buildBoard({ cardCounts: [ 3, 1 ] });
+        board.querySelector(".board-column")?.classList.add("collapsed");
+
+        const { columns, areas } = measureBoard(board);
+
+        expect(board.querySelectorAll(".board-column")[0].querySelectorAll(".board-note"))
+            .toHaveLength(3);
+        expect(columns[0].cards).toEqual([]);
+        expect(areas.has("To Do")).toBe(false);
+    });
+
     it("counts a column with no card area as holding no cards", () => {
         const board = buildBoard();
         board.querySelector(".board-column-content")?.remove();

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -63,10 +63,36 @@ export function toAreaY(area: HTMLElement, clientY: number): number {
 }
 
 /**
+ * What each card measures, kept by note so that a column can be placed against without reading a
+ * rectangle for every card in it.
+ *
+ * A card's height is settled by its content and by the column's width, and a column is a fixed
+ * width the reader cannot change, so a height holds until the card itself changes. The one thing
+ * that moves it is the width a phone gives a column, which follows the size of the window.
+ */
+const heights = new Map<string, number>();
+
+/** What stands between two cards, which is one rule the board over and so is read once. */
+let spacing: number | undefined;
+
+/** Drops what has been measured, for a window whose size has changed under it. */
+export function forgetCardHeights() {
+    heights.clear();
+    spacing = undefined;
+}
+
+/**
  * The cards of one column, in the area's content space.
  *
- * The dragged card is measured with the rest: the index this leads to names a place in the list the
- * board holds, which is the list a move is expressed against.
+ * A card whose height is already known is placed by counting up from the one above it rather than
+ * by reading a rectangle of its own, which on a column of thousands is the whole cost of a drag.
+ * One that is not is read and remembered. The dragged card is counted with the rest, so the index
+ * this leads to names a place in the list the board holds, which is the list a move is expressed
+ * against.
+ *
+ * The gap standing open for the carried card holds the cards under it a place lower than they are
+ * measured to be. What a place is counted against is the column without the drag's own doing in
+ * it, so the room the gap takes is given back to everything below it.
  */
 function measureCards(area: HTMLElement | null) {
     if (!area) {
@@ -75,22 +101,53 @@ function measureCards(area: HTMLElement | null) {
 
     const top = area.getBoundingClientRect().top - area.scrollTop;
     const cards: CardBox[] = [];
-    // The gap standing open for the carried card holds the cards under it a place lower than they
-    // are measured to be. What a place is counted against is the column without the drag's own
-    // doing in it, so the room the gap takes is given back to everything below it.
     let gap = 0;
+    /** Where the next card stands if it has to be counted rather than read. */
+    let next = 0;
+    /** The foot of the last card read, which the next one read settles the spacing against. */
+    let foot: number | undefined;
+    /** Whether where the column's cards begin has been read yet. */
+    let anchored = false;
 
     for (const child of area.children) {
-        const rect = child.getBoundingClientRect();
-
-        if (child.classList.contains("board-drop-placeholder")) {
-            gap += rect.height + Number.parseFloat(getComputedStyle(child).marginBottom || "0");
+        if (!(child instanceof HTMLElement)) {
             continue;
         }
 
-        if (child.classList.contains("board-note")) {
-            cards.push({ top: rect.top - top - gap, height: rect.height });
+        if (child.classList.contains("board-drop-placeholder")) {
+            const box = child.getBoundingClientRect();
+            gap += box.height + Number.parseFloat(getComputedStyle(child).marginBottom || "0");
+            continue;
         }
+
+        if (!child.classList.contains("board-note")) {
+            continue;
+        }
+
+        const noteId = child.dataset.noteId ?? "";
+        let height = heights.get(noteId);
+        let at: number | undefined;
+
+        // The first card is always read, whatever is known of it: where a column's cards begin is
+        // its own, and the ones under it are counted up from there. A card whose height is not
+        // known yet is read as well, and remembered.
+        if (height === undefined || !anchored) {
+            const box = child.getBoundingClientRect();
+            height ??= box.height;
+            at = box.top - top - gap;
+            anchored = true;
+            if (noteId && box.height) {
+                heights.set(noteId, box.height);
+            }
+            if (spacing === undefined && foot !== undefined) {
+                spacing = at - foot;
+            }
+            foot = at + height;
+        }
+
+        const stands = at ?? next;
+        cards.push({ top: stands, height });
+        next = stands + height + (spacing ?? 0);
     }
 
     return cards;

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -30,7 +30,11 @@ export function measureBoard(container: HTMLElement, withCards = true): BoardMea
     for (const element of drawn) {
         const value = element.dataset.column ?? "";
         const rect = element.getBoundingClientRect();
-        const area = element.querySelector<HTMLElement>(".board-column-content");
+        // A strip holds its cards in the page but draws none of them: they measure nothing, and a
+        // card carried over one goes to the front of whatever it holds.
+        const area = element.classList.contains("collapsed")
+            ? null
+            : element.querySelector<HTMLElement>(".board-column-content");
 
         if (area) {
             areas.set(value, area);

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -9,12 +9,16 @@ export interface BoardMeasurement {
 }
 
 /**
- * Measures every column and card on the board.
+ * Measures every column on the board, and the cards in each of them.
  *
  * Called once when a drag starts. A gesture reads two rectangles per move afterwards, whatever the
  * board holds, where measuring per move would read one for every card on it.
+ *
+ * @param withCards whether to measure the cards as well, which only a card is placed against. A
+ * column is placed against the column boxes alone, and reading a rectangle per card for one is a
+ * pass over the whole board that nothing goes on to look at.
  */
-export function measureBoard(container: HTMLElement): BoardMeasurement {
+export function measureBoard(container: HTMLElement, withCards = true): BoardMeasurement {
     const origin = container.getBoundingClientRect().left - container.scrollLeft;
     const columns: ColumnBox[] = [];
     const areas = new Map<string, HTMLElement>();
@@ -38,7 +42,7 @@ export function measureBoard(container: HTMLElement): BoardMeasurement {
             width: rect.width,
             top: rect.top,
             height: rect.height,
-            cards: measureCards(area)
+            cards: withCards ? measureCards(area) : []
         });
     }
 

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -75,6 +75,14 @@ const heights = new Map<string, number>();
 /** What stands between two cards, which is one rule the board over and so is read once. */
 let spacing: number | undefined;
 
+/**
+ * What stands between two cards, which is what a gap takes up on top of the card it stands for.
+ * Nothing until a column has been measured, which a drag does before it opens any gap.
+ */
+export function cardSpacing() {
+    return spacing ?? 0;
+}
+
 /** Drops what has been measured, for a window whose size has changed under it. */
 export function forgetCardHeights() {
     heights.clear();
@@ -90,9 +98,8 @@ export function forgetCardHeights() {
  * this leads to names a place in the list the board holds, which is the list a move is expressed
  * against.
  *
- * The gap standing open for the carried card holds the cards under it a place lower than they are
- * measured to be. What a place is counted against is the column without the drag's own doing in
- * it, so the room the gap takes is given back to everything below it.
+ * The gap the carried card leaves room for stands outside the column's flow, so it displaces no
+ * card and none of its room has to be given back: what is measured is the column as it stands.
  */
 function measureCards(area: HTMLElement | null) {
     if (!area) {
@@ -101,7 +108,6 @@ function measureCards(area: HTMLElement | null) {
 
     const top = area.getBoundingClientRect().top - area.scrollTop;
     const cards: CardBox[] = [];
-    let gap = 0;
     /** Where the next card stands if it has to be counted rather than read. */
     let next = 0;
     /** The foot of the last card read, which the next one read settles the spacing against. */
@@ -111,12 +117,6 @@ function measureCards(area: HTMLElement | null) {
 
     for (const child of area.children) {
         if (!(child instanceof HTMLElement)) {
-            continue;
-        }
-
-        if (child.classList.contains("board-drop-placeholder")) {
-            const box = child.getBoundingClientRect();
-            gap += box.height + Number.parseFloat(getComputedStyle(child).marginBottom || "0");
             continue;
         }
 
@@ -134,7 +134,7 @@ function measureCards(area: HTMLElement | null) {
         if (height === undefined || !anchored) {
             const box = child.getBoundingClientRect();
             height ??= box.height;
-            at = box.top - top - gap;
+            at = box.top - top;
             anchored = true;
             if (noteId && box.height) {
                 heights.set(noteId, box.height);

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -70,9 +70,8 @@ export function toAreaY(area: HTMLElement, clientY: number): number {
  * What each card measures, kept by note so that a column can be placed against without reading a
  * rectangle for every card in it.
  *
- * A card's height is settled by its content and by the column's width, and a column is a fixed
- * width the reader cannot change, so a height holds until the card itself changes. The one thing
- * that moves it is the width a phone gives a column, which follows the size of the window.
+ * A height holds until the card's own content changes, which {@link measureCards} checks for, or
+ * until the window does, which drops the lot.
  */
 const heights = new Map<string, number>();
 
@@ -96,28 +95,53 @@ export function forgetCardHeights() {
 /**
  * The cards of one column, in the area's content space.
  *
- * A card whose height is already known is placed by counting up from the one above it rather than
- * by reading a rectangle of its own, which on a column of thousands is the whole cost of a drag.
- * One that is not is read and remembered. The dragged card is counted with the rest, so the index
- * this leads to names a place in the list the board holds, which is the list a move is expressed
- * against.
- *
- * The gap the carried card leaves room for stands outside the column's flow, so it displaces no
- * card and none of its room has to be given back: what is measured is the column as it stands.
+ * A card whose height is known is placed by counting up from the one above it rather than by
+ * reading a rectangle of its own, which on a column of thousands is the whole cost of a drag. The
+ * dragged card is counted with the rest, so the index this leads to names a place in the list the
+ * board holds.
  */
-function measureCards(area: HTMLElement | null) {
+function measureCards(area: HTMLElement | null): CardBox[] {
     if (!area) {
         return [];
     }
 
+    const counted = countCards(area, false);
+    const { cards, elements } = counted;
+    const last = cards.length - 1;
+
+    // A card whose title or attributes changed stands a different height, and nothing says so, so
+    // where the last card really is settles whether what was remembered still holds.
+    if (counted.borrowed && last > 0) {
+        const at = elements[last].getBoundingClientRect().top - counted.top;
+        if (Math.abs(at - cards[last].top) > 1) {
+            for (const element of elements) {
+                heights.delete(element.dataset.noteId ?? "");
+            }
+
+            return countCards(area, true).cards;
+        }
+    }
+
+    return cards;
+}
+
+/**
+ * Walks a column's cards, reading what is not known and counting up from what is.
+ *
+ * @param readEvery whether to read every card rather than the first and the unknown ones alone.
+ */
+function countCards(area: HTMLElement, readEvery: boolean) {
     const top = area.getBoundingClientRect().top - area.scrollTop;
     const cards: CardBox[] = [];
+    const elements: HTMLElement[] = [];
     /** Where the next card stands if it has to be counted rather than read. */
     let next = 0;
     /** The foot of the last card read, which the next one read settles the spacing against. */
     let foot: number | undefined;
     /** Whether where the column's cards begin has been read yet. */
     let anchored = false;
+    /** Whether any card's height came from what was remembered rather than from the page. */
+    let borrowed = false;
 
     for (const child of area.children) {
         if (!(child instanceof HTMLElement)) {
@@ -135,9 +159,9 @@ function measureCards(area: HTMLElement | null) {
         // The first card is always read, whatever is known of it: where a column's cards begin is
         // its own, and the ones under it are counted up from there. A card whose height is not
         // known yet is read as well, and remembered.
-        if (height === undefined || !anchored) {
+        if (height === undefined || !anchored || readEvery) {
             const box = child.getBoundingClientRect();
-            height ??= box.height;
+            height = box.height;
             at = box.top - top;
             anchored = true;
             if (noteId && box.height) {
@@ -147,12 +171,15 @@ function measureCards(area: HTMLElement | null) {
                 spacing = at - foot;
             }
             foot = at + height;
+        } else {
+            borrowed = true;
         }
 
         const stands = at ?? next;
         cards.push({ top: stands, height });
+        elements.push(child);
         next = stands + height + (spacing ?? 0);
     }
 
-    return cards;
+    return { cards, elements, borrowed, top };
 }

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -522,6 +522,8 @@ body.mobile .board-view-container .board-add-column {
    stops it at the column instead of passing it on, and the board never moves. */
 .board-view-container .board-column-content {
   overscroll-behavior-y: contain;
+  /* What the gap is placed against, and what a card's `offsetTop` is then counted from. */
+  position: relative;
 }
 
 /* And while something is carried, the end does not spring back either: the copy is positioned
@@ -741,7 +743,19 @@ body.mobile .board-view-container .board-add-column {
   }
 }
 
+/* Outside the column's flow and standing there for good. Carrying it into the cards, or out of
+   them, is a change to what the column holds, and the board restyles every element it holds for
+   that; sliding it instead costs nothing. */
 .board-drop-placeholder {
+  position: absolute;
+  /* It stands over the cards whether it is showing or not, and a press belongs to the card under
+     it, not to the space being held open. */
+  pointer-events: none;
+  /* Anchored at the top of the column's content, which the transform then counts down from. Left
+     to its own place in the flow it would start below every card. */
+  top: 0;
+  left: 0;
+  right: 0;
   height: 40px;
   /* The gap below is the card's, in em, so it has to be read at the card's own font size. */
   font-size: var(--card-font-size);
@@ -751,9 +765,18 @@ body.mobile .board-view-container .board-add-column {
   background-color: rgba(0, 0, 0, 0.15);
   opacity: 0;
   /* Opacity only: the height is the carried card's, so any change in it is a mismatch to see
-     rather than a movement to smooth over. */
+     rather than a movement to smooth over, and it slides to follow the pointer rather than easing
+     after it. */
   transition: opacity 0.15s ease;
   box-sizing: border-box;
+}
+
+/* The room the gap takes out of the column, so it still scrolls past its last card while one is
+   held there. It stands in the flow at no height, and is given one for as long as the gap needs
+   it: growing an element that stays put costs nothing, where adding one does not. */
+.board-drop-room {
+  height: 0;
+  flex-shrink: 0;
 }
 
 .board-drop-placeholder.show {

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -519,9 +519,8 @@ body.mobile .board-view-container .board-add-column {
   overscroll-behavior-y: contain;
   /* What the gap is placed against, and what a card's `offsetTop` is then counted from. */
   position: relative;
-  /* Pinned rather than left to stretch: a column animates its own width open, and a body that
-     follows it lays out every card in it on every frame, their titles rewrapping as it grows.
-     Matches the column's content box, so a column standing still is drawn no differently. */
+  /* Pinned rather than left to stretch, a body that follows the column's width laying out every
+     card in it on each frame of an open. Matches the column's content box. */
   width: calc(var(--board-column-width) - 2 * var(--board-column-border-width));
 }
 
@@ -742,9 +741,8 @@ body.mobile .board-view-container .board-add-column {
   }
 }
 
-/* Outside the column's flow and standing there for good. Carrying it into the cards, or out of
-   them, is a change to what the column holds, and the board restyles every element it holds for
-   that; sliding it instead costs nothing. */
+/* Outside the column's flow and standing there for good: carrying it into the cards, or out of
+   them, restyles every element the board holds. */
 .board-drop-placeholder {
   position: absolute;
   /* It stands over the cards whether it is showing or not, and a press belongs to the card under
@@ -771,8 +769,7 @@ body.mobile .board-view-container .board-add-column {
 }
 
 /* The room the gap takes out of the column, so it still scrolls past its last card while one is
-   held there. It stands in the flow at no height, and is given one for as long as the gap needs
-   it: growing an element that stays put costs nothing, where adding one does not. */
+   held there. Grown from nothing rather than added, an element that stays put costing nothing. */
 .board-drop-room {
   height: 0;
   flex-shrink: 0;
@@ -922,9 +919,8 @@ body.mobile .column-drop-placeholder {
   overflow: hidden;
 }
 
-/* The cards stay in the page while the column is a strip, and this is what stops them being drawn.
-   Taking them out instead costs a quarter of a second to close and over a second to open, both of
-   which land on the frames the width is animating across. */
+/* What stops a strip's cards being drawn while they stay in the page. Taking them out instead
+   lands on the frames the width is animating across. */
 .board-view-container .board-column.collapsed > .board-column-content {
   content-visibility: hidden;
 }
@@ -952,15 +948,10 @@ body.mobile .column-drop-placeholder {
     width var(--board-expand-duration) ease;
 }
 
-/* The one frame the board is drawn in as a drag lifts something or lets it go. What the drag
-   carried aside by a transform already stands where the gap, or the new order, puts it, so the
-   transform has nothing left to ease: given a transition it would carry the element a full width,
-   or a column's width, from a place it never stood in. The gap is included so that it takes the
-   place of the card at once rather than fading into it. Written against the selectors above, which
-   it has to outweigh.
-
-   The cards are left out: a rule here reaches every one of them, and Chrome restyles all of them
-   for the few that move. `placeCard` writes this on those few instead. */
+/* The one frame the board is drawn in as a drag lifts something or lets it go, where everything
+   already stands where it is about to be drawn. Written against the selectors above, which it has
+   to outweigh. The cards are left out, a rule here reaching every one of them: `placeCard` writes
+   the same thing on the few that move. */
 .board-view-container.board-still .board-drop-placeholder,
 .board-view-container.board-still .board-column,
 .board-view-container.board-still .board-column.collapsed:not(.board-drag-preview),
@@ -991,9 +982,8 @@ body.mobile .column-drop-placeholder {
   width: calc(var(--board-column-width) - 2 * var(--board-column-border-width));
 }
 
-/* The heading stays where it is, and is revealed with the column; only the cards wait. Hidden by
-   one property on the body that scrolls them rather than by one on each card: a rule reaching
-   every card restyles the whole column. */
+/* The heading is revealed with the column; only the cards wait. Hidden by one property on the
+   body that scrolls them, a rule reaching every card restyling the whole column. */
 .board-view-container .board-column.expanding > .board-column-content,
 .board-view-container .board-column.expanding > .board-new-item {
   opacity: 0;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -769,7 +769,8 @@ body.mobile .board-view-container .board-add-column {
   border-radius: 8px;
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 0;
-  transition: opacity 0.15s ease;
+  /* Carried to where the column would land, the same way the columns it passes step aside. */
+  transition: opacity 0.15s ease, transform 0.2s ease;
 }
 
 body.mobile .column-drop-placeholder {
@@ -920,6 +921,16 @@ body.mobile .column-drop-placeholder {
 .board-view-container .board-column.quick-expand:not(.board-drag-preview) {
   transition: border-color 0.2s ease, transform 0.2s ease,
     width var(--board-expand-duration) ease;
+}
+
+/* The one frame the row is drawn in after a column is dropped. Each column already stands where
+   that order puts it, carried there by the transform the drag wrote, so taking the transform off
+   has nothing left to ease: given a transition it would carry the column a full width from a place
+   it never stood in. Written against the selectors above, which it has to outweigh. */
+.board-view-container.board-columns-landing .board-column,
+.board-view-container.board-columns-landing .board-column.collapsed:not(.board-drag-preview),
+.board-view-container.board-columns-landing .board-column.quick-expand:not(.board-drag-preview) {
+  transition: none;
 }
 
 /*

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -923,13 +923,13 @@ body.mobile .column-drop-placeholder {
     width var(--board-expand-duration) ease;
 }
 
-/* The one frame the row is drawn in after a column is dropped. Each column already stands where
-   that order puts it, carried there by the transform the drag wrote, so taking the transform off
-   has nothing left to ease: given a transition it would carry the column a full width from a place
-   it never stood in. Written against the selectors above, which it has to outweigh. */
-.board-view-container.board-columns-landing .board-column,
-.board-view-container.board-columns-landing .board-column.collapsed:not(.board-drag-preview),
-.board-view-container.board-columns-landing .board-column.quick-expand:not(.board-drag-preview) {
+/* The one frame the board is drawn in after something is dropped. Whatever was carried aside by a
+   transform already stands where the new order puts it, so taking the transform off has nothing
+   left to ease: given a transition it would carry the element a full width, or a card's height,
+   from a place it never stood in. Written against the selectors above, which it has to outweigh. */
+.board-view-container.board-landing .board-column,
+.board-view-container.board-landing .board-column.collapsed:not(.board-drag-preview),
+.board-view-container.board-landing .board-column.quick-expand:not(.board-drag-preview) {
   transition: none;
 }
 

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -946,13 +946,17 @@ body.mobile .column-drop-placeholder {
     width var(--board-expand-duration) ease;
 }
 
-/* The one frame the board is drawn in after something is dropped. Whatever was carried aside by a
-   transform already stands where the new order puts it, so taking the transform off has nothing
-   left to ease: given a transition it would carry the element a full width, or a card's height,
-   from a place it never stood in. Written against the selectors above, which it has to outweigh. */
-.board-view-container.board-landing .board-column,
-.board-view-container.board-landing .board-column.collapsed:not(.board-drag-preview),
-.board-view-container.board-landing .board-column.quick-expand:not(.board-drag-preview) {
+/* The one frame the board is drawn in as a drag lifts something or lets it go. What the drag
+   carried aside by a transform already stands where the gap, or the new order, puts it, so the
+   transform has nothing left to ease: given a transition it would carry the element a full width,
+   or a card's height, from a place it never stood in. The gap is included so that it takes the
+   place of the card at once rather than fading into it. Written against the selectors above, which
+   it has to outweigh. */
+.board-view-container.board-still .board-note,
+.board-view-container.board-still .board-drop-placeholder,
+.board-view-container.board-still .board-column,
+.board-view-container.board-still .board-column.collapsed:not(.board-drag-preview),
+.board-view-container.board-still .board-column.quick-expand:not(.board-drag-preview) {
   transition: none;
 }
 

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -519,6 +519,10 @@ body.mobile .board-view-container .board-add-column {
   overscroll-behavior-y: contain;
   /* What the gap is placed against, and what a card's `offsetTop` is then counted from. */
   position: relative;
+  /* Pinned rather than left to stretch: a column animates its own width open, and a body that
+     follows it lays out every card in it on every frame, their titles rewrapping as it grows.
+     Matches the column's content box, so a column standing still is drawn no differently. */
+  width: calc(var(--board-column-width) - 2 * var(--board-column-border-width));
 }
 
 /* And while something is carried, the end does not spring back either: the copy is positioned
@@ -976,17 +980,25 @@ body.mobile .column-drop-placeholder {
 /* The children are named rather than matched with `> *`: a universal selector cannot be narrowed
    into an invalidation set, so the class going on and off restyles the whole column. */
 .board-view-container .board-column.expanding > h3,
-.board-view-container .board-column.expanding > .board-column-content,
 .board-view-container .board-column.expanding > .board-new-item {
   width: calc(var(--board-column-width) - 2 * var(--board-column-border-width));
 }
 
-/* The heading stays where it is, and is revealed with the column; only the cards wait. They fade
-   in as the class is dropped, through the transition each of them already carries: the scrolling
-   body cannot, its own `transition` being the scroll fade's. */
-.board-view-container .board-column.expanding .board-note,
+/* The heading stays where it is, and is revealed with the column; only the cards wait. Hidden by
+   one property on the body that scrolls them rather than by one on each card: a rule reaching
+   every card restyles the whole column. */
+.board-view-container .board-column.expanding > .board-column-content,
 .board-view-container .board-column.expanding > .board-new-item {
   opacity: 0;
+}
+
+/* Carries the fade the cards are revealed by. Restated rather than added to, `transition` being a
+   single property: the two fade entries must match `.scroll-fade` in scroll_fade.css. */
+.board-view-container .board-column-content {
+  transition:
+    --scroll-fade-start var(--scroll-fade-duration, 300ms) ease,
+    --scroll-fade-end var(--scroll-fade-duration, 300ms) ease,
+    opacity 0.15s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -997,9 +1009,14 @@ body.mobile .column-drop-placeholder {
   }
 
   /* The column is at its width already, so there is nothing for the cards to wait for. */
-  .board-view-container .board-column.expanding .board-note,
+  .board-view-container .board-column.expanding > .board-column-content,
   .board-view-container .board-column.expanding > .board-new-item {
     opacity: 1;
+  }
+
+  /* `.scroll-fade` turns its own off here, and the rule above outweighs it. */
+  .board-view-container .board-column-content {
+    transition: none;
   }
 }
 

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -922,6 +922,13 @@ body.mobile .column-drop-placeholder {
   overflow: hidden;
 }
 
+/* The cards stay in the page while the column is a strip, and this is what stops them being drawn.
+   Taking them out instead costs a quarter of a second to close and over a second to open, both of
+   which land on the frames the width is animating across. */
+.board-view-container .board-column.collapsed > .board-column-content {
+  content-visibility: hidden;
+}
+
 /* Width and not a transform: the columns beside it have to move with it. The copy being carried is
    left out, or it would ease towards each frame's position instead of taking it: its `transition:
    none` above carries no more weight than this rule and stands above it in the file. */

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -507,11 +507,6 @@ body.mobile .board-view-container .board-add-column {
   box-shadow: 4px 8px 16px rgba(0, 0, 0, 0.5);
 }
 
-/* While a card is carried, so the page does not take the touch for a scroll. */
-.board-view-container.board-dragging {
-  touch-action: none;
-}
-
 /* Reaching the end of the board scrolls neither the page nor anything else. */
 .board-view-container {
   overscroll-behavior: contain;
@@ -949,10 +944,12 @@ body.mobile .column-drop-placeholder {
 /* The one frame the board is drawn in as a drag lifts something or lets it go. What the drag
    carried aside by a transform already stands where the gap, or the new order, puts it, so the
    transform has nothing left to ease: given a transition it would carry the element a full width,
-   or a card's height, from a place it never stood in. The gap is included so that it takes the
+   or a column's width, from a place it never stood in. The gap is included so that it takes the
    place of the card at once rather than fading into it. Written against the selectors above, which
-   it has to outweigh. */
-.board-view-container.board-still .board-note,
+   it has to outweigh.
+
+   The cards are left out: a rule here reaches every one of them, and Chrome restyles all of them
+   for the few that move. `placeCard` writes this on those few instead. */
 .board-view-container.board-still .board-drop-placeholder,
 .board-view-container.board-still .board-column,
 .board-view-container.board-still .board-column.collapsed:not(.board-drag-preview),
@@ -976,7 +973,11 @@ body.mobile .column-drop-placeholder {
   overflow: hidden;
 }
 
-.board-view-container .board-column.expanding > * {
+/* The children are named rather than matched with `> *`: a universal selector cannot be narrowed
+   into an invalidation set, so the class going on and off restyles the whole column. */
+.board-view-container .board-column.expanding > h3,
+.board-view-container .board-column.expanding > .board-column-content,
+.board-view-container .board-column.expanding > .board-new-item {
   width: calc(var(--board-column-width) - 2 * var(--board-column-border-width));
 }
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -271,8 +271,12 @@ describe("Collapsed board columns", () => {
     const isCollapsed = (container: HTMLElement, index: number) =>
         columnAt(container, index).classList.contains("collapsed");
 
+    // How many cards the column draws. A strip holds its own in the page without drawing them,
+    // which is what the reader sees and what the keyboard and a drag both go by.
     const cardCount = (container: HTMLElement, index: number) =>
-        columnAt(container, index).querySelectorAll(".board-note").length;
+        isCollapsed(container, index)
+            ? 0
+            : columnAt(container, index).querySelectorAll(".board-note").length;
 
     /** Selects a column the way a click on it does, press and release included. */
     async function select(container: HTMLElement, index: number) {
@@ -301,6 +305,8 @@ describe("Collapsed board columns", () => {
         expect(cardCount(mountPoint, 0)).toBe(0);
         // The count is what the strip reports in place of the cards.
         expect(columnAt(mountPoint, 0).querySelector(".counter-badge")?.textContent).toBe("2");
+        // Never drawn at all, so a reader who keeps a long column closed pays nothing for it.
+        expect(columnAt(mountPoint, 0).querySelector(".board-column-content")).toBeNull();
 
         // Every other column is untouched.
         expect(isCollapsed(mountPoint, 1)).toBe(false);
@@ -317,6 +323,10 @@ describe("Collapsed board columns", () => {
         await select(mountPoint, 1);
         expect(isCollapsed(mountPoint, 0)).toBe(true);
         expect(cardCount(mountPoint, 0)).toBe(0);
+        // Held in the page once they have been drawn once, the stylesheet keeping them off the
+        // screen: taking them out again is what makes a column of thousands close in three frames.
+        expect(columnAt(mountPoint, 0)
+            .querySelectorAll(":scope > .board-column-content > .board-note")).toHaveLength(2);
     });
 
     /**

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -788,12 +788,16 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     }, []);
 
     // A board taken off the page leaves nothing of a gesture behind it to run in a later frame.
-    useEffect(() => () => {
-        if (stillFor.current !== undefined) {
-            cancelAnimationFrame(stillFor.current);
-        }
+    // The container is held from the mount: a ref is empty again by the time this is called.
+    useEffect(() => {
+        const container = containerRef.current;
+        return () => {
+            if (stillFor.current !== undefined) {
+                cancelAnimationFrame(stillFor.current);
+            }
 
-        settleCards();
+            settleCards(container);
+        };
     }, []);
 
     const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -592,10 +592,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // card's own dimming are drawn from one place whichever brought the card here.
     const { isDragging: isDraggingItem, remeasure } = useBoardDrag(containerRef, {
         onCardStart: (card) => {
-            // The card leaves the flow as it is lifted, and the gap opens in its place by pushing
-            // the cards below it down again. Under their transition that reads as the column
-            // closing up and then sliding back open, so the frame the gap opens in runs without
-            // one and the column is left looking untouched.
+            // The card leaves the flow and the gap opens in its place, which eased would read as
+            // the column closing up and sliding back open.
             holdStill();
             setDraggedCard({
                 noteId: card.noteId,
@@ -616,9 +614,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             }
         },
         onCardEnd: (card, position) => {
-            // The cards below the gap carry a `translateY` that the drop replaces with the layout
-            // the reorder gives them. Cleared under their transition, they slide up from a place
-            // they never stood in, so the frame the new order is drawn in runs without one.
+            // The reorder gives the cards below the gap the layout their `translateY` was
+            // standing in for, so clearing it under a transition would slide them up.
             holdStill();
             // Put back here rather than left to the columns to draw: the board is about to move a
             // card, hide the gap and close the room it took, and if those reach the screen in
@@ -766,19 +763,28 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // landed among them all once some are archived and hidden. Translated here so a reorder leaves
     // every hidden column where it was rather than herding them to the end.
     /**
-     * Draws the next frame without transitions.
+     * Draws the next frame without transitions, for the lift and the drop, where every element is
+     * already standing where it is about to be drawn.
      *
-     * A drag opens its gap with transforms, and the board draws the elements those transforms
-     * already moved: at the lift the gap replaces the card that has left the flow, and at the drop
-     * the reorder replaces the gap. Eased, each element would set off from a place it never stood
-     * in. Taken off a frame later than the one that draws it, since a frame's callbacks run before
-     * the styles it paints are worked out.
+     * Let go a frame later than the one that draws it, a frame's callbacks running before the
+     * styles it paints are worked out.
      */
+    const stillFor = useRef<number>();
     const holdStill = useCallback(() => {
         const container = containerRef.current;
         container?.classList.add("board-still");
-        requestAnimationFrame(() => requestAnimationFrame(
-            () => container?.classList.remove("board-still")));
+        // Started afresh on every call: a lift and the drop that follows it a frame later would
+        // otherwise be let go on the first one's schedule, before the drop has been drawn.
+        if (stillFor.current !== undefined) {
+            cancelAnimationFrame(stillFor.current);
+        }
+
+        stillFor.current = requestAnimationFrame(() => {
+            stillFor.current = requestAnimationFrame(() => {
+                stillFor.current = undefined;
+                container?.classList.remove("board-still");
+            });
+        });
     }, []);
 
     const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {
@@ -978,10 +984,8 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
  * Puts every card back where the column draws it, closes every gap and gives back the room they
  * took.
  *
- * The columns do this for themselves as they are drawn, but a drop moves a card, hides a gap and
- * closes its room in one go, and those reaching the screen in separate frames is a gap the reader
- * sees open where nothing is being carried. Done here first, the board is already tidy whichever
- * way the drawing falls.
+ * The columns do this for themselves as they are drawn, but a drop is three changes at once and
+ * the reader sees a gap standing open if they reach the screen in separate frames.
  */
 function closeGaps(container: HTMLElement | null) {
     if (!container) {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -591,13 +591,20 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // The gesture drives the same state a drag from the note tree does, so the placeholders and the
     // card's own dimming are drawn from one place whichever brought the card here.
     const { isDragging: isDraggingItem, remeasure } = useBoardDrag(containerRef, {
-        onCardStart: (card) => setDraggedCard({
-            noteId: card.noteId,
-            branchId: byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId ?? "",
-            fromColumn: card.fromColumn,
-            index: card.index,
-            height: card.height
-        }),
+        onCardStart: (card) => {
+            // The card leaves the flow as it is lifted, and the gap opens in its place by pushing
+            // the cards below it down again. Under their transition that reads as the column
+            // closing up and then sliding back open, so the frame the gap opens in runs without
+            // one and the column is left looking untouched.
+            holdStill();
+            setDraggedCard({
+                noteId: card.noteId,
+                branchId: byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId ?? "",
+                fromColumn: card.fromColumn,
+                index: card.index,
+                height: card.height
+            });
+        },
         onCardMove: (position, inside) => {
             // Written together: two writes would wake every column watching the gap twice over.
             dropState.set({ position, target: position?.column ?? null });
@@ -609,6 +616,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             }
         },
         onCardEnd: (card, position) => {
+            // The cards below the gap carry a `translateY` that the drop replaces with the layout
+            // the reorder gives them. Cleared under their transition, they slide up from a place
+            // they never stood in, so the frame the new order is drawn in runs without one.
+            holdStill();
             // Put back here rather than left to the columns to draw: the board is about to move a
             // card, hide the gap and close the room it took, and if those reach the screen in
             // separate frames the reader sees a gap open where nothing is being carried any more.
@@ -659,7 +670,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                 // where each column already stands where that order puts it. Eased to zero they
                 // would carry it a column's width from a place it never stood in, so the frame
                 // that takes them off runs without a transition.
-                land();
+                holdStill();
                 // Not animated either: the row puts the columns exactly where they already are.
                 handleColumnDrop(from, to, false);
             }
@@ -757,16 +768,17 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     /**
      * Draws the next frame without transitions.
      *
-     * What a drag carried aside it carried by a transform, and the board is about to draw it where
-     * that transform already had it. Eased instead, each element would set off from a place it
-     * never stood in. Taken off a frame later than the one that draws it, since a frame's
-     * callbacks run before the styles it paints are worked out.
+     * A drag opens its gap with transforms, and the board draws the elements those transforms
+     * already moved: at the lift the gap replaces the card that has left the flow, and at the drop
+     * the reorder replaces the gap. Eased, each element would set off from a place it never stood
+     * in. Taken off a frame later than the one that draws it, since a frame's callbacks run before
+     * the styles it paints are worked out.
      */
-    const land = useCallback(() => {
+    const holdStill = useCallback(() => {
         const container = containerRef.current;
-        container?.classList.add("board-landing");
+        container?.classList.add("board-still");
         requestAnimationFrame(() => requestAnimationFrame(
-            () => container?.classList.remove("board-landing")));
+            () => container?.classList.remove("board-still")));
     }, []);
 
     const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -40,7 +40,7 @@ import { CollectionFilterInput, useCollectionFilter } from "../collection_filter
 import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
 import { useBoardDrag } from "./board_drag";
-import { movesColumn } from "./drag_geometry";
+import { columnGapStandsAside, columnStandsAside, movesColumn } from "./drag_geometry";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { DEFAULT_COLUMN_ICON, DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
@@ -130,6 +130,10 @@ interface ColumnDrag {
     index: number;
     /** What the column measures, so the gap held open for it is the size it will land in. */
     size?: { width: number, height: number };
+    /** How much room it takes out of the row, its width and the gap after it. */
+    stride?: number;
+    /** Where each column stood before it was taken out, and where one added at the end would. */
+    lefts?: number[];
 }
 
 /**
@@ -628,11 +632,30 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                 revealColumn(position.column);
             }
         },
-        onColumnStart: (column, index, size) => setDraggedColumn({ column, index, size }),
+        onColumnStart: (column, index, size, row) => setDraggedColumn({
+            column, index, size, stride: row.stride, lefts: row.lefts
+        }),
         onColumnMove: setColumnDropPosition,
         onColumnEnd: (from, to) => {
+            // The row is drawn again as the gesture lets go, and the columns land where their
+            // transforms already had them. No card moves inside a column for that, so the same
+            // window that covers a column changing width covers this too.
+            columnResizingUntil.current = Date.now() + EXPAND_MS;
             if (to !== null && movesColumn(from, to)) {
-                handleColumnDrop(from, to);
+                // The transforms come off in the same frame the row is drawn in its new order,
+                // where each column already stands where that order puts it. Eased to zero they
+                // would carry it a column's width from a place it never stood in, so the frame
+                // that takes them off runs without a transition.
+                const container = containerRef.current;
+                container?.classList.add("board-columns-landing");
+
+                // Taken off a frame after the one that draws the row, not on it: a frame's
+                // callbacks run before the styles it paints are worked out, so putting the
+                // transition back in the first of them puts it back in time to be used.
+                requestAnimationFrame(() => requestAnimationFrame(
+                    () => container?.classList.remove("board-columns-landing")));
+                // Not animated either: the row puts the columns exactly where they already are.
+                handleColumnDrop(from, to, false);
             }
             setDraggedColumn(null);
             setColumnDropPosition(null);
@@ -665,8 +688,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
         axis: "horizontal",
         // Only for a move the reader made, tracked by `columnMovedUntil`. A value change redraws
         // the columns, and the order churns while the cards, the definition and the stored config
-        // catch up with one another; sliding for that animates a rename as a move.
-        disabled: !draggedColumn && Date.now() > columnMovedUntil.current
+        // catch up with one another; sliding for that animates a rename as a move. A carried
+        // column is left out as well: the columns beside it are moved by their own transforms,
+        // which this would measure and then slide back from.
+        disabled: !!draggedColumn || Date.now() > columnMovedUntil.current
     });
 
     /**
@@ -723,8 +748,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // The drag reports where the column landed among the ones on screen, which is not where it
     // landed among them all once some are archived and hidden. Translated here so a reorder leaves
     // every hidden column where it was rather than herding them to the end.
-    const handleColumnDrop = useCallback((fromIndex: number, toIndex: number) => {
-        columnMovedUntil.current = Date.now() + FLIP_SETTLE_MS;
+    const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {
+        if (animate) {
+            columnMovedUntil.current = Date.now() + FLIP_SETTLE_MS;
+        }
         // The list the api holds, which is also the one it reorders. A column the board is not
         // showing is in neither, so indexing into `columns` would be off by one.
         const allColumns = api.columns;
@@ -809,10 +836,16 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                         <div className="board-columns">
                         {shownColumns.map((column, index) => (
                             <Fragment key={column}>
-                                {columnDropPosition === index && (
+                                {draggedColumn?.index === index && (
                                     <div
                                         className="column-drop-placeholder show"
-                                        style={placeholderSize}
+                                        style={{
+                                            ...placeholderSize,
+                                            transform: `translateX(${columnGapStandsAside(
+                                                draggedColumn.index, columnDropPosition,
+                                                draggedColumn.lefts ?? [],
+                                                draggedColumn.stride ?? 0)}px)`
+                                        }}
                                     />
                                 )}
                                 <Column
@@ -828,6 +861,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                                     isActive={activeColumn === column}
                                     isPeeked={isPeekingAll}
                                     isResizing={isResizingColumns}
+                                    standsAside={draggedColumn
+                                        ? columnStandsAside(index, draggedColumn.index,
+                                            columnDropPosition, draggedColumn.stride ?? 0)
+                                        : 0}
                                     cardTemplates={cardTemplates}
                                     nested={storedColumns.get(column)?.nested}
                                     limit={storedColumns.get(column)?.limit}
@@ -842,9 +879,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                                 />
                             </Fragment>
                         ))}
-                        {columnDropPosition === shownColumns.length && draggedColumn && (
-                            <div className="column-drop-placeholder show" style={placeholderSize} />
-                        )}
+
                         </div>
 
                         <AddNewColumn

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -45,7 +45,7 @@ import { forgetCardHeights } from "./drag_measure";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { DEFAULT_COLUMN_ICON, DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
-import Column, { EXPAND_MS } from "./column";
+import Column, { EXPAND_MS, placeCard } from "./column";
 import { currentCardTemplate, DEFAULT_CARD_TEMPLATES } from "./card_templates";
 import ColumnLimitDialog from "./column_limit";
 import BoardProperties from "./properties";
@@ -990,7 +990,7 @@ function closeGaps(container: HTMLElement | null) {
 
     for (const card of container.querySelectorAll<HTMLElement>(".board-note")) {
         if (card.style.transform) {
-            card.style.removeProperty("transform");
+            placeCard(card, null, true);
         }
     }
 

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -44,7 +44,7 @@ import { movesColumn } from "./drag_geometry";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { DEFAULT_COLUMN_ICON, DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
-import Column from "./column";
+import Column, { EXPAND_MS } from "./column";
 import { currentCardTemplate, DEFAULT_CARD_TEMPLATES } from "./card_templates";
 import ColumnLimitDialog from "./column_limit";
 import BoardProperties from "./properties";
@@ -470,6 +470,21 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     /** Until when a column move can still be settling, which is when `useFlip` slides columns. */
     const columnMovedUntil = useRef(0);
 
+    // Which columns stand narrow, as a line, so that one opening or closing is read off a single
+    // comparison. A column changing width hides or shows its own cards and moves no card inside
+    // any other, so there is nothing for any column to measure while it is happening.
+    const columnResizingUntil = useRef(0);
+    const columnWidths = useRef<string>();
+    const widths = shownColumns
+        .map(column => storedColumns.get(column)?.collapsed
+            && column !== activeColumn && !isPeekingAll ? "1" : "0")
+        .join("");
+    if (columnWidths.current !== undefined && columnWidths.current !== widths) {
+        columnResizingUntil.current = Date.now() + EXPAND_MS;
+    }
+    columnWidths.current = widths;
+    const isResizingColumns = Date.now() < columnResizingUntil.current;
+
     const boardDragState = useMemo<BoardDragState>(() => ({
         branchIdToEdit,
         columnNameToEdit,
@@ -812,6 +827,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                                     keepCollapsed={storedColumns.get(column)?.keepCollapsed}
                                     isActive={activeColumn === column}
                                     isPeeked={isPeekingAll}
+                                    isResizing={isResizingColumns}
                                     cardTemplates={cardTemplates}
                                     nested={storedColumns.get(column)?.nested}
                                     limit={storedColumns.get(column)?.limit}

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -41,6 +41,7 @@ import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
 import { useBoardDrag } from "./board_drag";
 import { columnGapStandsAside, columnStandsAside, movesColumn } from "./drag_geometry";
+import { forgetCardHeights } from "./drag_measure";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { DEFAULT_COLUMN_ICON, DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
@@ -473,6 +474,14 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     const containerRef = useRef<HTMLDivElement>(null);
     /** Until when a column move can still be settling, which is when `useFlip` slides columns. */
     const columnMovedUntil = useRef(0);
+
+    // What a card measures is kept between drags, which holds while a column is the width it was
+    // measured at. A phone gives a column a share of the window, so a window that changes size
+    // takes the heights with it.
+    useEffect(() => {
+        window.addEventListener("resize", forgetCardHeights);
+        return () => window.removeEventListener("resize", forgetCardHeights);
+    }, []);
 
     // Which columns stand narrow, as a line, so that one opening or closing is read off a single
     // comparison. A column changing width hides or shows its own cards and moves no card inside

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -45,7 +45,7 @@ import { forgetCardHeights } from "./drag_measure";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { DEFAULT_COLUMN_ICON, DEFAULT_GROUP_BY, getStatusDefinition, INBOX_COLUMN } from "./columns";
-import Column, { EXPAND_MS, placeCard } from "./column";
+import Column, { EXPAND_MS, placeCard, settleCards } from "./column";
 import { currentCardTemplate, DEFAULT_CARD_TEMPLATES } from "./card_templates";
 import ColumnLimitDialog from "./column_limit";
 import BoardProperties from "./properties";
@@ -785,6 +785,15 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                 container?.classList.remove("board-still");
             });
         });
+    }, []);
+
+    // A board taken off the page leaves nothing of a gesture behind it to run in a later frame.
+    useEffect(() => () => {
+        if (stillFor.current !== undefined) {
+            cancelAnimationFrame(stillFor.current);
+        }
+
+        settleCards();
     }, []);
 
     const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -655,14 +655,7 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
                 // where each column already stands where that order puts it. Eased to zero they
                 // would carry it a column's width from a place it never stood in, so the frame
                 // that takes them off runs without a transition.
-                const container = containerRef.current;
-                container?.classList.add("board-columns-landing");
-
-                // Taken off a frame after the one that draws the row, not on it: a frame's
-                // callbacks run before the styles it paints are worked out, so putting the
-                // transition back in the first of them puts it back in time to be used.
-                requestAnimationFrame(() => requestAnimationFrame(
-                    () => container?.classList.remove("board-columns-landing")));
+                land();
                 // Not animated either: the row puts the columns exactly where they already are.
                 handleColumnDrop(from, to, false);
             }
@@ -757,6 +750,21 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
     // The drag reports where the column landed among the ones on screen, which is not where it
     // landed among them all once some are archived and hidden. Translated here so a reorder leaves
     // every hidden column where it was rather than herding them to the end.
+    /**
+     * Draws the next frame without transitions.
+     *
+     * What a drag carried aside it carried by a transform, and the board is about to draw it where
+     * that transform already had it. Eased instead, each element would set off from a place it
+     * never stood in. Taken off a frame later than the one that draws it, since a frame's
+     * callbacks run before the styles it paints are worked out.
+     */
+    const land = useCallback(() => {
+        const container = containerRef.current;
+        container?.classList.add("board-landing");
+        requestAnimationFrame(() => requestAnimationFrame(
+            () => container?.classList.remove("board-landing")));
+    }, []);
+
     const handleColumnDrop = useCallback((fromIndex: number, toIndex: number, animate = true) => {
         if (animate) {
             columnMovedUntil.current = Date.now() + FLIP_SETTLE_MS;

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -609,6 +609,10 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
             }
         },
         onCardEnd: (card, position) => {
+            // Put back here rather than left to the columns to draw: the board is about to move a
+            // card, hide the gap and close the room it took, and if those reach the screen in
+            // separate frames the reader sees a gap open where nothing is being carried any more.
+            closeGaps(containerRef.current);
             const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
             if (position && branchId && byColumn && allByColumn) {
                 // Drawn at once, into `allByColumn` since that is what `byColumn` derives from, at
@@ -958,6 +962,35 @@ export default function BoardView({ note: parentNote, noteIds, viewConfig, saveC
  * Naming the winning check, rather than returning a boolean, is what lets the profiler attribute a
  * redraw to a cause.
  */
+/**
+ * Puts every card back where the column draws it, closes every gap and gives back the room they
+ * took.
+ *
+ * The columns do this for themselves as they are drawn, but a drop moves a card, hides a gap and
+ * closes its room in one go, and those reaching the screen in separate frames is a gap the reader
+ * sees open where nothing is being carried. Done here first, the board is already tidy whichever
+ * way the drawing falls.
+ */
+function closeGaps(container: HTMLElement | null) {
+    if (!container) {
+        return;
+    }
+
+    for (const card of container.querySelectorAll<HTMLElement>(".board-note")) {
+        if (card.style.transform) {
+            card.style.removeProperty("transform");
+        }
+    }
+
+    for (const gap of container.querySelectorAll(".board-drop-placeholder")) {
+        gap.classList.remove("show");
+    }
+
+    for (const room of container.querySelectorAll<HTMLElement>(".board-drop-room")) {
+        room.style.height = "0px";
+    }
+}
+
 export function findRefreshReason(loadResults: LoadResults, statusAttribute: string, noteIds: string[], parentNoteId: string): string | null {
     // A card moved between columns.
     if (loadResults.getAttributeRows().some(attr => attr.name === statusAttribute && noteIds.includes(attr.noteId ?? ""))) {

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -1,3 +1,4 @@
+import { cardFollows } from "./columns";
 import { RefObject } from "preact";
 import { useCallback, useLayoutEffect, useRef } from "preact/hooks";
 
@@ -502,7 +503,7 @@ function reveal(element: HTMLElement) {
         // The last card scrolls its column to the end rather than just into view: its own bottom
         // margin and the fade over the column's bottom edge would otherwise cover it.
         const content = element.closest<HTMLElement>(".board-column-content");
-        if (content && !element.nextElementSibling) {
+        if (content && !cardFollows(element)) {
             content.scrollTop = content.scrollHeight;
         }
 

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -578,5 +578,10 @@ function columnsOf(container: HTMLElement) {
 }
 
 function cardsOf(column: Element | undefined) {
-    return column ? [ ...column.querySelectorAll<HTMLElement>(".board-note") ] : [];
+    // A strip holds its cards in the page but draws none of them, so it offers none to walk onto.
+    if (!column || column.classList.contains("collapsed")) {
+        return [];
+    }
+
+    return [ ...column.querySelectorAll<HTMLElement>(".board-note") ];
 }

--- a/apps/client/src/widgets/react/Card.css
+++ b/apps/client/src/widgets/react/Card.css
@@ -177,10 +177,8 @@ body[dir=rtl] .tn-card-option::after {
 }
 
 /* On a narrow card a text box, a combo or any other wide control has no room left beside its label,
-   so it takes the line below it instead. Small controls stay beside the label: they leave it room,
-   and moving a switch down would cost a whole row and break the line the labels are read down. A
-   bare figure is small enough to stay; one carrying a unit beside it is not. A chevron is no
-   control at all but the mark of a row that leads somewhere, and keeps its place at every width. */
+   so it takes the line below it instead. `OptionCardSection` reads which control a row holds and
+   marks the wide ones; `SMALL_CONTROLS` there is the list that stays beside the label. */
 @container (max-width: 500px) {
     /* On a narrow card the name reads as a field label, set apart by weight rather than by size.
        Every row gets it, or a card would mix two kinds of label between its rows. */
@@ -194,10 +192,7 @@ body[dir=rtl] .tn-card-option::after {
         --card-padding-block: 12px;
     }
 
-    .tn-card-option:not(:has(> :is(
-        .switch-widget, .icon-action, .tn-card-option-actions, select, .dropdown,
-        .tn-card-section-chevron, input[type="number"]
-    ))) {
+    .tn-card-option-wide {
         flex-direction: column;
         align-items: stretch;
         /* Down the page the label already leads its control, so they need less room between. */

--- a/apps/client/src/widgets/react/Card.spec.tsx
+++ b/apps/client/src/widgets/react/Card.spec.tsx
@@ -1,3 +1,5 @@
+import { ComponentChild } from "preact";
+import { act } from "preact/test-utils";
 import { describe, expect, it, vi } from "vitest";
 
 import { renderInto } from "../../test/render";
@@ -108,6 +110,30 @@ describe("OptionCardSection", () => {
 
         const stacked = renderInto(<OptionCardSection label="Address" stacked><input /></OptionCardSection>);
         expect(stacked.querySelector(".tn-card-option")?.className).toContain("tn-card-option-stacked");
+    });
+
+    /**
+     * Which control a row holds is read off the row rather than matched by a `:has()` rule, a rule
+     * of that shape costing a restyle of the whole document on every change made anywhere in it.
+     */
+    it("marks a row whose control has no room to stand beside its label", () => {
+        // The row is read once it stands in the page, so the draw has to have settled.
+        const draw = (node: ComponentChild) => {
+            let container: HTMLElement | undefined;
+            act(() => { container = renderInto(node); });
+            return container?.querySelector(".tn-card-option")?.className ?? "";
+        };
+
+        expect(draw(<OptionCardSection label="Address"><input type="text" /></OptionCardSection>))
+            .toContain("tn-card-option-wide");
+        expect(draw(<OptionCardSection label="Enabled"><span className="switch-widget" /></OptionCardSection>))
+            .not.toContain("tn-card-option-wide");
+        expect(draw(<OptionCardSection label="Copies"><input type="number" /></OptionCardSection>))
+            .not.toContain("tn-card-option-wide");
+        // A row that leads somewhere carries a chevron rather than a control, and keeps its place
+        // at every width.
+        expect(draw(<OptionCardSection label="Backup" href="#root/_hidden/_options" />))
+            .not.toContain("tn-card-option-wide");
     });
 });
 

--- a/apps/client/src/widgets/react/Card.tsx
+++ b/apps/client/src/widgets/react/Card.tsx
@@ -1,7 +1,7 @@
 import "./Card.css";
 import { cloneElement, ComponentChildren, createContext, isValidElement } from "preact";
 import { JSX, HTMLAttributes } from "preact";
-import { useContext } from "preact/hooks";
+import { useCallback, useContext, useLayoutEffect, useRef, useState } from "preact/hooks";
 import clsx from "clsx";
 
 import {
@@ -117,6 +117,8 @@ export interface CardSectionProps {
      * as any of them is (see {@link FilterRole}).
      */
     filterRole?: FilterRole;
+    /** Hands back the element the section is drawn as, for a caller that reads what it holds. */
+    elementRef?: (element: HTMLElement | null) => void;
 }
 
 interface CardSectionContextType {
@@ -139,6 +141,7 @@ export function CardSection(props: {children: ComponentChildren} & CardSectionPr
     return <>
         {props.href
             ? <a className={clsx(className, "tn-card-section-link", "no-tooltip-preview")}
+                 ref={props.elementRef}
                  style={style}
                  href={props.href}
                  data-no-contained-navigation={props.noContainedNavigation ? "" : undefined}
@@ -147,6 +150,7 @@ export function CardSection(props: {children: ComponentChildren} & CardSectionPr
                 <span className="tn-card-section-chevron" />
             </a>
             : <section className={className}
+                       ref={props.elementRef}
                        style={style}
                        onClick={props.onAction}>
                 {props.children}
@@ -205,11 +209,24 @@ export function OptionCardSection(props: OptionCardSectionProps) {
     const filtering = useIsFiltering();
     const id = useUniqueName(name);
     const bound = !!name && isValidElement(children);
+    const row = useRef<HTMLElement | null>(null);
+    const keepRow = useCallback((element: HTMLElement | null) => { row.current = element; }, []);
+    const [ wide, setWide ] = useState(false);
+
+    // Whether the control is one of the wide ones, which stack under the label on a narrow card.
+    // Read off the row rather than matched by a `:has()` rule: Chrome restyles the whole document
+    // on every structural change anywhere in it for as long as such a rule is loaded.
+    useLayoutEffect(() => {
+        const element = row.current;
+        setWide(!!element && !holdsSmallControl(element));
+    });
 
     if (!matched && !subSections) return null;
 
-    return <CardSection className={clsx("tn-card-option", className, {
-                            "tn-card-option-stacked": stacked
+    return <CardSection elementRef={keepRow}
+                        className={clsx("tn-card-option", className, {
+                            "tn-card-option-stacked": stacked,
+                            "tn-card-option-wide": wide
                         })}
                         // Kept for its details rather than itself, which is what a companion is.
                         filterRole={filtering ? (matched ? "match" : "companion") : undefined}
@@ -227,6 +244,26 @@ export function OptionCardSection(props: OptionCardSectionProps) {
 
         {bound ? cloneElement(children, { id }) : children}
     </CardSection>;
+}
+
+/**
+ * Controls small enough to stay beside their label on a narrow card.
+ *
+ * A switch moved below its label would cost a whole row and break the line the labels are read
+ * down. A bare figure is small enough to stay; one carrying a unit beside it is not. A chevron is
+ * no control at all but the mark of a row that leads somewhere, and keeps its place at every width.
+ */
+const SMALL_CONTROLS = ".switch-widget, .icon-action, .tn-card-option-actions, select, .dropdown,"
+    + " .tn-card-section-chevron, input[type=\"number\"]";
+
+function holdsSmallControl(element: HTMLElement) {
+    for (const child of element.children) {
+        if (child.matches(SMALL_CONTROLS)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 // #endregion

--- a/apps/client/src/widgets/react/flip.ts
+++ b/apps/client/src/widgets/react/flip.ts
@@ -37,8 +37,8 @@ export interface FlipOptions {
      * Whether to stop measuring the children while keeping the places they were last measured at.
      *
      * For a container that is not taking part yet: its children still stand where they were
-     * measured, so it slides them from there the moment it does take part. Takes precedence over
-     * {@link disabled}.
+     * measured, so it slides them from there the moment it does take part. Where {@link disabled}
+     * is set as well, the places are dropped: forgetting outranks remembering.
      */
     paused?: boolean;
 }


### PR DESCRIPTION
Boards holding thousands of cards now stay responsive while they are being worked in. Picking a card up, carrying it between columns, dropping it, reordering columns, collapsing and expanding them, and adding or removing cards no longer stop the interface for a second or more at a time. The largest gains are on the biggest boards, and several of the changes reach the rest of the application as well, because the cost they remove was being paid on every click and on every change made to the page.

### Style recalculation

- Replace the `.tn-card-option:not(:has(> :is(…)))` layout rule with a `tn-card-option-wide` class that `OptionCardSection` sets from the control the row actually holds, a `:has()` rule of that shape costing a restyle of the whole document on every structural change made anywhere in it.
- Remove `div.promoted-attribute-cell .multiplicity:has(span)` and its child rule from the Next theme, along with the `.multiplicity` rule in the base stylesheet, no client code having rendered that class since promoted attributes were ported to Preact.
- Remove `touch-action: none` from `.board-view-container.board-dragging`, the non-passive `touchmove` handler in `board_drag.ts` already refusing the scroll, where the property change cost Chrome a pass over the whole subtree at each end of every drag.
- Drop the `:not(:has(.multiplicity > span))` clause from the boolean promoted-attribute rule, which the class no longer being rendered made always true.
- Suppress a card's transform transition on the card itself, through `placeCard`, rather than under a `.board-still` rule that matched every card on the board.
- Hide a column's cards while it expands with one `opacity` on the scrolling body instead of one rule reaching each card.
- Name the children of `.board-column.expanding` rather than matching them with `> *`, a universal selector not being reducible to an invalidation set.
- Add an `elementRef` callback to `CardSectionProps`, so a card section can hand back the element it is drawn as.

### Carrying and dropping a card

- Hold the drop gap and the room it takes as two permanent elements in every column, sliding the gap by transform rather than inserting an element among the cards.
- Move at most thirty cards below the gap out of its way, instead of every card beneath it.
- Take every transition off for the one frame that lifts a card and the one frame that drops it, so no element eases out of a place it never stood in.
- Put every card back, hide every gap and close every room in a single step as a card is let go, rather than leaving each column to draw it in its own frame.
- Remember what each card measures between drags, keyed by note, so a drag reads one rectangle per column instead of one per card.
- Forget the remembered heights when the window is resized, a phone giving each column a share of the window.
- Read whether a card is the last of its column by walking to the next `.board-note`, the gap and the room now always standing after it.

### Reordering columns

- Step the columns that a carried column passes aside by a transform, leaving the row's order untouched until it is let go.
- Slide the gap held open for the carried column to the place it would land, in step with the columns that moved for it.
- Measure the columns without their cards when a column is carried, nothing placing a column against them.
- Land the row without animation, every column already standing where the new order puts it.
- Give the column drop placeholder a transform transition, so it travels the way the columns beside it do.

### Collapsing and expanding a column

- Keep a collapsed column's cards in the page and stop them being drawn with `content-visibility: hidden`, rather than taking them out and building them again.
- Draw a column's cards only once it has been open, so a board that opens with a long column collapsed builds none of them.
- Pin the scrolling body to the column's content width at all times, so its cards are not laid out again on each frame of a widening.
- Treat a collapsed column as holding no cards in both the keyboard walk and the drag measurement.

### Measurement and animation

- Measure a column's card positions only when its own cards have changed, rather than whenever anything redraws the board.
- Switch `useFlip` off for the length of a drag, so the commit that ends one records where the cards landed instead of sliding them there.
- Leave every column unmeasured while any column is taking a new width, no card moving inside a column for that.
- Correct the `paused` documentation in `useFlip`, `disabled` taking precedence over it rather than the other way round.
