### PR TITLE
fix(llm): use a configured API version path as entered

### DIFF
--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
@@ -110,6 +110,11 @@
   from the <em>Custom endpoint</em> section.</p>
 <p>This allows you to set the base URL to an OpenAI-compatible API, with
   an optional API key if required by the service.</p>
+<p>Enter the base URL exactly as the service documents it, including its
+  version path, such as <code spellcheck="false">https://api.groq.com/openai/v1</code>
+  or <code spellcheck="false">https://open.bigmodel.cn/api/paas/v4</code>. Only
+  a bare host such as <code spellcheck="false">http://localhost:8080</code> is
+  completed with <code spellcheck="false">/v1</code>.</p>
 <p>For custom endpoints, the pricing of the models is not known so the cost
   of a conversation will not be displayed; this is especially relevant for
   hosted providers.</p>

--- a/docs/User Guide/User Guide/AI/Providers.md
+++ b/docs/User Guide/User Guide/AI/Providers.md
@@ -69,4 +69,6 @@ If your desired hosted (e.g. OpenRouter, Groq, Mistral) or local LLM provider is
 
 This allows you to set the base URL to an OpenAI-compatible API, with an optional API key if required by the service.
 
+Enter the base URL exactly as the service documents it, including its version path, such as `https://api.groq.com/openai/v1` or `https://open.bigmodel.cn/api/paas/v4`. Only a bare host such as `http://localhost:8080` is completed with `/v1`.
+
 For custom endpoints, the pricing of the models is not known so the cost of a conversation will not be displayed; this is especially relevant for hosted providers.

--- a/packages/trilium-core/src/services/llm/providers/local.spec.ts
+++ b/packages/trilium-core/src/services/llm/providers/local.spec.ts
@@ -108,6 +108,16 @@ describe("LocalProvider", () => {
             expect(createOpenAiMock).toHaveBeenLastCalledWith({ apiKey: "local", baseURL: "https://proxy.example.com/llm/v1", fetch: llmFetch });
         });
 
+        it("uses a path-carrying URL as entered, appending /v1 only to a bare host", () => {
+            // Zhipu serves its OpenAI-compatible API under /v4, so /v1 must not be appended.
+            new LocalProvider("openai-compatible", "", "https://open.bigmodel.cn/api/paas/v4");
+            expect(createOpenAiMock).toHaveBeenLastCalledWith({ apiKey: "local", baseURL: "https://open.bigmodel.cn/api/paas/v4", fetch: llmFetch });
+
+            // A path naming no version is used as entered too — appending /v1 would invent a route.
+            new LocalProvider("openai-compatible", "", "https://gateway.example.com/openai");
+            expect(createOpenAiMock).toHaveBeenLastCalledWith({ apiKey: "local", baseURL: "https://gateway.example.com/openai", fetch: llmFetch });
+        });
+
         it("forwards a supplied API key to the SDK", () => {
             new LocalProvider("openai-compatible", "sk-proxy", "http://box:8080/v1");
             expect(createOpenAiMock).toHaveBeenLastCalledWith({ apiKey: "sk-proxy", baseURL: "http://box:8080/v1", fetch: llmFetch });
@@ -187,6 +197,20 @@ describe("LocalProvider", () => {
 
             expect(models[0].pricing).toBeUndefined();
             expect(provider.getModelPricing("gpt-4.1")).toBeUndefined();
+        });
+
+        it("lists models from an explicit non-v1 API version", async () => {
+            fetchMock.mockImplementation(routes({ "/api/paas/v4/models": openAiModels(["glm-4.5"]) }));
+
+            const provider = new LocalProvider("openai-compatible", "", "https://open.bigmodel.cn/api/paas/v4");
+
+            await expect(provider.listModels()).resolves.toEqual([expect.objectContaining({ id: "glm-4.5" })]);
+            // Only `/v1` is dropped from the probe root, so a `/v4` endpoint keeps its full path.
+            expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+                "https://open.bigmodel.cn/api/paas/v4/api/tags",
+                "https://open.bigmodel.cn/api/paas/v4/api/v0/models",
+                "https://open.bigmodel.cn/api/paas/v4/models"
+            ]);
         });
 
         it("prices an endpoint identified as a local runtime as free", async () => {

--- a/packages/trilium-core/src/services/llm/providers/local.ts
+++ b/packages/trilium-core/src/services/llm/providers/local.ts
@@ -3,12 +3,13 @@
  * Studio and generic "OpenAI-compatible" provider cards.
  *
  * Every local runtime worth supporting (llama.cpp, vLLM, SGLang, LocalAI, Jan,
- * KoboldCpp, llamafile, LiteLLM, …) exposes the OpenAI-compatible `/v1`
- * surface, so that is the chat path in all cases. Two of them additionally
- * serve a *native* model listing carrying metadata `/v1/models` omits — Ollama's
- * `/api/tags` (parameter size, quantization) and LM Studio's `/api/v0/models`
- * (quantization, context length) — so listing probes those first and falls back
- * to `/v1/models` for everything else.
+ * KoboldCpp, llamafile, LiteLLM, …) exposes the OpenAI-compatible surface, so
+ * that is the chat path in all cases — under `/v1`, or under whichever version
+ * the configured URL names. Two of them additionally serve a *native* model
+ * listing carrying metadata the OpenAI one omits — Ollama's `/api/tags`
+ * (parameter size, quantization) and LM Studio's `/api/v0/models` (quantization,
+ * context length) — so listing probes those first and falls back to the
+ * OpenAI-compatible `/models` for everything else.
  *
  * The named cards exist only to prefill a URL and a setup hint in the UI; all
  * three dispatch here, and the card id arrives as {@link LocalProviderKind}.
