### PR TITLE
fix(client): keep the tree and the note in place when deleting a note

### DIFF
--- a/apps/client/src/services/branches.spec.ts
+++ b/apps/client/src/services/branches.spec.ts
@@ -282,7 +282,8 @@ describe("deleteNotes", () => {
 
         const result = await branches.deleteNotes(["delBranch4"], false, false);
         expect(result).toBe(true);
-        // getActiveContext only used by activateNeighbouringNotePath, which is skipped
+        // With moveToParent off, the active tab is left alone: the collection views that pass it
+        // delete a child of the note they show, so there is nothing to navigate away from.
         expect(getActiveContext).not.toHaveBeenCalled();
     });
 

--- a/apps/client/src/services/branches.spec.ts
+++ b/apps/client/src/services/branches.spec.ts
@@ -307,7 +307,7 @@ describe("deleteNotes", () => {
 });
 
 describe("activateNeighbouringNotePath (via deleteNotes navigation)", () => {
-    /** Confirms the delete dialog with the given options and captures where the active tab navigates. */
+    /** Confirms the delete dialog with the given options and captures where the tab navigates. */
     function confirmDeletion(notePathArray: string[], deleteAllClones = false) {
         const setNote = vi.fn(async () => {});
         appContext.tabManager = {
@@ -319,9 +319,12 @@ describe("activateNeighbouringNotePath (via deleteNotes navigation)", () => {
         return setNote;
     }
 
-    it("activates the next sibling, or the previous one when the deleted note is the last", async () => {
+    it("activates the next sibling, or the previous one for the last note", async () => {
         const parent = buildNote({ title: "P", children: [
-            { id: "sibA", title: "A" }, { id: "sibB", title: "B" }, { id: "sibC", title: "C" }, { id: "sibD", title: "D" }
+            { id: "sibA", title: "A" },
+            { id: "sibB", title: "B" },
+            { id: "sibC", title: "C" },
+            { id: "sibD", title: "D" }
         ] });
         const p = parent.noteId;
 
@@ -340,9 +343,11 @@ describe("activateNeighbouringNotePath (via deleteNotes navigation)", () => {
         expect(setNote).toHaveBeenCalledWith(`root/${p}/sibB`);
     });
 
-    it("skips siblings that the deletion also removes and archived ones, falling back to the parent", async () => {
+    it("skips removed and archived siblings, falling back to the parent", async () => {
         const parent = buildNote({ title: "P2", children: [
-            { id: "arcA", title: "A", "#archived": "" }, { id: "selB", title: "B" }, { id: "selC", title: "C" }
+            { id: "arcA", title: "A", "#archived": "" },
+            { id: "selB", title: "B" },
+            { id: "selC", title: "C" }
         ] });
         const p = parent.noteId;
 
@@ -425,8 +430,9 @@ describe("activateNeighbouringNotePath (via deleteNotes navigation)", () => {
             getActiveContext: () => ({ notePathArray: undefined, setNote })
         } as any;
         appContext.triggerCommand = vi.fn((_name: any, data: any) => {
-            // Remove the branch after filtering but before navigation, so activateNeighbouringNotePath's
-            // `froca.getBranch(...)` returns undefined and the `if (branch)` false arm is taken.
+            // Remove the branch after filtering but before navigation, so that
+            // activateNeighbouringNotePath's `froca.getBranch(...)` returns undefined and the
+            // `if (branch)` false arm is taken.
             delete froca.branches["ancBranch"];
             data.callback({ proceed: true, deleteAllClones: false, eraseNotes: false });
         }) as any;

--- a/apps/client/src/services/branches.spec.ts
+++ b/apps/client/src/services/branches.spec.ts
@@ -240,7 +240,7 @@ describe("deleteNotes", () => {
         expect(firstArg).toContain("eraseNotes=false");
         expect(firstArg).toContain("last=false");
         expect(secondArg).toContain("last=true");
-        // navigated to the parent path ("root")
+        // root has no children registered here, so the parent path ("root") is the fallback
         expect(setNote).toHaveBeenCalledWith("root");
     });
 
@@ -282,7 +282,7 @@ describe("deleteNotes", () => {
 
         const result = await branches.deleteNotes(["delBranch4"], false, false);
         expect(result).toBe(true);
-        // getActiveContext only used by activateParentNotePath, which is skipped
+        // getActiveContext only used by activateNeighbouringNotePath, which is skipped
         expect(getActiveContext).not.toHaveBeenCalled();
     });
 
@@ -306,7 +306,85 @@ describe("deleteNotes", () => {
     });
 });
 
-describe("activateParentNotePath (via deleteNotes navigation)", () => {
+describe("activateNeighbouringNotePath (via deleteNotes navigation)", () => {
+    /** Confirms the delete dialog with the given options and captures where the active tab navigates. */
+    function confirmDeletion(notePathArray: string[], deleteAllClones = false) {
+        const setNote = vi.fn(async () => {});
+        appContext.tabManager = {
+            getActiveContext: () => ({ notePathArray, setNote })
+        } as any;
+        appContext.triggerCommand = vi.fn((_name: any, data: any) => {
+            data.callback({ proceed: true, deleteAllClones, eraseNotes: false });
+        }) as any;
+        return setNote;
+    }
+
+    it("activates the next sibling, or the previous one when the deleted note is the last", async () => {
+        const parent = buildNote({ title: "P", children: [
+            { id: "sibA", title: "A" }, { id: "sibB", title: "B" }, { id: "sibC", title: "C" }, { id: "sibD", title: "D" }
+        ] });
+        const p = parent.noteId;
+
+        let setNote = confirmDeletion(["root", p, "sibB"]);
+        await branches.deleteNotes([`${p}_sibB`]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/sibC`);
+
+        setNote = confirmDeletion(["root", p, "sibD"]);
+        await branches.deleteNotes([`${p}_sibD`]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/sibC`);
+
+        // The deleted note is an ancestor of the active one: its own siblings are what count.
+        buildNote({ id: "grandchild", title: "G" });
+        setNote = confirmDeletion(["root", p, "sibA", "grandchild"]);
+        await branches.deleteNotes([`${p}_sibA`]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/sibB`);
+    });
+
+    it("skips siblings that the deletion also removes and archived ones, falling back to the parent", async () => {
+        const parent = buildNote({ title: "P2", children: [
+            { id: "arcA", title: "A", "#archived": "" }, { id: "selB", title: "B" }, { id: "selC", title: "C" }
+        ] });
+        const p = parent.noteId;
+
+        // B and C are both selected, A is archived: nothing survives, so the parent is the target.
+        let setNote = confirmDeletion(["root", p, "selB"]);
+        await branches.deleteNotes([`${p}_selB`, `${p}_selC`]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}`);
+
+        // Only B is selected, so C survives.
+        setNote = confirmDeletion(["root", p, "selB"]);
+        await branches.deleteNotes([`${p}_selB`]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/selC`);
+    });
+
+    it("treats a clone of a deleted note as gone only when all clones are deleted", async () => {
+        // X hangs both under P3 (right after B) and under Q; only its Q branch is selected.
+        const parent = buildNote({ title: "P3", children: [
+            { id: "clB", title: "B" }, { id: "clX", title: "X" }, { id: "clC", title: "C" }
+        ] });
+        const other = buildNote({ title: "Q" });
+        const p = parent.noteId;
+        makeBranch("Q_clX", "clX", other.noteId);
+        other.addChild("clX", "Q_clX", false);
+        froca.getNoteFromCache("clX")?.addParent(other.noteId, "Q_clX", false);
+
+        let setNote = confirmDeletion(["root", p, "clB"], false);
+        await branches.deleteNotes([`${p}_clB`, "Q_clX"]);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/clX`);
+
+        setNote = confirmDeletion(["root", p, "clB"], true);
+        await branches.deleteNotes([`${p}_clB`, "Q_clX"], true);
+        expect(setNote).toHaveBeenCalledWith(`root/${p}/clC`);
+    });
+
+    it("falls back to the parent when its children are not loaded in froca", async () => {
+        const note = buildNote({ title: "Lonely" });
+        makeBranch("lonelyBranch", note.noteId, "root");
+        const setNote = confirmDeletion(["root", note.noteId]);
+        await branches.deleteNotes(["lonelyBranch"]);
+        expect(setNote).toHaveBeenCalledWith("root");
+    });
+
     it("does not navigate when the deleted note is not on the active path", async () => {
         const note = buildNote({ title: "Off" });
         makeBranch("offBranch", note.noteId, "root");
@@ -347,7 +425,7 @@ describe("activateParentNotePath (via deleteNotes navigation)", () => {
             getActiveContext: () => ({ notePathArray: undefined, setNote })
         } as any;
         appContext.triggerCommand = vi.fn((_name: any, data: any) => {
-            // Remove the branch after filtering but before navigation, so activateParentNotePath's
+            // Remove the branch after filtering but before navigation, so activateNeighbouringNotePath's
             // `froca.getBranch(...)` returns undefined and the `if (branch)` false arm is taken.
             delete froca.branches["ancBranch"];
             data.callback({ proceed: true, deleteAllClones: false, eraseNotes: false });

--- a/apps/client/src/services/branches.ts
+++ b/apps/client/src/services/branches.ts
@@ -184,7 +184,12 @@ async function activateNeighbouringNotePath(branchIdsToDelete: string[], deleteA
         return;
     }
 
-    const siblingNoteId = findSurvivingSibling(parentPath[parentPath.length - 1], activeNotePath[earliestIndex], branchIdsToDelete, deleteAllClones);
+    const siblingNoteId = findSurvivingSibling(
+        parentPath[parentPath.length - 1],
+        activeNotePath[earliestIndex],
+        branchIdsToDelete,
+        deleteAllClones
+    );
     const targetPath = siblingNoteId ? [ ...parentPath, siblingNoteId ] : parentPath;
     await activeContext?.setNote(targetPath.join("/"));
 }
@@ -194,7 +199,12 @@ async function activateNeighbouringNotePath(branchIdsToDelete: string[], deleteA
  * are deleted: the next sibling, else the previous one. Archived siblings are skipped, since the
  * tree can be set to hide them.
  */
-function findSurvivingSibling(parentNoteId: string, noteId: string, branchIdsToDelete: string[], deleteAllClones: boolean) {
+function findSurvivingSibling(
+    parentNoteId: string,
+    noteId: string,
+    branchIdsToDelete: string[],
+    deleteAllClones: boolean
+) {
     const parentNote = froca.getNoteFromCache(parentNoteId);
     if (!parentNote) {
         return null;
@@ -207,13 +217,18 @@ function findSurvivingSibling(parentNoteId: string, noteId: string, branchIdsToD
     }
 
     // Deleting all clones removes every branch of the deleted notes, not only the selected ones.
-    const deletedNoteIds = new Set(branchIdsToDelete.map((branchId) => froca.getBranch(branchId)?.noteId));
+    const deletedNoteIds = new Set(
+        branchIdsToDelete.map((branchId) => froca.getBranch(branchId)?.noteId)
+    );
     const survives = (branch: FBranch) =>
         !branchIdsToDelete.includes(branch.branchId)
         && !(deleteAllClones && deletedNoteIds.has(branch.noteId))
         && !froca.getNoteFromCache(branch.noteId)?.isArchived;
 
-    const candidates = [ ...siblingBranches.slice(index + 1), ...siblingBranches.slice(0, index).reverse() ];
+    const candidates = [
+        ...siblingBranches.slice(index + 1),
+        ...siblingBranches.slice(0, index).reverse()
+    ];
     return candidates.find(survives)?.noteId ?? null;
 }
 

--- a/apps/client/src/services/branches.ts
+++ b/apps/client/src/services/branches.ts
@@ -1,4 +1,5 @@
 import appContext from "../components/app_context.js";
+import type FBranch from "../entities/fbranch.js";
 import type { ResolveOptions } from "../widgets/dialogs/delete_notes.js";
 import froca from "./froca.js";
 import hoistedNoteService from "./hoisted_note.js";
@@ -120,7 +121,7 @@ async function deleteNotes(branchIdsToDelete: string[], forceDeleteAllClones = f
 
     if (moveToParent) {
         try {
-            await activateParentNotePath(branchIdsToDelete);
+            await activateNeighbouringNotePath(branchIdsToDelete, deleteAllClones);
         } catch (e) {
             console.error(e);
         }
@@ -152,7 +153,13 @@ async function deleteNotes(branchIdsToDelete: string[], forceDeleteAllClones = f
     return true;
 }
 
-async function activateParentNotePath(branchIdsToDelete: string[]) {
+/**
+ * Moves the active tab off a note that the deletion is about to remove from its path. The
+ * destination is the nearest sibling that survives the deletion (the next one, else the previous
+ * one), so the tree keeps its scroll position and the user stays where they were working; the
+ * parent is the fallback when no sibling survives.
+ */
+async function activateNeighbouringNotePath(branchIdsToDelete: string[], deleteAllClones = false) {
     const activeContext = appContext.tabManager.getActiveContext();
     const activeNotePath = activeContext?.notePathArray ?? [];
 
@@ -168,13 +175,46 @@ async function activateParentNotePath(branchIdsToDelete: string[]) {
         }
     }
 
-    // Navigate to the parent of the highest deleted ancestor
-    if (earliestIndex < activeNotePath.length) {
-        const parentPath = activeNotePath.slice(0, earliestIndex);
-        if (parentPath.length > 0) {
-            await activeContext?.setNote(parentPath.join("/"));
-        }
+    if (earliestIndex >= activeNotePath.length) {
+        return;
     }
+
+    const parentPath = activeNotePath.slice(0, earliestIndex);
+    if (parentPath.length === 0) {
+        return;
+    }
+
+    const siblingNoteId = findSurvivingSibling(parentPath[parentPath.length - 1], activeNotePath[earliestIndex], branchIdsToDelete, deleteAllClones);
+    const targetPath = siblingNoteId ? [ ...parentPath, siblingNoteId ] : parentPath;
+    await activeContext?.setNote(targetPath.join("/"));
+}
+
+/**
+ * Finds the child of `parentNoteId` closest to `noteId` that is still there once the given branches
+ * are deleted: the next sibling, else the previous one. Archived siblings are skipped, since the
+ * tree can be set to hide them.
+ */
+function findSurvivingSibling(parentNoteId: string, noteId: string, branchIdsToDelete: string[], deleteAllClones: boolean) {
+    const parentNote = froca.getNoteFromCache(parentNoteId);
+    if (!parentNote) {
+        return null;
+    }
+
+    const siblingBranches = parentNote.getChildBranches();
+    const index = siblingBranches.findIndex((branch) => branch.noteId === noteId);
+    if (index === -1) {
+        return null;
+    }
+
+    // Deleting all clones removes every branch of the deleted notes, not only the selected ones.
+    const deletedNoteIds = new Set(branchIdsToDelete.map((branchId) => froca.getBranch(branchId)?.noteId));
+    const survives = (branch: FBranch) =>
+        !branchIdsToDelete.includes(branch.branchId)
+        && !(deleteAllClones && deletedNoteIds.has(branch.noteId))
+        && !froca.getNoteFromCache(branch.noteId)?.isArchived;
+
+    const candidates = [ ...siblingBranches.slice(index + 1), ...siblingBranches.slice(0, index).reverse() ];
+    return candidates.find(survives)?.noteId ?? null;
 }
 
 async function moveNodeUpInHierarchy(node: Fancytree.FancytreeNode) {

--- a/apps/client/src/services/focus.spec.ts
+++ b/apps/client/src/services/focus.spec.ts
@@ -11,9 +11,9 @@ afterEach(() => {
 describe("focus service", () => {
     it("does nothing (no focus change) when nothing was focused at save time", () => {
         // saveFocusedElement() always assigns a jQuery object: $(":focus") is never null, only an
-        // empty wrapped set (or, under happy-dom, the <body> itself). So the early-return at the top
-        // of focusSavedElement() is NOT hit here; execution falls through to .hasClass("ck") (false)
-        // and then to a focus() that changes nothing.
+        // empty wrapped set (or, under happy-dom, the <body> itself). So the early-return at the
+        // top of focusSavedElement() is NOT hit here; execution falls through to .hasClass("ck")
+        // (false) and then to a focus() that changes nothing.
         const $body = $(document.body);
         ($body[0] as HTMLElement).focus();
         // happy-dom keeps focus on <body> by default; record the active element to prove it is unchanged.

--- a/apps/client/src/services/focus.spec.ts
+++ b/apps/client/src/services/focus.spec.ts
@@ -10,10 +10,10 @@ afterEach(() => {
 
 describe("focus service", () => {
     it("does nothing (no focus change) when nothing was focused at save time", () => {
-        // saveFocusedElement() always assigns a jQuery object: $(":focus") is an *empty* wrapped
-        // set when nothing is focused (never null). So the early-return at the top of
-        // focusSavedElement() is NOT hit here; execution falls through to .hasClass("ck") (false)
-        // then .focus() on the empty set, which is a harmless no-op.
+        // saveFocusedElement() always assigns a jQuery object: $(":focus") is never null, only an
+        // empty wrapped set (or, under happy-dom, the <body> itself). So the early-return at the top
+        // of focusSavedElement() is NOT hit here; execution falls through to .hasClass("ck") (false)
+        // and then to a focus() that changes nothing.
         const $body = $(document.body);
         ($body[0] as HTMLElement).focus();
         // happy-dom keeps focus on <body> by default; record the active element to prove it is unchanged.
@@ -21,11 +21,7 @@ describe("focus service", () => {
 
         saveFocusedElement();
 
-        // Spy on jQuery's focus to prove no real element receives focus via the empty-set branch.
-        const focusProtoSpy = vi.spyOn($.fn, "focus");
         expect(() => focusSavedElement()).not.toThrow();
-        // .focus() is invoked on the empty wrapped set (harmless), but the active element is unchanged.
-        expect(focusProtoSpy).toHaveBeenCalledTimes(1);
         expect(document.activeElement).toBe(before);
     });
 
@@ -63,8 +59,12 @@ describe("focus service", () => {
         ($other[0] as HTMLInputElement).focus();
         expect(document.activeElement).toBe($other[0]);
 
+        // The element is focused natively and without scrolling: the user has not moved, so the
+        // page must not move either.
+        const focusSpy = vi.spyOn(el, "focus");
         focusSavedElement();
         expect(document.activeElement).toBe(el);
+        expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
 
         // After restoring, the saved element is cleared -> calling again is a no-op.
         ($other[0] as HTMLInputElement).focus();

--- a/apps/client/src/services/focus.ts
+++ b/apps/client/src/services/focus.ts
@@ -22,7 +22,10 @@ export function focusSavedElement() {
             console.log("Could not find CKEditor instance to focus last element");
         }
     } else {
-        $lastFocusedElement.focus();
+        // The user has not moved since the dialog opened, so the focus goes back without the
+        // browser scrolling the element into view. Without `preventScroll`, restoring focus to a
+        // tree node the user has since scrolled away from drags the tree back to it.
+        $lastFocusedElement[0]?.focus({ preventScroll: true });
     }
 
     $lastFocusedElement = null;


### PR DESCRIPTION
Deleting a note scrolled both the note tree and the note content away from where the user was working. Two unrelated causes, both fixed here.

## Focus restore after the confirm dialog

`focusSavedElement` re-focused whatever had focus when the dialog opened with a plain `focus()`, and the browser scrolls a focused element into view. With the tree focused and scrolled elsewhere, closing the delete dialog dragged the tree back to the active node (measured: 0 → 622 px, and 500 → 7387 px in a longer tree). The CKEditor branch was already safe because it goes through `editor.editing.view.focus()`.

Focus is now restored with `{ preventScroll: true }`: the user has not moved since the dialog opened, so nothing should move on its way back. This applies to every dialog opened through `openDialog`, not only deletion.

## Navigation before deleting the active note

`deleteNotes` moved the tab to the **parent** of the deleted note before deleting, and the tree's scroll-follow then animated to that parent. Inside a workspace the parent is the hoisted root, so the tree landed at 0 and the note pane showed the workspace root from the top. That is what "everything scrolls to the top on delete" looks like.

The tab now moves to the nearest sibling that survives the deletion (the next one, else the previous one), which is what `NoteTreeWidget.#processBranchRows` already tried to do for the tree but never reached, since the tab had already left. The parent stays the fallback when no sibling survives: every sibling selected, archived siblings only, or the parent's children not loaded in froca. A sibling counts as gone when its branch is selected, or when "delete all clones" is on and it is a clone of a selected note.

Measured in a 60-child workspace with the active note visible in the tree (Playwright against the in-memory fixture server):

| Scenario | Tree scroll before → after | Opens |
|---|---|---|
| Delete active note, root hoisted | 1546 → 1584 | next sibling |
| Delete active note, workspace hoisted | 1162 → 1200 (was 1162 → 0) | next sibling (was workspace root) |
| Delete last child, workspace hoisted | 1774 → 1736 | previous sibling |

The remaining ±38 px is one tree row, from scroll-follow keeping the new active node within `scrollOfs`.

## Behaviour change to be aware of

Deleting the note you are on now opens its neighbour instead of its parent. That is the part of this change that is a product decision rather than a bug fix; the rest of the PR stands on its own if the parent is preferred.

## Tests

- `branches.spec.ts`: next/previous sibling selection, an ancestor of the active note being deleted, siblings removed by the same deletion, archived siblings, clones under "delete all clones", and the parent fallback.
- `focus.spec.ts`: focus is restored with `preventScroll`.
- All new assertions fail on `main` and pass with the change; `pnpm typecheck` is clean.
