### PR TITLE
feat(text): double-click expands inline diagrams, formulas and code blocks

### DIFF
--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -25,6 +25,7 @@ import { IncludeNoteOpts } from "../widgets/dialogs/include_note.jsx";
 import type { InfoProps } from "../widgets/dialogs/info.jsx";
 import type { MarkdownImportOpts } from "../widgets/dialogs/markdown_import.jsx";
 import { ChooseNoteTypeCallback } from "../widgets/dialogs/note_type_chooser.jsx";
+import type { ContentLightboxData } from "../widgets/dialogs/content_lightbox.jsx";
 import type { PrintPreviewData } from "../widgets/dialogs/print_preview.jsx";
 import type { NotePickerDialogOptions } from "../widgets/dialogs/note_picker.js";
 import type { ItemPickerDialogOptions } from "../widgets/dialogs/item_picker.js";
@@ -358,6 +359,7 @@ export type CommandMappings = {
     lastTab: CommandData;
     showNoteSource: CommandData;
     showNoteOCRText: CommandData;
+    showContentLightbox: CommandData & ContentLightboxData;
     showOcrTextDialog: CommandData & {
         textUrl: string;
         processUrl: string;

--- a/apps/client/src/layouts/layout_commons.tsx
+++ b/apps/client/src/layouts/layout_commons.tsx
@@ -43,6 +43,7 @@ export function applyModals(rootContainer: RootContainer) {
         .child(<LazyDialog triggerEvents={["showNoteAttributes"]} loader={() => import("../widgets/dialogs/note_attributes.jsx")} />)
         .child(<LazyDialog triggerEvents={["showUploadAttachmentsDialog"]} loader={() => import("../widgets/dialogs/upload_attachments.js")} />)
         .child(<LazyDialog triggerEvents={["openInTreePopup"]} loader={() => import("../widgets/dialogs/TreePopupEditor.jsx")} />)
+        .child(<LazyDialog triggerEvents={["showContentLightbox"]} loader={() => import("../widgets/dialogs/content_lightbox.jsx")} />)
         // The following three are deliberately eager (not wrapped in LazyDialog):
         //  - PopupEditor keeps itself in the DOM (`keepInDom`) for fast hover-preview latency, so deferring its module would defeat the purpose.
         //  - CallToAction has no summon event; it decides whether to show itself on startup, so there is nothing to lazily mount against.

--- a/apps/client/src/services/syntax_highlight.ts
+++ b/apps/client/src/services/syntax_highlight.ts
@@ -221,7 +221,7 @@ export function isSyntaxHighlightEnabled() {
  * @param el the HTML element from which to extract the language tag.
  * @returns the normalized MIME type (e.g. `text-css` instead of `language-text-css`).
  */
-function extractLanguageFromClassList(el: HTMLElement) {
+export function extractLanguageFromClassList(el: HTMLElement) {
     const prefix = "language-";
     for (const className of el.classList) {
         if (className.startsWith(prefix)) {

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -4223,5 +4223,10 @@
     "creation-date": "Creation date & time",
     "ascending": "Ascending",
     "descending": "Descending"
+  },
+  "content_lightbox": {
+    "diagram_title": "Diagram",
+    "formula_title": "Formula",
+    "code_title": "Code block"
   }
 }

--- a/apps/client/src/widgets/dialogs/content_lightbox.css
+++ b/apps/client/src/widgets/dialogs/content_lightbox.css
@@ -1,0 +1,19 @@
+.modal.content-lightbox {
+    /* The viewer draws its own surface, so it runs to the edges of the dialog. */
+    .modal-body:has(.content-lightbox-viewport) {
+        padding: 0;
+
+        /*
+         * `ZoomPanViewer.css` sizes the viewport at `height: 100%`, which needs a definite height on
+         * an ancestor to resolve against. On mobile the full-page dialog owns the height instead.
+         */
+        body.desktop & {
+            height: 80vh;
+        }
+    }
+
+    /* A text note caps a diagram at the column width; here the viewer decides how large it is. */
+    .content-lightbox-content svg {
+        max-width: none;
+    }
+}

--- a/apps/client/src/widgets/dialogs/content_lightbox.spec.tsx
+++ b/apps/client/src/widgets/dialogs/content_lightbox.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * The dialog that shows a diagram, a formula or a code block from a text note at full size.
+ *
+ * These tests pin two things: the payload's `kind` alone picks the title and the renderer, and the
+ * dialog handles every later summons. The same instance stays mounted for the rest of the session,
+ * so the failure modes to guard against are a stale body and a dialog that cannot reopen.
+ */
+import type { ComponentChildren } from "preact";
+import { act } from "preact/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Component from "../../components/component";
+import { renderInto } from "../../test/render";
+import { ParentComponent } from "../react/react_utils";
+import ContentLightboxDialog, { type ContentLightboxData } from "./content_lightbox";
+
+const mocks = vi.hoisted(() => ({ applySingleBlockSyntaxHighlight: vi.fn(async () => {}) }));
+
+vi.mock("../../services/i18n", () => ({ t: (key: string) => key }));
+
+// The viewer measures its content and drives react-zoom-pan-pinch, neither of which happy-dom can
+// do. Render the children instead: this dialog only decides to wrap the visual kinds in it.
+vi.mock("../react/ZoomPanViewer", () => ({
+    ZOOM_PAN_HINTS: [],
+    default: ({ children, viewportClassName }: { children: ComponentChildren; viewportClassName?: string }) => (
+        <div className={viewportClassName}>{children}</div>
+    )
+}));
+
+vi.mock("../../services/syntax_highlight", () => ({
+    applySingleBlockSyntaxHighlight: mocks.applySingleBlockSyntaxHighlight,
+    isSyntaxHighlightEnabled: () => true
+}));
+
+const MERMAID_SVG = `<svg id="in-mermaid-graph-3-lightbox" width="120" height="80"><g></g></svg>`;
+const KATEX_HTML = `<span class="katex"><span class="katex-mathml">x</span></span>`;
+
+describe("ContentLightboxDialog", () => {
+    beforeEach(() => {
+        mocks.applySingleBlockSyntaxHighlight.mockClear();
+    });
+
+    it("shows a mermaid diagram in the zoom/pan viewer", async () => {
+        const summon = mountDialog();
+        await summon({ kind: "svg", svg: MERMAID_SVG });
+
+        expect(title()).toBe("content_lightbox.diagram_title");
+        const body = modalBody();
+        expect(body?.querySelector("svg#in-mermaid-graph-3-lightbox")).toBeTruthy();
+        expect(body?.querySelector(".code-block")).toBeNull();
+    });
+
+    it("shows a formula in the zoom/pan viewer", async () => {
+        const summon = mountDialog();
+        await summon({ kind: "html", html: KATEX_HTML });
+
+        expect(title()).toBe("content_lightbox.formula_title");
+        expect(modalBody()?.querySelector(".katex")).toBeTruthy();
+    });
+
+    it("shows code in a code block, highlighted as the language the payload names", async () => {
+        const summon = mountDialog();
+        await summon({ kind: "code", code: "a { b: c }", language: "text-css" });
+
+        expect(title()).toBe("content_lightbox.code_title");
+        expect(modalBody()?.querySelector(".code-block code")?.textContent).toBe("a { b: c }");
+        expect(mocks.applySingleBlockSyntaxHighlight).toHaveBeenCalledWith(expect.anything(), "text-css");
+    });
+
+    it("replaces what it shows when summoned again while still open", async () => {
+        const summon = mountDialog();
+        await summon({ kind: "svg", svg: MERMAID_SVG });
+        await summon({ kind: "code", code: "second", language: null });
+
+        expect(title()).toBe("content_lightbox.code_title");
+        const body = modalBody();
+        expect(body?.querySelector("svg#in-mermaid-graph-3-lightbox")).toBeNull();
+        expect(body?.querySelector(".code-block code")?.textContent).toBe("second");
+    });
+
+    it("can be raised again after it has been closed", async () => {
+        const summon = mountDialog();
+        await summon({ kind: "svg", svg: MERMAID_SVG });
+
+        const modal = document.querySelector(".modal.content-lightbox");
+        expect(modal).toBeTruthy();
+        // `hidden.bs.modal` is the only signal that the dialog is down.
+        await act(async () => {
+            modal?.dispatchEvent(new CustomEvent("hidden.bs.modal", { bubbles: true }));
+        });
+        expect(modalBody()).toBeNull();
+
+        await summon({ kind: "html", html: KATEX_HTML });
+        expect(modalBody()?.querySelector(".katex")).toBeTruthy();
+    });
+});
+
+/** Mounts the dialog and returns the function that summons it, as the double-click handler does. */
+function mountDialog() {
+    const host = new Component();
+    renderInto(
+        <ParentComponent.Provider value={host}>
+            <ContentLightboxDialog />
+        </ParentComponent.Provider>
+    );
+
+    return async (data: ContentLightboxData) => {
+        await act(async () => {
+            await host.handleEvent("showContentLightbox", data);
+        });
+    };
+}
+
+/** The dialog's body, which is in the page only while the dialog is up. */
+function modalBody() {
+    return document.querySelector(".modal.content-lightbox .modal-body");
+}
+
+function title() {
+    return document.querySelector(".modal.content-lightbox .modal-title")?.textContent;
+}

--- a/apps/client/src/widgets/dialogs/content_lightbox.tsx
+++ b/apps/client/src/widgets/dialogs/content_lightbox.tsx
@@ -1,0 +1,78 @@
+import "./content_lightbox.css";
+
+import { useState } from "preact/hooks";
+
+import { t } from "../../services/i18n";
+import CodeBlock from "../react/CodeBlock";
+import { useTriliumEvent, useTriliumOptionBool } from "../react/hooks";
+import Modal from "../react/Modal";
+import { RawHtmlBlock } from "../react/RawHtml";
+import ZoomPanViewer, { ZOOM_PAN_HINTS } from "../react/ZoomPanViewer";
+
+/** The payload `setupContentExpansion` in `type_widgets/text/utils.ts` sends with the command. */
+export type ContentLightboxData =
+    | { kind: "svg"; svg: string }
+    | { kind: "html"; html: string }
+    | { kind: "code"; code: string; language: string | null };
+
+/**
+ * Shows one diagram, formula or code block from a text note at full size.
+ *
+ * A diagram or a formula lays out at its natural size inside {@link ZoomPanViewer}, which scales it
+ * to fit and lets the reader zoom and pan; code goes into the same {@link CodeBlock} the rest of the
+ * UI uses, so it is highlighted and copyable.
+ */
+export default function ContentLightboxDialog() {
+    const [ data, setData ] = useState<ContentLightboxData>();
+    const [ shown, setShown ] = useState(false);
+    const [ codeBlockWordWrap ] = useTriliumOptionBool("codeBlockWordWrap");
+
+    useTriliumEvent("showContentLightbox", (payload) => {
+        setData(payload);
+        setShown(true);
+    });
+
+    return (
+        <Modal
+            className="content-lightbox"
+            size="xl"
+            isFullPageOnMobile
+            show={shown}
+            onHidden={() => setShown(false)}
+            scrollable={data?.kind === "code"}
+            title={getTitle(data)}
+        >
+            {data?.kind === "code" ? (
+                <CodeBlock
+                    code={data.code}
+                    mimeType={data.language ?? undefined}
+                    copyable
+                    wrap={codeBlockWordWrap}
+                />
+            ) : data && (
+                <ZoomPanViewer fit="measure" hints={ZOOM_PAN_HINTS} viewportClassName="content-lightbox-viewport">
+                    {/* Raw, not sanitized: DOMPurify strips the `<style>` and `foreignObject` a
+                        mermaid diagram is drawn with, and this markup already rendered in the note. */}
+                    <RawHtmlBlock
+                        className="content-lightbox-content"
+                        html={data.kind === "svg" ? data.svg : data.html}
+                    />
+                </ZoomPanViewer>
+            )}
+        </Modal>
+    );
+}
+
+/** Names what is being shown, for the dialog header. */
+function getTitle(data: ContentLightboxData | undefined) {
+    switch (data?.kind) {
+        case "svg":
+            return t("content_lightbox.diagram_title");
+        case "html":
+            return t("content_lightbox.formula_title");
+        case "code":
+            return t("content_lightbox.code_title");
+        default:
+            return undefined;
+    }
+}

--- a/apps/client/src/widgets/react/ImageViewer.css
+++ b/apps/client/src/widgets/react/ImageViewer.css
@@ -1,24 +1,12 @@
-/* Focusable wrapper that receives keyboard zoom/pan; fills the available space. */
+/* Hosts the viewer and the error message, which fills it (see ContentErrorMessage). */
 .image-viewer-root {
     position: relative;
     width: 100%;
     height: 100%;
-    outline: none;
 }
 
-/* Pinned by the corner it names (see `placement` on OverlayControlGroup); left here is only what it
-   stands above, which is the image and nothing else. The shortcut-hints button opposite it needs
-   nothing at all — it stands where every one of them does, and brings that with it. */
-.image-viewer-controls {
-    z-index: 1;
-}
-
-/* Make the library's viewport fill the available space so the image fits and pans within it. */
-.image-viewer-viewport.react-transform-wrapper {
-    width: 100%;
-    height: 100%;
-}
-
+/* The image fits itself to the viewport, so the content box takes the whole of it and centers what
+   it holds. */
 .image-viewer-content.react-transform-component {
     width: 100%;
     height: 100%;
@@ -46,15 +34,6 @@
 
 .image-viewer-viewport.img-loading-error {
     background-color: var(--dropdown-item-icon-destructive-color);
-}
-
-/* The the grab cursor only while the image is large enough to pan (zoomed past fit). */
-.image-viewer-viewport.pannable {
-    cursor: grab;
-}
-
-.image-viewer-viewport.pannable.panning {
-    cursor: grabbing;
 }
 
 /* At high zoom, render crisp edges instead of blurred interpolation. */

--- a/apps/client/src/widgets/react/ImageViewer.tsx
+++ b/apps/client/src/widgets/react/ImageViewer.tsx
@@ -1,17 +1,14 @@
 import "./ImageViewer.css";
 
+import clsx from "clsx";
 import { Ref } from "preact";
-import { useCallback, useEffect, useRef, useState } from "preact/hooks";
-import { type ReactZoomPanPinchRef, TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
+import { useEffect, useRef, useState } from "preact/hooks";
+import type { ReactZoomPanPinchRef } from "react-zoom-pan-pinch";
 
 import { t } from "../../services/i18n";
 import type { ShortcutHintDefinition } from "../../services/shortcut_hints";
-import { isMobile } from "../../services/utils";
-import ShortcutHintButton from "../shortcut_hints/shortcut_hint_button";
 import ContentErrorMessage from "./ContentErrorMessage";
-import { useContextualShortcutHints } from "./hooks";
-import { useImageViewerKeyboard } from "./image_viewer_keyboard";
-import OverlayControlGroup, { OverlayControlButton } from "./OverlayControlGroup";
+import ZoomPanViewer, { ZOOM_PAN_HINTS } from "./ZoomPanViewer";
 
 interface ImageViewerProps {
     src: string;
@@ -26,30 +23,11 @@ interface ImageViewerProps {
 
 /** Beyond this multiple of the image's native resolution, switch to crisp (non-smoothed) rendering. */
 const CRISP_NATIVE_SCALE = 4;
-/** Scale step applied per zoom-in/out button click (react-zoom-pan-pinch's zoomIn/zoomOut step). */
-const BUTTON_ZOOM_STEP = 0.5;
 /** Reveal the image even if `decode()` never settles (it can stall for some images, e.g. SVGs). */
 const REVEAL_FALLBACK_MS = 1000;
 
 const IMAGE_VIEWER_HINTS: ShortcutHintDefinition = [
-    {
-        titleKey: "image_viewer.hints.zoom",
-        hints: [
-            { keys: ["Ctrl++", "E"], labelKey: "image_viewer.hints.zoom_in" },
-            { keys: ["Ctrl+-", "Q"], labelKey: "image_viewer.hints.zoom_out" },
-            { keys: ["/", "Numpad /"], labelKey: "image_viewer.hints.reset_zoom" }
-        ]
-    },
-    {
-        titleKey: "image_viewer.hints.pan",
-        hints: [
-            { keys: ["Up", "W"], labelKey: "image_viewer.hints.pan_up" },
-            { keys: ["Down", "S"], labelKey: "image_viewer.hints.pan_down" },
-            { keys: ["Left", "A"], labelKey: "image_viewer.hints.pan_left" },
-            { keys: ["Right", "D"], labelKey: "image_viewer.hints.pan_right" },
-            { keys: ["Shift"], labelKey: "image_viewer.hints.pan_fast" }
-        ]
-    },
+    ...ZOOM_PAN_HINTS,
     {
         titleKey: "image_viewer.hints.navigation",
         hints: [
@@ -73,35 +51,15 @@ export function evaluateImageZoom(scale: number, img: { naturalWidth: number; cl
 }
 
 /**
- * Interactive image viewer: the image is fit to the viewport on load, then the user can zoom
- * (wheel/pinch/buttons/keyboard) and pan (drag/keyboard). Double-clicking resets to the fitted view.
+ * Interactive image viewer: the image is fit to the viewport by CSS, then a {@link ZoomPanViewer}
+ * carries the zoom and pan. The image reveals itself once it has decoded, and tints the viewport on
+ * a failed load.
  */
 export default function ImageViewer({ src, imgClassName, alt = "", minScale = 0.5, maxScale = 50, apiRef }: ImageViewerProps) {
-    const [ pannable, setPannable ] = useState(false);
-    const [ panning, setPanning ] = useState(false);
     const [ largeZoom, setLargeZoom ] = useState(false);
-    const [ zoomPercent, setZoomPercent ] = useState(0);
     const [ loaded, setLoaded ] = useState(false);
     const [ loadingError, setLoadingError ] = useState(false);
     const imgRef = useRef<HTMLImageElement>(null);
-    const rootRef = useRef<HTMLDivElement>(null);
-    const zoomRef = useRef<ReactZoomPanPinchRef>(null);
-
-    // Keep our own ref to drive keyboard control, while still forwarding to the caller's apiRef.
-    const setZoomRef = useCallback((instance: ReactZoomPanPinchRef | null) => {
-        zoomRef.current = instance;
-        if (typeof apiRef === "function") apiRef(instance);
-        else if (apiRef) (apiRef as { current: ReactZoomPanPinchRef | null }).current = instance;
-    }, [ apiRef ]);
-
-    // Recompute the cursor/rendering flags and the displayed (native-relative) zoom percentage.
-    // The setters bail out on identical values, so no manual change checks are needed.
-    const updateZoomState = (scale: number) => {
-        const { pannable: nextPannable, largeZoom: nextLargeZoom, nativeScale } = evaluateImageZoom(scale, imgRef.current);
-        setPannable(nextPannable);
-        setLargeZoom(nextLargeZoom);
-        setZoomPercent(Math.round(nativeScale * 100));
-    };
 
     // Reveal (or fail) the image, driven by decode() rather than the load event. decode() resolves once
     // the bitmap is ready whether or not we observed `load`, so a fast/cached image that finishes before
@@ -122,10 +80,7 @@ export default function ImageViewer({ src, imgClassName, alt = "", minScale = 0.
             clearTimeout(timer);
             action();
         };
-        const reveal = () => settle(() => {
-            setLoaded(true);
-            updateZoomState(zoomRef.current?.instance?.state?.scale ?? 1);
-        });
+        const reveal = () => settle(() => setLoaded(true));
         const timer = setTimeout(reveal, REVEAL_FALLBACK_MS);
         if (typeof img.decode === "function") {
             img.decode().then(reveal, () => {
@@ -143,69 +98,35 @@ export default function ImageViewer({ src, imgClassName, alt = "", minScale = 0.
         return () => settle(() => {});
     }, [ src ]);
 
-    useImageViewerKeyboard(zoomRef, rootRef);
-    useContextualShortcutHints(IMAGE_VIEWER_HINTS);
-
-    const wrapperClass = [
-        "image-viewer-viewport",
-        pannable && "pannable",
-        panning && "panning",
-        largeZoom && "tn-image-large-zoom",
-        loaded && "img-loaded",
-        loadingError && "img-loading-error"
-    ].filter(Boolean).join(" ");
-
     return (
-        <div ref={rootRef} tabIndex={0} className="image-viewer-root">
-            <TransformWrapper
-                ref={setZoomRef}
+        <div className="image-viewer-root">
+            <ZoomPanViewer
+                apiRef={apiRef}
                 minScale={minScale}
                 maxScale={maxScale}
-                centerOnInit
-                centerZoomedOut
-                wheel={{ step: 0.0085 }}
-                autoAlignment={{ disabled: true }}
-                doubleClick={{ mode: "reset" }}
-                onTransform={(_ref, { scale }) => updateZoomState(scale)}
-                onPanningStart={() => setPanning(true)}
-                onPanningStop={() => setPanning(false)}
+                ready={loaded}
+                hints={IMAGE_VIEWER_HINTS}
+                viewportClassName={clsx(
+                    "image-viewer-viewport",
+                    largeZoom && "tn-image-large-zoom",
+                    loaded && "img-loaded",
+                    loadingError && "img-loading-error"
+                )}
+                contentClassName="image-viewer-content"
+                controlsClassName="image-viewer-controls"
+                nativeScale={(scale) => evaluateImageZoom(scale, imgRef.current).nativeScale}
+                onScaleChange={(scale) => setLargeZoom(evaluateImageZoom(scale, imgRef.current).largeZoom)}
             >
-                <TransformComponent wrapperClass={wrapperClass} contentClass="image-viewer-content">
-                    <img
-                        ref={imgRef}
-                        className={imgClassName}
-                        src={src}
-                        alt={alt}
-                    />
-                </TransformComponent>
-            </TransformWrapper>
+                <img
+                    ref={imgRef}
+                    className={imgClassName}
+                    src={src}
+                    alt={alt}
+                />
+            </ZoomPanViewer>
 
             {loadingError && (
                 <ContentErrorMessage message={t("image_viewer.loading_error")} />
-            )}
-
-            {!isMobile() && loaded && (
-                <ShortcutHintButton />
-            )}
-
-            {!isMobile() && loaded && (
-                <OverlayControlGroup className="image-viewer-controls" placement="bottom-end">
-                    <OverlayControlButton
-                        title={t("image_buttons.zoom_out")}
-                        icon="bx-minus-circle"
-                        onClick={() => zoomRef.current?.zoomOut(BUTTON_ZOOM_STEP)}
-                    />
-                    <OverlayControlButton
-                        title={t("image_buttons.reset_zoom")}
-                        text={`${zoomPercent}%`}
-                        onClick={() => zoomRef.current?.resetTransform()}
-                    />
-                    <OverlayControlButton
-                        title={t("image_buttons.zoom_in")}
-                        icon="bx-plus-circle"
-                        onClick={() => zoomRef.current?.zoomIn(BUTTON_ZOOM_STEP)}
-                    />
-                </OverlayControlGroup>
             )}
         </div>
     );

--- a/apps/client/src/widgets/react/ZoomPanViewer.css
+++ b/apps/client/src/widgets/react/ZoomPanViewer.css
@@ -1,0 +1,34 @@
+/* Focusable wrapper that receives keyboard zoom/pan; fills the available space. */
+.zoom-pan-viewer-root {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    outline: none;
+
+    /* Overrides the `fit-content` sizing react-zoom-pan-pinch injects, so the viewport fills the root
+       and the content fits and pans within it. */
+    .zoom-pan-viewer-viewport.react-transform-wrapper {
+        width: 100%;
+        height: 100%;
+    }
+
+    /* The grab cursor only while the content is large enough to pan (zoomed past the fitted size). */
+    .zoom-pan-viewer-viewport.pannable {
+        cursor: grab;
+    }
+
+    .zoom-pan-viewer-viewport.pannable.panning {
+        cursor: grabbing;
+    }
+
+    /* In measure mode the fit scale lands only once the viewport and the content have been measured;
+       until then the content would show at scale 1. */
+    .zoom-pan-viewer-viewport.fitting {
+        visibility: hidden;
+    }
+
+    /* Above the transformed content; see `placement` on OverlayControlGroup for the corner. */
+    .zoom-pan-viewer-controls {
+        z-index: 1;
+    }
+}

--- a/apps/client/src/widgets/react/ZoomPanViewer.spec.tsx
+++ b/apps/client/src/widgets/react/ZoomPanViewer.spec.tsx
@@ -1,0 +1,200 @@
+import { type ComponentChildren } from "preact";
+import { forwardRef } from "preact/compat";
+import { useImperativeHandle } from "preact/hooks";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Component from "../../components/component";
+import { collectShortcutHints } from "../../services/shortcut_hints";
+import { renderInto } from "../../test/render";
+import { ParentComponent } from "./react_utils";
+
+// Capture the props handed to the zoom library without mounting it (it needs real layout), and stand
+// in for the instance it exposes, whose content box the viewer measures in fit="measure".
+const { transformWrapperSpy, contentRef } = vi.hoisted(() => ({
+    transformWrapperSpy: vi.fn(),
+    contentRef: { current: null as HTMLDivElement | null }
+}));
+
+vi.mock("react-zoom-pan-pinch", () => ({
+    TransformWrapper: forwardRef((props: { children?: ComponentChildren }, ref) => {
+        transformWrapperSpy(props);
+        useImperativeHandle(ref, () => ({
+            instance: { contentComponent: contentRef.current },
+            resetTransform: () => {}
+        }));
+        return props.children;
+    }),
+    // Mirror the library's wrapper and content boxes so both class names can be observed.
+    TransformComponent: (props: { children?: ComponentChildren; wrapperClass?: string; contentClass?: string }) => (
+        <div className={props.wrapperClass}>
+            <div ref={contentRef} className={props.contentClass}>{props.children}</div>
+        </div>
+    )
+}));
+
+// Keep the real hooks, but stub the bootstrap-Tooltip one, which needs real layout.
+vi.mock("./hooks", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./hooks")>()),
+    useStaticTooltip: () => {}
+}));
+
+import ZoomPanViewer, { computeFitScale, ZOOM_PAN_HINTS } from "./ZoomPanViewer";
+
+describe("ZoomPanViewer", () => {
+    beforeEach(() => {
+        transformWrapperSpy.mockClear();
+    });
+
+    it("renders its children in the content box and puts each class name on its own element", () => {
+        const container = renderInto(
+            <ZoomPanViewer
+                viewportClassName="my-viewport"
+                contentClassName="my-content"
+                controlsClassName="my-controls"
+            >
+                <span className="payload">content</span>
+            </ZoomPanViewer>
+        );
+
+        expect(container.querySelector(".my-content .payload")).not.toBeNull();
+        expect(container.querySelector(".my-viewport .my-content")).not.toBeNull();
+        expect(container.querySelector(".zoom-pan-viewer-root")).not.toBeNull();
+        expect(container.querySelector(".my-controls")).not.toBeNull();
+    });
+
+    it("holds back the controls until the caller says it is ready", () => {
+        const ready = renderInto(<ZoomPanViewer controlsClassName="my-controls"><span /></ZoomPanViewer>);
+        expect(ready.querySelector(".my-controls")).not.toBeNull();
+
+        const notReady = renderInto(
+            <ZoomPanViewer ready={false} controlsClassName="my-controls"><span /></ZoomPanViewer>
+        );
+        expect(notReady.querySelector(".my-controls")).toBeNull();
+    });
+
+    it("wires up the interactive zoom behavior", () => {
+        renderInto(<ZoomPanViewer><span /></ZoomPanViewer>);
+
+        const props = transformWrapperSpy.mock.calls[0][0];
+        expect(props.centerOnInit).toBe(true);
+        expect(props.centerZoomedOut).toBe(true);
+        expect(props.autoAlignment).toEqual({ disabled: true });
+        expect(props.doubleClick).toEqual({ mode: "reset" });
+        expect(props.initialScale).toBe(1);
+        expect(props.wheel.step).toBe(0.0085);
+        // The scale envelope is caller-tunable — assert the relationship, not exact values.
+        expect(props.maxScale).toBeGreaterThan(props.minScale);
+    });
+
+    it("leaves the caller's minScale alone in css mode, where the content fits itself", () => {
+        renderInto(<ZoomPanViewer minScale={2}><span /></ZoomPanViewer>);
+
+        expect(transformWrapperSpy.mock.calls[0][0].minScale).toBe(2);
+    });
+
+    it("registers its hints on the host component, and no provider at all when given none", () => {
+        const withHints = new Component();
+        act(() => {
+            renderInto(
+                <ParentComponent.Provider value={withHints}>
+                    <ZoomPanViewer hints={ZOOM_PAN_HINTS}><span /></ZoomPanViewer>
+                </ParentComponent.Provider>
+            );
+        });
+        expect(collectShortcutHints(withHints).map((section) => section.titleKey)).toEqual([
+            "image_viewer.hints.zoom",
+            "image_viewer.hints.pan"
+        ]);
+
+        // A viewer given no hints must leave the host's own provider in place, rather than displacing
+        // it with an empty one.
+        const withoutHints = new Component();
+        withoutHints.getContextualShortcutHints = (collector) => collector.add({ titleKey: "host.section", hints: [] });
+        act(() => {
+            renderInto(
+                <ParentComponent.Provider value={withoutHints}>
+                    <ZoomPanViewer><span /></ZoomPanViewer>
+                </ParentComponent.Provider>
+            );
+        });
+        expect(collectShortcutHints(withoutHints).map((section) => section.titleKey)).toEqual([ "host.section" ]);
+    });
+
+    it("reports the on-screen size through nativeScale and hands the raw scale to onScaleChange", () => {
+        const onScaleChange = vi.fn();
+        const container = renderInto(
+            <ZoomPanViewer nativeScale={(scale) => scale * 0.25} onScaleChange={onScaleChange}>
+                <span />
+            </ZoomPanViewer>
+        );
+
+        const { onTransform } = transformWrapperSpy.mock.calls[0][0];
+        act(() => {
+            onTransform(null, { scale: 2 });
+        });
+
+        expect(container.querySelector(".tn-overlay-text-button")?.textContent).toBe("50%");
+        expect(onScaleChange).toHaveBeenCalledWith(2);
+    });
+
+    describe("with a measured viewport", () => {
+        // happy-dom's ResizeObserver never fires and every box measures zero, so the viewport gets a
+        // size here while the content keeps the 0x0 of content that renders after mount.
+        beforeEach(() => {
+            vi.stubGlobal("ResizeObserver", class {
+                constructor(private readonly callback: () => void) {}
+                observe() { this.callback(); }
+                unobserve() {}
+                disconnect() {}
+            });
+            vi.spyOn(HTMLElement.prototype, "getBoundingClientRect")
+                .mockReturnValue({ width: 800, height: 600 } as DOMRect);
+        });
+        afterEach(() => {
+            vi.unstubAllGlobals();
+            vi.restoreAllMocks();
+        });
+
+        it("keeps content that has no size yet hidden, rather than showing it at scale 1", () => {
+            let container: HTMLElement | undefined;
+            act(() => {
+                container = renderInto(
+                    <ZoomPanViewer fit="measure" viewportClassName="my-viewport"><span /></ZoomPanViewer>
+                );
+            });
+
+            expect(container?.querySelector(".my-viewport")?.classList.contains("fitting")).toBe(true);
+        });
+
+        it("never hides content that fits itself, which needs no measurement", () => {
+            let container: HTMLElement | undefined;
+            act(() => {
+                container = renderInto(<ZoomPanViewer viewportClassName="my-viewport"><span /></ZoomPanViewer>);
+            });
+
+            expect(container?.querySelector(".my-viewport")?.classList.contains("fitting")).toBe(false);
+        });
+    });
+});
+
+describe("computeFitScale", () => {
+    const viewport = (width: number, height: number) => ({ width, height });
+
+    it("shrinks content larger than the viewport and grows content smaller than it", () => {
+        // Both axes overflow by 2x, so the fit is the tighter (equal) of the two.
+        expect(computeFitScale(viewport(800, 300), { width: 1600, height: 600 }, 0.5, 50)).toBe(0.5);
+        // A small formula grows until the first axis fills: 400/100 = 4 before 300/20 = 15.
+        expect(computeFitScale(viewport(400, 300), { width: 100, height: 20 }, 0.5, 50)).toBe(4);
+    });
+
+    it("stays within the caller's scale envelope", () => {
+        expect(computeFitScale(viewport(400, 300), { width: 10, height: 10 }, 0.5, 8)).toBe(8);
+        expect(computeFitScale(viewport(400, 300), { width: 8000, height: 6000 }, 0.2, 50)).toBe(0.2);
+    });
+
+    it("falls back to 1 for content that has no measured size", () => {
+        expect(computeFitScale(viewport(400, 300), { width: 0, height: 0 }, 0.5, 50)).toBe(1);
+        expect(computeFitScale(viewport(0, 0), { width: 100, height: 100 }, 0.5, 50)).toBe(1);
+    });
+});

--- a/apps/client/src/widgets/react/ZoomPanViewer.tsx
+++ b/apps/client/src/widgets/react/ZoomPanViewer.tsx
@@ -1,0 +1,230 @@
+import "./ZoomPanViewer.css";
+
+import clsx from "clsx";
+import type { ComponentChildren, Ref } from "preact";
+import { useCallback, useEffect, useRef, useState } from "preact/hooks";
+import { type ReactZoomPanPinchRef, TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
+
+import { t } from "../../services/i18n";
+import type { ShortcutHintDefinition } from "../../services/shortcut_hints";
+import { isMobile } from "../../services/utils";
+import ShortcutHintButton from "../shortcut_hints/shortcut_hint_button";
+import { useContextualShortcutHints, useElementSize } from "./hooks";
+import { useImageViewerKeyboard } from "./image_viewer_keyboard";
+import OverlayControlGroup, { OverlayControlButton } from "./OverlayControlGroup";
+
+export interface ZoomPanViewerProps {
+    children: ComponentChildren;
+    /**
+     * How the content is sized against the viewport. `"css"` leaves that to the content itself (an
+     * `<img>` capped at `max-width`/`max-height` 100%), so scale 1 is the fitted view. `"measure"`
+     * lays the content out at its natural size and lets the viewer drive the fit scale, which both
+     * shrinks a diagram larger than the viewport and grows a formula smaller than it.
+     */
+    fit?: "css" | "measure";
+    minScale?: number;
+    maxScale?: number;
+    /** Readout numerator: on-screen size as a multiple of the content's own pixels. Identity by default. */
+    nativeScale?: (scale: number) => number;
+    /** Controls and hints render only when true. */
+    ready?: boolean;
+    viewportClassName?: string;
+    contentClassName?: string;
+    controlsClassName?: string;
+    /** Contextual shortcut hints to register, usually {@link ZOOM_PAN_HINTS} or an extension of it. */
+    hints?: ShortcutHintDefinition;
+    onScaleChange?: (scale: number) => void;
+    /** Exposes the zoom/pan instance so the parent can drive zoom in/out/reset. */
+    apiRef?: Ref<ReactZoomPanPinchRef>;
+}
+
+/**
+ * Interactive zoom/pan viewport: the content is fit to the viewport, then the user can zoom
+ * (wheel/pinch/buttons/keyboard) and pan (drag/keyboard). Double-clicking returns to the fitted view.
+ */
+export default function ZoomPanViewer({
+    children,
+    fit = "css",
+    minScale = 0.5,
+    maxScale = 50,
+    nativeScale,
+    ready = true,
+    viewportClassName,
+    contentClassName,
+    controlsClassName,
+    hints,
+    onScaleChange,
+    apiRef
+}: ZoomPanViewerProps) {
+    const [ scale, setScale ] = useState<number | null>(null);
+    const [ panning, setPanning ] = useState(false);
+    const [ contentSize, setContentSize ] = useState<{ width: number; height: number } | null>(null);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const zoomRef = useRef<ReactZoomPanPinchRef>(null);
+    const viewportSize = useElementSize(rootRef);
+
+    // Keep our own ref to drive keyboard control, while still forwarding to the caller's apiRef.
+    const setZoomRef = useCallback((instance: ReactZoomPanPinchRef | null) => {
+        zoomRef.current = instance;
+        if (typeof apiRef === "function") apiRef(instance);
+        else if (apiRef) (apiRef as { current: ReactZoomPanPinchRef | null }).current = instance;
+    }, [ apiRef ]);
+
+    // In measure mode the library's content box is `fit-content`, so the content lays out at its
+    // natural size and its offset box measures it independent of the transform. The observer follows
+    // content that resizes after mount, such as a diagram that renders asynchronously.
+    useEffect(() => {
+        if (fit !== "measure") return;
+
+        const content = zoomRef.current?.instance?.contentComponent;
+        if (!content) return;
+
+        const measure = () => setContentSize({ width: content.offsetWidth, height: content.offsetHeight });
+        measure();
+        const observer = new ResizeObserver(measure);
+        observer.observe(content);
+        return () => observer.disconnect();
+    }, [ fit ]);
+
+    const fitted = fit === "css" || (hasSize(viewportSize) && hasSize(contentSize));
+    const fitScale = fit === "measure" && hasSize(viewportSize) && hasSize(contentSize)
+        ? computeFitScale(viewportSize, contentSize, minScale, maxScale)
+        : 1;
+
+    // `TransformWrapper` pushes prop changes into its instance and `resetTransform` re-derives the
+    // view from the current `initialScale`, so this applies each new fit — and so does every other
+    // reset path (the readout button, `/`, double-click).
+    useEffect(() => {
+        if (fit === "measure") zoomRef.current?.resetTransform(0);
+    }, [ fit, fitScale ]);
+
+    useImageViewerKeyboard(zoomRef, rootRef);
+
+    const currentScale = scale ?? fitScale;
+    const zoomPercent = Math.round((nativeScale ? nativeScale(currentScale) : currentScale) * 100);
+    const showControls = ready && !isMobile();
+
+    const wrapperClass = clsx(
+        "zoom-pan-viewer-viewport",
+        viewportClassName,
+        currentScale > fitScale && "pannable",
+        panning && "panning",
+        !fitted && "fitting"
+    );
+
+    return (
+        <div ref={rootRef} tabIndex={0} className="zoom-pan-viewer-root">
+            <TransformWrapper
+                ref={setZoomRef}
+                initialScale={fitScale}
+                // A diagram far larger than the viewport fits below the caller's floor, which
+                // `createState` would otherwise clamp the fit scale away to. In css mode the content
+                // fits itself at scale 1, so the floor stands as the caller set it.
+                minScale={fit === "measure" ? Math.min(minScale, fitScale) : minScale}
+                maxScale={maxScale}
+                centerOnInit
+                centerZoomedOut
+                wheel={{ step: 0.0085 }}
+                autoAlignment={{ disabled: true }}
+                doubleClick={{ mode: "reset" }}
+                onTransform={(_ref, { scale: nextScale }) => {
+                    setScale(nextScale);
+                    onScaleChange?.(nextScale);
+                }}
+                onPanningStart={() => setPanning(true)}
+                onPanningStop={() => setPanning(false)}
+            >
+                <TransformComponent
+                    wrapperClass={wrapperClass}
+                    contentClass={clsx("zoom-pan-viewer-content", contentClassName)}
+                >
+                    {children}
+                </TransformComponent>
+            </TransformWrapper>
+
+            {hints && <ZoomPanShortcutHints hints={hints} showButton={showControls} />}
+
+            {showControls && (
+                <OverlayControlGroup className={clsx("zoom-pan-viewer-controls", controlsClassName)} placement="bottom-end">
+                    <OverlayControlButton
+                        title={t("image_buttons.zoom_out")}
+                        icon="bx-minus-circle"
+                        onClick={() => zoomRef.current?.zoomOut(BUTTON_ZOOM_STEP)}
+                    />
+                    <OverlayControlButton
+                        title={t("image_buttons.reset_zoom")}
+                        text={`${zoomPercent}%`}
+                        onClick={() => zoomRef.current?.resetTransform()}
+                    />
+                    <OverlayControlButton
+                        title={t("image_buttons.zoom_in")}
+                        icon="bx-plus-circle"
+                        onClick={() => zoomRef.current?.zoomIn(BUTTON_ZOOM_STEP)}
+                    />
+                </OverlayControlGroup>
+            )}
+        </div>
+    );
+}
+
+/** Scale step applied per zoom-in/out button click (react-zoom-pan-pinch's zoomIn/zoomOut step). */
+const BUTTON_ZOOM_STEP = 0.5;
+
+/** The zoom and pan keys the viewer claims, offered to whichever widget hosts it. */
+export const ZOOM_PAN_HINTS: ShortcutHintDefinition = [
+    {
+        titleKey: "image_viewer.hints.zoom",
+        hints: [
+            { keys: ["Ctrl++", "E"], labelKey: "image_viewer.hints.zoom_in" },
+            { keys: ["Ctrl+-", "Q"], labelKey: "image_viewer.hints.zoom_out" },
+            { keys: ["/", "Numpad /"], labelKey: "image_viewer.hints.reset_zoom" }
+        ]
+    },
+    {
+        titleKey: "image_viewer.hints.pan",
+        hints: [
+            { keys: ["Up", "W"], labelKey: "image_viewer.hints.pan_up" },
+            { keys: ["Down", "S"], labelKey: "image_viewer.hints.pan_down" },
+            { keys: ["Left", "A"], labelKey: "image_viewer.hints.pan_left" },
+            { keys: ["Right", "D"], labelKey: "image_viewer.hints.pan_right" },
+            { keys: ["Shift"], labelKey: "image_viewer.hints.pan_fast" }
+        ]
+    }
+];
+
+/**
+ * The scale at which `content` fits inside `viewport` along both axes, kept within the caller's
+ * envelope. Content or viewport with no measured size falls back to 1, so the view stays usable
+ * while either is still zero-sized.
+ */
+export function computeFitScale(
+    viewport: { width: number; height: number },
+    content: { width: number; height: number },
+    minScale: number,
+    maxScale: number
+): number {
+    if (viewport.width <= 0 || viewport.height <= 0 || content.width <= 0 || content.height <= 0) {
+        return 1;
+    }
+
+    const scale = Math.min(viewport.width / content.width, viewport.height / content.height);
+    return Math.min(Math.max(scale, minScale), maxScale);
+}
+
+/**
+ * Whether a measured box has a size to fit against. Content that renders after mount — a diagram, a
+ * formula — reports 0×0 first, which is not yet a measurement.
+ */
+function hasSize(box: { width: number; height: number } | null | undefined): box is { width: number; height: number } {
+    return !!box && box.width > 0 && box.height > 0;
+}
+
+/**
+ * Registers the hints on the host component and, once the viewer is ready, offers the button that
+ * opens them. A component of its own so that a viewer given no hints registers no provider, which
+ * would otherwise displace the host's own.
+ */
+function ZoomPanShortcutHints({ hints, showButton }: { hints: ShortcutHintDefinition; showButton: boolean }) {
+    useContextualShortcutHints(hints);
+    return showButton ? <ShortcutHintButton /> : null;
+}

--- a/apps/client/src/widgets/type_widgets/text/EditableText.css
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.css
@@ -12,6 +12,18 @@ body.mobile .note-detail-editable-text {
     padding-inline-start: 4px;
 }
 
+.note-detail-editable-text {
+    .ck-mermaid__preview svg,
+    .ck-math-tex {
+        cursor: zoom-in;
+    }
+
+    /* An included diagram opens its note, so it gets the same cursor as an image. */
+    .include-note-content.type-mermaid svg {
+        cursor: pointer;
+    }
+}
+
 .note-detail-editable-text a:hover {
     cursor: pointer;
 }

--- a/apps/client/src/widgets/type_widgets/text/EditableText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/EditableText.tsx
@@ -22,7 +22,7 @@ import CKEditorWithWatchdog, { CKEditorApi, NotificationEventData, NotificationE
 import getTemplates, { updateTemplateCache } from "./snippets.js";
 import linkEmbedService from "../../../services/link_embed";
 import { usesClassicToolbar } from "./toolbar";
-import { loadIncludedNote, refreshIncludedNote, setupImageOpening } from "./utils";
+import { loadIncludedNote, refreshIncludedNote, setupContentExpansion, setupImageOpening } from "./utils";
 
 /**
  * The editor can operate into two distinct modes:
@@ -464,6 +464,7 @@ export default function EditableText({ note, parentComponent, ntxId, noteContext
                 onEditorInitialized={(editor) => {
                     if (containerRef.current) {
                         setupImageOpening(containerRef.current, false);
+                        setupContentExpansion(containerRef.current, { codeBlocks: false });
                     }
 
                     initialized.current.resolve();

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.css
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.css
@@ -13,6 +13,17 @@
         max-width: 100%;
         height: auto;
     }
+
+    .mermaid-diagram[data-processed="true"] svg,
+    span.math-tex,
+    pre:has(> code) {
+        cursor: zoom-in;
+    }
+
+    /* An included diagram opens its note, so it gets the same cursor as an image. */
+    .include-note-content.type-mermaid svg {
+        cursor: pointer;
+    }
 }
 
 /* Top-level (not scoped to the note view) so a swallowed mermaid failure is

--- a/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
+++ b/apps/client/src/widgets/type_widgets/text/ReadOnlyText.tsx
@@ -22,7 +22,7 @@ import { useNoteBlob, useNoteLabel, useSearchTermsConsumer, useSyncedRef, useTri
 import { RawHtmlBlock } from "../../react/RawHtml";
 import { TypeWidgetProps } from "../type_widget";
 import { applyReferenceLinks } from "./read_only_helper";
-import { loadIncludedNote, refreshIncludedNote, setupImageOpening } from "./utils";
+import { loadIncludedNote, refreshIncludedNote, setupContentExpansion, setupImageOpening } from "./utils";
 
 export default function ReadOnlyText({ note, noteContext, ntxId, parentComponent, isVisible }: TypeWidgetProps) {
     // The componentId matters: the WS echo of a save made by the editable-text editor in the same
@@ -117,6 +117,7 @@ export function ReadOnlyTextContent({ html, ntxId, dir, className, contentRef: e
 
         applyMath(container);
         setupImageOpening(container, true);
+        setupContentExpansion(container, { codeBlocks: true });
     }, [ html, ntxId, contentRef ]);
 
     // React to included note changes.

--- a/apps/client/src/widgets/type_widgets/text/utils.spec.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.spec.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type FNote from "../../../entities/fnote";
 
+vi.mock("../../../components/app_context", () => ({
+    default: {
+        triggerCommand: vi.fn(),
+        tabManager: { getActiveContext: vi.fn(), openTabWithNoteWithHoisting: vi.fn() }
+    }
+}));
 vi.mock("../../../services/froca", () => ({
-    default: { getNote: vi.fn() }
+    default: { getNote: vi.fn(), getAttachment: vi.fn() }
 }));
 vi.mock("../../../services/link", () => ({
     default: { createLink: vi.fn() }
@@ -12,10 +18,12 @@ vi.mock("../../../services/content_renderer", () => ({
     default: { getRenderedContent: vi.fn(), disposeInteractiveContent: vi.fn() }
 }));
 
+import appContext from "../../../components/app_context";
 import content_renderer from "../../../services/content_renderer";
 import froca from "../../../services/froca";
 import link from "../../../services/link";
-import { loadIncludedNote } from "./utils";
+import type { ExpansionTarget } from "./utils";
+import { loadIncludedNote, resolveExpansionTarget, setupContentExpansion, setupImageOpening } from "./utils";
 
 const note = { noteId: "noteY" } as unknown as FNote;
 
@@ -71,3 +79,297 @@ describe("loadIncludedNote", () => {
         expect(content_renderer.disposeInteractiveContent).toHaveBeenCalledWith($el);
     });
 });
+
+const MERMAID_ID = "mermaid-inline-0";
+
+describe("resolveExpansionTarget", () => {
+    it("serializes a read-only mermaid diagram, retargeting every reference to the svg id", () => {
+        const container = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg id="${MERMAID_ID}" viewBox="0 0 640 320" width="100%" style="max-width: 640px;">
+                    <marker id="${MERMAID_ID}_marker"></marker>
+                    <g class="node" marker-end="url(#${MERMAID_ID}_marker)"></g>
+                </svg>
+            </div>`);
+        addSvgStyle(requireEl(container, "svg"), `#${MERMAID_ID} .node { fill: red; }`);
+
+        const svg = expectSvgPayload(resolveExpansionTarget(requireEl(container, "g.node"), { codeBlocks: true }));
+
+        expect(svg).toContain(`id="${MERMAID_ID}-lightbox"`);
+        expect(svg).not.toContain(`id="${MERMAID_ID}"`);
+        expect(svg).toContain(`#${MERMAID_ID}-lightbox .node`);
+        expect(svg).toContain(`url(#${MERMAID_ID}-lightbox_marker)`);
+        // The viewBox gives the natural size a `fit-content` lightbox box can lay out.
+        expect(svg).toContain('width="640"');
+        expect(svg).toContain('height="320"');
+        expect(svg).not.toContain("max-width");
+    });
+
+    it("leaves an svg without a viewBox or an id untouched", () => {
+        const noViewBox = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg id="s2" width="100%" style="max-width: 300px;"><g class="node"></g></svg>
+            </div>`);
+        const kept = expectSvgPayload(resolveExpansionTarget(requireEl(noViewBox, "g.node"), { codeBlocks: true }));
+        expect(kept).toContain('width="100%"');
+        expect(kept).toContain("max-width: 300px");
+        expect(kept).toContain('id="s2-lightbox"');
+
+        const noId = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg viewBox="0 0 10 20"><g class="node"></g></svg>
+            </div>`);
+        const asIs = expectSvgPayload(resolveExpansionTarget(requireEl(noId, "g.node"), { codeBlocks: true }));
+        expect(asIs).toContain('width="10"');
+        expect(asIs).not.toContain("lightbox");
+    });
+
+    it("sizes from a viewBox that carries surrounding whitespace", () => {
+        const container = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg id="pad0" viewBox=" 0 0 640 320" width="100%" style="max-width: 640px;"><g class="node"></g></svg>
+            </div>`);
+
+        const svg = expectSvgPayload(resolveExpansionTarget(requireEl(container, "g.node"), { codeBlocks: true }));
+        expect(svg).toContain('width="640"');
+        expect(svg).toContain('height="320"');
+    });
+
+    it("resolves the edit-mode mermaid preview", () => {
+        const container = buildContainer(`
+            <div class="ck-mermaid__wrapper">
+                <textarea class="ck-mermaid__editing-view">graph TD;</textarea>
+                <div class="ck-mermaid__preview"><svg id="edit0" viewBox="0 0 100 50"><g class="node"></g></svg></div>
+            </div>`);
+
+        const svg = expectSvgPayload(resolveExpansionTarget(requireEl(container, "g.node"), { codeBlocks: false }));
+        expect(svg).toContain('id="edit0-lightbox"');
+    });
+
+    it("navigates to an included mermaid note, even when nested inside another include", () => {
+        const container = buildContainer(`
+            <section class="include-note" data-note-id="outer">
+                <div class="include-note-wrapper">
+                    <div class="include-note-content type-text">
+                        <section class="include-note" data-note-id="n1">
+                            <div class="include-note-wrapper">
+                                <div class="include-note-content type-mermaid">
+                                    <div class="rendered-content"><svg id="inc0"><g class="node"></g></svg></div>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </section>`);
+
+        expect(resolveExpansionTarget(requireEl(container, "g.node"), { codeBlocks: true })).toEqual({ type: "navigate", noteId: "n1" });
+    });
+
+    it("resolves read-only math to the widest KaTeX wrapper available", () => {
+        const display = buildContainer(`<span class="math-tex"><span class="katex-display"><span class="katex">E</span></span></span>`);
+        expect(expectHtmlPayload(resolveExpansionTarget(requireEl(display, ".katex"), { codeBlocks: true })))
+            .toBe(requireEl(display, ".katex-display").outerHTML);
+
+        const inline = buildContainer(`<span class="math-tex"><span class="katex">E</span></span>`);
+        expect(expectHtmlPayload(resolveExpansionTarget(requireEl(inline, ".katex"), { codeBlocks: true })))
+            .toBe(requireEl(inline, ".katex").outerHTML);
+    });
+
+    it("resolves edit-mode math", () => {
+        const container = buildContainer(`<span class="ck-math-tex ck-math-tex-inline"><div><span class="katex">E</span></div></span>`);
+        expect(expectHtmlPayload(resolveExpansionTarget(requireEl(container, ".katex"), { codeBlocks: false })))
+            .toBe(requireEl(container, ".katex").outerHTML);
+    });
+
+    it("resolves a code block with its language token", () => {
+        const css = buildContainer(`<pre class="hljs"><code class="language-text-css">body { color: red; }</code><button class="copy-button"></button></pre>`);
+        expect(resolveExpansionTarget(requireEl(css, "code"), { codeBlocks: true }))
+            .toEqual({ type: "lightbox", data: { kind: "code", code: "body { color: red; }", language: "text-css" } });
+
+        const auto = buildContainer(`<pre><code class="language-text-x-trilium-auto">hi</code></pre>`);
+        expect(resolveExpansionTarget(requireEl(auto, "code"), { codeBlocks: true }))
+            .toEqual({ type: "lightbox", data: { kind: "code", code: "hi", language: "text-x-trilium-auto" } });
+
+        const plain = buildContainer(`<pre><code>hi</code></pre>`);
+        expect(resolveExpansionTarget(requireEl(plain, "code"), { codeBlocks: true }))
+            .toEqual({ type: "lightbox", data: { kind: "code", code: "hi", language: null } });
+    });
+
+    it("ignores targets that own the gesture or are not ready", () => {
+        const link = buildContainer(`<a href="#"><span class="math-tex"><span class="katex">E</span></span></a>`);
+        expect(resolveExpansionTarget(requireEl(link, ".katex"), { codeBlocks: true })).toBeNull();
+
+        const copyButton = buildContainer(`<pre><code class="language-text-css">a</code><button class="copy-button"></button></pre>`);
+        expect(resolveExpansionTarget(requireEl(copyButton, "button.copy-button"), { codeBlocks: true })).toBeNull();
+
+        const textarea = buildContainer(`<div class="ck-mermaid__wrapper"><textarea class="ck-mermaid__editing-view">graph TD;</textarea></div>`);
+        expect(resolveExpansionTarget(requireEl(textarea, "textarea"), { codeBlocks: false })).toBeNull();
+
+        const unprocessed = buildContainer(`<div class="mermaid-diagram"><svg id="p0"><g class="node"></g></svg></div>`);
+        expect(resolveExpansionTarget(requireEl(unprocessed, "g.node"), { codeBlocks: true })).toBeNull();
+
+        const unrendered = buildContainer(`<span class="ck-math-tex ck-math-tex-inline"><div>\\(E\\)</div></span>`);
+        expect(resolveExpansionTarget(requireEl(unrendered, "div"), { codeBlocks: true })).toBeNull();
+    });
+
+    it("skips code blocks when they are disabled, without affecting the other shapes", () => {
+        const code = buildContainer(`<pre><code class="language-text-css">a</code></pre>`);
+        expect(resolveExpansionTarget(requireEl(code, "code"), { codeBlocks: false })).toBeNull();
+
+        const math = buildContainer(`<span class="math-tex"><span class="katex">E</span></span>`);
+        expect(resolveExpansionTarget(requireEl(math, ".katex"), { codeBlocks: false })).not.toBeNull();
+    });
+});
+
+describe("setupContentExpansion", () => {
+    const activeContext = { setNote: vi.fn() };
+
+    beforeEach(() => {
+        vi.mocked(appContext.triggerCommand).mockReset();
+        vi.mocked(appContext.tabManager.openTabWithNoteWithHoisting).mockReset();
+        activeContext.setNote.mockReset();
+        vi.mocked(appContext.tabManager.getActiveContext).mockReturnValue(activeContext as never);
+    });
+
+    it("opens the lightbox once on a double click, however many times it is installed", () => {
+        const container = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg id="${MERMAID_ID}" viewBox="0 0 640 320"><g class="node"></g></svg>
+            </div>`);
+
+        setupContentExpansion(container, { codeBlocks: true });
+        setupContentExpansion(container, { codeBlocks: true });
+        requireEl(container, "g.node").dispatchEvent(mouseEvent("dblclick"));
+
+        expect(appContext.triggerCommand).toHaveBeenCalledTimes(1);
+        expect(appContext.triggerCommand).toHaveBeenCalledWith("showContentLightbox", { kind: "svg", svg: expect.stringContaining(`id="${MERMAID_ID}-lightbox"`) });
+    });
+
+    it("navigates to an included note like an image does", () => {
+        const container = includedMermaidContainer();
+        setupContentExpansion(container, { codeBlocks: true });
+        const svg = requireEl(container, "g.node");
+
+        svg.dispatchEvent(mouseEvent("click", { ctrlKey: true }));
+        expect(appContext.tabManager.openTabWithNoteWithHoisting).toHaveBeenCalledWith("n1", { activate: false });
+
+        // Browsers deliver a non-primary button as `auxclick`, so this covers the contract mirrored
+        // from `setupImageOpening` rather than a gesture reachable in the app.
+        svg.dispatchEvent(mouseEvent("click", { which: 2, shiftKey: true }));
+        expect(appContext.tabManager.openTabWithNoteWithHoisting).toHaveBeenLastCalledWith("n1", { activate: true });
+
+        svg.dispatchEvent(mouseEvent("click"));
+        expect(appContext.tabManager.openTabWithNoteWithHoisting).toHaveBeenCalledTimes(2);
+        expect(activeContext.setNote).not.toHaveBeenCalled();
+
+        svg.dispatchEvent(mouseEvent("dblclick"));
+        expect(activeContext.setNote).toHaveBeenCalledWith("n1");
+    });
+
+    it("resolves only the navigate case on a modifier click, leaving a diagram unserialized", () => {
+        const container = buildContainer(`
+            <div class="mermaid-diagram" data-processed="true">
+                <svg id="${MERMAID_ID}" viewBox="0 0 640 320"><g class="node"></g></svg>
+            </div>`);
+        setupContentExpansion(container, { codeBlocks: true });
+        const node = requireEl(container, "g.node");
+        // `serializeSvgForLightbox` clones the svg before it serializes, so an uncalled `cloneNode`
+        // proves no payload was built. Spying the element keeps this off the prototype.
+        const cloneNode = vi.spyOn(requireEl(container, "svg"), "cloneNode");
+
+        node.dispatchEvent(mouseEvent("click", { ctrlKey: true }));
+        node.dispatchEvent(mouseEvent("click", { which: 2 }));
+
+        expect(cloneNode).not.toHaveBeenCalled();
+        expect(appContext.triggerCommand).not.toHaveBeenCalled();
+        expect(appContext.tabManager.openTabWithNoteWithHoisting).not.toHaveBeenCalled();
+        expect(activeContext.setNote).not.toHaveBeenCalled();
+
+        // A double click still opens the lightbox, so the spy watches a call that does happen.
+        node.dispatchEvent(mouseEvent("dblclick"));
+        expect(cloneNode).toHaveBeenCalled();
+        expect(appContext.triggerCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it("installs nothing for the print renderer", () => {
+        const original = window.glob.device;
+        window.glob.device = "print";
+        try {
+            const container = includedMermaidContainer();
+            setupContentExpansion(container, { codeBlocks: true });
+            requireEl(container, "g.node").dispatchEvent(mouseEvent("dblclick"));
+        } finally {
+            window.glob.device = original;
+        }
+
+        expect(activeContext.setNote).not.toHaveBeenCalled();
+        expect(appContext.triggerCommand).not.toHaveBeenCalled();
+    });
+});
+
+describe("setupImageOpening", () => {
+    it("opens an image once however many times it is installed", async () => {
+        const activeContext = { setNote: vi.fn() };
+        vi.mocked(appContext.tabManager.getActiveContext).mockReturnValue(activeContext as never);
+        const container = buildContainer(`<img src="http://localhost/api/images/n1/pic.png">`);
+
+        setupImageOpening(container, true);
+        setupImageOpening(container, true);
+        requireEl(container, "img").dispatchEvent(mouseEvent("dblclick"));
+        await vi.waitFor(() => expect(activeContext.setNote).toHaveBeenCalled());
+
+        expect(activeContext.setNote).toHaveBeenCalledTimes(1);
+        expect(activeContext.setNote).toHaveBeenCalledWith("n1", { viewScope: {} });
+    });
+});
+
+function buildContainer(html: string) {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    return container;
+}
+
+function includedMermaidContainer() {
+    return buildContainer(`
+        <section class="include-note" data-note-id="n1">
+            <div class="include-note-wrapper">
+                <div class="include-note-content type-mermaid">
+                    <div class="rendered-content"><svg id="inc0"><g class="node"></g></svg></div>
+                </div>
+            </div>
+        </section>`);
+}
+
+/** happy-dom drops the text of a `<style>` parsed inside an `<svg>`, so mermaid's scoped rules are added as a node. */
+function addSvgStyle(svg: Element, css: string) {
+    const style = document.createElementNS("http://www.w3.org/2000/svg", "style");
+    style.textContent = css;
+    svg.prepend(style);
+}
+
+function requireEl<T extends Element>(root: ParentNode, selector: string): T {
+    const el = root.querySelector<T>(selector);
+    if (!el) throw new Error(`Fixture is missing "${selector}"`);
+    return el;
+}
+
+/** happy-dom's `MouseEvent` has no legacy `which`, which is how jQuery tells a left click from a middle one. */
+function mouseEvent(type: string, { which = 1, ...init }: MouseEventInit & { which?: number } = {}) {
+    const event = new MouseEvent(type, { bubbles: true, ...init });
+    Object.defineProperty(event, "which", { value: which });
+    return event;
+}
+
+function expectSvgPayload(result: ExpansionTarget | null) {
+    if (result?.type !== "lightbox" || result.data.kind !== "svg") {
+        throw new Error(`Expected an svg lightbox payload, got ${JSON.stringify(result)}`);
+    }
+    return result.data.svg;
+}
+
+function expectHtmlPayload(result: ExpansionTarget | null) {
+    if (result?.type !== "lightbox" || result.data.kind !== "html") {
+        throw new Error(`Expected an html lightbox payload, got ${JSON.stringify(result)}`);
+    }
+    return result.data.html;
+}

--- a/apps/client/src/widgets/type_widgets/text/utils.ts
+++ b/apps/client/src/widgets/type_widgets/text/utils.ts
@@ -2,7 +2,9 @@ import appContext from "../../../components/app_context";
 import content_renderer from "../../../services/content_renderer";
 import froca from "../../../services/froca";
 import link, { ViewScope } from "../../../services/link";
+import { extractLanguageFromClassList } from "../../../services/syntax_highlight";
 import utils from "../../../services/utils";
+import type { ContentLightboxData } from "../../dialogs/content_lightbox";
 
 export async function loadIncludedNote(noteId: string, $el: JQuery<HTMLElement>, boxSize?: string) {
     const note = await froca.getNote(noteId);
@@ -74,8 +76,11 @@ export function refreshIncludedNote(container: HTMLDivElement, noteId: string) {
 
 export function setupImageOpening(container: HTMLDivElement, singleClickOpens: boolean) {
     const $container = $(container);
-    $container.on("dblclick", "img", (e) => openImageInCurrentTab($(e.target)));
-    $container.on("click", "img", (e) => {
+    // The read-only view renders into a persistent element, so this runs again on every content
+    // change against the same container; the namespace lets the previous handlers be dropped.
+    $container.off("dblclick.imageOpening click.imageOpening");
+    $container.on("dblclick.imageOpening", "img", (e) => openImageInCurrentTab($(e.target)));
+    $container.on("click.imageOpening", "img", (e) => {
         e.stopPropagation();
         const isLeftClick = e.which === 1;
         const isMiddleClick = e.which === 2;
@@ -88,6 +93,87 @@ export function setupImageOpening(container: HTMLDivElement, singleClickOpens: b
             openImageInCurrentTab($(e.target));
         }
     });
+}
+
+export type ExpansionTarget =
+    | { type: "navigate"; noteId: string }
+    | { type: "lightbox"; data: ContentLightboxData };
+
+/**
+ * Installs the double-click gesture that expands an inline diagram, formula or code block.
+ *
+ * Code blocks are opted out of in edit mode, where a double click is the word-selection gesture.
+ */
+export function setupContentExpansion(container: HTMLDivElement, { codeBlocks }: { codeBlocks: boolean }) {
+    if (glob.device === "print") return;
+
+    const $container = $(container);
+    $container.off("dblclick.contentExpansion click.contentExpansion");
+    $container.on("dblclick.contentExpansion", (e) => {
+        const resolution = resolveExpansionTarget(e.target as Element, { codeBlocks });
+        if (!resolution) return;
+
+        e.stopPropagation();
+        runExpansion(resolution, { newTab: false, activate: false });
+    });
+    // Ctrl-click and middle-click open a note in another tab, matching what images already do; a
+    // plain click keeps whatever meaning the content itself has.
+    $container.on("click.contentExpansion", (e) => {
+        const isLeftClick = e.which === 1;
+        const isMiddleClick = e.which === 2;
+        const ctrlKey = utils.isCtrlKey(e);
+        if (!((isLeftClick && ctrlKey) || isMiddleClick)) return;
+
+        const resolution = resolveExpansionTarget(e.target as Element, { codeBlocks, navigateOnly: true });
+        if (resolution?.type !== "navigate") return;
+
+        e.stopPropagation();
+        const activate = (isLeftClick && ctrlKey && e.shiftKey) || (isMiddleClick && e.shiftKey);
+        runExpansion(resolution, { newTab: true, activate });
+    });
+}
+
+/**
+ * Decides what a double click on `target` expands, or `null` when the gesture belongs elsewhere.
+ *
+ * `navigateOnly` narrows the answer to the note-navigation case, so a caller that acts on nothing
+ * else stops before `serializeSvgForLightbox` copies a whole diagram.
+ */
+export function resolveExpansionTarget(target: Element, { codeBlocks, navigateOnly = false }: { codeBlocks: boolean; navigateOnly?: boolean }): ExpansionTarget | null {
+    if (target.closest("a, button, textarea.ck-mermaid__editing-view")) {
+        return null;
+    }
+
+    const svg = target.closest<SVGSVGElement>("svg");
+    // Checked before the code-block diagrams so an included one navigates instead of opening a copy.
+    if (svg?.closest(".include-note-content")?.classList.contains("type-mermaid")) {
+        const noteId = svg.closest<HTMLElement>("section.include-note")?.dataset.noteId;
+        return noteId ? { type: "navigate", noteId } : null;
+    }
+
+    if (navigateOnly) {
+        return null;
+    }
+
+    if (svg?.closest('div.mermaid-diagram[data-processed="true"], div.ck-mermaid__preview')) {
+        return { type: "lightbox", data: { kind: "svg", svg: serializeSvgForLightbox(svg) } };
+    }
+
+    const math = target.closest("span.math-tex, .ck-math-tex");
+    if (math) {
+        // KaTeX has not run yet on a formula that carries no rendered output.
+        const katex = math.querySelector(".katex-display") ?? math.querySelector(".katex");
+        return katex ? { type: "lightbox", data: { kind: "html", html: katex.outerHTML } } : null;
+    }
+
+    if (codeBlocks) {
+        const code = target.closest("pre")?.querySelector(":scope > code");
+        if (code instanceof HTMLElement) {
+            return { type: "lightbox", data: { kind: "code", code: code.textContent ?? "", language: extractLanguageFromClassList(code) } };
+        }
+    }
+
+    return null;
 }
 
 async function openImageInCurrentTab($img: JQuery<HTMLElement>) {
@@ -137,4 +223,37 @@ async function parseFromImage($img: JQuery<HTMLElement>): Promise<{ noteId: stri
     }
 
     return null;
+}
+
+/**
+ * Copies a rendered mermaid diagram into standalone markup the lightbox can lay out.
+ *
+ * Mermaid scopes its `<style>` rules to the svg id and prefixes every `<marker id>` and `url(#…)`
+ * reference with it, so replacing the id throughout keeps the copy self-contained instead of
+ * resolving against the original, which can sit inside a collapsed include. A `useMaxWidth` diagram
+ * carries `width="100%"` plus an inline `max-width`, which cannot size itself in a `fit-content`
+ * box, so the viewBox supplies explicit dimensions.
+ */
+function serializeSvgForLightbox(svg: SVGSVGElement) {
+    const clone = svg.cloneNode(true) as SVGSVGElement;
+    const [ , , width, height ] = (clone.getAttribute("viewBox") ?? "").trim().split(/[\s,]+/);
+    if (width && height) {
+        clone.setAttribute("width", width);
+        clone.setAttribute("height", height);
+        clone.style.removeProperty("max-width");
+    }
+
+    const markup = clone.outerHTML;
+    const id = svg.getAttribute("id");
+    return id ? markup.split(id).join(`${id}-lightbox`) : markup;
+}
+
+function runExpansion(resolution: ExpansionTarget, { newTab, activate }: { newTab: boolean; activate: boolean }) {
+    if (resolution.type === "lightbox") {
+        appContext.triggerCommand("showContentLightbox", resolution.data);
+    } else if (newTab) {
+        appContext.tabManager.openTabWithNoteWithHoisting(resolution.noteId, { activate });
+    } else {
+        appContext.tabManager.getActiveContext()?.setNote(resolution.noteId);
+    }
 }


### PR DESCRIPTION
Double-clicking an inline diagram, formula or code block inside a text note now expands it. Requested for Mermaid code blocks, which rendered at note width with no way to read a large graph; the same gesture covers the other inline things that have the same problem.

## Behaviour

Follows the existing image convention: where a note exists, double-click opens it; otherwise the content opens in a lightbox.

- **Included Mermaid note** (Include Note of a `mermaid` note): double-click navigates to that note in the current tab, Ctrl+click or middle-click opens it in a new tab, exactly like an image in a text note.
- **Mermaid code block** (`language-mermaid`), in both the editor preview and the read-only view: opens a lightbox with the diagram in a zoom/pan viewer.
- **Math formula** (KaTeX, inline or display), both modes: opens the same lightbox, scaled up to fit.
- **Code block**, read-only view only: opens the lightbox with the code in the shared `CodeBlock` component (copy button, word-wrap follows the `codeBlockWordWrap` option). Not bound in the editor, where double-click is the word-selection gesture.
- Double-click only; the only added chrome is `cursor: zoom-in` on the expandable elements (`pointer` on an included diagram, since that one navigates).

Because the read-only renderer is shared, the markdown live preview and the LLM chat panel get the same gesture.

## Handler (`type_widgets/text/utils.ts`)

`setupContentExpansion(container, { codeBlocks })` is one delegated `dblclick`/`click` listener on the content root, installed next to the image handler in `ReadOnlyText` (`codeBlocks: true`) and `EditableText` (`codeBlocks: false`). A pure `resolveExpansionTarget(target, opts)` maps the event target to either a navigation or a `ContentLightboxData` payload, in a fixed order: anchors, buttons and the Mermaid source textarea are ignored; an included Mermaid note is matched before the code-block shapes so it is never mistaken for one; math resolves only once KaTeX has produced its output.

The read-only content root is a persistent element whose layout effect re-runs on every content change, so the existing image handler accumulated a duplicate listener per re-render (every keystroke in the markdown preview). Both installers now use namespaced events with `.off()` before `.on()`, and a spec pins one navigation after two installs.

Mermaid SVGs are serialised for the lightbox with every occurrence of the diagram id rewritten to `<id>-lightbox`: mermaid scopes its `<style>` rules to `#id` and prefixes marker ids and `url(#…)` refs with it, so the copy never resolves to the original, which can sit inside a collapsed include. A `viewBox` is turned into explicit `width`/`height` and the inline `max-width` dropped, for the `pie` case that mermaid renders with `useMaxWidth: true`.

## Lightbox (`dialogs/content_lightbox.tsx`)

An event-summoned, lazily registered `Modal` (`showContentLightbox` command, size `xl`, full page on mobile). Diagrams and formulas render through `RawHtmlBlock` (not the sanitising variant: the markup already lived in the document and DOMPurify would strip the `<style>` and `foreignObject` mermaid depends on) inside `ZoomPanViewer` in measure mode. The body height is set on `.modal-body` so the viewer's own `height: 100%` chain resolves against a definite size.

## `ZoomPanViewer` (extracted from `ImageViewer`)

The image note's zoom/pan viewport, overlay zoom buttons and keyboard control are now a generic `ZoomPanViewer` with children; `ImageViewer` composes it with identical public props and its spec passes unedited. A new `fit="measure"` mode lays the content out at natural size, measures it against the viewport, and drives the fit through `initialScale`, so `resetTransform()` (the `%` button, the `/` key, double-click) returns to the fitted, centred view. The content stays hidden until a real (non-zero) measurement lands, so asynchronously sized content never paints one frame at scale 1. `computeFitScale` is exported and unit-tested. Verified against the installed react-zoom-pan-pinch 4.2.0.

## Tests

- `type_widgets/text/utils.spec.ts`: 13 new cases (resolver table, ignored targets, `codeBlocks` gate, nested include, idempotent install, click modifiers, print device, SVG serialisation).
- `dialogs/content_lightbox.spec.tsx`: 5 cases (each payload kind, replacement on re-summons, reopen after hide).
- `react/ZoomPanViewer.spec.tsx`: 9 cases (wrapper props, class placement, `ready`, `computeFitScale`, readout, hidden-until-measured, no hint provider without `hints`).
- `ImageViewer.spec.tsx` and `image_viewer_keyboard.spec.ts` unchanged and green. Each new spec was run against a reverted implementation to confirm every assertion fails without it. `pnpm typecheck` clean.

## Not covered here

- **User Guide** (edited via `pnpm edit-docs:edit-docs`, so not in this PR): "Insert buttons" (Mermaid diagram section), "Math Equations", "Developer-specific formatting" / "Code blocks", and "Include Note" should each mention the double-click.
- `fit="measure"` cannot be exercised under happy-dom (zero-sized rects); the fit chain is verified by reading the library, not by a spec. Please try the topology diagram in a real note in both edit and read-only mode, and a formula.
- The CKEditor widget balloon (`z-index` 10000) should hide when focus moves into the modal; if it stays visible over the lightbox in edit mode, the fix is the `zIndex` prop on `Modal`.
- Double-tap on iOS Safari does not synthesise `dblclick`.
- The lightbox body height is desktop-only (`body.desktop`); on mobile the full-page dialog owns the height, which was not checked on a device.

## Deferred polish (from review)

- `evaluateImageZoom(...).pannable` is no longer read in production (the viewer derives it); kept because `ImageViewer.spec.tsx` asserts it.
- `ZOOM_PAN_HINTS` still uses the `image_viewer.hints.*` keys; renaming touches 39 locales.
- Ctrl/middle-click on an included diagram mirrors the image handler, which binds `click`; modern browsers deliver non-primary buttons as `auxclick`, so middle-click is unreachable for both. A follow-up should bind `auxclick` on both installers together.
- react-zoom-pan-pinch 4.2.0 ships `fitOnInit`; adopting it would replace the `initialScale` fit path rather than extend it, so it stays a separate change.