@@ -49,6 +50,17 @@ const TITLE_MODEL_MAX_PARAMS_B = 4;
 /** Id shapes that suggest a small model, used when no parameter count is reported. */
 const SMALL_MODEL_NAME = /small|mini|tiny|phi|gemma.*2b/i;
 
+/**
+ * The two roots a card resolves to: the OpenAI-compatible paths hang off
+ * `apiBaseURL`, the native listings off `root` beside it.
+ */
+interface Endpoint {
+    /** What the native listing paths hang off. */
+    root: string;
+    /** What the OpenAI-compatible paths hang off. */
+    apiBaseURL: string;
+}
+
 /** A listed model, plus the parameter count when the endpoint reports one. */
 interface LocalModel extends RemoteModel {
     /** Parameter count in billions. */
@@ -64,8 +76,10 @@ export class LocalProvider extends BaseProvider {
 
     private readonly kind: LocalProviderKind;
     private openai: OpenAISDKProvider;
-    /** Canonical endpoint root, without a trailing `/v1`. */
+    /** Endpoint root the native listings hang off, without a trailing `/v1`. */
     private root: string;
+    /** OpenAI-compatible API base: the configured URL, or a bare host plus `/v1`. */
+    private apiBaseURL: string;
     /**
      * Whether the models are known to come from a local runtime, and are
      * therefore free to run. The named cards are local by definition; the
@@ -79,11 +93,13 @@ export class LocalProvider extends BaseProvider {
         this.kind = kind;
         this.name = kind;
         this.isLocalRuntime = kind !== "openai-compatible";
-        this.root = resolveRoot(kind, this.baseURL);
+        const endpoint = resolveEndpoint(kind, this.baseURL);
+        this.root = endpoint.root;
+        this.apiBaseURL = endpoint.apiBaseURL;
 
         this.openai = createOpenAI({
             apiKey: apiKey || PLACEHOLDER_API_KEY,
-            baseURL: `${this.root}/v1`,
+            baseURL: this.apiBaseURL,
             fetch: llmFetch
         });
     }
@@ -168,12 +184,12 @@ export class LocalProvider extends BaseProvider {
         return null;
     }
 
-    /** The universal fallback: the OpenAI-compatible `/v1/models` listing. */
+    /** The universal fallback: the OpenAI-compatible `/models` listing. */
     private async listOpenAiCompatibleModels(): Promise<LocalModel[]> {
-        const url = `${this.root}/v1/models`;
+        const url = `${this.apiBaseURL}/models`;
         const payload = await this.probeJson(url);
         if (payload === undefined) {
-            throw new Error(`No model listing endpoint found at ${this.root} — is this an OpenAI-compatible server?`);
+            throw new Error(`No model listing endpoint found at ${this.apiBaseURL} — is this an OpenAI-compatible server?`);
         }
         const data = (payload as { data?: unknown }).data;
         if (!Array.isArray(data)) {
@@ -259,38 +275,47 @@ export class LocalProvider extends BaseProvider {
 }
 
 /**
- * Canonical endpoint root for a card: the configured URL (validated), or the
- * card's own default, with any trailing `/v1` removed so both spellings a user
- * might enter — `http://localhost:1234` and `http://localhost:1234/v1` — resolve
- * to the same instance. The `/v1` is re-appended for the SDK and the
- * OpenAI-compatible listing; the native listings hang off the root.
+ * Endpoints for a card: the configured URL (validated), or the card's own
+ * default, split by {@link endpointFromUrl}.
  */
-function resolveRoot(kind: LocalProviderKind, baseURL: string | undefined): string {
+function resolveEndpoint(kind: LocalProviderKind, baseURL: string | undefined): Endpoint {
     const fallback = DEFAULT_BASE_URLS[kind];
     if (!baseURL) {
         if (!fallback) {
             throw new Error("A base URL is required for an OpenAI-compatible provider.");
         }
-        return stripApiVersion(fallback);
+        return endpointFromUrl(fallback);
     }
     try {
         const parsed = new URL(baseURL);
         if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
             throw new Error(`unsupported protocol ${parsed.protocol}`);
         }
-        return stripApiVersion(baseURL);
+        return endpointFromUrl(baseURL);
     } catch (e) {
         if (!fallback) {
             throw new Error(`Invalid base URL "${baseURL}": ${e instanceof Error ? e.message : String(e)}`);
         }
         getLog().error(`${kind}: invalid base URL "${baseURL}" (${e}), falling back to ${fallback}`);
-        return stripApiVersion(fallback);
+        return endpointFromUrl(fallback);
     }
 }
 
-/** Trailing slashes are already gone (the base class normalizes them). */
-function stripApiVersion(url: string): string {
-    return url.endsWith("/v1") ? url.slice(0, -"/v1".length) : url;
+/**
+ * Split a URL into the roots of {@link Endpoint}. A URL carrying a path is the
+ * API base as entered, so an endpoint under a version of its own — Zhipu's
+ * `/api/paas/v4` — reaches that version rather than a `/v1` below it; a bare
+ * host names no API and takes the conventional `/v1`.
+ *
+ * Only `/v1` is dropped from `root`: it is the exact suffix of the two runtimes
+ * that serve the native listings, which sit beside it. Trailing slashes are
+ * already gone (the base class normalizes them).
+ */
+function endpointFromUrl(url: string): Endpoint {
+    return {
+        root: url.endsWith("/v1") ? url.slice(0, -"/v1".length) : url,
+        apiBaseURL: new URL(url).pathname === "/" ? `${url}/v1` : url
+    };
 }
 
 /**


### PR DESCRIPTION
## What

A provider configured with `https://open.bigmodel.cn/api/paas/v4` chatted at `/api/paas/v4/v1/chat/completions`. `stripApiVersion` knew only the literal `/v1`, so any other version fell through unchanged and the constructor appended a second one — Zhipu, Volcengine (`/api/v3`) and anything else not versioned at `/v1` were unreachable through the OpenAI-compatible card.

Fixes #11323.

## How

The endpoint now resolves from what the URL carries, rather than from a guess at which trailing segment is a version:

```ts
function endpointFromUrl(url: string): Endpoint {
    return {
        root: url.endsWith("/v1") ? url.slice(0, -"/v1".length) : url,
        apiBaseURL: new URL(url).pathname === "/" ? `${url}/v1` : url
    };
}
```

`new URL(url).pathname === "/"` decides it exactly. A bare host names no API and takes the conventional `/v1` — which is what still lets `http://localhost:1234` and `http://localhost:1234/v1` reach the same LM Studio. A URL carrying a path is the API base as entered.

**`root` keeps its literal `/v1` strip, so every native probe URL is unchanged.** That suffix is exact knowledge about the two runtimes that serve `/api/tags` and `/api/v0/models` — they sit beside `/v1`, never beside `/v4`. Nothing about Ollama, LM Studio, the `isLocalRuntime` free-pricing signal or the probe chain moves.

## Relationship to #11406

#11406 reports and diagnoses the same bug, and resolves it by matching a version suffix with a pattern (`/\/v\d+(?:[a-z]+\d*)?$/i`). Its two test cases are a correct specification of the behavior and are adapted here with credit; the author is a co-author on the commit.

Compared across real endpoint shapes the two rules agree everywhere except three:

| URL | pattern | pathname |
|---|---|---|
| `https://host/v1/openai` | `…/v1/openai/v1` ✗ | `…/v1/openai` ✓ |
| `https://host/openai/deployments/gpt-4o` | `…/gpt-4o/v1` ✗ | `…/gpt-4o` ✓ |
| `https://api.groq.com/openai` | `…/openai/v1` ✓ | `…/openai` ✗ |

Version-in-the-middle and Azure-style deployment paths are broken on `main`, stay broken under a pattern, and are fixed here. A pattern wins only for a partial path such as Groq's, whose real base is `/openai/v1` — and that case is undecidable from the string, so believing the path the user typed is the answer that does not guess.

A pattern also has to reshape `root`, which is what makes it change the native probe URLs and the "no model listing endpoint" message; this version leaves both alone.

## Behavior change

One spelling resolves differently for an existing configuration: a path that names no version — `https://api.groq.com/openai` — resolved to `/openai/v1` before and is now used as entered. The settings hint already asks for the version path ("usually ending in `/v1`"), and the model listing reports the URL it tried, so the failure is legible. Every other stored spelling is interpreted exactly as before.

## Testing

- `pnpm --filter server test llm/providers/local.spec` — 33 passed
- `pnpm --filter standalone test llm/providers/local.spec` — 33 passed (core specs run under both runtimes)
- Reverted the implementation with the specs in place: both new tests fail, the other 31 pass. The second assertion of the resolution test was isolated into a scratch spec to confirm it fails on its own rather than riding on the first.
- `pnpm typecheck` — no errors

## Docs

The _Custom endpoints_ section said only that the base URL can be set, leaving which spellings work to be discovered by trying them. It now names the rule: the URL is used as entered, and only a bare host is completed with `/v1`.

Both copies of the page are updated — the Markdown export `docs/User Guide/User Guide/AI/Providers.md` and the in-app `apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html` — one paragraph each, edited by hand rather than through `pnpm edit-docs:edit-docs`, matching the HTML's existing wrap and `<code spellcheck="false">` conventions so the pair stays in sync and no page is reflowed. `!!!meta.json` carries note structure with no content-derived field, so it needs no regeneration; `doc_notes.spec.ts` (2 passed) and `in_app_help.spec.ts` (11 passed) confirm nothing depends on the page's text.

`llm.setup_hint_openai_compatible` ("usually ending in `/v1`") stays accurate, so no translation-catalogue churn. The providers the section names — OpenRouter, Groq, Mistral — all publish `/v1`-terminated base URLs, so none is affected by the behavior change above.
