### PR TITLE
Add a Plumber score check and badge

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,37 @@
+name: Plumber
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - uses: getplumber/plumber@c85c712bca3c9f547a88c66bb2541db179a1a79e # v0.4.52
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,27 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the actions this repo
+      # already uses on top of it, all pinned by commit SHA.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - dorny/paths-filter
+        - eps1lon/actions-label-merge-conflict
+        - imjasonh/setup-crane
+        - softprops/action-gh-release
+        - stringbean/docker-healthcheck-action
+        - vedantmgoyal9/winget-releaser
+
+    # main is protected. The release/* branches are one frozen branch
+    # per shipped release, the requirement stays where releases cut
+    # from.
+    branchMustBeProtected:
+      defaultMustBeProtected: true
+      namePatterns:
+        - main

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/eliandoran) ![LiberaPay patrons](https://img.shields.io/liberapay/patrons/ElianDoran)  
 ![Docker Pulls](https://img.shields.io/docker/pulls/triliumnext/trilium)
 ![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/triliumnext/trilium/total)  
-[![Translation status](https://hosted.weblate.org/widget/trilium/svg-badge.svg)](https://hosted.weblate.org/engage/trilium/)
+[![Translation status](https://hosted.weblate.org/widget/trilium/svg-badge.svg)](https://hosted.weblate.org/engage/trilium/) [![Plumber Score](https://score.getplumber.io/github.com/TriliumNext/Trilium.svg)](https://score.getplumber.io/github.com/TriliumNext/Trilium)
 
 <!-- translate:off -->
 <!-- LANGUAGE SWITCHER -->


### PR DESCRIPTION
Follows up on #11325, merged earlier.

This adds a small workflow that runs the [Plumber](https://github.com/getplumber/plumber) CLI on pushes to main and on pull requests. It checks the security posture of the GitHub workflows, the classes of findings the hardening PR fixed, and gates at 85 points so one small finding never blocks a PR. The `.plumber.yaml` overlay inherits the built-in defaults, trusts the six third party actions this repo already uses, all pinned by commit SHA, and keeps the branch protection requirement on main since the release branches are frozen history.

## Score badge

It works like OpenSSF Scorecard's published results: every run publishes the score, the badge shows main, and a failed publish never fails your CI. No token or secret is needed. The badge shows gray UNKNOWN until the first run on main. If you want the check without the badge, removing the `score-push` line is the whole opt-out.

I work on Plumber. If you do not want the tool, no hard feelings, say so and I close this PR, the hardening stands on its own.