### PR TITLE
Board: multiple selection, native drag & drop and other improvements

### DIFF
--- a/apps/client/src/components/app_context.ts
+++ b/apps/client/src/components/app_context.ts
@@ -569,6 +569,8 @@ type EventMappings = {
     geoMapCreateChildNote: {
         ntxId: string | null | undefined; // TODO: deduplicate ntxId
     };
+    /** Opens the board's properties dialog, which only the board itself can show. */
+    showBoardProperties: { ntxId: string | null | undefined; };
     tabReorder: {
         ntxIdsInOrder: string[];
     };

--- a/apps/client/src/menus/context_menu_utils.ts
+++ b/apps/client/src/menus/context_menu_utils.ts
@@ -1,24 +1,32 @@
+import type FNote from "../entities/fnote"
+import type { MenuItem } from "./context_menu"
 import { t } from "../services/i18n"
-import attributes from "../services/attributes"
-import FNote from "../entities/fnote"
+import { setArchivedOnNotes, shared } from "../services/note_set"
 import { escapeHtml } from "../services/utils"
 
-export function getArchiveMenuItem(note: FNote) {
-    if (!note.isArchived) {
-        return {
-            title: t("board_view.archive-note"),
-            uiIcon: "bx bx-archive",
-            handler: () => attributes.addLabel(note.noteId, "archived")
-        }
-    } else {
-        return {
+/**
+ * The entry that archives the notes, or unarchives them when they are all archived already.
+ *
+ * Returns nothing where the notes disagree: one entry cannot say what picking it would do, and
+ * both entries at once would read as two states the same notes are in.
+ */
+export function getArchiveMenuItems<T>(notes: FNote[]): MenuItem<T>[] {
+    const state = shared(notes, (note) => note.isArchived)
+    if (!state.agreed) {
+        return []
+    }
+
+    return [ state.value
+        ? {
             title: t("board_view.unarchive-note"),
             uiIcon: "bx bx-archive-out",
-            handler: async () => {
-                attributes.removeOwnedLabelByName(note, "archived")
-            }
+            handler: () => { void setArchivedOnNotes(notes, false) }
         }
-    }
+        : {
+            title: t("board_view.archive-note"),
+            uiIcon: "bx bx-archive",
+            handler: () => { void setArchivedOnNotes(notes, true) }
+        } ]
 }
 
 /**

--- a/apps/client/src/services/note_set.spec.ts
+++ b/apps/client/src/services/note_set.spec.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildNote } from "../test/easy-froca";
+import froca from "./froca";
+import {
+    clearLabelOnNotes, setArchivedOnNotes, setLabelOnNotes, shared
+} from "./note_set";
+
+// The writes alone, so the rest of the service reads a note the way the application does. Both
+// shapes are replaced: `note_set` calls one of these by name and the others off the default export.
+const writes = vi.hoisted(() => ({
+    setLabelValues: vi.fn(),
+    addLabel: vi.fn(),
+    removeOwnedLabelByName: vi.fn()
+}));
+vi.mock("./attributes", async (importOriginal) => {
+    const original = await importOriginal<{ default: object }>();
+    return { ...original, ...writes, default: { ...original.default, ...writes } };
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("shared", () => {
+    it("answers with the value every note holds", () => {
+        const notes = [
+            buildNote({ title: "One", "#state": "Doing" }),
+            buildNote({ title: "Two", "#state": "Doing" })
+        ];
+
+        expect(shared(notes, (note) => note.getLabelValue("state")))
+            .toEqual({ agreed: true, value: "Doing" });
+    });
+
+    it("answers with nothing where the notes disagree", () => {
+        const notes = [
+            buildNote({ title: "One", "#state": "Doing" }),
+            buildNote({ title: "Two", "#state": "Done" })
+        ];
+
+        expect(shared(notes, (note) => note.getLabelValue("state"))).toEqual({ agreed: false });
+    });
+
+    /**
+     * Every note being unset is something they agree on, which a menu marks, and is not the same
+     * answer as notes holding different values.
+     */
+    it("counts every note holding none as an agreement", () => {
+        const notes = [ buildNote({ title: "One" }), buildNote({ title: "Two" }) ];
+
+        expect(shared(notes, (note) => note.getLabelValue("state")))
+            .toEqual({ agreed: true, value: null });
+    });
+
+    it("answers with nothing for no notes at all", () => {
+        expect(shared([], (note) => note.title)).toEqual({ agreed: false });
+    });
+
+    it("reads whatever the caller asks for, not only labels", () => {
+        const notes = [
+            buildNote({ title: "One", "#archived": "" }),
+            buildNote({ title: "Two", "#archived": "" })
+        ];
+
+        expect(shared(notes, (note) => note.isArchived)).toEqual({ agreed: true, value: true });
+    });
+});
+
+describe("writing to a set of notes", () => {
+    it("sets the label on every one of them", async () => {
+        const first = buildNote({ title: "One" });
+        const second = buildNote({ title: "Two", "#state": "Done" });
+
+        await setLabelOnNotes([ first, second ], "state", "Doing");
+
+        expect(writes.setLabelValues).toHaveBeenCalledWith(first, "state", [ "Doing" ]);
+        expect(writes.setLabelValues).toHaveBeenCalledWith(second, "state", [ "Doing" ]);
+    });
+
+    it("takes the label off every one of them", async () => {
+        const first = buildNote({ title: "One", "#state": "Doing" });
+        const second = buildNote({ title: "Two", "#state": "Done" });
+
+        await clearLabelOnNotes([ first, second ], "state");
+
+        expect(writes.setLabelValues).toHaveBeenCalledWith(first, "state", []);
+        expect(writes.setLabelValues).toHaveBeenCalledWith(second, "state", []);
+    });
+
+    /**
+     * Only the labels a note owns are removed, so a note with nothing of its own would keep what it
+     * inherits. An empty label of its own overrides it.
+     */
+    it("shadows an inherited value rather than removing nothing", async () => {
+        const parent = buildNote({
+            title: "Parent",
+            "#state(inheritable)": "Doing",
+            children: [ { title: "Card" } ]
+        });
+        const child = froca.notes[parent.getChildNoteIds()[0]];
+        if (!child) throw new Error("expected the card to be built");
+
+        await clearLabelOnNotes([ child ], "state");
+
+        expect(writes.setLabelValues).toHaveBeenCalledWith(child, "state", [ "" ]);
+    });
+
+    it("archives the notes that are not archived already", async () => {
+        const plain = buildNote({ title: "One" });
+        const archived = buildNote({ title: "Two", "#archived": "" });
+
+        await setArchivedOnNotes([ plain, archived ], true);
+
+        expect(writes.addLabel).toHaveBeenCalledExactlyOnceWith(plain.noteId, "archived");
+    });
+
+    it("unarchives the notes that are archived", async () => {
+        const plain = buildNote({ title: "One" });
+        const archived = buildNote({ title: "Two", "#archived": "" });
+
+        await setArchivedOnNotes([ plain, archived ], false);
+
+        expect(writes.removeOwnedLabelByName).toHaveBeenCalledExactlyOnceWith(archived, "archived");
+    });
+});

--- a/apps/client/src/services/note_set.ts
+++ b/apps/client/src/services/note_set.ts
@@ -32,8 +32,8 @@ export function shared<T>(notes: FNote[], read: (note: FNote) => T): Shared<T> {
  * Written through `setLabelValues`, which reuses the labels already there and leaves inherited ones
  * alone. The bulk-action endpoint would be one request instead of several, but its
  * `updateLabelValue` only touches labels a note already owns and `addLabel` always adds another,
- * so neither writes "hold this value" on a note that may or may not already hold it. The notes go
- * together instead, so a set is not written one card at a time.
+ * so neither says "hold this value" for a note that might already hold it. The notes go together
+ * instead, so a set is not written one card at a time.
  */
 export async function setLabelOnNotes(notes: FNote[], name: string, value: string) {
     await Promise.all(notes.map((note) => setLabelValues(note, name, [ value ])));

--- a/apps/client/src/services/note_set.ts
+++ b/apps/client/src/services/note_set.ts
@@ -29,15 +29,14 @@ export function shared<T>(notes: FNote[], read: (note: FNote) => T): Shared<T> {
 /**
  * Sets a label to one value on every note.
  *
- * Written note by note through `setLabelValues`, which reuses the labels already there and leaves
- * inherited ones alone. The bulk-action endpoint would be one request instead of several, but its
+ * Written through `setLabelValues`, which reuses the labels already there and leaves inherited ones
+ * alone. The bulk-action endpoint would be one request instead of several, but its
  * `updateLabelValue` only touches labels a note already owns and `addLabel` always adds another,
- * so neither writes "hold this value" on a note that may or may not already hold it.
+ * so neither writes "hold this value" on a note that may or may not already hold it. The notes go
+ * together instead, so a set is not written one card at a time.
  */
 export async function setLabelOnNotes(notes: FNote[], name: string, value: string) {
-    for (const note of notes) {
-        await setLabelValues(note, name, [ value ]);
-    }
+    await Promise.all(notes.map((note) => setLabelValues(note, name, [ value ])));
 }
 
 /**
@@ -48,24 +47,18 @@ export async function setLabelOnNotes(notes: FNote[], name: string, value: strin
  * holds and what `renderLabelValue` draws as nothing.
  */
 export async function clearLabelOnNotes(notes: FNote[], name: string) {
-    for (const note of notes) {
+    await Promise.all(notes.map((note) => {
         const isInherited = note.getAttributes("label", name)
             .some((attribute) => attribute.noteId !== note.noteId);
-        await setLabelValues(note, name, isInherited ? [ "" ] : []);
-    }
+        return setLabelValues(note, name, isInherited ? [ "" ] : []);
+    }));
 }
 
 /** Adds or removes `#archived` on every note, leaving the ones already in that state alone. */
 export async function setArchivedOnNotes(notes: FNote[], archived: boolean) {
-    for (const note of notes) {
-        if (note.isArchived === archived) {
-            continue;
-        }
-
-        if (archived) {
-            await attributes.addLabel(note.noteId, "archived");
-        } else {
-            attributes.removeOwnedLabelByName(note, "archived");
-        }
-    }
+    await Promise.all(notes
+        .filter((note) => note.isArchived !== archived)
+        .map((note) => archived
+            ? attributes.addLabel(note.noteId, "archived")
+            : attributes.removeOwnedLabelByName(note, "archived")));
 }

--- a/apps/client/src/services/note_set.ts
+++ b/apps/client/src/services/note_set.ts
@@ -1,0 +1,71 @@
+import type FNote from "../entities/fnote";
+import attributes, { setLabelValues } from "./attributes";
+
+/**
+ * What a set of notes holds in common: one value they all agree on, or nothing.
+ *
+ * Kept apart from a plain `T | undefined` because the two answers are different: every note being
+ * unset is an agreement, and a menu marks it, while notes that disagree mark nothing at all.
+ */
+export type Shared<T> = { agreed: true, value: T } | { agreed: false };
+
+/**
+ * Reads one thing off every note and reports what they agree on.
+ *
+ * Takes a reader rather than a property name, so the same function answers for a label, a flag or
+ * anything else an `FNote` can be asked. An empty set agrees on nothing.
+ */
+export function shared<T>(notes: FNote[], read: (note: FNote) => T): Shared<T> {
+    if (!notes.length) {
+        return { agreed: false };
+    }
+
+    const value = read(notes[0]);
+    return notes.every((note) => read(note) === value)
+        ? { agreed: true, value }
+        : { agreed: false };
+}
+
+/**
+ * Sets a label to one value on every note.
+ *
+ * Written note by note through `setLabelValues`, which reuses the labels already there and leaves
+ * inherited ones alone. The bulk-action endpoint would be one request instead of several, but its
+ * `updateLabelValue` only touches labels a note already owns and `addLabel` always adds another,
+ * so neither writes "hold this value" on a note that may or may not already hold it.
+ */
+export async function setLabelOnNotes(notes: FNote[], name: string, value: string) {
+    for (const note of notes) {
+        await setLabelValues(note, name, [ value ]);
+    }
+}
+
+/**
+ * Takes a label off every note.
+ *
+ * `setLabelValues` removes only the labels a note owns, so an inherited value would still apply.
+ * Such a note is given an empty label of its own instead, which is what an unset promoted field
+ * holds and what `renderLabelValue` draws as nothing.
+ */
+export async function clearLabelOnNotes(notes: FNote[], name: string) {
+    for (const note of notes) {
+        const isInherited = note.getAttributes("label", name)
+            .some((attribute) => attribute.noteId !== note.noteId);
+        await setLabelValues(note, name, isInherited ? [ "" ] : []);
+    }
+}
+
+/** Adds or removes `#archived` on every note, leaving the ones already in that state alone. */
+export async function setArchivedOnNotes(notes: FNote[], archived: boolean) {
+    for (const note of notes) {
+        if (note.isArchived === archived) {
+            continue;
+        }
+
+        if (archived) {
+            await attributes.addLabel(note.noteId, "archived");
+        } else {
+            attributes.removeOwnedLabelByName(note, "archived");
+        }
+    }
+}

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3526,10 +3526,11 @@
     "card-outside-filter": "This card is outside of the current filtering scope",
     "sort": "Sort",
     "sort-manually": "Manually",
-    "sort-cards": "Sort cards",
+    "default-card-order": "Default card order",
+    "default-card-order-description": "How cards are sorted in each column, unless you choose different sorting options for a particular column.",
     "sort-board-default": "Board's default",
-    "sort-actions": "More actions",
-    "reset-columns-to-default": "Reset all columns to default",
+    "reset-column-sorting": "Reset sorting options to default for all columns",
+    "reset-column-sorting-confirm": "Do you want to reset the sorting options for all columns from the current view to default?",
     "sorted-no-reorder": "Cards cannot be reordered, since this is a sorted column."
   },
   "dashboard_view": {

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -3514,7 +3514,10 @@
       "move_across": "Move to the previous / next column",
       "move_to_end_column": "Move to the first / last column",
       "move_column": "Move the column left / right",
-      "move_column_to_edge": "Move the column to the far left / right"
+      "move_column_to_edge": "Move the column to the far left / right",
+      "selection": "Selection",
+      "select_column": "Select every item of the column",
+      "clear_selection": "Clear the selection"
     },
     "status-alias": "Status",
     "filter-placeholder": "Filter board...",

--- a/apps/client/src/translations/en/translation.json
+++ b/apps/client/src/translations/en/translation.json
@@ -740,6 +740,7 @@
     "max_nesting_depth": "How many levels of children a table shows. Notes cannot be reordered while it is set.",
     "include_archived": "Includes archived notes in this collection, which are otherwise left out.",
     "enable_inbox_column": "For board collections, shows the inbox column, which lists all child notes that are not assigned to a board column.",
+    "board_card_redirect_to": "On a board card, opening the card jumps to the note this points at instead of opening the card itself.",
     "sort_columns": "For board collections, the order the columns sort their cards in, which a column follows unless it is given an order of its own. Holds <code>title</code>, <code>creationDate</code> or <code>attr:</code> followed by a promoted attribute's name.",
     "sort_columns_descending": "For board collections, runs the order in <code>#sortColumns</code> backwards.",
     "calendar_view": "Which view a calendar opens in: <code>timeGridDay</code>, <code>timeGridWeek</code>, <code>dayGridMonth</code>, <code>multiMonthYear</code> or <code>listMonth</code>.",

--- a/apps/client/src/widgets/attribute_widgets/attr_help.ts
+++ b/apps/client/src/widgets/attribute_widgets/attr_help.ts
@@ -192,6 +192,7 @@ export const ATTR_HELP: AttrHelpMap = {
         internalBookmark: t("attribute_detail.internal_bookmark")
     },
     relation: {
+        boardCardRedirectTo: t("attribute_detail.board_card_redirect_to"),
         runOnNoteCreation: t("attribute_detail.run_on_note_creation"),
         runOnChildNoteCreation: t("attribute_detail.run_on_child_note_creation"),
         runOnNoteTitleChange: t("attribute_detail.run_on_note_title_change"),

--- a/apps/client/src/widgets/attribute_widgets/attribute_detail.spec.tsx
+++ b/apps/client/src/widgets/attribute_widgets/attribute_detail.spec.tsx
@@ -5,6 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Component from "../../components/component";
 import { ParentComponent } from "../react/react_utils";
 
+// i18next is never initialized here, so `t()` returns undefined and a row whose label is only a
+// translated string renders without the `<label for>` the tests below look rows up by.
+vi.mock("../../services/i18n", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../../services/i18n")>()),
+    t: (key: string) => key
+}));
+
 // The popup docks differently under the new layout, and the flag behind that is read once when the
 // module loads — so the two are exercised by loading it twice.
 const newLayout = vi.hoisted(() => ({ enabled: false }));
@@ -198,6 +205,7 @@ describe("attribute detail popup naming", () => {
         expect(isSameShow(shown, opts({ ...shown, hideInheritance: true }))).toBe(false);
         expect(isSameShow(shown, opts({ ...shown, hideMultiplicity: true }))).toBe(false);
         expect(isSameShow(shown, opts({ ...shown, hideType: true }))).toBe(false);
+        expect(isSameShow(shown, opts({ ...shown, hideTypeOptions: true }))).toBe(false);
 
         // ...but the very same request handed back is the host re-rendering around an untouched
         // popup, which every keystroke does — rebuilding the form there costs the focus and, with a
@@ -346,10 +354,11 @@ describe("the rows the form carries", () => {
             !!host.querySelector(`[name="${name}"], [id^="${name}"], [for^="${name}"]`);
     }
 
-    it("carries the kind, multiplicity and inheritance rows by default", async () => {
+    it("carries the kind, kind options, multiplicity and inheritance rows by default", async () => {
         const has = await renderForm();
 
         expect(has("attr-label-type")).toBe(true);
+        expect(has("attr-select-options")).toBe(true);
         expect(has("attr-multiplicity")).toBe(true);
         expect(has("attr-inheritable")).toBe(true);
     });
@@ -361,6 +370,18 @@ describe("the rows the form carries", () => {
         expect(has("attr-label-type")).toBe(false);
         // Only that row: the rest of the form is untouched.
         expect(has("attr-name")).toBe(true);
+        expect(has("attr-multiplicity")).toBe(true);
+        expect(has("attr-inheritable")).toBe(true);
+    });
+
+    /** A host that fills the kind's own rows in itself, such as a board making the columns. */
+    it("leaves out the select options alone for `hideTypeOptions`", async () => {
+        const has = await renderForm({ hideTypeOptions: true });
+
+        expect(has("attr-select-options")).toBe(false);
+        // Only that row: the rest of the form is untouched.
+        expect(has("attr-name")).toBe(true);
+        expect(has("attr-label-type")).toBe(true);
         expect(has("attr-multiplicity")).toBe(true);
         expect(has("attr-inheritable")).toBe(true);
     });

--- a/apps/client/src/widgets/attribute_widgets/attribute_detail.tsx
+++ b/apps/client/src/widgets/attribute_widgets/attribute_detail.tsx
@@ -60,6 +60,11 @@ export interface AttributeDetailOpts {
      */
     hideType?: boolean;
     /**
+     * Leaves out the rows the chosen kind adds, such as the precision of a number or the options of a
+     * select. For a host that fills them in itself, such as a board whose columns are the options.
+     */
+    hideTypeOptions?: boolean;
+    /**
      * Places the popup beside this element instead of at `x`/`y`. For hosts whose attributes are shown
      * far from the note attributes pane the coordinates are otherwise resolved against, e.g. the
      * attributes panel in the right pane.
@@ -339,6 +344,7 @@ export function isSameShow(previous: AttributeDetailOpts | null, next: Attribute
         && previous.hideMultiplicity === next.hideMultiplicity
         && previous.hideInheritance === next.hideInheritance
         && previous.hideType === next.hideType
+        && previous.hideTypeOptions === next.hideTypeOptions
         && previous.attribute.noteId === next.attribute.noteId
         && previous.attribute.type === next.attribute.type
         && previous.attribute.name === next.attribute.name
@@ -625,7 +631,8 @@ export function AttributeForm({ opts, attrType: initialAttrType, currentNoteId, 
                     </OptionsRow>
                 )}
 
-                {attrType === "label-definition" && definition.labelType === "number" && (
+                {attrType === "label-definition" && definition.labelType === "number"
+                    && !opts.hideTypeOptions && (
                     <OptionsRow
                         name="attr-number-precision"
                         label={t("attribute_detail.precision")}
@@ -645,7 +652,8 @@ export function AttributeForm({ opts, attrType: initialAttrType, currentNoteId, 
                     </OptionsRow>
                 )}
 
-                {attrType === "label-definition" && definition.labelType === "select" && (
+                {attrType === "label-definition" && definition.labelType === "select"
+                    && !opts.hideTypeOptions && (
                     <OptionsRow
                         name="attr-select-options"
                         label={t("attribute_detail.select_options")}
@@ -666,7 +674,7 @@ export function AttributeForm({ opts, attrType: initialAttrType, currentNoteId, 
                     </OptionsRow>
                 )}
 
-                {attrType === "relation-definition" && (
+                {attrType === "relation-definition" && !opts.hideTypeOptions && (
                     <OptionsRow
                         name="attr-inverse-relation"
                         label={t("attribute_detail.inverse_relation")}

--- a/apps/client/src/widgets/collections/attribute_menu.spec.ts
+++ b/apps/client/src/widgets/collections/attribute_menu.spec.ts
@@ -62,7 +62,7 @@ describe("buildAttributeMenuItems", () => {
 
         it("is marked while the item carries it, and turned off when picked", () => {
             const note = buildNote({ title: "Card", "#done": "true" });
-            const items = buildAttributeMenuItems<string>({ note, attributes: flag });
+            const items = buildAttributeMenuItems<string>({ notes: [ note ], attributes: flag });
 
             expect(items[1]).toMatchObject({ trailingIcon: "bx bx-check" });
             pick(items[1]);
@@ -71,11 +71,33 @@ describe("buildAttributeMenuItems", () => {
 
         it("is unmarked while the item does not, and turned on when picked", () => {
             const note = buildNote({ title: "Card" });
-            const items = buildAttributeMenuItems<string>({ note, attributes: flag });
+            const items = buildAttributeMenuItems<string>({ notes: [ note ], attributes: flag });
 
             expect(items[1]).toMatchObject({ trailingIcon: undefined });
             pick(items[1]);
             expect(writes.setLabelValues).toHaveBeenCalledWith(note, "done", [ "true" ]);
+        });
+
+        it("is marked only while every selected item carries it", () => {
+            const set = buildNote({ title: "One", "#done": "true" });
+            const unset = buildNote({ title: "Two" });
+
+            expect(buildAttributeMenuItems<string>({ notes: [ set, unset ], attributes: flag })[1])
+                .toMatchObject({ trailingIcon: undefined });
+            expect(buildAttributeMenuItems<string>({
+                notes: [ set, buildNote({ title: "Three", "#done": "true" }) ], attributes: flag
+            })[1]).toMatchObject({ trailingIcon: "bx bx-check" });
+        });
+
+        it("writes the value to every selected item, settling a disagreement", async () => {
+            const set = buildNote({ title: "One", "#done": "true" });
+            const unset = buildNote({ title: "Two" });
+
+            await pick(
+                buildAttributeMenuItems<string>({ notes: [ set, unset ], attributes: flag })[1]);
+
+            expect(writes.setLabelValues).toHaveBeenCalledWith(set, "done", [ "true" ]);
+            expect(writes.setLabelValues).toHaveBeenCalledWith(unset, "done", [ "true" ]);
         });
 
         // The stored values are the checkbox's own, so the entry says what the item draws: a box
@@ -83,7 +105,9 @@ describe("buildAttributeMenuItems", () => {
         it("counts every value but true as unset", () => {
             for (const value of [ "false", "", "yes" ]) {
                 const note = buildNote({ title: "Card", "#done": value });
-                const items = buildAttributeMenuItems<string>({ note, attributes: flag });
+                const items = buildAttributeMenuItems<string>({
+                    notes: [ note ], attributes: flag
+                });
 
                 expect(items[1]).toMatchObject({ trailingIcon: undefined });
             }
@@ -99,8 +123,8 @@ describe("buildAttributeMenuItems", () => {
         }) ];
 
         /** The entries a state's submenu offers, the caller having none of its own to add. */
-        function options(note: FNote) {
-            const items = buildAttributeMenuItems<string>({ note, attributes: state });
+        function options(...notes: FNote[]) {
+            const items = buildAttributeMenuItems<string>({ notes, attributes: state });
             const entry = items[1];
             if (!entry || !("items" in entry)) throw new Error("expected a submenu");
             return entry.items ?? [];
@@ -144,6 +168,35 @@ describe("buildAttributeMenuItems", () => {
             expect(writes.setLabelValues).toHaveBeenCalledWith(note, "state", []);
         });
 
+        it("marks the option only while every selected item holds it", () => {
+            const doing = buildNote({ title: "One", "#state": "Doing" });
+
+            expect(marked(options(doing, buildNote({ title: "Two", "#state": "Doing" }))))
+                .toEqual([ `<span class="tn-menu-name">Doing</span>` ]);
+            expect(marked(options(doing, buildNote({ title: "Two", "#state": "Done" }))))
+                .toEqual([]);
+            expect(marked(options(doing, buildNote({ title: "Two" })))).toEqual([]);
+        });
+
+        it("marks Not set only while every selected item holds none", () => {
+            const unset = buildNote({ title: "One" });
+
+            expect(marked(options(unset, buildNote({ title: "Two" }))))
+                .toEqual([ `<span class="tn-menu-name">attribute_menu.not-set</span>` ]);
+            expect(marked(options(unset, buildNote({ title: "Two", "#state": "Doing" }))))
+                .toEqual([]);
+        });
+
+        it("writes the option picked to every selected item", async () => {
+            const first = buildNote({ title: "One" });
+            const second = buildNote({ title: "Two", "#state": "Done" });
+
+            await pick(options(first, second)[2]);
+
+            expect(writes.setLabelValues).toHaveBeenCalledWith(first, "state", [ "Doing" ]);
+            expect(writes.setLabelValues).toHaveBeenCalledWith(second, "state", [ "Doing" ]);
+        });
+
         /**
          * Only the labels a note owns are removed, so a note with nothing of its own would keep the
          * value it inherits. An empty label of its own overrides it.
@@ -182,7 +235,7 @@ function build(
     attributes: PromotedAttribute[],
     title?: string
 ) {
-    return buildAttributeMenuItems<string>({ note: buildNote(note), attributes, title });
+    return buildAttributeMenuItems<string>({ notes: [ buildNote(note) ], attributes, title });
 }
 
 function attribute(fields: Partial<PromotedAttribute> & { name: string }): PromotedAttribute {
@@ -206,7 +259,8 @@ const marked = (items: MenuItem<string>[]) => items
     .filter(item => "trailingIcon" in item && item.trailingIcon)
     .map(item => ("title" in item ? item.title : ""));
 
+/** Runs an entry's handler and hands back what it returns, so a caller can wait for its writes. */
 function pick(item: MenuItem<string> | undefined) {
     if (!item || !("handler" in item)) throw new Error("expected a menu entry");
-    item.handler?.(item as MenuCommandItem<string>, {} as never);
+    return item.handler?.(item as MenuCommandItem<string>, {} as never);
 }

--- a/apps/client/src/widgets/collections/attribute_menu.ts
+++ b/apps/client/src/widgets/collections/attribute_menu.ts
@@ -1,8 +1,8 @@
 import type FNote from "../../entities/fnote";
 import type { MenuCommandItem, MenuItem } from "../../menus/context_menu";
 import { menuName } from "../../menus/context_menu_utils";
-import { setLabelValues } from "../../services/attributes";
 import { t } from "../../services/i18n";
+import { clearLabelOnNotes, setLabelOnNotes, shared } from "../../services/note_set";
 import { promotedAttributeIcon } from "../attribute_widgets/attribute_types";
 import type { PromotedAttribute } from "./promoted_attributes";
 
@@ -14,8 +14,12 @@ const TRUE = "true";
 const FALSE = "false";
 
 export interface AttributeMenuOptions {
-    /** The item whose values the entries read and write. */
-    note: FNote;
+    /**
+     * The items whose values the entries read and write. One note for a menu opened on a single
+     * item, every selected note for a menu opened on a selection: an entry is marked only where
+     * they all hold the same value, and picking one writes it to each of them.
+     */
+    notes: FNote[];
     /** The attributes the collection shows on its items, in the order it shows them. */
     attributes: PromotedAttribute[];
     /** What the section is called. "Attributes" unless the caller names it. */
@@ -34,7 +38,7 @@ export interface AttributeMenuOptions {
  * checking for an empty section.
  */
 export function buildAttributeMenuItems<T>({
-    note, attributes, title
+    notes, attributes, title
 }: AttributeMenuOptions): MenuItem<T>[] {
     const items = attributes.flatMap<MenuItem<T>>((attribute) => {
         if (attribute.hidden || attribute.type !== "label") {
@@ -42,12 +46,12 @@ export function buildAttributeMenuItems<T>({
         }
 
         if (attribute.labelType === "boolean") {
-            return [ buildBooleanItem<T>(note, attribute) ];
+            return [ buildBooleanItem<T>(notes, attribute) ];
         }
 
         // A select without options is skipped: its submenu would hold "Not set" alone.
         if (attribute.labelType === "select" && attribute.selectOptions?.length) {
-            return [ buildSelectItem<T>(note, attribute, attribute.selectOptions) ];
+            return [ buildSelectItem<T>(notes, attribute, attribute.selectOptions) ];
         }
 
         return [];
@@ -66,27 +70,32 @@ export function buildAttributeMenuItems<T>({
  * Read and written as `"true"` and `"false"`, the values the field's own checkbox stores, so the
  * entry says what the item draws. A value stored any other way counts as unset, as it does on the
  * item.
+ *
+ * Notes that disagree leave the entry unmarked, and picking it sets them all, which is the only
+ * move that ends with them agreeing.
  */
-function buildBooleanItem<T>(note: FNote, attribute: PromotedAttribute): MenuCommandItem<T> {
-    const isSet = note.getLabelValue(attribute.name) === TRUE;
+function buildBooleanItem<T>(notes: FNote[], attribute: PromotedAttribute): MenuCommandItem<T> {
+    const state = shared(notes, (note) => note.getLabelValue(attribute.name) === TRUE);
+    const isSet = state.agreed && state.value;
 
     return {
         ...attributeEntry<T>(attribute),
         trailingIcon: isSet ? CHECK : undefined,
         handler: () => {
-            void setLabelValues(note, attribute.name, [ isSet ? FALSE : TRUE ]);
+            void setLabelOnNotes(notes, attribute.name, isSet ? FALSE : TRUE);
         }
     };
 }
 
 /**
  * A `select`, its options in a submenu in the order the definition lists them, with the value the
- * item holds marked. A value the definition no longer lists marks nothing.
+ * item holds marked. A value the definition no longer lists marks nothing, and so do notes holding
+ * different values.
  */
 function buildSelectItem<T>(
-    note: FNote, attribute: PromotedAttribute, options: string[]
+    notes: FNote[], attribute: PromotedAttribute, options: string[]
 ): MenuCommandItem<T> {
-    const current = note.getLabelValue(attribute.name);
+    const current = shared(notes, (note) => note.getLabelValue(attribute.name));
 
     return {
         ...attributeEntry<T>(attribute),
@@ -97,30 +106,16 @@ function buildSelectItem<T>(
                 // Boxed like the options: a menu row is a flex line, so a bare title keeps the
                 // space that separates it from the icon and renders as indented.
                 title: menuName(t("attribute_menu.not-set")),
-                trailingIcon: current ? undefined : CHECK,
-                handler: () => { void clearValue(note, attribute.name); }
+                trailingIcon: current.agreed && !current.value ? CHECK : undefined,
+                handler: () => { void clearLabelOnNotes(notes, attribute.name); }
             },
             ...options.map<MenuItem<T>>((option) => ({
                 title: menuName(option),
-                trailingIcon: option === current ? CHECK : undefined,
-                handler: () => { void setLabelValues(note, attribute.name, [ option ]); }
+                trailingIcon: current.agreed && current.value === option ? CHECK : undefined,
+                handler: () => { void setLabelOnNotes(notes, attribute.name, option); }
             }))
         ]
     };
-}
-
-/**
- * Takes the value off the note.
- *
- * `setLabelValues` removes only the labels the note owns, so an inherited value would still apply.
- * The note is given an empty label of its own instead, which is what an unset promoted field holds
- * and what `renderLabelValue` draws as nothing.
- */
-function clearValue(note: FNote, name: string) {
-    const isInherited = note.getAttributes("label", name)
-        .some((attribute) => attribute.noteId !== note.noteId);
-
-    return setLabelValues(note, name, isInherited ? [ "" ] : []);
 }
 
 /** What every entry carries: the attribute's display name, under the icon of its type. */

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -555,13 +555,21 @@ describe("BoardApi card operations", () => {
         const [ first ] = items;
 
         // The target column is empty, so there is nothing to place it against.
-        await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 1, "Done", "To Do");
+        await api.moveWithinBoard(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "To Do", 1);
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
 
-        await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 1, "To Do", "Done");
+    });
+
+    it("files a card arriving from another column before the one it was dropped on", async () => {
+        const { api, done, spare } = createBoardWithSpareCard();
+
+        await api.moveWithinBoard(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done", 1);
+
         expect(branches.moveBeforeBranch)
-            .toHaveBeenCalledWith([ first.branch.branchId ], items[1].branch.branchId);
+            .toHaveBeenCalledWith([ spare.branch.branchId ], done[1].branch.branchId);
     });
 
     /** A board whose "Done" column holds three cards, with a fourth waiting in "To Do". */
@@ -599,7 +607,8 @@ describe("BoardApi card operations", () => {
     it("files a card dropped past the last card of another column after it", async () => {
         const { api, done, spare } = createBoardWithSpareCard();
 
-        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 3, "To Do", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done", 3);
 
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
         expect(branches.moveAfterBranch)
@@ -609,7 +618,8 @@ describe("BoardApi card operations", () => {
     it("files a card dropped into a column a filter empties after the cards it hides", async () => {
         const { api, done, spare } = createBoardWithSpareCard(() => []);
 
-        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 0, "To Do", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done", 0);
 
         expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
@@ -618,7 +628,8 @@ describe("BoardApi card operations", () => {
     it("files a card dropped past the last card shown after that one, not the hidden", async () => {
         const { api, done, spare } = createBoardWithSpareCard((all) => [ all[0] ]);
 
-        await api.moveWithinBoard(spare.note.noteId, spare.branch.branchId, 0, 1, "To Do", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done", 1);
 
         expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[0].branch.branchId);
@@ -627,7 +638,8 @@ describe("BoardApi card operations", () => {
     it("sends a card after the last one drawn in a column a filter narrows", async () => {
         const { api, done, spare } = createBoardWithSpareCard((all) => [ all[0] ]);
 
-        await api.moveToColumnEnd(spare.note.noteId, spare.branch.branchId, "Done");
+        await api.moveToColumnEnd(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done");
 
         expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[0].branch.branchId);
@@ -636,7 +648,8 @@ describe("BoardApi card operations", () => {
     it("sends a card past the cards a filter hides when it draws none of them", async () => {
         const { api, done, spare } = createBoardWithSpareCard(() => []);
 
-        await api.moveToColumnEnd(spare.note.noteId, spare.branch.branchId, "Done");
+        await api.moveToColumnEnd(
+            [ { noteId: spare.note.noteId, branchId: spare.branch.branchId } ], "Done");
 
         expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ spare.branch.branchId ], done[2].branch.branchId);
@@ -673,11 +686,13 @@ describe("BoardApi card operations", () => {
         const { api, items } = createBoardWithCards();
         const [ first, , third ] = items;
 
-        await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 2, "Done", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "Done", 2);
         expect(branches.moveBeforeBranch)
             .toHaveBeenCalledWith([ first.branch.branchId ], third.branch.branchId);
 
-        await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 0, 3, "Done", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "Done", 3);
         expect(branches.moveAfterBranch)
             .toHaveBeenCalledWith([ first.branch.branchId ], third.branch.branchId);
     });
@@ -690,10 +705,12 @@ describe("BoardApi card operations", () => {
         const { api, items } = createBoardWithCards();
         const [ first, second ] = items;
 
-        await api.moveToColumnEnd(first.note.noteId, first.branch.branchId, "To Do");
+        await api.moveToColumnEnd(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "To Do");
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
 
-        await api.moveToColumnEnd(second.note.noteId, second.branch.branchId, "To Do");
+        await api.moveToColumnEnd(
+            [ { noteId: second.note.noteId, branchId: second.branch.branchId } ], "To Do");
         expect(branches.moveAfterBranch)
             .toHaveBeenLastCalledWith([ second.branch.branchId ], first.branch.branchId);
     });
@@ -707,7 +724,8 @@ describe("BoardApi card operations", () => {
         const { api, items } = createBoardWithCards();
         const [ first, second, third ] = items;
 
-        await api.moveToColumnEnd(first.note.noteId, first.branch.branchId, "To Do");
+        await api.moveToColumnEnd(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "To Do");
 
         // The refresh that catches up, and with it a card that now stands last in that column.
         api.update(
@@ -715,7 +733,8 @@ describe("BoardApi card operations", () => {
             [ "To Do", "Done" ], first.note.getParentNotes()[0], "status", {}, () => {}, () => {});
 
         // Behind what the board now shows last, not behind what this sent before it.
-        await api.moveToColumnEnd(second.note.noteId, second.branch.branchId, "To Do");
+        await api.moveToColumnEnd(
+            [ { noteId: second.note.noteId, branchId: second.branch.branchId } ], "To Do");
         expect(branches.moveAfterBranch)
             .toHaveBeenLastCalledWith([ second.branch.branchId ], third.branch.branchId);
     });
@@ -724,8 +743,10 @@ describe("BoardApi card operations", () => {
         const { api, items } = createBoardWithCards();
         const [ first ] = items;
 
-        await api.moveWithinBoard(first.note.noteId, first.branch.branchId, 1, 1, "Done", "Done");
-        await api.moveWithinBoard("missingNote", "missingBranch", 0, 2, "Done", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: first.note.noteId, branchId: first.branch.branchId } ], "Done", 1);
+        await api.moveWithinBoard(
+            [ { noteId: "missingNote", branchId: "missingBranch" } ], "Done", 2);
 
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
@@ -735,11 +756,11 @@ describe("BoardApi card operations", () => {
         const { api, items } = createBoardWithCards();
         const removeLabel = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
 
-        await api.removeFromBoard(items[0].note.noteId);
+        await api.removeFromBoard([ items[0].note.noteId ]);
         expect(removeLabel).toHaveBeenCalledWith(items[0].note, "status");
 
         // A note the cache has never heard of is left alone rather than throwing.
-        await api.removeFromBoard("missingNote");
+        await api.removeFromBoard([ "missingNote" ]);
         expect(removeLabel).toHaveBeenCalledTimes(1);
     });
 
@@ -758,7 +779,7 @@ describe("BoardApi card operations", () => {
         const removeLabel = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
         const setLabel = vi.spyOn(attributes, "setLabel").mockResolvedValue(undefined as never);
 
-        await api.removeFromBoard(cardId);
+        await api.removeFromBoard([ cardId ]);
 
         expect(setLabel).toHaveBeenCalledWith(cardId, "status", "");
         expect(removeLabel).not.toHaveBeenCalled();
@@ -770,7 +791,7 @@ describe("BoardApi card operations", () => {
         const removeRelation = vi.spyOn(attributes, "removeOwnedRelationByName")
             .mockReturnValue(true);
 
-        await api.removeFromBoard(board.getChildNoteIds()[0]);
+        await api.removeFromBoard([ board.getChildNoteIds()[0] ]);
         expect(removeRelation).toHaveBeenCalledWith(expect.anything(), "status");
     });
 
@@ -789,7 +810,7 @@ describe("BoardApi card operations", () => {
             .mockReturnValue(true);
         const message = vi.spyOn(toast, "showMessage").mockReturnValue(undefined);
 
-        await api.removeFromBoard(board.getChildNoteIds()[0]);
+        await api.removeFromBoard([ board.getChildNoteIds()[0] ]);
 
         expect(message).toHaveBeenCalledWith("board_view.inherited-column", 3000);
         expect(removeRelation).not.toHaveBeenCalled();
@@ -1828,7 +1849,7 @@ describe("filing a card under the inbox", () => {
         const removeRelation = vi.spyOn(attributes, "removeOwnedRelationByName")
             .mockReturnValue(true);
 
-        await api.removeFromBoard(board.getChildNoteIds()[0]);
+        await api.removeFromBoard([ board.getChildNoteIds()[0] ]);
 
         expect(removeRelation).toHaveBeenCalled();
     });
@@ -2130,7 +2151,8 @@ describe("moving a card into or inside a sorted column", () => {
     it("writes the value alone when a card crosses into one", async () => {
         const { api } = sortedApi([ "Done" ]);
 
-        await api.moveWithinBoard("a2", "b_a2", 1, 0, "To Do", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: "a2", branchId: "b_a2" } ], "Done", 0);
 
         expect(setLabel).toHaveBeenCalledWith("a2", "status", "Done");
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
@@ -2140,7 +2162,8 @@ describe("moving a card into or inside a sorted column", () => {
     it("writes nothing at all for a move inside one", async () => {
         const { api } = sortedApi([ "To Do" ]);
 
-        await api.moveWithinBoard("a1", "b_a1", 0, 2, "To Do", "To Do");
+        await api.moveWithinBoard(
+            [ { noteId: "a1", branchId: "b_a1" } ], "To Do", 2);
 
         expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
@@ -2149,7 +2172,8 @@ describe("moving a card into or inside a sorted column", () => {
     it("still places a card in a column left in the manual order", async () => {
         const { api } = sortedApi([ "To Do" ]);
 
-        await api.moveWithinBoard("a2", "b_a2", 1, 0, "To Do", "Done");
+        await api.moveWithinBoard(
+            [ { noteId: "a2", branchId: "b_a2" } ], "Done", 0);
 
         expect(setLabel).toHaveBeenCalledWith("a2", "status", "Done");
         expect(branches.moveBeforeBranch).toHaveBeenCalledWith([ "b_a2" ], "b_b1");
@@ -2158,7 +2182,7 @@ describe("moving a card into or inside a sorted column", () => {
     it("sends a card across to a sorted column by value alone", async () => {
         const { api } = sortedApi([ "Done" ]);
 
-        await api.moveToColumnEnd("a1", "b_a1", "Done");
+        await api.moveToColumnEnd([ { noteId: "a1", branchId: "b_a1" } ], "Done");
 
         expect(setLabel).toHaveBeenCalledWith("a1", "status", "Done");
         expect(branches.moveAfterBranch).not.toHaveBeenCalled();
@@ -2248,7 +2272,7 @@ describe("a selection of cards", () => {
         const { api, items } = createBoard();
         const moved = [ items[3], items[0] ];
 
-        await api.moveManyWithinBoard(
+        await api.moveWithinBoard(
             moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
             "Done", 2);
 
@@ -2266,7 +2290,7 @@ describe("a selection of cards", () => {
         const { api, items } = createBoard();
         const moved = [ items[3] ];
 
-        await api.moveManyWithinBoard(
+        await api.moveWithinBoard(
             moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
             "Done", 3);
 
@@ -2281,7 +2305,7 @@ describe("a selection of cards", () => {
             { columns: [ { value: "Done", orderBy: "title" } ] });
         const moved = [ items[3] ];
 
-        await api.moveManyWithinBoard(
+        await api.moveWithinBoard(
             moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
             "Done", 0);
 

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -739,6 +739,22 @@ describe("BoardApi card operations", () => {
             .toHaveBeenLastCalledWith([ second.branch.branchId ], third.branch.branchId);
     });
 
+    /**
+     * The place a card is dropped at is counted among the cards on screen, so a filter can leave
+     * that order unchanged for a move that does reorder the column underneath. Read as standing
+     * still, the move would be dropped and the board would snap back.
+     */
+    it("places a card a filter makes look as though it has not moved", async () => {
+        const { api, done } = createBoardWithSpareCard((all) => [ all[0], all[2] ]);
+
+        // Before the second card drawn, which stands past the one the filter hides.
+        await api.moveWithinBoard(
+            [ { noteId: done[0].note.noteId, branchId: done[0].branch.branchId } ], "Done", 1);
+
+        expect(branches.moveBeforeBranch)
+            .toHaveBeenCalledWith([ done[0].branch.branchId ], done[2].branch.branchId);
+    });
+
     it("moves nothing for a card dropped where it is, or one it cannot find", async () => {
         const { api, items } = createBoardWithCards();
         const [ first ] = items;

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import appContext from "../../../components/app_context";
 import FAttribute from "../../../entities/fattribute";
 import type FBranch from "../../../entities/fbranch";
 import branches from "../../../services/branches";
@@ -549,6 +550,53 @@ describe("BoardApi card operations", () => {
 
         return { ...createApi({}, [ "To Do", "Done" ], board, "status", byColumn), items };
     }
+
+    describe("opening a card", () => {
+        /**
+         * The board can be one split of several, and the focused pane is often the one the reader
+         * came from, so a redirect navigates the pane the board itself is drawn in.
+         */
+        it("navigates the board's own pane rather than the focused one", () => {
+            const { api, items } = createBoardWithCards();
+            const own = vi.fn();
+            const focused = vi.fn();
+            api.noteContext = { setNote: own } as never;
+            const previousTabManager = appContext.tabManager;
+            appContext.tabManager = { getActiveContext: () => ({ setNote: focused }) } as never;
+
+            try {
+                addRedirect(items[0].note, "targetNote");
+                api.openCard(items[0].note);
+            } finally {
+                appContext.tabManager = previousTabManager;
+            }
+
+            expect(own).toHaveBeenCalledWith("targetNote");
+            expect(focused).not.toHaveBeenCalled();
+        });
+
+        it("opens the card itself where it redirects nowhere", () => {
+            const { api, items } = createBoardWithCards();
+            const open = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);
+
+            api.openCard(items[0].note);
+
+            expect(open).toHaveBeenCalledWith(
+                "openInPopup", { noteIdOrPath: items[0].note.noteId });
+        });
+
+        /** Files the relation straight into froca, which is all `openCard` reads. */
+        function addRedirect(note: FNote, target: string) {
+            const attributeId = `redirect-${note.noteId}`;
+            froca.attributes[attributeId] = new FAttribute(froca, {
+                noteId: note.noteId, attributeId, type: "relation",
+                name: "boardCardRedirectTo", value: target, position: 0, isInheritable: false
+            });
+            note.attributes.push(attributeId);
+            // Cleared rather than emptied: the cache is rebuilt only for a note it has no entry for.
+            delete noteAttributeCache.attributes[note.noteId];
+        }
+    });
 
     it("files a card moved to another column before the one it was dropped on", async () => {
         const { api, items } = createBoardWithCards();

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -740,19 +740,23 @@ describe("BoardApi card operations", () => {
     });
 
     /**
-     * The place a card is dropped at is counted among the cards on screen, so a filter can leave
-     * that order unchanged for a move that does reorder the column underneath. Read as standing
-     * still, the move would be dropped and the board would snap back.
+     * A card can only be placed against a neighbour that is drawn, so a move leaving the cards on
+     * screen where they are would move the ones a filter hides instead: dropping the second card
+     * drawn back at the end writes `moveAfterBranch` against the first, taking it past the hidden
+     * card between them.
      */
-    it("places a card a filter makes look as though it has not moved", async () => {
+    it("moves nothing for a drop that leaves the cards a filter draws where they are", async () => {
         const { api, done } = createBoardWithSpareCard((all) => [ all[0], all[2] ]);
 
-        // Before the second card drawn, which stands past the one the filter hides.
+        // Back at the end of the two cards drawn, which is where the second one already stands.
+        await api.moveWithinBoard(
+            [ { noteId: done[2].note.noteId, branchId: done[2].branch.branchId } ], "Done", 2);
+        // And the same drop read from the other card: before the second drawn, where it already is.
         await api.moveWithinBoard(
             [ { noteId: done[0].note.noteId, branchId: done[0].branch.branchId } ], "Done", 1);
 
-        expect(branches.moveBeforeBranch)
-            .toHaveBeenCalledWith([ done[0].branch.branchId ], done[2].branch.branchId);
+        expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+        expect(branches.moveAfterBranch).not.toHaveBeenCalled();
     });
 
     it("moves nothing for a card dropped where it is, or one it cannot find", async () => {

--- a/apps/client/src/widgets/collections/board/api.spec.ts
+++ b/apps/client/src/widgets/collections/board/api.spec.ts
@@ -2179,3 +2179,116 @@ describe("moving a card into or inside a sorted column", () => {
         expect(api.isColumnSorted("To Do")).toBe(false);
     });
 });
+
+describe("a selection of cards", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.spyOn(server, "put").mockResolvedValue(undefined);
+        vi.mocked(branches.moveBeforeBranch).mockClear();
+        vi.mocked(branches.moveAfterBranch).mockClear();
+    });
+
+    /** A board of four cards, three under "Done" and one under "To Do". */
+    function createBoard(sorts?: BoardViewData) {
+        const board = buildNote({
+            title: "Board",
+            children: [
+                { title: "First", "#status": "Done" },
+                { title: "Second", "#status": "Done" },
+                { title: "Third", "#status": "Done" },
+                { title: "Spare", "#status": "To Do" }
+            ]
+        });
+
+        const items = board.getChildBranches().flatMap(branch => {
+            const note = froca.getNoteFromCache(branch.noteId);
+            return note ? [ { branch, note } ] : [];
+        });
+        const byColumn: ColumnMap = new Map([
+            [ "To Do", [ items[3] ] ],
+            [ "Done", items.slice(0, 3) ]
+        ]);
+
+        return {
+            ...createApi(sorts ?? {}, [ "To Do", "Done" ], board, "status", byColumn),
+            items
+        };
+    }
+
+    const ids = (items: ColumnItem[]) => items.map((item) => item.note.noteId);
+    const branchIds = (items: ColumnItem[]) => items.map((item) => item.branch.branchId);
+
+    it("names the cards a column draws, in the order it draws them", () => {
+        const { api, items } = createBoard();
+
+        expect(api.getColumnNoteIds("Done")).toEqual(ids(items.slice(0, 3)));
+        expect(api.getColumnNoteIds("Nowhere")).toEqual([]);
+    });
+
+    it("says which column a card stands in, and nothing for one it is not drawing", () => {
+        const { api, items } = createBoard();
+
+        expect(api.getCardColumn(items[0].note.noteId)).toBe("Done");
+        expect(api.getCardColumn(items[3].note.noteId)).toBe("To Do");
+        expect(api.getCardColumn("elsewhere")).toBeUndefined();
+    });
+
+    /**
+     * A selection kept from before a refresh can name a card the board has stopped drawing, which
+     * is left out rather than making a command act on something that is no longer there.
+     */
+    it("resolves a selection in board order, leaving out what it no longer holds", () => {
+        const { api, items } = createBoard();
+        const asked = new Set([ items[2].note.noteId, items[3].note.noteId, "gone" ]);
+
+        expect(ids(api.getCards(asked))).toEqual([ items[3].note.noteId, items[2].note.noteId ]);
+    });
+
+    it("files every card under the column and places them before the card dropped on", async () => {
+        const { api, items } = createBoard();
+        const moved = [ items[3], items[0] ];
+
+        await api.moveManyWithinBoard(
+            moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
+            "Done", 2);
+
+        // Each card's grouping value is written, then one placement carries the whole set.
+        expect(server.put).toHaveBeenCalledWith(
+            `notes/${items[3].note.noteId}/set-attribute`,
+            { type: "label", name: "status", value: "Done", isInheritable: false }, undefined);
+        // Counted among the cards as drawn: `First` is moving and stands above the place, so the
+        // set lands before `Third` rather than before `Second`.
+        expect(branches.moveBeforeBranch)
+            .toHaveBeenCalledWith(branchIds(moved), items[2].branch.branchId);
+    });
+
+    it("places a set dropped past the last card after the one staying at the end", async () => {
+        const { api, items } = createBoard();
+        const moved = [ items[3] ];
+
+        await api.moveManyWithinBoard(
+            moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
+            "Done", 3);
+
+        expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+        expect(branches.moveAfterBranch)
+            .toHaveBeenCalledWith(branchIds(moved), items[2].branch.branchId);
+    });
+
+    /** A sorted column decides where its own cards go, so nothing is written against one. */
+    it("writes no placement into a column that sorts itself", async () => {
+        const { api, items } = createBoard(
+            { columns: [ { value: "Done", orderBy: "title" } ] });
+        const moved = [ items[3] ];
+
+        await api.moveManyWithinBoard(
+            moved.map((item) => ({ noteId: item.note.noteId, branchId: item.branch.branchId })),
+            "Done", 0);
+
+        expect(server.put).toHaveBeenCalledWith(
+            `notes/${items[3].note.noteId}/set-attribute`,
+            { type: "label", name: "status", value: "Done", isInheritable: false }, undefined);
+        expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+        expect(branches.moveAfterBranch).not.toHaveBeenCalled();
+    });
+});

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1250,6 +1250,17 @@ export default class BoardApi {
     }
 
     /**
+     * Whether the board draws the inbox column, which holds the cards with no grouping value.
+     *
+     * {@link removeFromBoard} takes that value away, so with the inbox drawn a card has nowhere to
+     * go: it lands in the inbox instead of leaving, and one already there does not move at all.
+     * The menu and the Delete key leave the action out where this is true.
+     */
+    get isInboxEnabled() {
+        return !!this.parentNote?.isLabelTruthy("enableInboxColumn");
+    }
+
+    /**
      * Takes cards off the board, which leaves the notes where they are and only takes the grouping
      * value away. Written together, so a set does not leave a card at a time.
      */

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1390,23 +1390,34 @@ export default class BoardApi {
         const staying = targetItems.filter((item) => !moved.has(item.branch.branchId));
         const at = targetIndex - above;
 
+        // The column as the board holds it, cards a filter hides included, which is what says
+        // whether a card is arriving from elsewhere and whether this move changes anything.
+        const whole = this.allByColumn?.get(targetColumn) ?? targetItems;
+        const held = whole.map((item) => item.branch.branchId);
+
         // Nothing at all is written where the cards already stand where this would put them, which
         // is what a card dropped back where it was picked up amounts to.
-        const standing = targetItems.map((item) => item.branch.branchId);
-        const landing = [
-            ...staying.slice(0, at).map((item) => item.branch.branchId),
-            ...branchIds,
-            ...staying.slice(at).map((item) => item.branch.branchId)
-        ];
-        if (landing.length === standing.length
-                && landing.every((branchId, place) => branchId === standing[place])) {
-            return;
+        //
+        // Only where the column is drawn whole. The places are counted among the cards on screen,
+        // so a filter hiding some of them leaves that order unchanged for a move that does reorder
+        // what is underneath, and the move would be dropped for standing still.
+        if (whole.length === targetItems.length) {
+            const standing = targetItems.map((item) => item.branch.branchId);
+            const landing = [
+                ...staying.slice(0, at).map((item) => item.branch.branchId),
+                ...branchIds,
+                ...staying.slice(at).map((item) => item.branch.branchId)
+            ];
+            if (landing.length === standing.length
+                    && landing.every((branchId, place) => branchId === standing[place])) {
+                return;
+            }
         }
 
         // Only the cards arriving from elsewhere are written: one already under this column holds
         // the value already, and writing it again is a change the board has to redraw for.
         // Together rather than one after another, so a set does not arrive a card at a time.
-        const arriving = moving.filter((card) => !standing.includes(card.branchId));
+        const arriving = moving.filter((card) => !held.includes(card.branchId));
         if (arriving.length) {
             await Promise.all(arriving.map((card) => this.changeColumn(card.noteId, targetColumn)));
         }

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -34,6 +34,9 @@ import { SORT_DESCENDING_LABEL, SORT_LABEL } from "./sort";
 /** Which end of a column a new card is made at. */
 export type CardPlacement = "top" | "bottom";
 
+/** The relation a card carries to stand in for another note rather than open an editor of its own. */
+export const CARD_REDIRECT_RELATION = "boardCardRedirectTo";
+
 /** One write's claim on a column, held until that write lands or is taken back. */
 interface ColumnClaim {
     /**
@@ -1211,6 +1214,23 @@ export default class BoardApi {
 
     openNote(noteId: string) {
         appContext.triggerCommand("openInPopup", { noteIdOrPath: noteId });
+    }
+
+    /**
+     * Answers the card's own open gesture, a click or Space.
+     *
+     * A card carrying `boardCardRedirectTo` stands in for the note that relation points at, so it
+     * navigates there instead of opening an editor of its own. Quick edit calls `openNote` and
+     * still opens the card's own editor.
+     */
+    openCard(note: FNote) {
+        const target = note.getRelationValue(CARD_REDIRECT_RELATION);
+        if (target) {
+            void appContext.tabManager.getActiveContext()?.setNote(target);
+            return;
+        }
+
+        this.openNote(note.noteId);
     }
 
     startEditing(branchId: string) {

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -374,7 +374,7 @@ export default class BoardApi {
             return;
         }
 
-        return this.removeFromBoard(noteId);
+        return this.removeCardFromBoard(noteId);
     }
 
     /**
@@ -1249,7 +1249,15 @@ export default class BoardApi {
             .some(attribute => attribute.noteId !== note.noteId);
     }
 
-    removeFromBoard(noteId: string) {
+    /**
+     * Takes cards off the board, which leaves the notes where they are and only takes the grouping
+     * value away. Written together, so a set does not leave a card at a time.
+     */
+    async removeFromBoard(noteIds: string[]) {
+        await Promise.all(noteIds.map((noteId) => this.removeCardFromBoard(noteId)));
+    }
+
+    private removeCardFromBoard(noteId: string) {
         const note = froca.getNoteFromCache(noteId);
         if (!note) return;
         if (this.isRelationMode) {
@@ -1278,28 +1286,40 @@ export default class BoardApi {
         return !!this.getEffectiveColumnSort(column).orderBy;
     }
 
-    /** Moves a card to the end of another column, where a card sent by the keyboard belongs. */
-    async moveToColumnEnd(noteId: string, branchId: string, targetColumn: string) {
-        // Only the grouping value is written: `sortColumnMap` decides where the card is drawn.
-        if (this.isColumnSorted(targetColumn)) {
-            await this.changeColumn(noteId, targetColumn);
+    /**
+     * Sends cards to the end of another column, where the ones the keyboard sends belong, keeping
+     * the order they are given in.
+     *
+     * The grouping values go together rather than one after another, which is what keeps a set from
+     * arriving a card at a time: each is a request of its own, and one at a time makes the wait the
+     * sum of them. `moveAfterBranch` then places the whole set against one card, in order.
+     */
+    async moveToColumnEnd(cards: { noteId: string, branchId: string }[], targetColumn: string) {
+        const arrived = cards.at(-1);
+        if (!arrived) {
             return;
         }
 
         // What is already at the end, as far as this instance can know: nothing waits for the board
         // to redraw between two keystrokes, so the column map still shows the target as it was
-        // before the card the last press sent. Anything sent since is remembered here instead, and
+        // before the cards the last press sent. Anything sent since is remembered here instead, and
         // the memory lasts exactly as long as the map it stands in for, both being rebuilt by the
-        // refresh that catches up.
-        const last = this.sentToColumnEnd.get(targetColumn)
-            ?? this.lastInColumn(targetColumn);
+        // refresh that catches up. Read before the writes below for the same reason.
+        const last = this.sentToColumnEnd.get(targetColumn) ?? this.lastInColumn(targetColumn);
 
-        await this.changeColumn(noteId, targetColumn);
-        if (last && last !== branchId) {
-            await branches.moveAfterBranch([ branchId ], last);
+        await Promise.all(cards.map((card) => this.changeColumn(card.noteId, targetColumn)));
+
+        // Only the grouping value is written for a sorted column: `sortColumnMap` decides where
+        // its cards are drawn.
+        if (this.isColumnSorted(targetColumn)) {
+            return;
         }
 
-        this.sentToColumnEnd.set(targetColumn, branchId);
+        if (last && last !== arrived.branchId) {
+            await branches.moveAfterBranch(cards.map((card) => card.branchId), last);
+        }
+
+        this.sentToColumnEnd.set(targetColumn, arrived.branchId);
     }
 
     /**
@@ -1349,22 +1369,46 @@ export default class BoardApi {
      * `moveBeforeBranch` and `moveAfterBranch` both take the whole set and keep its order, so the
      * cards land together rather than each being placed against the one before it.
      */
-    async moveManyWithinBoard(
+    async moveWithinBoard(
         cards: { noteId: string, branchId: string }[], targetColumn: string, targetIndex: number
     ) {
+        // A card the cache has never heard of is left out rather than written for.
+        const moving = cards.filter((card) => froca.getNoteFromCache(card.noteId));
+        if (!moving.length) {
+            return;
+        }
+
         // Read before the writes below: a redraw between them hands this instance the map with the
         // cards already moved.
         const targetItems = this.byColumn?.get(targetColumn) ?? [];
-        const moved = new Set(cards.map((card) => card.branchId));
+        const branchIds = moving.map((card) => card.branchId);
+        const moved = new Set(branchIds);
         // The place is counted among the cards as they are drawn, which includes the ones being
         // moved. Each of those standing above it names one place that is about to close up.
         const above = targetItems.slice(0, targetIndex)
             .filter((item) => moved.has(item.branch.branchId)).length;
         const staying = targetItems.filter((item) => !moved.has(item.branch.branchId));
-        const before = staying[targetIndex - above];
+        const at = targetIndex - above;
 
-        for (const card of cards) {
-            await this.changeColumn(card.noteId, targetColumn);
+        // Nothing at all is written where the cards already stand where this would put them, which
+        // is what a card dropped back where it was picked up amounts to.
+        const standing = targetItems.map((item) => item.branch.branchId);
+        const landing = [
+            ...staying.slice(0, at).map((item) => item.branch.branchId),
+            ...branchIds,
+            ...staying.slice(at).map((item) => item.branch.branchId)
+        ];
+        if (landing.length === standing.length
+                && landing.every((branchId, place) => branchId === standing[place])) {
+            return;
+        }
+
+        // Only the cards arriving from elsewhere are written: one already under this column holds
+        // the value already, and writing it again is a change the board has to redraw for.
+        // Together rather than one after another, so a set does not arrive a card at a time.
+        const arriving = moving.filter((card) => !standing.includes(card.branchId));
+        if (arriving.length) {
+            await Promise.all(arriving.map((card) => this.changeColumn(card.noteId, targetColumn)));
         }
 
         // A sorted column places its own cards, so nothing is written against a card there.
@@ -1372,14 +1416,17 @@ export default class BoardApi {
             return;
         }
 
-        const branchIds = cards.map((card) => card.branchId);
+        const before = staying[at];
         if (before) {
             await branches.moveBeforeBranch(branchIds, before.branch.branchId);
-        } else {
-            const last = staying.at(-1);
-            if (last) {
-                await branches.moveAfterBranch(branchIds, last.branch.branchId);
-            }
+            return;
+        }
+
+        // What the cards are placed after: the last one staying, or `lastInColumn`'s answer where
+        // a filter draws none of them at all.
+        const after = staying.at(-1)?.branch.branchId ?? this.lastInColumn(targetColumn);
+        if (after && !moved.has(after)) {
+            await branches.moveAfterBranch(branchIds, after);
         }
     }
 
@@ -1422,55 +1469,7 @@ export default class BoardApi {
             return;
         }
 
-        await this.moveWithinBoard(noteId, branchId, at, 0, column, column);
-    }
-
-    async moveWithinBoard(noteId: string, sourceBranchId: string, sourceIndex: number, targetIndex: number, sourceColumn: string, targetColumn: string) {
-        const targetItems = this.byColumn?.get(targetColumn) ?? [];
-        // Read before the writes below, since a redraw between them hands this instance the map
-        // with the card already moved.
-        const lastInTarget = this.lastInColumn(targetColumn);
-
-        const note = froca.getNoteFromCache(noteId);
-        if (!note) return;
-
-        // A move into or inside a sorted column writes the grouping value and no branch
-        // position. Clearing `orderBy` then restores the arrangement the user made.
-        const isSortedTarget = this.isColumnSorted(targetColumn);
-
-        if (sourceColumn !== targetColumn) {
-            // Moving to a different column
-            await this.changeColumn(noteId, targetColumn);
-
-            if (isSortedTarget) {
-                return;
-            }
-
-            if (targetIndex < targetItems.length) {
-                const targetBranch = targetItems[targetIndex].branch;
-                await branches.moveBeforeBranch([ sourceBranchId ], targetBranch.branchId);
-            } else if (lastInTarget && lastInTarget !== sourceBranchId) {
-                await branches.moveAfterBranch([ sourceBranchId ], lastInTarget);
-            }
-        } else if (!isSortedTarget && sourceIndex !== targetIndex) {
-            // Reordering within the same column
-            let targetBranchId: string | null = null;
-
-            if (targetIndex < targetItems.length) {
-                // Moving before an existing item
-                const adjustedIndex = sourceIndex < targetIndex ? targetIndex : targetIndex;
-                if (adjustedIndex < targetItems.length) {
-                    targetBranchId = targetItems[adjustedIndex].branch.branchId;
-                    if (targetBranchId) {
-                        await branches.moveBeforeBranch([ sourceBranchId ], targetBranchId);
-                    }
-                }
-            } else if (targetIndex > 0) {
-                // Moving to the end - place after the last item
-                const lastItem = targetItems[targetItems.length - 1];
-                await branches.moveAfterBranch([ sourceBranchId ], lastItem.branch.branchId);
-            }
-        }
+        await this.moveWithinBoard([ { noteId, branchId } ], column, 0);
     }
 
 }

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1,6 +1,7 @@
 import { BulkAction, type DefinitionObject, promotedAttributeDefinitionParser } from "@triliumnext/commons";
 
 import appContext from "../../../components/app_context";
+import type NoteContext from "../../../components/note_context";
 import FNote from "../../../entities/fnote";
 import attributes from "../../../services/attributes";
 import branches from "../../../services/branches";
@@ -116,6 +117,14 @@ export default class BoardApi {
      * write is keyed by it, so one grouping's columns can never be stored under another's.
      */
     groupBy: string;
+
+    /**
+     * The pane the board is drawn in, set by the board on every render.
+     *
+     * A redirecting card navigates this rather than whichever pane holds the focus: the board can be
+     * one split of several, and the focused one is often the pane the reader came from.
+     */
+    noteContext: NoteContext | null | undefined;
 
     /** The config as the board last handed it over, against which a fresh one is recognised. */
     private viewConfigSource: BoardViewData | undefined;
@@ -1226,7 +1235,8 @@ export default class BoardApi {
     openCard(note: FNote) {
         const target = note.getRelationValue(CARD_REDIRECT_RELATION);
         if (target) {
-            void appContext.tabManager.getActiveContext()?.setNote(target);
+            const context = this.noteContext ?? appContext.tabManager?.getActiveContext();
+            void context?.setNote(target);
             return;
         }
 
@@ -1272,9 +1282,8 @@ export default class BoardApi {
     /**
      * Whether the board draws the inbox column, which holds the cards with no grouping value.
      *
-     * {@link removeFromBoard} takes that value away, so with the inbox drawn a card has nowhere to
-     * go: it lands in the inbox instead of leaving, and one already there does not move at all.
-     * The menu and the Delete key leave the action out where this is true.
+     * {@link removeFromBoard} clears that value, so a card lands in the inbox instead of leaving
+     * the board, and one already there does not move at all.
      */
     get isInboxEnabled() {
         return !!this.parentNote?.isLabelTruthy("enableInboxColumn");
@@ -1426,12 +1435,9 @@ export default class BoardApi {
         const whole = this.allByColumn?.get(targetColumn) ?? targetItems;
         const held = whole.map((item) => item.branch.branchId);
 
-        // Nothing at all is written where the cards already stand where this would put them, which
-        // is what a card dropped back where it was picked up amounts to.
-        //
-        // Compared over the cards on screen, which is the order the drop was aimed at. Under a
-        // filter `moveBeforeBranch` can only place a card against a visible neighbour, so writing
-        // a move that leaves the screen unchanged would reorder the hidden cards instead.
+        // A move that leaves `targetItems` in the order it already holds writes nothing:
+        // `moveBeforeBranch` places a card against a drawn neighbour, so under a filter it would
+        // reorder the hidden cards instead.
         const standing = targetItems.map((item) => item.branch.branchId);
         const landing = [
             ...staying.slice(0, at).map((item) => item.branch.branchId),

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -1398,20 +1398,18 @@ export default class BoardApi {
         // Nothing at all is written where the cards already stand where this would put them, which
         // is what a card dropped back where it was picked up amounts to.
         //
-        // Only where the column is drawn whole. The places are counted among the cards on screen,
-        // so a filter hiding some of them leaves that order unchanged for a move that does reorder
-        // what is underneath, and the move would be dropped for standing still.
-        if (whole.length === targetItems.length) {
-            const standing = targetItems.map((item) => item.branch.branchId);
-            const landing = [
-                ...staying.slice(0, at).map((item) => item.branch.branchId),
-                ...branchIds,
-                ...staying.slice(at).map((item) => item.branch.branchId)
-            ];
-            if (landing.length === standing.length
-                    && landing.every((branchId, place) => branchId === standing[place])) {
-                return;
-            }
+        // Compared over the cards on screen, which is the order the drop was aimed at. Under a
+        // filter `moveBeforeBranch` can only place a card against a visible neighbour, so writing
+        // a move that leaves the screen unchanged would reorder the hidden cards instead.
+        const standing = targetItems.map((item) => item.branch.branchId);
+        const landing = [
+            ...staying.slice(0, at).map((item) => item.branch.branchId),
+            ...branchIds,
+            ...staying.slice(at).map((item) => item.branch.branchId)
+        ];
+        if (landing.length === standing.length
+                && landing.every((branchId, place) => branchId === standing[place])) {
+            return;
         }
 
         // Only the cards arriving from elsewhere are written: one already under this column holds

--- a/apps/client/src/widgets/collections/board/api.ts
+++ b/apps/client/src/widgets/collections/board/api.ts
@@ -28,7 +28,7 @@ import {
     DEFAULT_GROUP_BY, INBOX_COLUMN, INBOX_COLUMN_ICON
 } from "./columns";
 import { readColumns, writeColumns } from "./column_storage";
-import { ColumnMap } from "./data";
+import { ColumnItem, ColumnMap } from "./data";
 import { SORT_DESCENDING_LABEL, SORT_LABEL } from "./sort";
 
 /** Which end of a column a new card is made at. */
@@ -1300,6 +1300,87 @@ export default class BoardApi {
         }
 
         this.sentToColumnEnd.set(targetColumn, branchId);
+    }
+
+    /**
+     * The notes a column draws, in the order it draws them.
+     *
+     * What a range selection is measured against, so a range covers only the cards the reader can
+     * see and never reaches into another column.
+     */
+    getColumnNoteIds(column: string) {
+        return (this.byColumn?.get(column) ?? []).map((item) => item.note.noteId);
+    }
+
+    /**
+     * The cards named by `noteIds`, in the order the board draws them.
+     *
+     * A note the board is not drawing is left out, so a selection that has fallen behind a refresh
+     * cannot make a command act on a card that is no longer there.
+     */
+    getCards(noteIds: ReadonlySet<string>) {
+        const cards: ColumnItem[] = [];
+        for (const items of this.byColumn?.values() ?? []) {
+            for (const item of items) {
+                if (noteIds.has(item.note.noteId)) {
+                    cards.push(item);
+                }
+            }
+        }
+
+        return cards;
+    }
+
+    /** Which column a card stands in, or nothing where the board is not drawing the card. */
+    getCardColumn(noteId: string) {
+        for (const [ column, items ] of this.byColumn ?? []) {
+            if (items.some((item) => item.note.noteId === noteId)) {
+                return column;
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Moves several cards into a column at one place, keeping the order they were drawn in.
+     *
+     * The grouping value is written for each card, then the branches are placed in one call:
+     * `moveBeforeBranch` and `moveAfterBranch` both take the whole set and keep its order, so the
+     * cards land together rather than each being placed against the one before it.
+     */
+    async moveManyWithinBoard(
+        cards: { noteId: string, branchId: string }[], targetColumn: string, targetIndex: number
+    ) {
+        // Read before the writes below: a redraw between them hands this instance the map with the
+        // cards already moved.
+        const targetItems = this.byColumn?.get(targetColumn) ?? [];
+        const moved = new Set(cards.map((card) => card.branchId));
+        // The place is counted among the cards as they are drawn, which includes the ones being
+        // moved. Each of those standing above it names one place that is about to close up.
+        const above = targetItems.slice(0, targetIndex)
+            .filter((item) => moved.has(item.branch.branchId)).length;
+        const staying = targetItems.filter((item) => !moved.has(item.branch.branchId));
+        const before = staying[targetIndex - above];
+
+        for (const card of cards) {
+            await this.changeColumn(card.noteId, targetColumn);
+        }
+
+        // A sorted column places its own cards, so nothing is written against a card there.
+        if (this.isColumnSorted(targetColumn)) {
+            return;
+        }
+
+        const branchIds = cards.map((card) => card.branchId);
+        if (before) {
+            await branches.moveBeforeBranch(branchIds, before.branch.branchId);
+        } else {
+            const last = staying.at(-1);
+            if (last) {
+                await branches.moveAfterBranch(branchIds, last.branch.branchId);
+            }
+        }
     }
 
     /** Whether a card stands at the head of its column, with nowhere left to be moved up to. */

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -66,6 +66,32 @@ describe("useBoardDrag, carrying a card", () => {
         expect(copy?.querySelector(".title")).toBeNull();
     });
 
+    /**
+     * A mouse drag is followed by a click on whatever the press and the release have in common,
+     * which for a card carried anywhere is the board itself. Left to stand, letting a card go
+     * would also read as a click on the board, which is a gesture of its own.
+     */
+    it("takes the click a mouse drag is followed by", () => {
+        setup();
+        const reached = vi.fn();
+        board.addEventListener("click", reached);
+
+        press(card("n1"), 50, 60);
+        move(90, 90);
+        release(90, 90);
+
+        const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+        card("n2").dispatchEvent(click);
+
+        expect(reached).not.toHaveBeenCalled();
+        expect(click.defaultPrevented).toBe(true);
+
+        // The one click, and no more: a press of the reader's own still counts.
+        const later = new MouseEvent("click", { bubbles: true, cancelable: true });
+        card("n2").dispatchEvent(later);
+        expect(reached).toHaveBeenCalledTimes(1);
+    });
+
     /** Two cards on the move leave one card behind the copy. */
     it("stacks one card behind a pair", () => {
         setup({ carried: [ "n1", "n2" ] });

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -590,6 +590,52 @@ describe("useBoardDrag, carrying a card", () => {
         expect(calls.start).toHaveLength(0);
     });
 
+    describe("the drag Ctrl hands to the browser", () => {
+        /**
+         * Nothing else reaches the note tree or a board in another split, so a Ctrl press makes the
+         * card natively draggable and stands back. `draggable` is set on the press rather than kept
+         * on the card, or every ordinary drag would become a native one.
+         */
+        it("makes the card draggable and opens no gesture of its own", () => {
+            setup();
+            const element = card("n1");
+            // `toBeFalsy`, not `toBe(false)`: happy-dom does not reflect the `draggable` attribute
+            // onto the property, so an element nothing has set it on reads undefined.
+            expect(element.draggable).toBeFalsy();
+
+            press(element, 50, 60, "mouse", { ctrlKey: true });
+            expect(element.draggable).toBe(true);
+
+            move(90, 90);
+            expect(calls.start).toHaveLength(0);
+        });
+
+        it("puts `draggable` back, whether the press became a drag or stayed a click", () => {
+            setup();
+            const element = card("n1");
+
+            press(element, 50, 60, "mouse", { ctrlKey: true });
+            act(() => { element.dispatchEvent(new Event("dragend", { bubbles: true })); });
+            expect(element.draggable).toBe(false);
+
+            // A Ctrl click that never moved delivers no `dragend`, so the release clears it.
+            press(element, 50, 60, "mouse", { ctrlKey: true });
+            release(50, 60);
+            expect(element.draggable).toBe(false);
+        });
+
+        it("leaves an ordinary press to the board's own gesture", () => {
+            setup();
+            const element = card("n1");
+
+            press(element, 50, 60);
+            move(90, 90);
+
+            expect(element.draggable).toBeFalsy();
+            expect(calls.start).toHaveLength(1);
+        });
+    });
+
     describe("carrying a column", () => {
         it("takes hold of it by its heading, and says what it measures", () => {
             setup();
@@ -770,18 +816,26 @@ describe("useBoardDrag, carrying a card", () => {
         }) as DOMRect;
     }
 
-    function pointer(type: string, clientX: number, clientY: number, pointerType: string) {
+    function pointer(
+        type: string, clientX: number, clientY: number, pointerType: string,
+        modifiers: { ctrlKey?: boolean } = {}
+    ) {
         const event = new Event(type, { bubbles: true, cancelable: true });
         for (const [ name, value ] of Object.entries({
-            clientX, clientY, pointerId: 1, button: 0, pointerType
+            clientX, clientY, pointerId: 1, button: 0, pointerType, ...modifiers
         })) {
             Object.defineProperty(event, name, { value, configurable: true });
         }
         return event;
     }
 
-    function press(target: HTMLElement, x: number, y: number, pointerType = "mouse") {
-        act(() => { target.dispatchEvent(pointer("pointerdown", x, y, pointerType)); });
+    function press(
+        target: HTMLElement, x: number, y: number, pointerType = "mouse",
+        modifiers: { ctrlKey?: boolean } = {}
+    ) {
+        act(() => {
+            target.dispatchEvent(pointer("pointerdown", x, y, pointerType, modifiers));
+        });
     }
 
     function move(x: number, y: number, pointerType = "mouse") {

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -66,6 +66,31 @@ describe("useBoardDrag, carrying a card", () => {
         expect(copy?.querySelector(".title")).toBeNull();
     });
 
+    /** Two cards on the move leave one card behind the copy. */
+    it("stacks one card behind a pair", () => {
+        setup({ carried: [ "n1", "n2" ] });
+
+        press(card("n1"), 50, 60);
+        move(90, 90);
+
+        expect(preview()?.dataset.layers).toBe("2");
+        expect(preview()?.textContent).toBe("2");
+    });
+
+    /**
+     * The stack says a set is on the move and the number says how big it is, so the stack stops at
+     * the depth the stylesheet draws however many cards are carried.
+     */
+    it("stacks no deeper than three, whatever the selection holds", () => {
+        setup({ carried: [ "n1", "n2", "n3", "n4", "n5" ] });
+
+        press(card("n1"), 50, 60);
+        move(90, 90);
+
+        expect(preview()?.dataset.layers).toBe("3");
+        expect(preview()?.textContent).toBe("5");
+    });
+
     it("carries a copy under the pointer without redrawing the board", () => {
         setup();
         const element = card("n1");

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -92,6 +92,20 @@ describe("useBoardDrag, carrying a card", () => {
         expect(reached).toHaveBeenCalledTimes(1);
     });
 
+    /**
+     * The gap holds the space the cards will fill, so the column they land in is already the size
+     * it will be. Sized for one of them, it would resize around the rest as they arrive.
+     */
+    it("holds a gap the size of everything being carried", () => {
+        setup({ carried: [ "n1", "n2" ] });
+
+        press(card("n1"), 50, 60);
+        move(90, 90);
+
+        // Both cards stand 50 tall, and the stylesheet the spacing comes from is not loaded here.
+        expect(calls.start[0]?.height).toBe(100);
+    });
+
     /** Two cards on the move leave one card behind the copy. */
     it("stacks one card behind a pair", () => {
         setup({ carried: [ "n1", "n2" ] });

--- a/apps/client/src/widgets/collections/board/board_drag.spec.tsx
+++ b/apps/client/src/widgets/collections/board/board_drag.spec.tsx
@@ -3,13 +3,15 @@ import { useRef } from "preact/hooks";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type BoardDragCallbacks, type DropPosition, useBoardDrag } from "./board_drag";
+import {
+    type BoardDragCallbacks, type DraggedCard, type DropPosition, useBoardDrag
+} from "./board_drag";
 
 describe("useBoardDrag, carrying a card", () => {
     let container: HTMLElement | undefined;
     let board: HTMLElement;
     let calls: {
-        start: unknown[],
+        start: DraggedCard[],
         move: { position: unknown | null, inside: boolean }[],
         end: { card: unknown, position: unknown }[],
         columnStart: { column: string, index: number, size: unknown }[],
@@ -45,7 +47,23 @@ describe("useBoardDrag, carrying a card", () => {
 
         move(70, 60);
         expect(calls.start)
-            .toEqual([ { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 } ]);
+            .toEqual([
+                { noteId: "n1", noteIds: [ "n1" ], fromColumn: "To Do", index: 0, height: 50 }
+            ]);
+    });
+
+    it("carries a selection as one card naming how many are on the move", () => {
+        setup({ carried: [ "n1", "n2", "n3" ] });
+
+        press(card("n1"), 50, 60);
+        move(90, 90);
+
+        expect(calls.start[0]?.noteIds).toEqual([ "n1", "n2", "n3" ]);
+        // A blank card holding the count, rather than a copy of the one under the pointer.
+        const copy = preview();
+        expect(copy?.classList.contains("board-drag-count")).toBe(true);
+        expect(copy?.textContent).toBe("3");
+        expect(copy?.querySelector(".title")).toBeNull();
     });
 
     it("carries a copy under the pointer without redrawing the board", () => {
@@ -255,7 +273,7 @@ describe("useBoardDrag, carrying a card", () => {
         release(320, 200);
 
         expect(calls.end).toEqual([ {
-            card: { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 },
+            card: { noteId: "n1", noteIds: [ "n1" ], fromColumn: "To Do", index: 0, height: 50 },
             position: { column: "Doing", index: 1 }
         } ]);
     });
@@ -458,7 +476,7 @@ describe("useBoardDrag, carrying a card", () => {
         });
 
         expect(calls.end).toEqual([ {
-            card: { noteId: "n1", fromColumn: "To Do", index: 0, height: 50 },
+            card: { noteId: "n1", noteIds: [ "n1" ], fromColumn: "To Do", index: 0, height: 50 },
             position: null
         } ]);
         expect(element.style.transform).toBe("");
@@ -593,12 +611,17 @@ describe("useBoardDrag, carrying a card", () => {
      * Two 100px columns, 200 apart, each card 50 tall. The first holds two cards, the second one.
      * happy-dom lays nothing out, so every box is declared.
      */
-    function setup({ disabled = false } = {}) {
+    function setup({ disabled = false, carried }: {
+        disabled?: boolean,
+        /** The cards a press answers with, for the tests about carrying a selection. */
+        carried?: string[]
+    } = {}) {
         const mountPoint = document.createElement("div");
         container = mountPoint;
         document.body.appendChild(mountPoint);
 
         const callbacks: BoardDragCallbacks = {
+            carriedWith: (noteId) => carried ?? [ noteId ],
             onCardStart: (card) => calls.start.push(card),
             onCardMove: (position, inside) => calls.move.push({ position, inside }),
             onCardEnd: (card, position) => calls.end.push({ card, position }),

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -45,7 +45,10 @@ export interface DraggedCard {
     noteIds: string[];
     fromColumn: string;
     index: number;
-    /** How tall it stands, so the gap held open for it is the size it will fill. */
+    /**
+     * How tall the cards being carried stand together, so the gap held open for them is the space
+     * they will fill and the column they land in does not resize around them.
+     */
     height: number;
 }
 
@@ -549,21 +552,39 @@ function startCard(
     if (!element || !columnElement || !noteId) return null;
 
     const cards = [ ...columnElement.querySelectorAll(".board-note") ];
+    const noteIds = carriedWith(noteId);
     return {
         kind: "card",
         element,
         menuTarget: element,
         card: {
             noteId,
-            noteIds: carriedWith(noteId),
+            noteIds,
             fromColumn: columnElement.dataset.column ?? "",
             index: cards.indexOf(element),
-            height: element.getBoundingClientRect().height
+            height: carriedHeight(element, noteIds)
         },
         position: null,
         inside: false,
         reported: false
     };
+}
+
+/**
+ * How much room the cards being carried take together: their own heights, and the space between
+ * each pair of them.
+ *
+ * Measured from the board rather than from the column, since a selection can reach across columns.
+ * A card the board is no longer drawing counts for nothing.
+ */
+function carriedHeight(element: HTMLElement, noteIds: string[]) {
+    const board = element.closest(".board-view-container") ?? element.ownerDocument;
+    const spacing = parseFloat(getComputedStyle(element).marginBottom) || 0;
+
+    return noteIds.reduce((total, noteId) => {
+        const card = board.querySelector<HTMLElement>(`.board-note[data-note-id="${noteId}"]`);
+        return total + (card?.getBoundingClientRect().height ?? 0);
+    }, spacing * (noteIds.length - 1));
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -20,6 +20,12 @@ const TOUCH_TOLERANCE = 8;
 /** How much a carried card shrinks. Written with the movement, a class could not add to it. */
 const DRAG_SCALE = 0.9;
 
+/**
+ * How many cards a carried selection is drawn as, however many are on the move: the one holding the
+ * count and the two behind it. `index.css` draws the ones behind from `data-layers`.
+ */
+const STACK_LAYERS = 3;
+
 /** How tall a carried column is allowed to stand, so a full one can be seen past. */
 const COLUMN_DRAG_MAX_HEIGHT = 150;
 
@@ -627,10 +633,17 @@ function lift(held: Gesture, container: HTMLElement) {
     };
 }
 
-/** A card-shaped copy standing for the cards being carried, with their number in the middle. */
+/**
+ * A card-shaped copy standing for the cards being carried, with their number in the middle and a
+ * stack drawn behind it.
+ *
+ * `data-layers` counts the copy itself, so two cards on the move leave one card behind it and any
+ * more leave two. The number in the middle is what says how many there really are.
+ */
 function countPreview(count: number) {
     const preview = document.createElement("div");
     preview.className = "board-note board-drag-count";
+    preview.dataset.layers = String(Math.min(count, STACK_LAYERS));
     preview.textContent = String(count);
     return preview;
 }

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -32,6 +32,11 @@ const COMPATIBILITY_WINDOW_MS = 700;
 /** Which card is being carried, named the way the board's own moves are. */
 export interface DraggedCard {
     noteId: string;
+    /**
+     * Every card on the move, in the order the board draws them, this one among them. Holds one
+     * entry unless the card was taken hold of as part of a selection.
+     */
+    noteIds: string[];
     fromColumn: string;
     index: number;
     /** How tall it stands, so the gap held open for it is the size it will fill. */
@@ -45,6 +50,13 @@ export interface DropPosition {
 }
 
 export interface BoardDragCallbacks {
+    /**
+     * Which cards travel with the one being pressed, in the order the board draws them.
+     *
+     * Asked as the press lands rather than when the drag opens, so the answer is the selection as
+     * it stood when the reader took hold. Answers with the card alone where it is not selected.
+     */
+    carriedWith(noteId: string): string[];
     /** A card has been taken hold of, and is now being carried. */
     onCardStart(card: DraggedCard): void;
     /**
@@ -269,7 +281,8 @@ export function useBoardDrag(
             // Anything the card or the heading offers in its own right keeps its press.
             if (!target || target.closest("input, textarea, button, a")) return;
 
-            const started = startCard(target) ?? startColumn(target, container);
+            const started = startCard(target, latest.current.carriedWith)
+                ?? startColumn(target, container);
             if (!started) return;
 
             gesture.current = {
@@ -505,7 +518,9 @@ function askForMenu(element: HTMLElement, clientX: number, clientY: number) {
 }
 
 /** What a press on a card starts, or nothing where the press was not on one. */
-function startCard(target: HTMLElement): CardSubject | null {
+function startCard(
+    target: HTMLElement, carriedWith: (noteId: string) => string[]
+): CardSubject | null {
     const element = target.closest<HTMLElement>(".board-note");
     const columnElement = element?.closest<HTMLElement>(".board-column");
     const noteId = element?.dataset.noteId;
@@ -518,6 +533,7 @@ function startCard(target: HTMLElement): CardSubject | null {
         menuTarget: element,
         card: {
             noteId,
+            noteIds: carriedWith(noteId),
             fromColumn: columnElement.dataset.column ?? "",
             index: cards.indexOf(element),
             height: element.getBoundingClientRect().height
@@ -558,7 +574,13 @@ function startColumn(target: HTMLElement, container: HTMLElement): ColumnSubject
  */
 function lift(held: Gesture, container: HTMLElement) {
     const rect = held.element.getBoundingClientRect();
-    const preview = held.element.cloneNode(true) as HTMLElement;
+    // A selection is carried as one blank card saying how many are on the move. The cards
+    // themselves stay where they are drawn, and a stack of copies would hide the board they are
+    // being placed on without saying any more than the count does.
+    const carried = held.kind === "card" ? held.card.noteIds.length : 1;
+    const preview = carried > 1
+        ? countPreview(carried)
+        : held.element.cloneNode(true) as HTMLElement;
 
     preview.classList.add("board-drag-preview");
     preview.removeAttribute("data-note-id");
@@ -603,6 +625,14 @@ function lift(held: Gesture, container: HTMLElement) {
             height: rect.height
         }
     };
+}
+
+/** A card-shaped copy standing for the cards being carried, with their number in the middle. */
+function countPreview(count: number) {
+    const preview = document.createElement("div");
+    preview.className = "board-note board-drag-count";
+    preview.textContent = String(count);
+    return preview;
 }
 
 interface CardSubject {

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -357,6 +357,7 @@ export function useBoardDrag(
             const tapped = held.touch && !held.active && event.type === "pointerup"
                 && Math.hypot(event.clientX - held.startX, event.clientY - held.startY)
                     <= TOUCH_TOLERANCE;
+            const dragged = held.active && event.type === "pointerup";
             const target = held.menuTarget;
             // A tap on a collapsed column opens it: that is what the strip is for, and its menu is
             // on the button it carries. Everything else answers a tap with its menu, the long
@@ -371,14 +372,29 @@ export function useBoardDrag(
                 // first of them takes the menu straight back off again. Refused at `touchend`,
                 // which is what the browser makes them from, and which has yet to be sent.
                 justTapped = true;
-                // The click is left out as well, for a browser that sends one regardless. Given up
-                // after a moment so a later click of the reader's own is never the one taken.
-                container.addEventListener("click", swallow, { capture: true, once: true });
-                window.setTimeout(
-                    () => container.removeEventListener("click", swallow, { capture: true }),
-                    COMPATIBILITY_WINDOW_MS);
+                // The click is left out as well, for a browser that sends one regardless.
+                swallowNextClick();
                 askForMenu(target, event.clientX, event.clientY);
             }
+
+            // A mouse drag is followed by a click on whatever the press and the release have in
+            // common, which for a card carried anywhere is the board itself. Taken here, so that
+            // what a click on the board means is not also what letting go of a card means.
+            if (dragged) {
+                swallowNextClick();
+            }
+        };
+
+        /**
+         * Refuses the one click the browser is about to send, if it sends one.
+         *
+         * Given up after a moment so a later click of the reader's own is never the one taken.
+         */
+        const swallowNextClick = () => {
+            container.addEventListener("click", swallow, { capture: true, once: true });
+            window.setTimeout(
+                () => container.removeEventListener("click", swallow, { capture: true }),
+                COMPATIBILITY_WINDOW_MS);
         };
 
         /** Set between a tap and the `touchend` the browser would make mouse events from. */

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -122,6 +122,8 @@ export function useBoardDrag(
     const [ isDragging, setDragging ] = useState(false);
     // Held in a ref rather than in state: every move reads them, and none of them draw anything.
     const gesture = useRef<Gesture | null>(null);
+    /** The card a Ctrl press made natively draggable, which `disarm` puts back. */
+    const armed = useRef<HTMLElement | null>(null);
     const latest = useRef(callbacks);
     latest.current = callbacks;
     // The board draws its container only once the notes have loaded, and filling a ref triggers no
@@ -290,6 +292,17 @@ export function useBoardDrag(
             // Anything the card or the heading offers in its own right keeps its press.
             if (!target || target.closest("input, textarea, button, a")) return;
 
+            // Ctrl hands the press to the browser's own drag, which is the only one that reaches
+            // outside the board: the note tree, and a board in another split. `draggable` is set
+            // here rather than left on the card so that an ordinary press still opens the board's
+            // own gesture, and cleared again in `disarm`.
+            const held = target.closest<HTMLElement>(".board-note");
+            if (held && !held.classList.contains("editing") && (event.ctrlKey || event.metaKey)) {
+                held.draggable = true;
+                armed.current = held;
+                return;
+            }
+
             const started = startCard(target, latest.current.carriedWith)
                 ?? startColumn(target, container);
             if (!started) return;
@@ -351,7 +364,23 @@ export function useBoardDrag(
             }
         };
 
+        /**
+         * Takes `draggable` off the card a Ctrl press armed.
+         *
+         * Left on, the next ordinary press on that card would start a native drag instead of the
+         * board's own. Called from `dragend` for a press that became a drag, and from `pointerup`
+         * for a Ctrl click that did not: a native drag delivers no `pointerup`.
+         */
+        const disarm = () => {
+            if (armed.current) {
+                armed.current.draggable = false;
+                armed.current = null;
+            }
+        };
+
         const onPointerUp = (event: PointerEvent) => {
+            disarm();
+
             const held = gesture.current;
             if (!held || event.pointerId !== held.pointerId) return;
 
@@ -440,6 +469,7 @@ export function useBoardDrag(
         };
 
         container.addEventListener("contextmenu", onContextMenu, { capture: true });
+        container.addEventListener("dragend", disarm);
         container.addEventListener("pointerdown", onPointerDown);
         container.addEventListener("pointermove", onPointerMove);
         container.addEventListener("pointerup", onPointerUp);
@@ -450,7 +480,9 @@ export function useBoardDrag(
 
         return () => {
             close(true);
+            disarm();
             container.removeEventListener("contextmenu", onContextMenu, { capture: true });
+            container.removeEventListener("dragend", disarm);
             container.removeEventListener("pointerdown", onPointerDown);
             container.removeEventListener("pointermove", onPointerMove);
             container.removeEventListener("pointerup", onPointerUp);

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -371,6 +371,40 @@ describe("Board card", () => {
         }
     });
 
+    describe("the drag that carries a card off the board", () => {
+        it("fills the drag with the one card, in the two entries the tree reads", async () => {
+            const { first } = await renderBoard();
+            const data = new Map<string, string>();
+
+            fireDrag(card(first), "dragstart", { setData: (type: string, value: string) => data.set(type, value) });
+
+            expect(data.get("application/x-fancytree-node")).toBe("");
+            expect(JSON.parse(data.get("text") ?? "[]")).toEqual([
+                { noteId: first, branchId: expect.any(String), title: "First" }
+            ]);
+        });
+
+        /** A drag started on a card that is picked out takes everything picked out with it. */
+        it("fills it with every card picked out, where the one dragged is among them", async () => {
+            const { first, second } = await renderBoard();
+            const data = new Map<string, string>();
+
+            await act(async () => {
+                card(first).dispatchEvent(new MouseEvent(
+                    "click", { bubbles: true, cancelable: true, detail: 1, ctrlKey: true }));
+            });
+            await act(async () => {
+                card(second).dispatchEvent(new MouseEvent(
+                    "click", { bubbles: true, cancelable: true, detail: 1, ctrlKey: true }));
+            });
+
+            fireDrag(card(first), "dragstart", { setData: (type: string, value: string) => data.set(type, value) });
+
+            expect(JSON.parse(data.get("text") ?? "[]").map((entry: { title: string }) => entry.title))
+                .toEqual([ "First", "Second" ]);
+        });
+    });
+
     /**
      * The card is the same height either way, so opening the editor neither drops what the card
      * shows nor moves the cards below it.

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -298,6 +298,19 @@ describe("Board card", () => {
             expect(selectedCards()).toEqual([ "Extra 2" ]);
         });
 
+        it("takes every card of the column focus is in on Ctrl+A", async () => {
+            const { first, extra } = await renderBoard([ "Done" ]);
+
+            await act(async () => {
+                card(first).focus();
+                press(card(first), "a", { ctrlKey: true });
+            });
+
+            // The card in the other column is left alone, whichever way the columns are drawn.
+            expect(selectedCards()).toEqual([ "First", "Second" ]);
+            expect(cardClasses(extra[0])).not.toContain("selected");
+        });
+
         it("gives the whole selection up on a plain click, which opens the note", async () => {
             const { first, second } = await renderBoard();
             const openInPopup = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -82,7 +82,7 @@ describe("Board card", () => {
 
         expect(cardClasses(first)).not.toContain("archived");
 
-        await addLabel(component, first, "archived");
+        await addAttribute(component, first, "archived");
 
         expect(cardClasses(first)).toContain("archived");
         expect(cardClasses(second)).not.toContain("archived");
@@ -117,7 +117,7 @@ describe("Board card", () => {
 
         expect(cardClasses(first)).not.toContain(coloured);
 
-        await addLabel(component, first, "color", "#ff0000");
+        await addAttribute(component, first, "color", "#ff0000");
 
         expect(cardClasses(first)).toContain(coloured);
         expect(cardClasses(second)).not.toContain(coloured);
@@ -128,7 +128,7 @@ describe("Board card", () => {
 
         expect(cardIcon(first)).not.toContain("bx-bug");
 
-        await addLabel(component, first, "iconClass", "bx bx-bug");
+        await addAttribute(component, first, "iconClass", "bx bx-bug");
 
         expect(cardIcon(first)).toContain("bx-bug");
     });
@@ -141,6 +141,51 @@ describe("Board card", () => {
 
         expect(openInPopup)
             .toHaveBeenCalledWith("openInPopup", { noteIdOrPath: first });
+    });
+
+    /**
+     * A card carrying `boardCardRedirectTo` stands in for the note it points at, so the open gesture
+     * navigates there rather than opening an editor for the card itself.
+     */
+    it("jumps to the note it redirects to instead of opening itself", async () => {
+        const { first, component } = await renderBoard();
+        await addAttribute(component, first, "boardCardRedirectTo", "targetNote", "relation");
+
+        const openInPopup = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);
+        const setNote = vi.fn();
+        const previousTabManager = appContext.tabManager;
+        appContext.tabManager = { getActiveContext: () => ({ setNote }) } as never;
+
+        try {
+            await act(async () => { card(first).click(); });
+        } finally {
+            // Put back before the assertions: a stub left standing reaches every later test.
+            appContext.tabManager = previousTabManager;
+        }
+
+        expect(setNote).toHaveBeenCalledWith("targetNote");
+        expect(openInPopup).not.toHaveBeenCalled();
+        // `shortcut` is what underlines the title on hover, drawing it as a link.
+        expect(cardClasses(first)).toContain("shortcut");
+    });
+
+    it("marks no card a shortcut without the relation", async () => {
+        const { first } = await renderBoard();
+
+        expect(cardClasses(first)).not.toContain("shortcut");
+    });
+
+    /**
+     * The underline is drawn on the text alone. A decoration set on `.title` would propagate to the
+     * icon standing beside the text, and a descendant cannot turn a propagated one off.
+     */
+    it("keeps the title text in an element of its own, apart from the icon", async () => {
+        const { first } = await renderBoard();
+        const title = card(first).querySelector(".title");
+
+        expect(title?.querySelector(".text")).toBeTruthy();
+        expect(title?.querySelector(".text .icon")).toBeNull();
+        expect(title?.querySelector(":scope > .icon")).toBeTruthy();
     });
 
     /**
@@ -554,18 +599,24 @@ describe("Board card", () => {
             .map(column => column.getAttribute("data-column"));
     }
 
-    /** Adds a label to a note already in froca and announces it the way a websocket message would. */
-    async function addLabel(component: Component, noteId: string, name: string, value = "") {
+    /**
+     * Adds an attribute to a note already in froca and announces it the way a websocket message
+     * would.
+     */
+    async function addAttribute(
+        component: Component, noteId: string, name: string, value = "",
+        type: "label" | "relation" = "label"
+    ) {
         const attributeId = utils.randomString(12);
         const attribute = new FAttribute(froca, {
-            noteId, attributeId, type: "label", name, value, position: 0, isInheritable: false
+            noteId, attributeId, type, name, value, position: 0, isInheritable: false
         });
 
         froca.attributes[attributeId] = attribute;
         froca.notes[noteId].attributes.push(attributeId);
         noteAttributeCache.attributes[noteId] = [ ...(noteAttributeCache.attributes[noteId] ?? []), attribute ];
 
-        const entity = { attributeId, noteId, type: "label", name, value, isDeleted: false };
+        const entity = { attributeId, noteId, type, name, value, isDeleted: false };
         const loadResults = new LoadResults([ {
             entityName: "attributes", entityId: attributeId, entity, hash: "", isSynced: true, isErased: false
         } ]);

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -371,6 +371,22 @@ describe("Board card", () => {
         }
     });
 
+    /**
+     * The card is the same height either way, so opening the editor neither drops what the card
+     * shows nor moves the cards below it.
+     */
+    it("keeps the badges it shows while its title is being edited", async () => {
+        const { first } = await renderBoard();
+        // Held on to: the editor takes the place of the title the lookup goes by.
+        const element = card(first);
+        expect(element.querySelector(".user-attributes")).toBeTruthy();
+
+        await act(async () => { press(element, "F2"); });
+
+        expect(element.querySelector("textarea")).toBeTruthy();
+        expect(element.querySelector(".user-attributes")).toBeTruthy();
+    });
+
     it("offers the card menu on a right click", async () => {
         const { first } = await renderBoard();
         const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -256,6 +256,108 @@ describe("Board card", () => {
         expect(openInPopup).not.toHaveBeenCalled();
     });
 
+    describe("picking several cards out", () => {
+        it("marks a card on Ctrl and click, and lets go of it on the next one", async () => {
+            const { first, second } = await renderBoard();
+            const openInPopup = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);
+
+            await click(first, { ctrlKey: true });
+            expect(cardClasses(first)).toContain("selected");
+            expect(cardClasses(second)).not.toContain("selected");
+            // Picking a card out is not opening it.
+            expect(openInPopup).not.toHaveBeenCalled();
+
+            await click(second, { ctrlKey: true });
+            expect(cardClasses(first)).toContain("selected");
+            expect(cardClasses(second)).toContain("selected");
+
+            await click(first, { ctrlKey: true });
+            expect(cardClasses(first)).not.toContain("selected");
+            expect(cardClasses(second)).toContain("selected");
+        });
+
+        it("takes everything between the two cards on Shift and click", async () => {
+            const { first, second, extra } = await renderBoard([ "To Do", "To Do" ]);
+
+            await click(first, { ctrlKey: true });
+            await click(extra[1], { shiftKey: true });
+
+            expect(selectedCards()).toEqual([ "First", "Second", "Extra 1", "Extra 2" ]);
+        });
+
+        /**
+         * A range is measured against one column, so an anchor left in another is not in the list
+         * the press is counted against and the card it landed on is taken on its own.
+         */
+        it("keeps a range inside one column", async () => {
+            const { first, extra } = await renderBoard([ "Done", "Done" ]);
+
+            await click(first, { ctrlKey: true });
+            await click(extra[1], { shiftKey: true });
+
+            expect(selectedCards()).toEqual([ "Extra 2" ]);
+        });
+
+        it("gives the whole selection up on a plain click, which opens the note", async () => {
+            const { first, second } = await renderBoard();
+            const openInPopup = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);
+
+            await click(first, { ctrlKey: true });
+            await click(second, { ctrlKey: true });
+            await click(first, {});
+
+            expect(selectedCards()).toEqual([]);
+            expect(openInPopup).toHaveBeenCalledTimes(1);
+        });
+
+        it("opens the menu on the whole selection when it is opened from within it", async () => {
+            const { first, second } = await renderBoard();
+            const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});
+
+            await click(first, { ctrlKey: true });
+            await click(second, { ctrlKey: true });
+            await act(async () => {
+                card(second).dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+            });
+
+            // The entries that only make sense for one card are gone.
+            expect(menuTitles(show)).not.toContain("board_view.edit-title");
+            expect(menuTitles(show)).toContain("board_view.remove-from-board");
+        });
+
+        it("acts on a card alone when the menu is opened outside the selection", async () => {
+            const { first, second } = await renderBoard();
+            const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});
+
+            await click(first, { ctrlKey: true });
+            await act(async () => {
+                card(second).dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+            });
+
+            expect(menuTitles(show)).toContain("board_view.edit-title");
+            expect(selectedCards()).toEqual([]);
+        });
+
+        /** The titles of the cards picked out, in the order the board draws them. */
+        function selectedCards() {
+            return [ ...(container?.querySelectorAll(".board-note.selected") ?? []) ]
+                .map((element) => element.querySelector(".title")?.textContent);
+        }
+
+        function menuTitles(show: { mock: { calls: unknown[][] } }) {
+            const items = (show.mock.calls.at(-1)?.[0] as
+                { items: { title?: string }[] } | undefined)?.items ?? [];
+            return items.map((item) => item.title);
+        }
+
+        async function click(noteId: string, modifiers: MouseEventInit) {
+            await act(async () => {
+                card(noteId).dispatchEvent(new MouseEvent(
+                    "click", { bubbles: true, cancelable: true, detail: 1, ...modifiers }));
+            });
+        }
+    });
+
     it("offers the card menu on a right click", async () => {
         const { first } = await renderBoard();
         const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});
@@ -284,16 +386,25 @@ describe("Board card", () => {
     }
 
     /** Renders a board of two cards and hands back the component their subscriptions register on. */
-    async function renderBoard() {
+    /**
+     * Draws a board of two cards under "To Do".
+     *
+     * @param extra the cards to add beyond those two, each named by the column it stands in. Only
+     * the tests about picking several cards out need them.
+     */
+    async function renderBoard(extra: string[] = []) {
         const first = `card${idSeed++}`;
         const second = `card${idSeed++}`;
+        const rest = extra.map((status, at) => (
+            { id: `card${idSeed++}`, title: `Extra ${at + 1}`, "#status": status }));
         const note = buildNote({
             title: "Board",
             "#collection": "",
             "#viewType": "board",
             children: [
                 { id: first, title: "First", "#status": "To Do" },
-                { id: second, title: "Second", "#status": "To Do" }
+                { id: second, title: "Second", "#status": "To Do" },
+                ...rest
             ]
         });
 
@@ -308,7 +419,7 @@ describe("Board card", () => {
                     <BoardView
                         note={note}
                         notePath={`root/${note.noteId}`}
-                        noteIds={[ first, second ]}
+                        noteIds={[ first, second, ...rest.map((card) => card.id) ]}
                         highlightedTokens={null}
                         viewConfig={{ columns: [ { value: "To Do" } ] }}
                         saveConfig={() => {}}
@@ -321,7 +432,7 @@ describe("Board card", () => {
         });
         await settle();
 
-        return { note, component, first, second };
+        return { note, component, first, second, extra: rest.map((card) => card.id) };
     }
 
     /** Moves a card to another column the way an edit made anywhere else reaches the board. */

--- a/apps/client/src/widgets/collections/board/card.spec.tsx
+++ b/apps/client/src/widgets/collections/board/card.spec.tsx
@@ -387,6 +387,33 @@ describe("Board card", () => {
         expect(element.querySelector(".user-attributes")).toBeTruthy();
     });
 
+    /**
+     * The wash over the board is raised by the stylesheet from the classes checked here, since each
+     * field keeps its own state and there is nothing above them all to read. These are the names it
+     * goes by; the wash itself is a rule that `happy-dom` lays nothing out for.
+     */
+    it("marks what a backdrop is raised for while a title is being typed", async () => {
+        const { first } = await renderBoard();
+        expect(container?.querySelector(".board-edit-backdrop")).toBeTruthy();
+        // Held on to: the editor takes the place of the title the lookup goes by.
+        const element = card(first);
+
+        await act(async () => { press(element, "F2"); });
+        expect(element.classList.contains("editing")).toBe(true);
+
+        const editor = element.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the title editor");
+        await act(async () => { press(editor, "Escape"); });
+        expect(element.classList.contains("editing")).toBe(false);
+
+        // The field that opens between two cards is marked; the one at the foot of the column is
+        // left as it is, and raises nothing.
+        await act(async () => { press(element, "Enter"); });
+        expect(container?.querySelectorAll(".board-new-item.inserting")).toHaveLength(1);
+        expect(container?.querySelector(".board-new-item:not(.inserting)")?.classList
+            .contains("inserting")).toBe(false);
+    });
+
     it("offers the card menu on a right click", async () => {
         const { first } = await renderBoard();
         const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -24,6 +24,7 @@ import {
 import { TooltipIcon } from "../../react/Icon";
 import { HighlightedText } from "../../react/RawHtml";
 import { useIsSelected, useSelection } from "../../react/selection";
+import { type DragData, TREE_CLIPBOARD_TYPE } from "../../note_tree";
 
 function Card({
     api,
@@ -163,6 +164,27 @@ function Card({
         api.openNote(note.noteId);
     }, [ api, note, column, selection ]);
 
+    /**
+     * Fills the drag with what the note tree reads, for the native drag a Ctrl press arms in
+     * `board_drag.ts`. Carries the whole selection where this card is part of one.
+     *
+     * The same two entries the tree writes, so a card reaches everything a note dragged from the
+     * tree does: `TREE_CLIPBOARD_TYPE` says the drag holds notes, `text` says which.
+     */
+    const handleDragStart = useCallback((e: DragEvent) => {
+        const carried = isSelected
+            ? api.getCards(selection.keys)
+            : [ { note, branch } ];
+        const dragged: DragData[] = carried.map((item) => ({
+            noteId: item.note.noteId,
+            branchId: item.branch.branchId,
+            title: item.note.title
+        }));
+
+        e.dataTransfer?.setData(TREE_CLIPBOARD_TYPE, "");
+        e.dataTransfer?.setData("text", JSON.stringify(dragged));
+    }, [ api, note, branch, isSelected, selection ]);
+
     const handleEdit = useCallback((e: MouseEvent) => {
         e.stopPropagation(); // don't also open the note
         setBranchIdToEdit(branch.branchId);
@@ -244,6 +266,7 @@ function Card({
             }}
             data-note-id={note.noteId}
             onContextMenu={handleContextMenu}
+            onDragStart={handleDragStart}
             onClick={!isEditing ? handleClick : undefined}
             onKeyDown={handleKeyDown}
             tabIndex={300}

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { memo } from "preact/compat";
 import {
     useCallback, useContext, useEffect, useLayoutEffect, useRef, useState
@@ -22,6 +23,7 @@ import {
 } from "../../react/hooks";
 import { TooltipIcon } from "../../react/Icon";
 import { HighlightedText } from "../../react/RawHtml";
+import { useIsSelected, useSelection } from "../../react/selection";
 
 function Card({
     api,
@@ -84,6 +86,11 @@ function Card({
     const [ title, setTitle ] = useState(note.title);
     // Tracks the `iconClass` label, which an attribute change carries and the note row never does.
     const icon = useNoteIcon(note);
+    // Read from the store rather than through the board's state, so picking one card redraws that
+    // card and no other. The store keeps one identity for the life of the board, so holding it
+    // here leaves the memo below intact.
+    const selection = useSelection();
+    const isSelected = useIsSelected(note.noteId);
 
     // A card owns its own title: the board does not redraw for a note-row change. Setting the value
     // already held is a no-op, so a save that left the title alone re-renders nothing.
@@ -95,17 +102,36 @@ function Card({
     });
 
     const handleContextMenu = useCallback((e: ContextMenuEvent) => {
-        openNoteContextMenu(
-            api, e, note, branch.branchId, column, index, onFocusCard, onInsert, onNewItem);
-    }, [ api, note, branch, column, index, onFocusCard, onInsert, onNewItem ]);
+        // A card outside the selection is acted on alone, and the selection it was not part of is
+        // dropped, so the menu never writes to cards the reader has stopped looking at.
+        if (!selection.has(note.noteId)) {
+            selection.clear();
+        }
 
-    const handleOpen = useCallback((e: MouseEvent) => {
+        const cards = api.getCards(selection.keys);
+        openNoteContextMenu(api, e, {
+            note,
+            branchId: branch.branchId,
+            column,
+            index,
+            notes: cards.length ? cards.map((card) => card.note) : [ note ],
+            branchIds: cards.length
+                ? cards.map((card) => card.branch.branchId)
+                : [ branch.branchId ],
+            onFocusCard,
+            onInsert,
+            onNewItem
+        });
+    }, [ api, note, branch, column, index, selection, onFocusCard, onInsert, onNewItem ]);
+
+    const handleClick = useCallback((e: MouseEvent) => {
         // A double click is one gesture, and its second click would open the note over itself: the
         // popup already standing is taken as the one to stack on, and closing that leaves neither.
         if (e.detail > 1) return;
 
         // A link to a note, such as a relation's target, opens in the popup. Cancelled here so that
         // `goToLink` does not open a tab for it as well; a link naming no note is left alone.
+        // Checked before the modifiers below, so Ctrl on a link still means what it means anywhere.
         const link = (e.target as HTMLElement | null)?.closest<HTMLAnchorElement>("a[href]");
         if (link) {
             const { notePath } = parseNavigationStateFromUrl(link.getAttribute("href") ?? undefined);
@@ -119,8 +145,23 @@ function Card({
             return;
         }
 
+        // Ctrl picks this card out on its own, keeping whatever else is picked. Neither modifier
+        // opens the note.
+        if (e.ctrlKey || e.metaKey) {
+            selection.toggle(note.noteId);
+            return;
+        }
+
+        // Shift takes everything between the card the selection started from and this one. Only
+        // this column is offered, so a range never reaches into another.
+        if (e.shiftKey) {
+            selection.selectRange(api.getColumnNoteIds(column), note.noteId);
+            return;
+        }
+
+        selection.clear();
         api.openNote(note.noteId);
-    }, [ api, note ]);
+    }, [ api, note, column, selection ]);
 
     const handleEdit = useCallback((e: MouseEvent) => {
         e.stopPropagation(); // don't also open the note
@@ -189,7 +230,13 @@ function Card({
     return (
         <div
             ref={cardRef}
-            className={`board-note ${colorClass} ${isDragging ? 'dragging' : ''} ${isEditing ? "editing" : ""} ${isArchived ? "archived" : ""} ${isNew && !isRevealed ? "appearing" : ""}`}
+            className={clsx("board-note", colorClass, {
+                dragging: isDragging,
+                editing: isEditing,
+                archived: isArchived,
+                selected: isSelected,
+                appearing: isNew && !isRevealed
+            })}
             onAnimationEnd={(e) => {
                 if (e.animationName === "board-item-appear") {
                     setIsRevealed(true);
@@ -197,7 +244,7 @@ function Card({
             }}
             data-note-id={note.noteId}
             onContextMenu={handleContextMenu}
-            onClick={!isEditing ? handleOpen : undefined}
+            onClick={!isEditing ? handleClick : undefined}
             onKeyDown={handleKeyDown}
             tabIndex={300}
         >

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -6,7 +6,7 @@ import {
 
 import FBranch from "../../../entities/fbranch";
 import FNote from "../../../entities/fnote";
-import BoardApi from "./api";
+import BoardApi, { CARD_REDIRECT_RELATION } from "./api";
 import {
     BoardActionsContext, BoardHighlightTokensContext, BoardKeptCardsContext,
     BoardPromotedAttributesContext, TitleEditor
@@ -19,7 +19,8 @@ import UserAttributesDisplay from "../../attribute_widgets/UserAttributesList";
 import { parseNavigationStateFromUrl } from "../../../services/link";
 import { FLIP_SETTLE_MS } from "../../react/flip";
 import {
-    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useTriliumEvent
+    useNoteColorClass, useNoteIcon, useNoteLabel, useNoteLabelBoolean, useNoteRelation,
+    useTriliumEvent
 } from "../../react/hooks";
 import { TooltipIcon } from "../../react/Icon";
 import { HighlightedText } from "../../react/RawHtml";
@@ -81,6 +82,9 @@ function Card({
     const cardRef = useRef<HTMLDivElement>(null);
     const [ isArchived ] = useNoteLabelBoolean(note, "archived");
     const [ iconClass, setIconClass ] = useNoteLabel(note, "iconClass");
+    // Only whether the card redirects, which is what draws its title as a link. Where it goes is
+    // read when the card is opened.
+    const [ redirectTo ] = useNoteRelation(note, CARD_REDIRECT_RELATION);
     // The card stays the one just made until another is, so what has already been shown is
     // remembered here rather than played again by every redraw of the column.
     const [ isRevealed, setIsRevealed ] = useState(false);
@@ -161,7 +165,7 @@ function Card({
         }
 
         selection.clear();
-        api.openNote(note.noteId);
+        api.openCard(note);
     }, [ api, note, column, selection ]);
 
     /**
@@ -253,6 +257,7 @@ function Card({
         <div
             ref={cardRef}
             className={clsx("board-note", colorClass, {
+                shortcut: !!redirectTo,
                 dragging: isDragging,
                 editing: isEditing,
                 archived: isArchived,
@@ -275,7 +280,8 @@ function Card({
                 <>
                     <span className="title">
                         <span class={`icon ${icon}`} />
-                        <HighlightedText text={title} highlightedTokens={highlightedTokens} />
+                        <HighlightedText
+                            className="text" text={title} highlightedTokens={highlightedTokens} />
                     </span>
                     <span
                         className="edit-icon icon bx bx-edit"

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -259,12 +259,6 @@ function Card({
                         title={t("board_view.edit-note-title")}
                         onClick={handleEdit}
                     />
-                    <UserAttributesDisplay
-                        note={note}
-                        ignoredAttributes={[statusAttribute]}
-                        shownAttributes={shownAttributes}
-                        badges={isOutsideFilter && <OutsideFilterBadge />}
-                    />
                 </>
             ) : (
                 <TitleEditor
@@ -283,6 +277,14 @@ function Card({
                     }}
                 />
             )}
+            {/* Drawn while the title is being edited as well, so a card keeps what it shows and
+                stands the same height either way. */}
+            <UserAttributesDisplay
+                note={note}
+                ignoredAttributes={[statusAttribute]}
+                shownAttributes={shownAttributes}
+                badges={isOutsideFilter && <OutsideFilterBadge />}
+            />
         </div>
     )
 }

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -190,6 +190,11 @@ export default function Column({
         useContext(BoardActionsContext);
     const { branchIdToEdit, columnNameToEdit, draggedCard, draggedColumn } =
         useContext(BoardDragStateContext);
+    // Every card on the move. The one under the pointer is taken out of the flow by the gesture
+    // itself; the rest of a carried selection stay where they are drawn and are dimmed instead.
+    const carriedNoteIds = draggedCard
+        ? new Set(draggedCard.noteIds ?? [ draggedCard.noteId ])
+        : null;
     // Asked about this column alone: where the gap stands changes on every step of a drag, and a
     // column that the answer does not concern is left as it is rather than drawn again.
     const standingDropIndex = useDropIndex(column);
@@ -672,7 +677,7 @@ export default function Column({
                             isNew={note.noteId === createdNoteId
                                 || note.noteId === landedNoteId}
                             focusOnArrival={note.noteId === insertedNoteId}
-                            isDragging={draggedCard?.noteId === note.noteId}
+                            isDragging={!!carriedNoteIds?.has(note.noteId)}
                             isEditing={branch.branchId === branchIdToEdit}
                             onFocusCard={onFocusCard}
                             onInsert={beginInsert}

--- a/apps/client/src/widgets/collections/board/context_menu.spec.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.spec.ts
@@ -678,6 +678,29 @@ describe("Board item context menu", () => {
     });
 
     /**
+     * The inbox is the column a card with no grouping value stands in, so taking that value away
+     * leaves the card there instead of off the board. Deleting the note is what removes it.
+     */
+    it("offers no way off the board while the inbox column is drawn", () => {
+        const api = {
+            columns: [],
+            isColumnArchived: () => false,
+            getColumnIcon: () => DEFAULT_COLUMN_ICON,
+            getColumnColorClass: () => "",
+            isInboxEnabled: true,
+            removeFromBoard: vi.fn()
+        } as unknown as BoardApi;
+
+        const items = openItemMenu(api);
+
+        expect(items.find(item => item && "uiIcon" in item && item.uiIcon === "bx bx-task-x"))
+            .toBeUndefined();
+        // Deleting the note is still offered, since that does take it off the board.
+        expect(items.find(item => item && "uiIcon" in item && item.uiIcon === "bx bx-trash"))
+            .toBeTruthy();
+    });
+
+    /**
      * A board can hold more columns than a menu has screen to stand in, so what does not fit goes
      * behind one entry. The card's own column is listed whatever its place, since the check beside
      * it is what says where the card stands.

--- a/apps/client/src/widgets/collections/board/context_menu.spec.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.spec.ts
@@ -726,10 +726,15 @@ describe("Board item context menu", () => {
         return `<span class="tn-menu-name">${name}</span>`;
     }
 
-    /** Opens the menu a card offers, and hands back what it was given to show. */
+    /**
+     * Opens the menu a card offers, and hands back what it was given to show.
+     *
+     * @param notes the selection the menu writes to, the card the menu was opened on standing
+     * first. One note unless a test is about what a selection changes.
+     */
     function openItemMenu(
         api: BoardApi, column = "To Do", focusCard = vi.fn(), insert = vi.fn(), index = 2,
-        newItem = vi.fn()) {
+        newItem = vi.fn(), notes?: FNote[]) {
         const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});
         const event = {
             preventDefault: () => {},
@@ -747,12 +752,22 @@ describe("Board item context menu", () => {
                 getColumnTitle: (name: string) => name,
                 getPromotedAttributes: () => [],
                 isFirstInColumn: () => false,
-                isColumnSorted: () => false
+                isColumnSorted: () => false,
+                getCardColumn: () => column
             },
             api);
-        openNoteContextMenu(
-            withDefaults, event, buildNote({ title: "Card" }) as FNote, "branchId", column, index,
-            focusCard, insert, newItem);
+        const selected = notes ?? [ buildNote({ title: "Card" }) as FNote ];
+        openNoteContextMenu(withDefaults, event, {
+            note: selected[0],
+            branchId: "branchId",
+            column,
+            index,
+            notes: selected,
+            branchIds: selected.map((_, at) => `branchId${at || ""}`),
+            onFocusCard: focusCard,
+            onInsert: insert,
+            onNewItem: newItem
+        });
 
         return show.mock.calls.at(-1)?.[0].items ?? [];
     }
@@ -915,6 +930,110 @@ describe("Board item context menu", () => {
         expect(statusItems(api)
             .map(item => !!(item && "badges" in item && item.badges?.length)))
             .toEqual([ false, true ]);
+    });
+
+    describe("opened on a selection", () => {
+        const columnApi = {
+            columns: [ "To Do", "Done" ],
+            isColumnArchived: () => false,
+            getColumnIcon: () => DEFAULT_COLUMN_ICON,
+            getColumnColorClass: () => ""
+        } as unknown as BoardApi;
+
+        it("leaves out the entries about one card, and leads with the columns", () => {
+            const items = openSelectionMenu(columnApi, [
+                buildNote({ title: "One" }), buildNote({ title: "Two" })
+            ]);
+
+            // No entries of its own above them, and no divider left standing where they were.
+            expect(items[0]).toEqual({ kind: "header", title: "Status" });
+            expect(titlesOf(items)).not.toContain("board_view.edit-title");
+            expect(titlesOf(items)).not.toContain("board_view.duplicate-item");
+            expect(titlesOf(items)).not.toContain("board_view.insert-above");
+        });
+
+        it("ticks a column only while every card stands in it", () => {
+            const notes = [ buildNote({ title: "One" }), buildNote({ title: "Two" }) ];
+            const together = {
+                ...columnApi, getCardColumn: () => "Done"
+            } as unknown as BoardApi;
+            const apart = {
+                ...columnApi,
+                getCardColumn: (noteId: string) => noteId === notes[0].noteId ? "To Do" : "Done"
+            } as unknown as BoardApi;
+
+            expect(marksOf(openSelectionMenu(together, notes)))
+                .toEqual([ undefined, "bx bx-check" ]);
+            expect(marksOf(openSelectionMenu(apart, notes))).toEqual([ undefined, undefined ]);
+        });
+
+        it("files every card under the column picked", async () => {
+            const changeColumn = vi.fn();
+            const notes = [ buildNote({ title: "One" }), buildNote({ title: "Two" }) ];
+            const api = { ...columnApi, changeColumn } as unknown as BoardApi;
+
+            const entry = openSelectionMenu(api, notes)
+                .find(item => item && "title" in item && item.title === boxed("Done"));
+            if (!entry || !("handler" in entry)) throw new Error("expected the Done entry");
+            await entry.handler?.(entry, {} as never);
+
+            expect(changeColumn).toHaveBeenCalledWith(notes[0].noteId, "Done");
+            expect(changeColumn).toHaveBeenCalledWith(notes[1].noteId, "Done");
+        });
+
+        it("deletes every branch the selection names in one call", () => {
+            const deleteNotes = vi.spyOn(branches, "deleteNotes").mockResolvedValue(false);
+            const notes = [ buildNote({ title: "One" }), buildNote({ title: "Two" }) ];
+
+            const entry = openSelectionMenu(columnApi, notes)
+                .find(item => item && "uiIcon" in item && item.uiIcon === "bx bx-trash");
+            if (!entry || !("handler" in entry)) throw new Error("expected the delete entry");
+            entry.handler?.(entry, {} as never);
+
+            expect(deleteNotes).toHaveBeenCalledWith([ "branchId", "branchId1" ], false, false);
+        });
+
+        /**
+         * One entry cannot say what picking it would do while the cards are in different states,
+         * and both entries at once would read as two states the same cards are in.
+         */
+        it("offers archiving only while the cards agree on what they are", () => {
+            const plain = buildNote({ title: "One" });
+            const archived = buildNote({ title: "Two", "#archived": "" });
+
+            expect(titlesOf(openSelectionMenu(columnApi, [ plain, plain ])))
+                .toContain("board_view.archive-note");
+            expect(titlesOf(openSelectionMenu(columnApi, [ archived, archived ])))
+                .toContain("board_view.unarchive-note");
+
+            const mixed = titlesOf(openSelectionMenu(columnApi, [ plain, archived ]));
+            expect(mixed).not.toContain("board_view.archive-note");
+            expect(mixed).not.toContain("board_view.unarchive-note");
+        });
+
+        /** The menu a selection opens, which is the card menu given more than one note. */
+        function openSelectionMenu(api: BoardApi, notes: FNote[]) {
+            return openItemMenu(api, "To Do", vi.fn(), vi.fn(), 2, vi.fn(), notes);
+        }
+
+        /** The column entries alone, which stand between the Status header and the separator. */
+        function columnEntries(items: MenuItem<unknown>[]) {
+            const header = items.findIndex(item =>
+                item && "kind" in item && item.kind === "header" && item.title === "Status");
+            const rest = items.slice(header + 1);
+            const end = rest.findIndex(item => item && "kind" in item && item.kind === "separator");
+            return rest.slice(0, end < 0 ? rest.length : end);
+        }
+
+        function marksOf(items: MenuItem<unknown>[]) {
+            return columnEntries(items)
+                .map(item => item && "trailingIcon" in item ? item.trailingIcon : undefined);
+        }
+
+        function titlesOf(items: MenuItem<unknown>[]) {
+            return items.flatMap(item =>
+                item && "title" in item && item.title ? [ item.title ] : []);
+        }
     });
 });
 

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -544,8 +544,8 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, target: N
             }),
             { kind: "separator" },
             ...getArchiveMenuItems<CommandNames>(notes),
-            // Left out where the inbox is drawn: taking the grouping value away would leave the
-            // card in the inbox rather than off the board. Deleting the note is what removes it.
+            // The inbox holds the cards with no grouping value, so clearing that value keeps a
+            // card on the board. Deleting the note is what takes it off.
             ...(api.isInboxEnabled ? [] : [ {
                 title: t("board_view.remove-from-board"),
                 uiIcon: "bx bx-task-x",

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -451,13 +451,12 @@ function buildColumnItems(api: Api, target: NoteMenuTarget): MenuItem<CommandNam
         badges: api.isColumnArchived(name)
             ? [ { title: t("board_view.archived-badge") } ]
             : undefined,
-        handler: async () => {
+        handler: () => {
             // Asked for before the write: the cards are drawn afresh under the column they land
             // in, so the element the menu was opened from will be gone.
             target.onFocusCard(target.note.noteId);
-            for (const note of target.notes) {
-                await api.changeColumn(note.noteId, name);
-            }
+            return Promise.all(
+                target.notes.map((note) => api.changeColumn(note.noteId, name)));
         }
     }));
 
@@ -570,11 +569,7 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, target: N
                 title: t("board_view.remove-from-board"),
                 uiIcon: "bx bx-task-x",
                 shortcut: "Delete",
-                handler: async () => {
-                    for (const selected of notes) {
-                        await api.removeFromBoard(selected.noteId);
-                    }
-                }
+                handler: () => api.removeFromBoard(notes.map((selected) => selected.noteId))
             },
             {
                 title: t("board_view.delete-note"),
@@ -610,13 +605,9 @@ function CardsColorPicker({ notes }: { notes: FNote[] }) {
         currentValue: currentColor,
         onChange: async (picked) => {
             setCurrentColor(picked);
-            for (const note of notes) {
-                if (picked !== null) {
-                    await attributes.setLabel(note.noteId, "color", picked);
-                } else {
-                    attributes.removeOwnedLabelByName(note, "color");
-                }
-            }
+            await Promise.all(notes.map((note) => picked !== null
+                ? attributes.setLabel(note.noteId, "color", picked)
+                : attributes.removeOwnedLabelByName(note, "color")));
         },
         tooltips: {
             clear: t("note-color.clear-color"),

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -544,12 +544,14 @@ export function openNoteContextMenu(api: Api, event: ContextMenuEvent, target: N
             }),
             { kind: "separator" },
             ...getArchiveMenuItems<CommandNames>(notes),
-            {
+            // Left out where the inbox is drawn: taking the grouping value away would leave the
+            // card in the inbox rather than off the board. Deleting the note is what removes it.
+            ...(api.isInboxEnabled ? [] : [ {
                 title: t("board_view.remove-from-board"),
                 uiIcon: "bx bx-task-x",
                 shortcut: "Delete",
                 handler: () => api.removeFromBoard(notes.map((selected) => selected.noteId))
-            },
+            } ]),
             {
                 title: t("board_view.delete-note"),
                 uiIcon: "bx bx-trash",

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -255,27 +255,6 @@ export function openColumnSortMenu(api: Api, x: number, y: number, column: strin
     });
 }
 
-/**
- * What can be done to the orders the columns hold, offered beside the board's own order.
- *
- * Opened at the pointer from the button in the properties card, as the template entries there open
- * theirs.
- */
-export function openSortActionsMenu(api: Api, event: { pageX: number, pageY: number }) {
-    contextMenu.show({
-        x: event.pageX,
-        y: event.pageY,
-        items: [
-            {
-                title: t("board_view.reset-columns-to-default"),
-                uiIcon: "bx bx-reset",
-                handler: () => api.resetColumnSortsToDefault()
-            }
-        ],
-        selectMenuItemHandler() {}
-    });
-}
-
 /** What the board asks the shared sort menu for, wherever it is opened. */
 function sortMenuOptions(api: Api, column: string): SortMenuOptions {
     return {

--- a/apps/client/src/widgets/collections/board/context_menu.ts
+++ b/apps/client/src/widgets/collections/board/context_menu.ts
@@ -1,14 +1,16 @@
 import { useState } from "preact/hooks";
 
-import FNote from "../../../entities/fnote";
-import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker";
 import type { CommandNames } from "../../../components/app_context";
+import FNote from "../../../entities/fnote";
 import contextMenu, { ContextMenuEvent, MenuItem } from "../../../menus/context_menu";
+import { getArchiveMenuItems, menuName } from "../../../menus/context_menu_utils";
+import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker";
 import link_context_menu from "../../../menus/link_context_menu";
+import attributes from "../../../services/attributes";
 import branches from "../../../services/branches";
 import dialog from "../../../services/dialog";
-import { getArchiveMenuItem, menuName } from "../../../menus/context_menu_utils";
 import { t } from "../../../services/i18n";
+import { shared } from "../../../services/note_set";
 import ColorPicker from "../../react/ColorPicker";
 import { buildAttributeMenuItems } from "../attribute_menu";
 import { buildSortMenuItems, type SortMenuOptions } from "../sort_menu";
@@ -401,33 +403,61 @@ function ColumnColorPicker({ api, value, color }: { api: Api, value: string, col
     });
 }
 
+/** What a card's menu acts on: the card it was opened from, and the notes it writes to. */
+export interface NoteMenuTarget {
+    /** The card the menu was opened on. */
+    note: FNote;
+    branchId: string;
+    column: string;
+    /** This card's index in its column, which an insert is placed against. */
+    index: number;
+    /**
+     * Every note the menu writes to: this card alone, or the whole selection it belongs to. Always
+     * holds the card the menu was opened on.
+     */
+    notes: FNote[];
+    /** The branches those notes have on this board, in the order `notes` lists them. */
+    branchIds: string[];
+    /** Refocuses the card after a column change has redrawn it elsewhere. */
+    onFocusCard: (noteId: string) => void;
+    /** Opens the new-card editor at an index in the column, above or below this card. */
+    onInsert: (index: number) => void;
+    /** Opens the editor at the foot of the column, which a sorted column offers instead. */
+    onNewItem: () => void;
+}
+
 /**
- * The columns a card can be moved to, listed in the menu rather than in a submenu, which would put
- * every column a step further away. Past `LISTED_COLUMNS`, the rest move into one submenu entry,
- * and the card's current column is always listed.
+ * The columns the cards can be moved to, listed in the menu rather than in a submenu, which would
+ * put every column a step further away. Past `LISTED_COLUMNS`, the rest move into one submenu
+ * entry, and the column the cards are in is always listed.
  *
- * An archived column is offered like any other, with a badge, since the card then leaves the
+ * An archived column is offered like any other, with a badge, since the cards then leave the
  * board's default view.
  */
-function buildColumnItems(
-    api: Api, note: FNote, column: string, onFocusCard: (noteId: string) => void
-): MenuItem<CommandNames>[] {
+function buildColumnItems(api: Api, target: NoteMenuTarget): MenuItem<CommandNames>[] {
+    // Marked only while every card stands in the same column: one check on a selection spanning
+    // several would name one column as the state of all of them.
+    const standing = shared(target.notes, (note) => api.getCardColumn(note.noteId));
+    const current = standing.agreed ? standing.value : undefined;
+
     const items: MenuItem<CommandNames>[] = api.columns.map((name) => ({
         title: menuName(api.getColumnTitle(name)),
         uiIcon: api.getColumnIcon(name),
         iconColorClass: api.getColumnColorClass(name),
-        // The one it is already under is shown rather than hidden, so the list reads as the whole
-        // set of columns and says which of them this card belongs to.
-        trailingIcon: name === column ? "bx bx-check" : undefined,
-        className: name === column ? "board-current-column" : undefined,
+        // The one they are already under is shown rather than hidden, so the list reads as the
+        // whole set of columns and says which of them the cards belong to.
+        trailingIcon: name === current ? "bx bx-check" : undefined,
+        className: name === current ? "board-current-column" : undefined,
         badges: api.isColumnArchived(name)
             ? [ { title: t("board_view.archived-badge") } ]
             : undefined,
-        handler: () => {
-            // Asked for before the write: the card is drawn afresh under the column
-            // it lands in, so the element the menu was opened from will be gone.
-            onFocusCard(note.noteId);
-            api.changeColumn(note.noteId, name);
+        handler: async () => {
+            // Asked for before the write: the cards are drawn afresh under the column they land
+            // in, so the element the menu was opened from will be gone.
+            target.onFocusCard(target.note.noteId);
+            for (const note of target.notes) {
+                await api.changeColumn(note.noteId, name);
+            }
         }
     }));
 
@@ -438,11 +468,11 @@ function buildColumnItems(
     const listed = items.slice(0, LISTED_COLUMNS);
     const rest = items.slice(LISTED_COLUMNS);
 
-    // The card's own column is listed even where it falls outside: the check beside it is what
-    // says which column the card is in, and behind an entry it says nothing.
-    const current = api.columns.indexOf(column);
-    if (current >= LISTED_COLUMNS) {
-        listed.push(...rest.splice(current - LISTED_COLUMNS, 1));
+    // The cards' own column is listed even where it falls outside: the check beside it is what
+    // says which column they are in, and behind an entry it says nothing.
+    const at = current === undefined ? -1 : api.columns.indexOf(current);
+    if (at >= LISTED_COLUMNS) {
+        listed.push(...rest.splice(at - LISTED_COLUMNS, 1));
     }
 
     return [
@@ -455,42 +485,37 @@ function buildColumnItems(
     ];
 }
 
-export function openNoteContextMenu(
-    api: Api, event: ContextMenuEvent, note: FNote, branchId: string, column: string,
-    /** This card's index in its column, which an insert is placed against. */
-    index: number,
-    /** Refocuses the card after a column change has redrawn it elsewhere. */
-    onFocusCard: (noteId: string) => void,
-    /** Opens the new-card editor at an index in the column, above or below this card. */
-    onInsert: (index: number) => void,
-    /** Opens the editor at the foot of the column, which a sorted column offers instead. */
-    onNewItem: () => void
-) {
+export function openNoteContextMenu(api: Api, event: ContextMenuEvent, target: NoteMenuTarget) {
+    const { note, branchId, column, index, notes, branchIds } = target;
+
     event.preventDefault();
     event.stopPropagation();
 
     // A sorted column decides where its cards go, so the entries naming a place are left out.
     const isSorted = api.isColumnSorted(column);
+    // What only makes sense for one card: a place to insert at, a title to edit, a note to open.
+    // Everything below writes to every selected note instead.
+    const isSingle = notes.length === 1;
 
     // What the card is placed beside, and the copy made below it.
-    const placement: MenuItem<CommandNames>[] = [
+    const placement: MenuItem<CommandNames>[] = !isSingle ? [] : [
         // A sorted column takes its new cards at the foot, where its own button makes them.
         ...(isSorted ? [ {
             title: t("board_view.insert-new"),
             uiIcon: "bx bx-plus",
-            handler: onNewItem
+            handler: target.onNewItem
         } ] : [
             {
                 title: t("board_view.insert-above"),
                 uiIcon: "bx bx-list-plus",
                 shortcut: "Shift+Enter",
-                handler: () => onInsert(index)
+                handler: () => target.onInsert(index)
             },
             {
                 title: t("board_view.insert-below"),
                 uiIcon: "bx bx-empty",
                 shortcut: "Enter",
-                handler: () => onInsert(index + 1)
+                handler: () => target.onInsert(index + 1)
             }
         ]),
         {
@@ -506,54 +531,97 @@ export function openNoteContextMenu(
             handler: () => {
                 // Asked for before the write: the card is blurred as it is moved in the page, and
                 // the reveal that follows the focus is what shows where it went.
-                onFocusCard(note.noteId);
+                target.onFocusCard(note.noteId);
                 api.moveToColumnStart(note.noteId, branchId, column);
             }
         } ])
+    ];
+
+    // What is done to the card itself, which a selection has none of: the menu it opens leads with
+    // the columns instead.
+    const identity: MenuItem<CommandNames>[] = !isSingle ? [] : [
+        // Space opens the same popup for the card the cursor stands on.
+        { ...link_context_menu.getQuickEditItem(), shortcut: "Space" },
+        {
+            title: t("board_view.edit-title"),
+            uiIcon: "bx bx-rename",
+            shortcut: "F2",
+            handler: () => api.startEditing(branchId)
+        },
+        link_context_menu.getOpenNoteItem(event),
+        { kind: "separator" }
     ];
 
     contextMenu.show({
         x: event.pageX,
         y: event.pageY,
         items: [
-            // Space opens the same popup for the card the cursor stands on.
-            { ...link_context_menu.getQuickEditItem(), shortcut: "Space" },
-            {
-                title: t("board_view.edit-title"),
-                uiIcon: "bx bx-rename",
-                shortcut: "F2",
-                handler: () => api.startEditing(branchId)
-            },
-            link_context_menu.getOpenNoteItem(event),
-            { kind: "separator" },
+            ...identity,
             ...placement,
             { kind: "header", title: api.getStatusLabel() },
-            ...buildColumnItems(api, note, column, onFocusCard),
+            ...buildColumnItems(api, target),
             ...buildAttributeMenuItems<CommandNames>({
-                note,
+                notes,
                 attributes: api.getPromotedAttributes()
             }),
             { kind: "separator" },
-            getArchiveMenuItem(note),
+            ...getArchiveMenuItems<CommandNames>(notes),
             {
                 title: t("board_view.remove-from-board"),
                 uiIcon: "bx bx-task-x",
                 shortcut: "Delete",
-                handler: () => api.removeFromBoard(note.noteId)
+                handler: async () => {
+                    for (const selected of notes) {
+                        await api.removeFromBoard(selected.noteId);
+                    }
+                }
             },
             {
                 title: t("board_view.delete-note"),
                 uiIcon: "bx bx-trash",
                 shortcut: "Shift+Delete",
-                handler: () => branches.deleteNotes([ branchId ], false, false)
+                handler: () => branches.deleteNotes(branchIds, false, false)
             },
             { kind: "separator" },
             {
                 kind: "custom",
-                componentFn: () => NoteColorPicker({note})
+                componentFn: () => isSingle
+                    ? NoteColorPicker({ note })
+                    : CardsColorPicker({ notes })
             }
         ],
         selectMenuItemHandler: ({ command }) =>  link_context_menu.handleLinkContextMenuItem(command, event, note.noteId),
     });
 }
 
+/**
+ * The colour of several cards at once, shown as their colour only while they agree on one.
+ *
+ * `NoteColorPicker` reads and writes one note, so a selection is painted through the plain picker,
+ * as a column's colour is. Keeps the picked value rather than re-reading it: the menu renders once,
+ * and a redraw underneath never reaches it.
+ */
+function CardsColorPicker({ notes }: { notes: FNote[] }) {
+    const agreed = shared(notes, (note) => note.getLabelValue("color") ?? null);
+    const [ currentColor, setCurrentColor ] = useState(agreed.agreed ? agreed.value : null);
+
+    return ColorPicker({
+        className: "note-color-picker",
+        currentValue: currentColor,
+        onChange: async (picked) => {
+            setCurrentColor(picked);
+            for (const note of notes) {
+                if (picked !== null) {
+                    await attributes.setLabel(note.noteId, "color", picked);
+                } else {
+                    attributes.removeOwnedLabelByName(note, "color");
+                }
+            }
+        },
+        tooltips: {
+            clear: t("note-color.clear-color"),
+            set: t("note-color.set-color"),
+            setCustom: t("note-color.set-custom-color")
+        }
+    });
+}

--- a/apps/client/src/widgets/collections/board/data.spec.ts
+++ b/apps/client/src/widgets/collections/board/data.spec.ts
@@ -9,11 +9,11 @@ import type { PromotedAttribute } from "../promoted_attributes";
 import type { SortContext, SortKey } from "../sorting";
 import { INBOX_COLUMN } from "./columns";
 import {
-    affectsSortOrder, applyCardMove, type ColumnMap, type ColumnSort, filterColumnMap,
+    affectsSortOrder, applyCardMoves, type ColumnMap, type ColumnSort, filterColumnMap,
     getBoardData, resolveColumnSorts, resolveSortWatch, sortColumnMap, unfilteredCardIndex
 } from "./data";
 
-describe("applyCardMove", () => {
+describe("applyCardMoves", () => {
     /** Cards named by their note id, which is all this reads them for. */
     function board(columns: Record<string, string[]>): ColumnMap {
         return new Map(Object.entries(columns).map(([ column, ids ]) => [
@@ -26,23 +26,23 @@ describe("applyCardMove", () => {
         (map.get(column) ?? []).map((item) => item.note.noteId);
 
     it("takes a card out of one column and puts it in another", () => {
-        const next = applyCardMove(board({ A: [ "a1", "a2", "a3" ], B: [ "b1", "b2" ] }),
-            "a2", "A", "B", 1);
+        const next = applyCardMoves(board({ A: [ "a1", "a2", "a3" ], B: [ "b1", "b2" ] }),
+            [ "a2" ], "B", 1);
 
         expect(names(next, "A")).toEqual([ "a1", "a3" ]);
         expect(names(next, "B")).toEqual([ "b1", "a2", "b2" ]);
     });
 
     it("puts it at either end of the column it lands in", () => {
-        const start = applyCardMove(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), "a1", "A", "B", 0);
+        const start = applyCardMoves(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), [ "a1" ], "B", 0);
         expect(names(start, "B")).toEqual([ "a1", "b1", "b2" ]);
 
-        const end = applyCardMove(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), "a1", "A", "B", 2);
+        const end = applyCardMoves(board({ A: [ "a1" ], B: [ "b1", "b2" ] }), [ "a1" ], "B", 2);
         expect(names(end, "B")).toEqual([ "b1", "b2", "a1" ]);
     });
 
     it("puts it in a column holding none", () => {
-        const next = applyCardMove(board({ A: [ "a1" ], B: [] }), "a1", "A", "B", 0);
+        const next = applyCardMoves(board({ A: [ "a1" ], B: [] }), [ "a1" ], "B", 0);
 
         expect(names(next, "A")).toEqual([]);
         expect(names(next, "B")).toEqual([ "a1" ]);
@@ -55,16 +55,35 @@ describe("applyCardMove", () => {
     it("counts a move down its own column against the list it came from", () => {
         const start = board({ A: [ "a1", "a2", "a3" ] });
 
-        expect(names(applyCardMove(start, "a1", "A", "A", 3), "A")).toEqual([ "a2", "a3", "a1" ]);
-        expect(names(applyCardMove(start, "a1", "A", "A", 2), "A")).toEqual([ "a2", "a1", "a3" ]);
-        expect(names(applyCardMove(start, "a3", "A", "A", 0), "A")).toEqual([ "a3", "a1", "a2" ]);
-        expect(names(applyCardMove(start, "a3", "A", "A", 1), "A")).toEqual([ "a1", "a3", "a2" ]);
+        expect(names(applyCardMoves(start, [ "a1" ], "A", 3), "A")).toEqual([ "a2", "a3", "a1" ]);
+        expect(names(applyCardMoves(start, [ "a1" ], "A", 2), "A")).toEqual([ "a2", "a1", "a3" ]);
+        expect(names(applyCardMoves(start, [ "a3" ], "A", 0), "A")).toEqual([ "a3", "a1", "a2" ]);
+        expect(names(applyCardMoves(start, [ "a3" ], "A", 1), "A")).toEqual([ "a1", "a3", "a2" ]);
+    });
+
+    it("moves several cards from several columns, keeping the order they are given in", () => {
+        const next = applyCardMoves(
+            board({ A: [ "a1", "a2", "a3" ], B: [ "b1", "b2" ], C: [] }),
+            [ "a1", "b2", "a3" ], "C", 0);
+
+        expect(names(next, "A")).toEqual([ "a2" ]);
+        expect(names(next, "B")).toEqual([ "b1" ]);
+        expect(names(next, "C")).toEqual([ "a1", "b2", "a3" ]);
+    });
+
+    it("counts a move of several down their own column against the cards staying put", () => {
+        const start = board({ A: [ "a1", "a2", "a3", "a4" ] });
+
+        expect(names(applyCardMoves(start, [ "a1", "a2" ], "A", 4), "A"))
+            .toEqual([ "a3", "a4", "a1", "a2" ]);
+        expect(names(applyCardMoves(start, [ "a1", "a4" ], "A", 2), "A"))
+            .toEqual([ "a2", "a1", "a4", "a3" ]);
     });
 
     it("leaves the board alone for a card it does not hold", () => {
         const start = board({ A: [ "a1" ], B: [] });
 
-        expect(applyCardMove(start, "nope", "A", "B", 0)).toBe(start);
+        expect(applyCardMoves(start, [ "nope" ], "B", 0)).toBe(start);
     });
 
     describe("filterColumnMap", () => {

--- a/apps/client/src/widgets/collections/board/data.ts
+++ b/apps/client/src/widgets/collections/board/data.ts
@@ -18,32 +18,50 @@ export interface ColumnItem {
 export type ColumnMap = Map<string, ColumnItem[]>;
 
 /**
- * The columns as they stand once a card has moved, for drawing the outcome before the writes land.
+ * The columns as they stand once cards have moved, for drawing the outcome before the writes land.
  *
  * A card crossing columns is written twice, the value first and the branch after, and each lands a
  * redraw of its own. The first shows the card in its new column at whatever place its old branch
  * gives it, which is above every card already there.
  *
- * @param index where the card goes, counting the target column as it stands at the moment of the
- *              drop, the card itself included where it does not leave its column.
+ * The cards keep the order `noteIds` lists them in, wherever they came from, and land together.
+ * A card the board does not hold is left out; where that is all of them, the map is handed back as
+ * it stands.
+ *
+ * @param index where the cards go, counting the target column as it stands at the moment of the
+ *              drop, the cards being moved included where they do not leave that column.
  */
-export function applyCardMove(
-    byColumn: ColumnMap, noteId: string, from: string, to: string, index: number
+export function applyCardMoves(
+    byColumn: ColumnMap, noteIds: string[], to: string, index: number
 ): ColumnMap {
-    const source = [ ...(byColumn.get(from) ?? []) ];
-    const at = source.findIndex((item) => item.note.noteId === noteId);
-    if (at < 0) {
+    const moving = new Set(noteIds);
+    const next: ColumnMap = new Map();
+    const picked = new Map<string, ColumnItem>();
+
+    for (const [ column, items ] of byColumn) {
+        const kept: ColumnItem[] = [];
+        for (const item of items) {
+            if (moving.has(item.note.noteId)) {
+                picked.set(item.note.noteId, item);
+            } else {
+                kept.push(item);
+            }
+        }
+
+        next.set(column, kept);
+    }
+
+    if (!picked.size) {
         return byColumn;
     }
 
-    const [ moved ] = source.splice(at, 1);
-    const next = new Map(byColumn);
-    next.set(from, source);
-
-    const target = from === to ? source : [ ...(byColumn.get(to) ?? []) ];
-    // Taking the card out shifts everything after it up one, so a place beyond where it stood
-    // names one card earlier in the list left behind.
-    target.splice(from === to && index > at ? index - 1 : index, 0, moved);
+    // Taking the cards out shifts everything below them up, so a place counted with them still in
+    // the column names one card earlier for each of them standing above it.
+    const above = (byColumn.get(to) ?? []).slice(0, index)
+        .filter((item) => moving.has(item.note.noteId)).length;
+    const target = next.get(to) ?? [];
+    target.splice(index - above, 0,
+        ...noteIds.flatMap((noteId) => picked.get(noteId) ?? []));
     next.set(to, target);
 
     return next;

--- a/apps/client/src/widgets/collections/board/group_by.spec.tsx
+++ b/apps/client/src/widgets/collections/board/group_by.spec.tsx
@@ -203,9 +203,10 @@ describe("BoardGroupBy", () => {
         expect(mocks.detail.opts).toMatchObject({
             isOwned: true,
             focus: "name",
-            // A grouping is a select whose options are the columns, and a card stands in one of
-            // them: none of the three is the reader's to change here.
+            // A grouping is a select whose options are the columns the board makes, and a card
+            // stands in one of them: none of the four is the reader's to change here.
             hideType: true,
+            hideTypeOptions: true,
             hideMultiplicity: true,
             hideInheritance: true,
             attribute: {

--- a/apps/client/src/widgets/collections/board/group_by.tsx
+++ b/apps/client/src/widgets/collections/board/group_by.tsx
@@ -64,9 +64,10 @@ export default function BoardGroupBy({ note, options, current, onSelect }: {
             x: event.pageX,
             y: event.pageY,
             focus: "name",
-            // The board answers for all three: a grouping is a promoted, inheritable select whose
-            // options are its columns, and a card stands in one column at a time.
+            // The board answers for all four: a grouping is a promoted, inheritable select whose
+            // options are the columns the board makes, and a card stands in one column at a time.
             hideType: true,
+            hideTypeOptions: true,
             hideMultiplicity: true,
             hideInheritance: true
         });

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -434,6 +434,13 @@ body.mobile .board-view-container .board-add-column {
   }
 }
 
+/* A card carrying `boardCardRedirectTo` opens the note it points at, so its title reads as a link.
+   Drawn on `.text` rather than on `.title`: a decoration set on the title propagates to the icon
+   beside it, and a descendant cannot turn a propagated one off. */
+.board-view-container .board-note.shortcut:hover > .title > .text {
+  text-decoration: underline;
+}
+
 .board-view-container .board-note > .title > .icon {
   flex: none;
   display: flex;

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -33,6 +33,9 @@
   --board-drag-ring-width: 3px;
   /* The ring a picked-out card carries. */
   --board-selected-ring-color: var(--link-color);
+  /* The wash the board goes behind while a card is being named. Light: it is there to draw the
+     eye to the field, not to shut the board off. */
+  --board-edit-backdrop: rgba(0, 0, 0, 0.15);
 
   --board-focus-outline-saturation: 55%;
   --board-focus-outline-lightness: 45%;
@@ -651,6 +654,60 @@ body.mobile .board-view-container .board-add-column {
   display: flex;
   align-items: center;
   padding: 0;
+}
+
+/* The board behind the card being named.
+ *
+ * A sibling of the scrolling container rather than a child, so it covers the board as it stands
+ * rather than as far as it scrolls. Nothing between a card and here opens a stacking context, so
+ * the card lifts through it on a `z-index` of its own. */
+.board-view .board-edit-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  background-color: var(--board-edit-backdrop);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+/* Read off the field itself rather than from the board's state: a new item's field is the column's
+   own business, and the one that opens between two cards is a third piece of state again.
+   `inserting` is that one alone, so the field at the foot of a column raises nothing. */
+.board-view:has(.board-note.editing, .board-new-item.inserting) .board-edit-backdrop {
+  opacity: 1;
+}
+
+.board-view-container .board-note.editing,
+.board-view-container .board-new-item.inserting {
+  z-index: 51;
+}
+
+/* While a title is being typed the board stops answering the pointer: a card neither lights up
+   under it nor takes a press, so leaving the field cannot also open a note or pick a card out.
+   `:hover` follows hit testing rather than any event, so this is the only thing that takes it away.
+   The columns themselves are left alone, which is what keeps the board scrolling, and the field is
+   excluded rather than re-enabled below: this rule outweighs a plainer one, and the field would go
+   inert with everything else.
+
+   It restyles every card on the board, which is a few hundred milliseconds on a board of thousands,
+   and is why it waits for `frozen` rather than following the wash: done in the same frame the wash
+   begins in, that recalculation eats the fade whole. */
+.board-view.frozen :is(
+  .board-column > h3,
+  .board-column > .board-new-item,
+  .board-column-content > *:not(.editing)
+) {
+  pointer-events: none;
+}
+
+/* The fade a column draws over its edges is a mask, and a mask holds everything under it in a
+   layer of its own, which the field being typed into could not rise out of. Taken off the one
+   column that holds it, for as long as it stands. `!important` because `useScrollFade` writes the
+   mask on the element itself. */
+.board-view-container .board-column:has(.board-note.editing, .board-new-item.inserting)
+    .board-column-content {
+  mask: none !important;
 }
 
 /* A card being edited stacks the field over what it shows, rather than standing them side by side:

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -22,6 +22,12 @@
   --board-collapse-duration-quick: 0.3s;
   --board-expand-duration: 0.2s;
 
+  /* The lift a card takes under the pointer, named so that a picked-out card can carry its ring
+     and this shadow together. */
+  --board-item-hover-shadow: 2px 4px 8px rgba(0, 0, 0, 0.1);
+  /* The ring a picked-out card carries. */
+  --board-selected-ring-color: var(--link-color);
+
   --board-focus-outline-saturation: 55%;
   --board-focus-outline-lightness: 45%;
   /* Follows the theme of its own accord, so neither theme has to name it again. */
@@ -440,7 +446,34 @@ body.mobile .board-view-container .board-add-column {
 }
 
 .board-view-container .board-note:hover {
-  box-shadow: 2px 4px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--board-item-hover-shadow);
+}
+
+/* A picked-out card. An inset ring rather than an outline, since focus is drawn as an outline and
+   a card can be both picked out and focused. */
+.board-view-container .board-note.selected {
+  box-shadow: inset 0 0 0 2px var(--board-selected-ring-color);
+}
+
+.board-view-container .board-note.selected:hover {
+  box-shadow:
+    inset 0 0 0 2px var(--board-selected-ring-color),
+    var(--board-item-hover-shadow);
+}
+
+/* A card travelling with the one under the pointer. That one is taken out of the flow by the
+   gesture; the rest stay where they are drawn. */
+.board-view-container .board-note.dragging {
+  opacity: 0.4;
+}
+
+/* What a carried selection is drawn as: one card-shaped block holding how many are on the move. */
+.board-view-container .board-note.board-drag-count {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6em;
+  font-weight: 600;
 }
 
 .board-view-container .board-note:hover > .edit-icon {

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -33,8 +33,8 @@
   --board-drag-ring-width: 3px;
   /* The ring a picked-out card carries. */
   --board-selected-ring-color: var(--link-color);
-  /* The wash the board goes behind while a card is being named. Light: it is there to draw the
-     eye to the field, not to shut the board off. */
+  /* Dims the board while a card is being named. Kept light: it draws the eye to the field rather
+     than hiding what is behind it. */
   --board-edit-backdrop: rgba(0, 0, 0, 0.15);
 
   --board-focus-outline-saturation: 55%;
@@ -656,11 +656,11 @@ body.mobile .board-view-container .board-add-column {
   padding: 0;
 }
 
-/* The board behind the card being named.
+/* Dims the board while a card is being named.
  *
- * A sibling of the scrolling container rather than a child, so it covers the board as it stands
- * rather than as far as it scrolls. Nothing between a card and here opens a stacking context, so
- * the card lifts through it on a `z-index` of its own. */
+ * A sibling of `.board-view-container` rather than a child, so it covers the board at its own size
+ * instead of the scrolled width. Nothing between a card and here opens a stacking context, so the
+ * card rises above it on its own `z-index`. */
 .board-view .board-edit-backdrop {
   position: absolute;
   inset: 0;
@@ -671,9 +671,9 @@ body.mobile .board-view-container .board-add-column {
   transition: opacity 0.3s ease;
 }
 
-/* Read off the field itself rather than from the board's state: a new item's field is the column's
-   own business, and the one that opens between two cards is a third piece of state again.
-   `inserting` is that one alone, so the field at the foot of a column raises nothing. */
+/* Matched on the field rather than on state in `index.tsx`: each column holds its own editing
+   state. `inserting` marks only the field that opens between two cards, so the one at the foot of
+   a column leaves the backdrop down. */
 .board-view:has(.board-note.editing, .board-new-item.inserting) .board-edit-backdrop {
   opacity: 1;
 }
@@ -683,17 +683,28 @@ body.mobile .board-view-container .board-add-column {
   z-index: 51;
 }
 
-/* While a title is being typed the board stops answering the pointer: a card neither lights up
-   under it nor takes a press, so leaving the field cannot also open a note or pick a card out.
-   `:hover` follows hit testing rather than any event, so this is the only thing that takes it away.
-   The columns themselves are left alone, which is what keeps the board scrolling, and the field is
-   excluded rather than re-enabled below: this rule outweighs a plainer one, and the field would go
-   inert with everything else.
+/* Stops the cards receiving the pointer while a title is being typed, so that dismissing the field
+   cannot also open a note or select a card. `:hover` follows hit testing rather than events, so
+   `pointer-events` is the only way to suppress it. `.board-column` itself keeps its events, which
+   is what keeps the board scrolling. The edited field is excluded with `:not(.editing)` rather than
+   re-enabled in a later rule, which this selector would outweigh.
 
-   It restyles every card on the board, which is a few hundred milliseconds on a board of thousands,
-   and is why it waits for `frozen` rather than following the wash: done in the same frame the wash
-   begins in, that recalculation eats the fade whole. */
+   This restyles every card, a few hundred milliseconds on a board of thousands, so it waits for
+   `frozen` instead of matching the backdrop: applied in the frame the fade starts in, the
+   recalculation drops the fade's frames. */
 .board-view.frozen :is(
+  .board-column > h3,
+  .board-column > .board-new-item,
+  .board-column-content > *:not(.editing)
+) {
+  pointer-events: none;
+}
+
+/* `motion-disabled` sets `transition: none !important` on everything, so `.board-edit-backdrop`
+   fires no `transitionend` and `frozen` is never set. There is no fade to protect either, so the
+   same fields freeze the board as soon as they open. */
+body#trilium-app.motion-disabled
+  .board-view:has(.board-note.editing, .board-new-item.inserting) :is(
   .board-column > h3,
   .board-column > .board-new-item,
   .board-column-content > *:not(.editing)

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -50,6 +50,8 @@
   --card-font-size: 0.9em;
   --card-line-height: 1.2;
   --card-padding: 0.6em;
+  /* What stands between a card's title and the row of badges under it, in both modes. */
+  --card-badge-gap: 8px;
   /* The icon a card carries, and where it and the title stand from the card's leading edge. The
      card and the editor it opens into are laid out from these, so switching between them moves
      nothing. All three are worked out in the card's own font. */
@@ -649,6 +651,27 @@ body.mobile .board-view-container .board-add-column {
   display: flex;
   align-items: center;
   padding: 0;
+}
+
+/* A card being edited stacks the field over what it shows, rather than standing them side by side:
+   the badges are drawn either way, so the card keeps its own height as the editor opens. */
+.board-view-container .board-note.editing {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* The card gives its padding to the field while one is open, so what stands under it is inset by
+   the card's own instead. The field's foot padding already stands between the text and this row,
+   so only what is left of the gap is added, and the card is the height it is either way. */
+.board-view-container .board-note.editing .user-attributes {
+  margin-block-start: calc(var(--card-badge-gap) - var(--card-padding));
+  padding-inline: var(--card-padding);
+  padding-block-end: var(--card-padding);
+}
+
+/* Named here as well, so both modes are worked out from the one value. */
+.board-view-container .board-note .user-attributes {
+  margin-block-start: var(--card-badge-gap);
 }
 
 /* One line stands exactly as tall as the card, or as the closed button; typing more grows it from

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -25,6 +25,12 @@
   /* The lift a card takes under the pointer, named so that a picked-out card can carry its ring
      and this shadow together. */
   --board-item-hover-shadow: 2px 4px 8px rgba(0, 0, 0, 0.1);
+  /* What a carried card casts, which the stack of a carried selection is drawn behind. */
+  --board-drag-shadow: 4px 8px 16px rgba(0, 0, 0, 0.5);
+  /* How far each card of a carried stack stands out from the one in front of it. */
+  --board-drag-stack-offset: 4px;
+  /* The ring a carried card wears, which the stack behind it starts clear of. */
+  --board-drag-ring-width: 3px;
   /* The ring a picked-out card carries. */
   --board-selected-ring-color: var(--link-color);
 
@@ -467,14 +473,6 @@ body.mobile .board-view-container .board-add-column {
   opacity: 0.4;
 }
 
-/* What a carried selection is drawn as: one card-shaped block holding how many are on the move. */
-.board-view-container .board-note.board-drag-count {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.6em;
-  font-weight: 600;
-}
 
 .board-view-container .board-note:hover > .edit-icon {
   position: absolute;
@@ -531,7 +529,8 @@ body.mobile .board-view-container .board-add-column {
 /* The card is focused by the press that picks it up and then taken out of the page, which drops the
    focus; the copy carries the ring on so what is being moved still reads as what is focused. */
 .board-view-container .board-note.board-drag-preview {
-  outline: 3px solid var(--board-focus-outline-color, var(--board-focus-outline-plain-color));
+  outline: var(--board-drag-ring-width) solid
+    var(--board-focus-outline-color, var(--board-focus-outline-plain-color));
   outline-offset: 0;
 }
 
@@ -546,7 +545,64 @@ body.mobile .board-view-container .board-add-column {
   pointer-events: none;
   cursor: move;
   opacity: 0.85;
-  box-shadow: 4px 8px 16px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--board-drag-shadow);
+}
+
+/* What a carried selection is drawn as: one card-shaped block holding how many are on the move. */
+.board-view-container .board-note.board-drag-count {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6em;
+  font-weight: 600;
+
+  /* The card's own colour, which the stack behind it is drawn in at lower opacity. */
+  --board-drag-stack-card:
+    var(--board-item-hue)
+    var(--board-item-saturation)
+    var(--board-item-background-lightness);
+}
+
+/* The cards behind the one carried, drawn as copies of its shape rather than as elements: only the
+   sliver past the front card shows, and a real card would repeat the ring the front one carries.
+   Each is a fill with a copy one pixel wider behind it, which is what draws its edge.
+
+   Every offset starts past the ring, which is drawn over the shapes below and would otherwise take
+   its own width out of the first card alone, leaving that one standing out less than the rest. */
+.board-view-container .board-note.board-drag-count {
+  --board-drag-stack-1:
+    calc(var(--board-drag-ring-width) + var(--board-drag-stack-offset));
+  --board-drag-stack-2:
+    calc(var(--board-drag-ring-width) + var(--board-drag-stack-offset) * 2 + 1px);
+
+  /* Each card behind stands back a little further than the one in front of it. */
+  --board-drag-stack-fade-1: 85%;
+  --board-drag-stack-fade-2: 75%;
+}
+
+.board-view-container .board-note.board-drag-count[data-layers="2"] {
+  box-shadow:
+    var(--board-drag-stack-1) var(--board-drag-stack-1) 0 0
+      hsl(var(--board-drag-stack-card) / var(--board-drag-stack-fade-1)),
+    var(--board-drag-stack-1) var(--board-drag-stack-1) 0 1px
+      color-mix(in srgb, var(--board-selected-ring-color)
+        var(--board-drag-stack-fade-1), transparent),
+    var(--board-drag-shadow);
+}
+
+.board-view-container .board-note.board-drag-count[data-layers="3"] {
+  box-shadow:
+    var(--board-drag-stack-1) var(--board-drag-stack-1) 0 0
+      hsl(var(--board-drag-stack-card) / var(--board-drag-stack-fade-1)),
+    var(--board-drag-stack-1) var(--board-drag-stack-1) 0 1px
+      color-mix(in srgb, var(--board-selected-ring-color)
+        var(--board-drag-stack-fade-1), transparent),
+    var(--board-drag-stack-2) var(--board-drag-stack-2) 0 0
+      hsl(var(--board-drag-stack-card) / var(--board-drag-stack-fade-2)),
+    var(--board-drag-stack-2) var(--board-drag-stack-2) 0 1px
+      color-mix(in srgb, var(--board-selected-ring-color)
+        var(--board-drag-stack-fade-2), transparent),
+    var(--board-drag-shadow);
 }
 
 /* Reaching the end of the board scrolls neither the page nor anything else. */

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Modal as BootstrapModal } from "bootstrap";
 
+import appContext from "../../../components/app_context";
 import Component from "../../../components/component";
 import contextMenu from "../../../menus/context_menu";
 import dialog from "../../../services/dialog";
@@ -788,10 +789,15 @@ describe("A board in a tab the reader is not looking at", () => {
         });
 
         // The context the board belongs to, reached the way `useNoteContext` reaches it: from the
-        // nearest ancestor carrying one.
-        let active = true;
+        // nearest ancestor carrying one. The board compares main contexts, so the tab is what the
+        // stub stands for and a split pane of it would answer with the same one.
+        const tab = {};
+        const otherTab = {};
+        let shown: object = tab;
         const host = new Component();
-        Object.assign(host, { noteContext: { isActive: () => active } });
+        Object.assign(host, { noteContext: { getMainContext: () => tab } });
+        const previousTabManager = appContext.tabManager;
+        appContext.tabManager = { getActiveMainContext: () => shown } as never;
 
         const mountPoint = document.createElement("div");
         container = mountPoint;
@@ -821,8 +827,8 @@ describe("A board in a tab the reader is not looking at", () => {
         await draw();
         expect(columnOf("First")).toBe("To Do");
 
-        // The card moves column while the tab is in the background.
-        active = false;
+        // The card moves column while another tab is the one being looked at.
+        shown = otherTab;
         for (const attribute of froca.getNoteFromCache("one")?.getAttributes() ?? []) {
             if (attribute.name === "status") attribute.value = "Done";
         }
@@ -830,9 +836,71 @@ describe("A board in a tab the reader is not looking at", () => {
         expect(columnOf("First")).toBe("To Do");
 
         // Looked at again, it catches up with what it missed.
-        active = true;
+        shown = tab;
         await draw();
         expect(columnOf("First")).toBe("Done");
+
+        appContext.tabManager = previousTabManager;
+    });
+
+    /**
+     * `getActiveMainContext` names one pane across the whole app, so a board sharing a tab with the
+     * focused pane is on screen and redraws: a card dropped onto it from another split appears at
+     * once rather than waiting for something to force a refresh.
+     */
+    it("redraws for a change while it is the split the reader is not focused on", async () => {
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { id: "split1", title: "First", "#status": "To Do" },
+                { id: "split2", title: "Second", "#status": "Done" }
+            ]
+        });
+
+        // One tab, and the board is in a pane of it that does not hold the focus.
+        const tab = {};
+        const host = new Component();
+        Object.assign(host, { noteContext: { getMainContext: () => tab } });
+        const previousTabManager = appContext.tabManager;
+        appContext.tabManager = { getActiveMainContext: () => tab } as never;
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        const draw = async () => {
+            await act(async () => {
+                render(
+                    <ParentComponent.Provider value={host}>
+                        <Harness
+                            note={note}
+                            noteIds={[ ...note.getChildNoteIds() ]}
+                            initialConfig={{ columns: [ { value: "To Do" }, { value: "Done" } ] }}
+                        />
+                    </ParentComponent.Provider>,
+                    mountPoint
+                );
+            });
+            await act(async () => { await flush(); });
+        };
+
+        const columnOf = (title: string) => [ ...mountPoint.querySelectorAll(".board-column") ]
+            .find(column => [ ...column.querySelectorAll(".board-note") ]
+                .some(card => card.textContent?.includes(title)))
+            ?.getAttribute("data-column");
+
+        await draw();
+        expect(columnOf("First")).toBe("To Do");
+
+        for (const attribute of froca.getNoteFromCache("split1")?.getAttributes() ?? []) {
+            if (attribute.name === "status") attribute.value = "Done";
+        }
+        await draw();
+        expect(columnOf("First")).toBe("Done");
+
+        appContext.tabManager = previousTabManager;
     });
 });
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -1124,7 +1124,8 @@ describe("Board column rename", () => {
         expect(sections.map(section => section.titleKey)).toEqual([
             "board_view.hints.navigation",
             "board_view.hints.editing",
-            "board_view.hints.moving"
+            "board_view.hints.moving",
+            "board_view.hints.selection"
         ]);
         // Every key the board answers for is spoken for, and none it does not.
         expect(sections.flatMap(section => section.hints)).toEqual([
@@ -1155,7 +1156,9 @@ describe("Board column rename", () => {
             {
                 keys: [ "Ctrl+Alt+Home", "Ctrl+Alt+End" ],
                 labelKey: "board_view.hints.move_column_to_edge"
-            }
+            },
+            { keys: [ "Ctrl+A" ], labelKey: "board_view.hints.select_column" },
+            { keys: [ "Escape" ], labelKey: "board_view.hints.clear_selection" }
         ]);
     });
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3974,3 +3974,84 @@ describe("Switchable board grouping", () => {
         expect(columnIcons(mountPoint)).toEqual([ "bx bx-down-arrow", DEFAULT_COLUMN_ICON ]);
     });
 });
+
+describe("Board properties from the note menu", () => {
+    let container: HTMLElement | undefined;
+
+    afterEach(() => {
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+
+        // A modal Bootstrap still believes is shown traps the focus of every later test, and its
+        // teardown waits on a transition happy-dom never runs.
+        const modal = document.querySelector<HTMLElement>(".board-properties-dialog");
+        if (modal) {
+            BootstrapModal.getInstance(modal)?.dispose();
+            modal.remove();
+        }
+        document.querySelector(".modal-backdrop")?.remove();
+        document.body.classList.remove("modal-open");
+    });
+
+    /**
+     * The menu is drawn outside the board, so it asks for the dialog by event. Each open board
+     * hears it, and only the one in the tab the menu was opened from answers.
+     */
+    it("opens the dialog for its own tab, and not for another one", async () => {
+        const host = await renderBoardInContext("ntx-1");
+        const isOpen = () => !!document.querySelector(".board-properties-dialog .modal-dialog");
+
+        expect(isOpen()).toBe(false);
+
+        await act(async () => {
+            await host.handleEvent("showBoardProperties", { ntxId: "ntx-2" });
+            await flush();
+        });
+        expect(isOpen()).toBe(false);
+
+        await act(async () => {
+            await host.handleEvent("showBoardProperties", { ntxId: "ntx-1" });
+            await flush();
+        });
+        expect(isOpen()).toBe(true);
+    });
+
+    /** Mounts a board belonging to the given tab, returning what events reach it through. */
+    async function renderBoardInContext(ntxId: string) {
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                { title: "First", "#status": "To Do" },
+                { title: "Second", "#status": "Done" }
+            ]
+        });
+
+        const host = new Component();
+        Object.assign(host, { noteContext: { ntxId, isActive: () => true } });
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={host}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={{ columns: [ { value: "To Do" }, { value: "Done" } ] }}
+                    />
+                </ParentComponent.Provider>,
+                mountPoint
+            );
+        });
+        await act(async () => { await flush(); });
+
+        return host;
+    }
+});

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -21,6 +21,7 @@ import { ContextMenuEvent } from "../../../menus/context_menu";
 import { isIMEComposing } from "../../../services/shortcuts";
 import type { ShortcutHintDefinition } from "../../../services/shortcut_hints";
 import toast from "../../../services/toast";
+import ws from "../../../services/ws";
 import { escapeHtml, isMobile } from "../../../services/utils";
 import { type NoteTypeOption, resolveNoteTypeOptions } from "../../../services/note_types";
 import { type PromotedAttributeSetting, resolvePromotedAttributes } from "../promoted_attributes";
@@ -829,19 +830,16 @@ export default function BoardView({
                     setLandedNoteId(card.noteId);
                 }
                 movesInFlight.current++;
-                // Any refresh already on its way is about the board as it stood before the drop,
-                // and would put the card back where it came from as it resolves.
+                // As `holdMove` does for a move made by the keyboard, and for the same reason: the
+                // board is held where the drop has drawn it until `froca` has the changes.
                 refreshSeqRef.current++;
-                // Nothing is asked for once the writes are in: `froca` learns of the branch move
-                // from the server a moment later, so a refresh here reads the new column with the
-                // old order and puts the card at the top of it. The change reaches the board as an
-                // entity reload, which settles it once there is something to read.
                 api.moveWithinBoard(
                     carried.map((item) => ({
                         noteId: item.note.noteId,
                         branchId: item.branch.branchId
                     })),
                     position.column, position.index)
+                    .then(settled)
                     .finally(() => { movesInFlight.current--; });
             }
             setDraggedCard(null);
@@ -1054,7 +1052,13 @@ export default function BoardView({
         // put the cards back where they came from as it resolves.
         refreshSeqRef.current++;
 
-        return done.finally(() => { movesInFlight.current--; });
+        // Held until `froca` has the changes, not merely until the server has answered for them:
+        // the answers come back over HTTP and the changes over the websocket, so a refresh let
+        // through in between reads a board with some of the cards moved and the rest still where
+        // they were, and draws that.
+        return done
+            .then(settled)
+            .finally(() => { movesInFlight.current--; });
     }, [ allByColumn ]);
 
     /** Sends cards to the end of another column, which is where the keyboard puts them. */
@@ -1288,6 +1292,23 @@ export default function BoardView({
  * Naming the winning check, rather than returning a boolean, is what lets the profiler attribute a
  * redraw to a cause.
  */
+/** How long the board waits for a move's changes before drawing again regardless. */
+const SETTLE_TIMEOUT_MS = 10000;
+
+/**
+ * Waits for `froca` to hold what a move has written.
+ *
+ * `waitForMaxKnownEntityChangeId` never settles while the websocket delivers nothing, and the board
+ * holds its refreshes until this resolves: unlimited, a connection gone quiet would stop the board
+ * redrawing for the rest of the session.
+ */
+function settled() {
+    return Promise.race([
+        ws.waitForMaxKnownEntityChangeId(),
+        new Promise<void>((resolve) => { window.setTimeout(resolve, SETTLE_TIMEOUT_MS); })
+    ]);
+}
+
 /**
  * Puts every card back where the column draws it, closes every gap and gives back the room they
  * took.

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -40,6 +40,7 @@ import ActionButton from "../../react/ActionButton";
 import { IconPickerButton } from "../../react/IconPicker";
 import { useDragPan } from "../../react/drag_pan";
 import { FLIP_SETTLE_MS, useFlip } from "../../react/flip";
+import { SelectionContext, SelectionStore } from "../../react/selection";
 import { CollectionFilterInput, useCollectionFilter } from "../collection_filter";
 import { ViewModeProps } from "../interface";
 import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api";
@@ -58,7 +59,7 @@ import BoardProperties from "./properties";
 import { openBoardContextMenu, openCreateColumnMenu } from "./context_menu";
 import { useBoardSort } from "./sort";
 import {
-    affectsSortOrder, applyCardMove, ColumnMap, filterColumnMap, getBoardData, resolveColumnSorts,
+    affectsSortOrder, applyCardMoves, ColumnMap, filterColumnMap, getBoardData, resolveColumnSorts,
     resolveSortWatch, sortColumnMap, unfilteredCardIndex
 } from "./data";
 import { useBoardKeyboard } from "./keyboard";
@@ -140,6 +141,11 @@ export interface BoardColumnData {
 
 interface CardDrag {
     noteId: string;
+    /**
+     * Every card on the move, this one among them. One entry unless the card was taken hold of as
+     * part of a selection; absent for a drag from the note tree, which carries no card.
+     */
+    noteIds?: string[];
     branchId: string;
     fromColumn: string;
     index: number;
@@ -342,6 +348,11 @@ export default function BoardView({
      * the gap is not near.
      */
     const dropState = useMemo(() => new DropStateStore(), []);
+    /**
+     * Which cards are picked out, kept out of the board's state for the same reason: selecting one
+     * card must wake that card and no other.
+     */
+    const selection = useMemo(() => new SelectionStore(), []);
     const setDropPosition = useCallback((position: ColumnDrag | null) => {
         dropState.set({ ...dropState.get(), position });
     }, [ dropState ]);
@@ -460,6 +471,16 @@ export default function BoardView({
     const sortWatch = useMemo(
         () => resolveSortWatch(allByColumn, columnSorts, sortContext.definitions),
         [ allByColumn, columnSorts, sortContext ]);
+
+    // A card the board has stopped drawing, because it was deleted, archived out of view or moved
+    // off the board, leaves the selection with it. A command would otherwise write to a note the
+    // reader can no longer see.
+    useEffect(() => {
+        if (byColumn) {
+            selection.retain(new Set([ ...byColumn.values() ]
+                .flatMap((items) => items.map((item) => item.note.noteId))));
+        }
+    }, [ byColumn, selection ]);
 
     if (!apiRef.current || apiRef.current.board !== boardIdentity) {
         apiRef.current = {
@@ -731,12 +752,21 @@ export default function BoardView({
     // The gesture drives the same state a drag from the note tree does, so the placeholders and the
     // card's own dimming are drawn from one place whichever brought the card here.
     const { isDragging: isDraggingItem, remeasure } = useBoardDrag(containerRef, {
+        carriedWith: (noteId) => (selection.has(noteId)
+            ? api.getCards(selection.keys).map((card) => card.note.noteId)
+            : [ noteId ]),
         onCardStart: (card) => {
             // The card leaves the flow and the gap opens in its place, which eased would read as
             // the column closing up and sliding back open.
             holdStill();
+            // A card taken hold of from outside the selection travels alone, and what was picked
+            // out is given up: those cards stay where they are, and would still read as selected.
+            if (!selection.has(card.noteId)) {
+                selection.clear();
+            }
             setDraggedCard({
                 noteId: card.noteId,
+                noteIds: card.noteIds,
                 branchId: byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId ?? "",
                 fromColumn: card.fromColumn,
                 index: card.index,
@@ -761,23 +791,29 @@ export default function BoardView({
             // card, hide the gap and close the room it took, and if those reach the screen in
             // separate frames the reader sees a gap open where nothing is being carried any more.
             closeGaps(containerRef.current);
-            const branchId = byColumn?.get(card.fromColumn)?.[card.index]?.branch.branchId;
+            // Every card on the move, in the order the board draws them, with the branches they
+            // are moved by. One entry unless the card was carried as part of a selection.
+            const carried = api.getCards(new Set(card.noteIds));
             const isSortedTarget = !!position && columnSorts.has(position.column);
-            // A drop inside a sorted column changes nothing: `sortColumnMap` already placed it.
-            if (isSortedTarget && position?.column === card.fromColumn) {
+            // A drop inside a sorted column changes nothing: `sortColumnMap` already placed the
+            // cards. Only while every card carried is already there; one from another column still
+            // has to be filed under this one.
+            const allInTarget = !!position && carried.every((item) =>
+                api.getCardColumn(item.note.noteId) === position.column);
+            if (isSortedTarget && allInTarget) {
                 setDraggedCard(null);
                 dropState.set({ position: null, target: null });
                 focusCard(card.noteId);
                 return;
             }
 
-            if (position && branchId && byColumn && allByColumn) {
+            if (position && carried.length && byColumn && allByColumn) {
                 // Drawn at once, into `allByColumn` since that is what `byColumn` derives from, at
                 // the index `unfilteredCardIndex` translates rather than the visible drop index.
                 // The index does not matter for a sorted column: `sortColumnMap` reorders the
                 // map afterwards.
-                setAllByColumn(applyCardMove(
-                    allByColumn, card.noteId, card.fromColumn, position.column,
+                setAllByColumn(applyCardMoves(
+                    allByColumn, carried.map((item) => item.note.noteId), position.column,
                     unfilteredCardIndex(
                         byColumn.get(position.column) ?? [],
                         allByColumn.get(position.column) ?? [],
@@ -789,13 +825,20 @@ export default function BoardView({
                 // Any refresh already on its way is about the board as it stood before the drop,
                 // and would put the card back where it came from as it resolves.
                 refreshSeqRef.current++;
-                api.moveWithinBoard(
-                    card.noteId, branchId, card.index, position.index,
-                    card.fromColumn, position.column)
-                    // Nothing is asked for once the writes are in: `froca` learns of the branch
-                    // move from the server a moment later, so a refresh here reads the new column
-                    // with the old order and puts the card at the top of it. The change reaches the
-                    // board as an entity reload, which settles it once there is something to read.
+                // Nothing is asked for once the writes are in: `froca` learns of the branch move
+                // from the server a moment later, so a refresh here reads the new column with the
+                // old order and puts the card at the top of it. The change reaches the board as an
+                // entity reload, which settles it once there is something to read.
+                (carried.length === 1
+                    ? api.moveWithinBoard(
+                        card.noteId, carried[0].branch.branchId, card.index, position.index,
+                        card.fromColumn, position.column)
+                    : api.moveManyWithinBoard(
+                        carried.map((item) => ({
+                            noteId: item.note.noteId,
+                            branchId: item.branch.branchId
+                        })),
+                        position.column, position.index))
                     .finally(() => { movesInFlight.current--; });
             }
             setDraggedCard(null);
@@ -984,7 +1027,13 @@ export default function BoardView({
         setColumnDropPosition(null);
     }, [ api, shownColumns ]);
 
-    const { onKeyDown: handleKeyDown, focusColumn, focusCard } = useBoardKeyboard({
+    const clearSelectionOutsideCards = useCallback((e: MouseEvent) => {
+        if (!(e.target as HTMLElement | null)?.closest(".board-note")) {
+            selection.clear();
+        }
+    }, [ selection ]);
+
+    const { onKeyDown: handleBoardKeys, focusColumn, focusCard } = useBoardKeyboard({
         containerRef,
         setActiveColumn,
         columns: shownColumns,
@@ -995,6 +1044,19 @@ export default function BoardView({
             setColumnNameToEdit(await api.insertColumn(relativeTo, direction));
         }, [ api ])
     });
+
+    // Escape gives the selection up, before the board's own keys are offered the press: nothing
+    // else on the board answers for Escape, and a reader who has picked cards out expects it to
+    // undo that first.
+    const handleKeyDown = useCallback((e: KeyboardEvent) => {
+        if (e.key === "Escape" && selection.size) {
+            e.stopPropagation();
+            selection.clear();
+            return;
+        }
+
+        handleBoardKeys(e);
+    }, [ selection, handleBoardKeys ]);
 
     useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
         // The column list is read off the definition, which may be edited from the attribute panel,
@@ -1046,6 +1108,7 @@ export default function BoardView({
                 <BoardKeptCardsContext.Provider value={filter.keptNoteIds}>
                 <BoardDropStateContext.Provider value={dropState}>
                 <BoardDragStateContext.Provider value={boardDragState}>
+                <SelectionContext.Provider value={selection}>
                     {byColumn && columns && <div
                         ref={containerRef}
                         className={clsx("board-view-container", {
@@ -1053,6 +1116,7 @@ export default function BoardView({
                             panning: isPanning
                         })}
                         onKeyDown={handleKeyDown}
+                        onClick={clearSelectionOutsideCards}
                         onContextMenu={openBoardMenu}
                         onWheel={onWheelHorizontalScroll}
                     >
@@ -1154,6 +1218,7 @@ export default function BoardView({
                             />
                         )}
                     </div>}
+                </SelectionContext.Provider>
                 </BoardDragStateContext.Provider>
                 </BoardDropStateContext.Provider>
                 </BoardKeptCardsContext.Provider>

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -836,16 +836,12 @@ export default function BoardView({
                 // from the server a moment later, so a refresh here reads the new column with the
                 // old order and puts the card at the top of it. The change reaches the board as an
                 // entity reload, which settles it once there is something to read.
-                (carried.length === 1
-                    ? api.moveWithinBoard(
-                        card.noteId, carried[0].branch.branchId, card.index, position.index,
-                        card.fromColumn, position.column)
-                    : api.moveManyWithinBoard(
-                        carried.map((item) => ({
-                            noteId: item.note.noteId,
-                            branchId: item.branch.branchId
-                        })),
-                        position.column, position.index))
+                api.moveWithinBoard(
+                    carried.map((item) => ({
+                        noteId: item.note.noteId,
+                        branchId: item.branch.branchId
+                    })),
+                    position.column, position.index)
                     .finally(() => { movesInFlight.current--; });
             }
             setDraggedCard(null);
@@ -1034,6 +1030,47 @@ export default function BoardView({
         setColumnDropPosition(null);
     }, [ api, shownColumns ]);
 
+    /**
+     * Draws a move where it will leave the cards and holds the board there until the writes are in.
+     *
+     * A move is a write per card that changes column and one per branch being placed, and each
+     * lands a redraw of its own. Drawn as they arrive, the cards are seen to shuffle into place one
+     * after another: under their new column in the order their old branches give them, then each
+     * into the position the next write settles. The board is drawn where the move ends instead.
+     */
+    const holdMove = useCallback((
+        cards: { noteId: string, branchId: string }[],
+        targetColumn: string,
+        targetIndex: number,
+        done: Promise<unknown>
+    ) => {
+        if (allByColumn) {
+            setAllByColumn(applyCardMoves(
+                allByColumn, cards.map((card) => card.noteId), targetColumn, targetIndex));
+        }
+
+        movesInFlight.current++;
+        // Any refresh already on its way is about the board as it stood before the move, and would
+        // put the cards back where they came from as it resolves.
+        refreshSeqRef.current++;
+
+        return done.finally(() => { movesInFlight.current--; });
+    }, [ allByColumn ]);
+
+    /** Sends cards to the end of another column, which is where the keyboard puts them. */
+    const sendCardsToColumn = useCallback((
+        cards: { noteId: string, branchId: string }[], targetColumn: string
+    ) => holdMove(
+        cards, targetColumn, api.getColumnNoteIds(targetColumn).length,
+        api.moveToColumnEnd(cards, targetColumn)),
+    [ api, holdMove ]);
+
+    /** Moves cards to a place among the ones already in a column. */
+    const moveCardsWithin = useCallback((
+        cards: { noteId: string, branchId: string }[], column: string, index: number
+    ) => holdMove(cards, column, index, api.moveWithinBoard(cards, column, index)),
+    [ api, holdMove ]);
+
     const clearSelectionOutsideCards = useCallback((e: MouseEvent) => {
         if (!(e.target as HTMLElement | null)?.closest(".board-note")) {
             selection.clear();
@@ -1048,6 +1085,8 @@ export default function BoardView({
         api,
         moveColumn: handleColumnDrop,
         selection,
+        sendCardsToColumn,
+        moveCardsWithin,
         insertColumn: useCallback(async (relativeTo: string, direction: "before" | "after") => {
             setColumnNameToEdit(await api.insertColumn(relativeTo, direction));
         }, [ api ])

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -386,7 +386,7 @@ export default function BoardView({
     /** Everything a card could be made from: the note types and every template. */
     const availableTemplates = useNoteTypeOptions();
     const [ isEditingProperties, setIsEditingProperties ] = useState(false);
-    /** Whether the board has stopped answering the pointer, which the wash arriving is what sets. */
+    /** Adds `frozen`, which takes `pointer-events` off the cards. Set once the backdrop has faded in. */
     const [ isFrozen, setIsFrozen ] = useState(false);
     const selectColumn = useCallback<Dispatch<StateUpdater<string | undefined>>>((column) => {
         setIsPeekingAll(false);
@@ -1147,12 +1147,12 @@ export default function BoardView({
 
     return (
         <div className={clsx("board-view", { frozen: isFrozen })}>
-            {/* Stands over the board while a title is being typed, with the field lifted through
-                it. Always drawn, so it fades in rather than appearing. Which fields raise it is
-                the stylesheet's to say, since each keeps its own state.
+            {/* Dims the board while a title is being typed, with the edited card lifted above it.
+                Always rendered so that it can fade in. `index.css` picks the fields that raise it
+                with `:has()`, since each column holds its own editing state.
 
-                The board is frozen once the wash has arrived rather than as it starts: freezing
-                restyles every card, which in the same frame would eat the fade whole. */}
+                `frozen` waits for the fade to finish: setting it restyles every card, which in the
+                same frame drops the fade's frames. */}
             <div
                 className="board-edit-backdrop"
                 onTransitionEnd={(e) => setIsFrozen(

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -11,6 +11,7 @@ import {
 
 import { type HighlightedTokenInfo, normalizeBoardGroupBy } from "@triliumnext/commons";
 
+import appContext from "../../../components/app_context";
 import FNote from "../../../entities/fnote";
 import attributes from "../../../services/attributes";
 import froca from "../../../services/froca";
@@ -671,9 +672,15 @@ export default function BoardView({
         // hears every change: a card renamed once redraws each of them, whichever is on screen. The
         // change is remembered instead, and drawn once the tab is looked at again. Asked of the
         // context rather than of the box, which is empty for a board that has not drawn yet.
+        // Compared by main context, not `noteContext.isActive()`: that names one pane across the
+        // whole app, so a board in a split the reader is not focused on is on screen but would
+        // never redraw, the `ResizeObserver` above having no size change to report.
         // Only once it has drawn: a board opened straight into a background tab has to draw at
         // least once, or there is no container to notice the tab being shown and it stays empty.
-        if (byColumn && noteContext && !noteContext.isActive()) {
+        // Nothing is deferred where the active tab cannot be read, so an answer that has yet to
+        // arrive leaves the board drawn rather than blank.
+        const shownTab = appContext.tabManager?.getActiveMainContext();
+        if (byColumn && noteContext && shownTab && shownTab !== noteContext.getMainContext()) {
             isStale.current = true;
             return;
         }

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -1111,6 +1111,13 @@ export default function BoardView({
         handleBoardKeys(e);
     }, [ selection, handleBoardKeys ]);
 
+    // The note actions menu offers the properties dialog, which lives here rather than in the menu.
+    useTriliumEvent("showBoardProperties", ({ ntxId }) => {
+        if (ntxId === noteContext?.ntxId) {
+            setIsEditingProperties(true);
+        }
+    });
+
     useTriliumEvent("entitiesReloaded", ({ loadResults }) => {
         // The column list is read off the definition, which may be edited from the attribute panel,
         // another split, or a synced instance. Re-reading it re-runs the refresh through the effect.

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -507,6 +507,9 @@ export default function BoardView({
             saveConfig, setBranchIdToEdit, statusDefinition, allByColumn, filter.keepNote);
     }
     const api = apiRef.current.api;
+    // Set here rather than passed in: the api outlives a refresh, and the board can be drawn in a
+    // pane other than the focused one.
+    api.noteContext = noteContext;
     // Every member is one of useState's own setters, so this value is built once and never changes
     // identity -- a drag cannot reach anything that reads only this.
     const openBoardMenu = useCallback((event: ContextMenuEvent) => {

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -386,6 +386,8 @@ export default function BoardView({
     /** Everything a card could be made from: the note types and every template. */
     const availableTemplates = useNoteTypeOptions();
     const [ isEditingProperties, setIsEditingProperties ] = useState(false);
+    /** Whether the board has stopped answering the pointer, which the wash arriving is what sets. */
+    const [ isFrozen, setIsFrozen ] = useState(false);
     const selectColumn = useCallback<Dispatch<StateUpdater<string | undefined>>>((column) => {
         setIsPeekingAll(false);
         setActiveColumn(column);
@@ -1137,7 +1139,18 @@ export default function BoardView({
         : undefined;
 
     return (
-        <div className="board-view">
+        <div className={clsx("board-view", { frozen: isFrozen })}>
+            {/* Stands over the board while a title is being typed, with the field lifted through
+                it. Always drawn, so it fades in rather than appearing. Which fields raise it is
+                the stylesheet's to say, since each keeps its own state.
+
+                The board is frozen once the wash has arrived rather than as it starts: freezing
+                restyles every card, which in the same frame would eat the fade whole. */}
+            <div
+                className="board-edit-backdrop"
+                onTransitionEnd={(e) => setIsFrozen(
+                    getComputedStyle(e.currentTarget as HTMLElement).opacity === "1")}
+            />
             <CollectionProperties
                 note={parentNote}
                 rightChildren={<>

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -298,6 +298,13 @@ const BOARD_HINTS: ShortcutHintDefinition = [
                 labelKey: "board_view.hints.move_column_to_edge"
             }
         ]
+    },
+    {
+        titleKey: "board_view.hints.selection",
+        hints: [
+            { keys: [ "Ctrl+A" ], labelKey: "board_view.hints.select_column" },
+            { keys: [ "Escape" ], labelKey: "board_view.hints.clear_selection" }
+        ]
     }
 ];
 
@@ -1040,6 +1047,7 @@ export default function BoardView({
         byColumn,
         api,
         moveColumn: handleColumnDrop,
+        selection,
         insertColumn: useCallback(async (relativeTo: string, direction: "before" | "after") => {
             setColumnNameToEdit(await api.insertColumn(relativeTo, direction));
         }, [ api ])

--- a/apps/client/src/widgets/collections/board/keyboard.spec.tsx
+++ b/apps/client/src/widgets/collections/board/keyboard.spec.tsx
@@ -1058,6 +1058,26 @@ describe("Board keyboard", () => {
         expect(open).toHaveBeenCalledWith("openInPopup", { noteIdOrPath: noteOf(board, "First") });
     });
 
+    /** Space is the card's open gesture, so it redirects where a click on the card would. */
+    it("jumps to the redirect target with Space", async () => {
+        const board = await renderBoard(undefined, undefined, [], false, true);
+        const open = vi.spyOn(appContext, "triggerCommand").mockReturnValue(undefined);
+        const setNote = vi.fn();
+        const previousTabManager = appContext.tabManager;
+        appContext.tabManager = { getActiveContext: () => ({ setNote }) } as never;
+
+        try {
+            focusCard(board, 0, 0);
+            press(board, " ");
+        } finally {
+            // Put back before the assertions: a stub left standing reaches every later test.
+            appContext.tabManager = previousTabManager;
+        }
+
+        expect(setNote).toHaveBeenCalledWith("targetNote");
+        expect(open).not.toHaveBeenCalled();
+    });
+
     /** Which column a card is drawn in, counted as the reader sees them. */
     function columnOf(board: HTMLElement, title: string) {
         return [ ...board.querySelectorAll(".board-column") ]
@@ -1196,7 +1216,8 @@ describe("Board keyboard", () => {
      * the tests about moving a run of them need a column deep enough to hold one.
      */
     async function renderBoard(
-        collapsed?: string, orderBy?: string, extra: string[] = [], inbox = false
+        collapsed?: string, orderBy?: string, extra: string[] = [], inbox = false,
+        redirect = false
     ) {
         boardNote = buildNote({
             title: "Board",
@@ -1204,7 +1225,11 @@ describe("Board keyboard", () => {
             "#viewType": "board",
             ...(inbox ? { "#enableInboxColumn": "true" } : {}),
             children: [
-                { title: "First", "#status": "To Do" },
+                {
+                    title: "First",
+                    "#status": "To Do",
+                    ...(redirect ? { "~boardCardRedirectTo": "targetNote" } : {})
+                },
                 { title: "Second", "#status": "To Do" },
                 { title: "Third", "#status": "Doing" },
                 ...extra.map((status, at) => (

--- a/apps/client/src/widgets/collections/board/keyboard.spec.tsx
+++ b/apps/client/src/widgets/collections/board/keyboard.spec.tsx
@@ -317,6 +317,71 @@ describe("Board keyboard", () => {
             expect(focusedName(board)).toBe("Second");
         });
 
+        it("takes every picked-out card off the board, not only the focused one", async () => {
+            const board = await renderBoard();
+            const strip = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
+            const first = noteOf(board, "First");
+            const third = noteOf(board, "Third");
+            pick(board, 0, 0);
+            pick(board, 1, 0);
+            focusCard(board, 0, 0);
+
+            press(board, "Delete");
+            await settleWrites();
+
+            expect(strip)
+                .toHaveBeenCalledWith(expect.objectContaining({ noteId: first }), "status");
+            expect(strip)
+                .toHaveBeenCalledWith(expect.objectContaining({ noteId: third }), "status");
+            // The card that was never picked out stays where it is.
+            expect(strip).toHaveBeenCalledTimes(2);
+        });
+
+        it("deletes every picked-out card with Shift and Delete, in one call", async () => {
+            const board = await renderBoard();
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "Delete", { shiftKey: true });
+
+            expect(branches.deleteNotes).toHaveBeenCalledWith(
+                [ branchOf(board, "First"), branchOf(board, "Second") ], false, false);
+        });
+
+        /**
+         * The card beside the focused one may be leaving with it, so focus walks past the cards on
+         * their way out rather than landing on one about to be drawn no more.
+         */
+        it("hands focus past the cards going with it", async () => {
+            const board = await renderBoard();
+            vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "Delete");
+
+            // Both cards of the column are going, so what is left to take focus is its button.
+            expect(document.activeElement?.classList.contains("board-new-item")).toBe(true);
+        });
+
+        /** A card the reader is standing on but has not picked out goes on its own. */
+        it("leaves a selection the focused card is no part of alone", async () => {
+            const board = await renderBoard();
+            const strip = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
+            const second = noteOf(board, "Second");
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "Delete");
+            await settleWrites();
+
+            expect(strip).toHaveBeenCalledTimes(1);
+            expect(strip)
+                .not.toHaveBeenCalledWith(expect.objectContaining({ noteId: second }), "status");
+        });
+
         it("takes the whole column off the board from its header, asking first", async () => {
             const board = await renderBoard();
             const strip = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
@@ -455,19 +520,212 @@ describe("Board keyboard", () => {
             expect(focusedName(board)).toBe("First");
         });
 
-        it("moves a card up and down its own column", async () => {
+        it("sends every picked-out card to the next column, and leaves them picked out", async () => {
+            const board = await renderBoard();
+            const write = vi.spyOn(attributes, "setLabel").mockResolvedValue(undefined);
+            const first = noteOf(board, "First");
+            const second = noteOf(board, "Second");
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowRight", { ctrlKey: true });
+            await settleWrites();
+
+            expect(write).toHaveBeenCalledWith(first, "status", "Doing");
+            expect(write).toHaveBeenCalledWith(second, "status", "Doing");
+            // One placement for the set, against the card already at the end of that column.
+            expect(branches.moveAfterBranch).toHaveBeenCalledExactlyOnceWith(
+                [ branchOf(board, "First"), branchOf(board, "Second") ],
+                branchOf(board, "Third"));
+            expect(pickedNames(board)).toEqual([ "First", "Second" ]);
+        });
+
+        /**
+         * A move is two writes, the grouping value and the branch position, and each lands a redraw
+         * of its own. Drawn only by the first, the cards stand under their new column in the order
+         * their old branches give them, and are seen to reorder a moment later.
+         */
+        it("draws the cards where the move will leave them, before the writes land", async () => {
+            const board = await renderBoard();
+            // Never answered, so what the board shows is only what it has drawn for itself.
+            vi.spyOn(attributes, "setLabel").mockReturnValue(new Promise(() => {}));
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowRight", { ctrlKey: true });
+
+            // At the end of the column they join, after the card already standing there.
+            expect(namesIn(board, 1)).toEqual([ "Third", "First", "Second" ]);
+            expect(namesIn(board, 0)).toEqual([]);
+        });
+
+        /**
+         * The set lands at the end of the column it joins, so the last of them is what the board
+         * scrolls to: focus is what `reveal` follows, and the reader is left at the end of what
+         * they sent rather than above it.
+         */
+        it("leaves focus on the last card of the set it has sent", async () => {
+            const board = await renderBoard();
+            vi.spyOn(attributes, "setLabel").mockResolvedValue(undefined);
+            const first = noteOf(board, "First");
+            const second = noteOf(board, "Second");
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowRight", { ctrlKey: true });
+            await settleWrites();
+
+            setStatus(first, "Doing");
+            setStatus(second, "Doing");
+            await redraw();
+
+            expect(focusedName(board)).toBe("Second");
+        });
+
+        /** Every card has a neighbour of its own, so there is no one column to send them all to. */
+        it("does nothing while the picked-out cards stand in several columns", async () => {
+            const board = await renderBoard();
+            const write = vi.spyOn(attributes, "setLabel").mockResolvedValue(undefined);
+            pick(board, 0, 0);
+            pick(board, 1, 0);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowRight", { ctrlKey: true });
+            await settleWrites();
+
+            expect(write).not.toHaveBeenCalled();
+            expect(pickedNames(board)).toEqual([ "First", "Third" ]);
+        });
+
+        /**
+         * A move takes nothing away, so a selection the focused card is no part of is left where it
+         * stands rather than given up as deleting gives it up.
+         */
+        it("sends a card that is not picked out on its own", async () => {
+            const board = await renderBoard();
+            const write = vi.spyOn(attributes, "setLabel").mockResolvedValue(undefined);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowRight", { ctrlKey: true });
+            await settleWrites();
+
+            expect(write).toHaveBeenCalledExactlyOnceWith(noteOf(board, "First"), "status", "Doing");
+            expect(pickedNames(board)).toEqual([ "Second" ]);
+        });
+
+        it("moves a card up its own column", async () => {
             const board = await renderBoard();
             focusCard(board, 0, 1);
 
             press(board, "ArrowUp", { ctrlKey: true });
+
             expect(branches.moveBeforeBranch)
                 .toHaveBeenCalledWith([ branchOf(board, "Second") ], branchOf(board, "First"));
+        });
 
+        /**
+         * A board of its own: the board draws a move as soon as it is asked for, so one press
+         * moves the cards the next press is counted against.
+         */
+        it("moves a card down its own column", async () => {
+            const board = await renderBoard();
             focusCard(board, 0, 0);
+
             press(board, "ArrowDown", { ctrlKey: true });
+
             // Placed past the card below it, which is the last, so it goes after that one.
             expect(branches.moveAfterBranch)
                 .toHaveBeenCalledWith([ branchOf(board, "First") ], branchOf(board, "Second"));
+        });
+
+        /** A column of four, so a run of two has cards both above and below it. */
+        const deepColumn = () => renderBoard(undefined, undefined, [ "To Do", "To Do" ]);
+
+        it("moves a run of picked-out cards up and down as one", async () => {
+            const board = await deepColumn();
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            // Already at the head, so there is nowhere above for the run to go.
+            press(board, "ArrowUp", { ctrlKey: true });
+            expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+            expect(branches.moveAfterBranch).not.toHaveBeenCalled();
+
+            // The whole run passes the card below it, in one call and in its own order.
+            press(board, "ArrowDown", { ctrlKey: true });
+            expect(branches.moveBeforeBranch).toHaveBeenCalledExactlyOnceWith(
+                [ branchOf(board, "First"), branchOf(board, "Second") ],
+                branchOf(board, "Fifth"));
+        });
+
+        it("sends a run of picked-out cards to either end of its column", async () => {
+            const board = await deepColumn();
+            pick(board, 0, 1);
+            pick(board, 0, 2);
+            focusCard(board, 0, 1);
+
+            press(board, "End", { ctrlKey: true });
+            expect(branches.moveAfterBranch).toHaveBeenCalledExactlyOnceWith(
+                [ branchOf(board, "Second"), branchOf(board, "Fourth") ],
+                branchOf(board, "Fifth"));
+
+            press(board, "Home", { ctrlKey: true });
+            expect(branches.moveBeforeBranch).toHaveBeenCalledExactlyOnceWith(
+                [ branchOf(board, "Second"), branchOf(board, "Fourth") ],
+                branchOf(board, "First"));
+        });
+
+        /**
+         * A run is placed one branch at a time, each write landing a redraw of its own, so the
+         * cards would be seen shuffling into place one after another.
+         */
+        it("draws a run where the move leaves it, before the writes land", async () => {
+            const board = await deepColumn();
+            // Never answered, so what the board shows is only what it has drawn for itself.
+            vi.mocked(branches.moveBeforeBranch).mockReturnValue(new Promise(() => {}));
+            pick(board, 0, 0);
+            pick(board, 0, 1);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowDown", { ctrlKey: true });
+
+            expect(namesIn(board, 0)).toEqual([ "Fourth", "First", "Second", "Fifth" ]);
+        });
+
+        /**
+         * Cards with others of their own column between them have no one place to be moved to, and
+         * a selection reaching into another column has no single order to keep.
+         */
+        it("moves nothing for picked-out cards that do not stand together", async () => {
+            const board = await deepColumn();
+            pick(board, 0, 0);
+            pick(board, 0, 2);
+            focusCard(board, 0, 0);
+
+            for (const key of [ "ArrowDown", "ArrowUp", "Home", "End" ]) {
+                press(board, key, { ctrlKey: true });
+            }
+
+            expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+            expect(branches.moveAfterBranch).not.toHaveBeenCalled();
+        });
+
+        it("moves nothing up or down while the cards stand in several columns", async () => {
+            const board = await deepColumn();
+            pick(board, 0, 0);
+            pick(board, 1, 0);
+            focusCard(board, 0, 0);
+
+            press(board, "ArrowDown", { ctrlKey: true });
+            press(board, "End", { ctrlKey: true });
+
+            expect(branches.moveBeforeBranch).not.toHaveBeenCalled();
+            expect(branches.moveAfterBranch).not.toHaveBeenCalled();
         });
 
         /** A sorted column decides its own order, so there is nowhere for a card to be sent. */
@@ -856,6 +1114,37 @@ describe("Board keyboard", () => {
             .querySelectorAll<HTMLElement>(".board-note")[item].focus();
     }
 
+    /**
+     * Lets a fan-out finish. The cards are written one after another, each awaiting the one before
+     * it, so a single turn of the microtask queue reaches only the first of them.
+     */
+    async function settleWrites() {
+        await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+    }
+
+    /** Picks a card out the way Ctrl and a click do. */
+    function pick(board: HTMLElement, column: number, item: number) {
+        const card = board.querySelectorAll(".board-column")[column]
+            .querySelectorAll<HTMLElement>(".board-note")[item];
+        act(() => {
+            card.dispatchEvent(new MouseEvent(
+                "click", { bubbles: true, cancelable: true, detail: 1, ctrlKey: true }));
+        });
+    }
+
+    /** The cards of one column, by title, in the order the board draws them. */
+    function namesIn(board: HTMLElement, column: number) {
+        return [ ...board.querySelectorAll(".board-column")[column]
+            .querySelectorAll(".board-note") ]
+            .map((card) => card.querySelector(".title")?.textContent?.trim());
+    }
+
+    /** The cards picked out, by title, in the order the board draws them. */
+    function pickedNames(board: HTMLElement) {
+        return [ ...board.querySelectorAll(".board-note.selected") ]
+            .map((card) => card.querySelector(".title")?.textContent?.trim());
+    }
+
     function focusButton(board: HTMLElement, column: number) {
         board.querySelectorAll(".board-column")[column]
             .querySelector<HTMLElement>(".board-new-item")?.focus();
@@ -874,8 +1163,13 @@ describe("Board keyboard", () => {
 
     let boardNote: ReturnType<typeof buildNote>;
 
-    /** Two columns of cards, one empty column, and the button that adds another. */
-    async function renderBoard(collapsed?: string, orderBy?: string) {
+    /**
+     * Two columns of cards, one empty column, and the button that adds another.
+     *
+     * @param extra the cards to add beyond the three, each named by the column it stands in. Only
+     * the tests about moving a run of them need a column deep enough to hold one.
+     */
+    async function renderBoard(collapsed?: string, orderBy?: string, extra: string[] = []) {
         boardNote = buildNote({
             title: "Board",
             "#collection": "",
@@ -883,7 +1177,9 @@ describe("Board keyboard", () => {
             children: [
                 { title: "First", "#status": "To Do" },
                 { title: "Second", "#status": "To Do" },
-                { title: "Third", "#status": "Doing" }
+                { title: "Third", "#status": "Doing" },
+                ...extra.map((status, at) => (
+                    { title: [ "Fourth", "Fifth", "Sixth" ][at], "#status": status }))
             ]
         });
 

--- a/apps/client/src/widgets/collections/board/keyboard.spec.tsx
+++ b/apps/client/src/widgets/collections/board/keyboard.spec.tsx
@@ -286,6 +286,32 @@ describe("Board keyboard", () => {
             expect(branches.deleteNotes).not.toHaveBeenCalled();
         });
 
+        /**
+         * The inbox holds the cards with no grouping value, so stripping the label would leave the
+         * card there rather than off the board. The card's own menu leaves the entry out to match.
+         */
+        it("leaves Delete unanswered while the inbox column is drawn", async () => {
+            const board = await renderBoard(undefined, undefined, [], true);
+            const strip = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
+            // The inbox is seeded at the front, so the first card stands in the column after it.
+            focusCard(board, 1, 0);
+
+            press(board, "Delete");
+
+            expect(strip).not.toHaveBeenCalled();
+            expect(branches.deleteNotes).not.toHaveBeenCalled();
+        });
+
+        /** Deleting the note is what takes it off a board drawing the inbox, so Shift still works. */
+        it("still deletes the note with Shift and Delete while the inbox is drawn", async () => {
+            const board = await renderBoard(undefined, undefined, [], true);
+            focusCard(board, 1, 0);
+
+            press(board, "Delete", { shiftKey: true });
+
+            expect(branches.deleteNotes).toHaveBeenCalled();
+        });
+
         it("deletes the note itself with Shift and Delete", async () => {
             const board = await renderBoard();
             const strip = vi.spyOn(attributes, "removeOwnedLabelByName").mockReturnValue(true);
@@ -1169,11 +1195,14 @@ describe("Board keyboard", () => {
      * @param extra the cards to add beyond the three, each named by the column it stands in. Only
      * the tests about moving a run of them need a column deep enough to hold one.
      */
-    async function renderBoard(collapsed?: string, orderBy?: string, extra: string[] = []) {
+    async function renderBoard(
+        collapsed?: string, orderBy?: string, extra: string[] = [], inbox = false
+    ) {
         boardNote = buildNote({
             title: "Board",
             "#collection": "",
             "#viewType": "board",
+            ...(inbox ? { "#enableInboxColumn": "true" } : {}),
             children: [
                 { title: "First", "#status": "To Do" },
                 { title: "Second", "#status": "To Do" },

--- a/apps/client/src/widgets/collections/board/keyboard.spec.tsx
+++ b/apps/client/src/widgets/collections/board/keyboard.spec.tsx
@@ -350,7 +350,7 @@ describe("Board keyboard", () => {
         });
 
         /**
-         * The card beside the focused one may be leaving with it, so focus walks past the cards on
+         * The card beside the focused one can be leaving with it, so focus walks past the cards on
          * their way out rather than landing on one about to be drawn no more.
          */
         it("hands focus past the cards going with it", async () => {

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -283,7 +283,7 @@ export function useBoardKeyboard({
             const item = itemAt(columns, byColumn, spot);
             if (item) {
                 take(e);
-                api.openNote(item.note.noteId);
+                api.openCard(item.note);
             }
             return;
         }

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -315,8 +315,8 @@ export function useBoardKeyboard({
         if (e.key === "Delete" && spot.kind === "item") {
             const item = itemAt(columns, byColumn, spot);
             if (!item) return;
-            // Plain Delete takes the card off the board, which the inbox leaves nowhere to do: the
-            // card would land there instead. The menu leaves the entry out for the same reason.
+            // Plain Delete clears the grouping value, which with the inbox drawn moves the card
+            // there rather than off the board. Shift+Delete still deletes the note.
             if (!e.shiftKey && api.isInboxEnabled) return;
             take(e);
 

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -315,6 +315,9 @@ export function useBoardKeyboard({
         if (e.key === "Delete" && spot.kind === "item") {
             const item = itemAt(columns, byColumn, spot);
             if (!item) return;
+            // Plain Delete takes the card off the board, which the inbox leaves nowhere to do: the
+            // card would land there instead. The menu leaves the entry out for the same reason.
+            if (!e.shiftKey && api.isInboxEnabled) return;
             take(e);
 
             // The whole selection while the focused card belongs to it, and that card alone

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -4,6 +4,7 @@ import { useCallback, useLayoutEffect, useRef } from "preact/hooks";
 
 import branches from "../../../services/branches";
 import { FLIP_SETTLE_MS } from "../../react/flip";
+import { SelectionStore } from "../../react/selection";
 import BoardApi from "./api";
 import { ColumnMap } from "./data";
 
@@ -70,6 +71,8 @@ export interface BoardKeyboardOptions {
      * for the focus to land on.
      */
     setActiveColumn: (column: string) => void;
+    /** Which cards are picked out, which Ctrl+A fills with the focused column. */
+    selection: SelectionStore;
 }
 
 /**
@@ -88,7 +91,7 @@ export interface BoardKeyboardOptions {
  * would otherwise be left focused on nothing.
  */
 export function useBoardKeyboard({
-    containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn
+    containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn, selection
 }: BoardKeyboardOptions) {
     const pendingFocus = useRef<PendingFocus | null>(null);
 
@@ -162,6 +165,14 @@ export function useBoardKeyboard({
         if (!spot) return;
 
         if (e.ctrlKey) {
+            // Every card of the column focus is in, wherever inside it focus sits. The button that
+            // adds a column stands in none, and Ctrl+A there is the page's own.
+            if (e.key === "a" && !e.altKey && !e.shiftKey && spot.kind !== "add-column") {
+                take(e);
+                selection.selectAll(api.getColumnNoteIds(columns[spot.column]));
+                return;
+            }
+
             // A column beside the one focus is in, wherever inside it focus sits. The button that
             // adds a column stands beside none, and is the plain way to add one at the end anyway.
             if (e.key === "Enter" && !e.altKey && spot.kind !== "add-column") {

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -6,7 +6,7 @@ import branches from "../../../services/branches";
 import { FLIP_SETTLE_MS } from "../../react/flip";
 import { SelectionStore } from "../../react/selection";
 import BoardApi from "./api";
-import { ColumnMap } from "./data";
+import { ColumnItem, ColumnMap } from "./data";
 
 /** Sideways, and with Ctrl, these carry the focused card the whole way rather than one column. */
 const CARD_END_KEYS = [ "ArrowLeft", "ArrowRight" ];
@@ -73,6 +73,17 @@ export interface BoardKeyboardOptions {
     setActiveColumn: (column: string) => void;
     /** Which cards are picked out, which Ctrl+A fills with the focused column. */
     selection: SelectionStore;
+    /**
+     * Sends cards to the end of another column, drawing them there while the writes are made. The
+     * board draws the outcome itself, so a move's two writes are not two redraws.
+     */
+    sendCardsToColumn: (
+        cards: { noteId: string, branchId: string }[], targetColumn: string
+    ) => Promise<unknown>;
+    /** As {@link sendCardsToColumn}, for a move to a place among the cards already in a column. */
+    moveCardsWithin: (
+        cards: { noteId: string, branchId: string }[], column: string, index: number
+    ) => Promise<unknown>;
 }
 
 /**
@@ -91,7 +102,8 @@ export interface BoardKeyboardOptions {
  * would otherwise be left focused on nothing.
  */
 export function useBoardKeyboard({
-    containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn, selection
+    containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn, selection,
+    sendCardsToColumn, moveCardsWithin
 }: BoardKeyboardOptions) {
     const pendingFocus = useRef<PendingFocus | null>(null);
 
@@ -202,10 +214,24 @@ export function useBoardKeyboard({
             }
 
             const moved = move(
-                spot, e.key, { columns, byColumn, api, setActiveColumn }, e.shiftKey);
+                spot,
+                e.key,
+                {
+                    columns, byColumn, api, setActiveColumn, selection, sendCardsToColumn,
+                    moveCardsWithin
+                },
+                e.shiftKey);
             if (moved) {
                 const pending: PendingFocus = { intent: moved.intent };
                 pendingFocus.current = pending;
+
+                // Taken now rather than left to the redraw, which gives the intent up when focus
+                // rests anywhere but where it names: a set of cards is sent from one of its own
+                // members, and the card it names is another of them. Scrolling is left to
+                // `reveal`, which waits for the card to stop moving.
+                if ("noteId" in moved.intent) {
+                    findCard(container, moved.intent.noteId)?.focus({ preventScroll: true });
+                }
 
                 // Nothing is going to arrive, so focus is not held for it any longer.
                 moved.done.catch(() => {
@@ -291,33 +317,53 @@ export function useBoardKeyboard({
             if (!item) return;
             take(e);
 
+            // The whole selection while the focused card belongs to it, and that card alone
+            // otherwise, which is the question the card's own menu answers the same way.
+            if (!selection.has(item.note.noteId)) {
+                selection.clear();
+            }
+            const selected = api.getCards(selection.keys);
+            const going = selected.length ? selected : [ item ];
+
             // Straight away rather than through `pendingFocus`, which waits for a redraw: until the
             // card goes, focus is still on it, and a redraw arriving first would read that as the
-            // reader having chosen where to be and let the intent go.
-            neighbourOf(container, columns, byColumn, spot)?.focus();
+            // reader having chosen where to be and let the intent go. The cards on their way out
+            // are passed over, since focus would land on one about to be drawn no more.
+            neighbourOf(container, columns, byColumn, spot,
+                new Set(going.map((card) => card.note.noteId)))?.focus();
 
             if (e.shiftKey) {
-                // The note itself, with the confirmation deleting one anywhere else asks for.
-                branches.deleteNotes([ item.branch.branchId ], false, false);
+                // The notes themselves, with the confirmation deleting one anywhere else asks for.
+                branches.deleteNotes(going.map((card) => card.branch.branchId), false, false);
             } else {
-                api.removeFromBoard(item.note.noteId);
+                void api.removeFromBoard(going.map((card) => card.note.noteId));
             }
         }
-    }, [ containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn ]);
+    }, [
+        containerRef, columns, byColumn, api, moveColumn, insertColumn, setActiveColumn, selection
+    ]);
 
     return { onKeyDown, focusColumn, focusCard };
 }
 
-/** What to put focus on once a card goes: the one under it, the one over it, or the column. */
+/**
+ * What to put focus on once a card goes: the one under it, the one over it, or the column.
+ *
+ * @param going the cards leaving with it, which are passed over: a whole selection can be deleted
+ * at once, and the card beside the focused one may be on its way out too.
+ */
 function neighbourOf(
     container: HTMLElement,
     columns: string[],
     byColumn: ColumnMap | undefined,
-    spot: Extract<Spot, { kind: "item" }>
+    spot: Extract<Spot, { kind: "item" }>,
+    going: ReadonlySet<string> = new Set()
 ) {
     const column = columns[spot.column];
     const items = byColumn?.get(column) ?? [];
-    const next = items[spot.item + 1] ?? items[spot.item - 1];
+    const stays = (item: ColumnItem) => !going.has(item.note.noteId);
+    const next = items.slice(spot.item + 1).find(stays)
+        ?? items.slice(0, spot.item).findLast(stays);
 
     return next
         ? findCard(container, next.note.noteId)
@@ -447,8 +493,10 @@ function entryOf(container: HTMLElement, column: number): Spot {
 function move(
     spot: Spot,
     key: string,
-    { columns, byColumn, api, setActiveColumn }:
-        Pick<BoardKeyboardOptions, "columns" | "byColumn" | "api" | "setActiveColumn">,
+    { columns, byColumn, api, setActiveColumn, selection, sendCardsToColumn, moveCardsWithin }:
+        Pick<BoardKeyboardOptions,
+            "columns" | "byColumn" | "api" | "setActiveColumn" | "selection"
+            | "sendCardsToColumn" | "moveCardsWithin">,
     /** Whether the card goes the whole way rather than one place. */
     toEnd = false
 ): { intent: FocusIntent; done: Promise<unknown> } | false {
@@ -458,7 +506,16 @@ function move(
     const column = columns[spot.column];
     const items = byColumn?.get(column) ?? [];
     const { noteId } = item.note;
-    const { branchId } = item.branch;
+
+    // The whole selection while the focused card belongs to it, and that card alone otherwise.
+    // A move leaves a selection the card is no part of standing: nothing is lost by it, and a key
+    // that only reorders should not also undo what the reader has picked out.
+    const selected = api.getCards(selection.keys);
+    const moving = selection.has(noteId) && selected.length ? selected : [ item ];
+    const carried = moving.map((card) => ({
+        noteId: card.note.noteId,
+        branchId: card.branch.branchId
+    }));
 
     if (key === "ArrowLeft" || key === "ArrowRight") {
         const target = toEnd
@@ -467,26 +524,51 @@ function move(
         // Only the whole way can ask for the column a card already stands in.
         if (!target || target === column) return false;
 
-        // The card is drawn under the column it lands in, so a collapsed one has to open first for
-        // there to be anything to focus.
+        // A selection standing in several columns is left alone: each card has a neighbour of its
+        // own, and sending them all to one column is not what the key means anywhere else.
+        if (moving.some((card) => api.getCardColumn(card.note.noteId) !== column)) {
+            return false;
+        }
+
+        // The cards are drawn under the column they land in, so a collapsed one has to open first
+        // for there to be anything to focus.
         setActiveColumn(target);
 
-        return { intent: { noteId }, done: api.moveToColumnEnd(noteId, branchId, target) };
+        // The last of them, which is the one that lands furthest down the column it joins: focus
+        // is what the board scrolls to, so this is what makes the end of the set visible. For one
+        // card it is that card, as it has always been.
+        const arrived = moving.at(-1) ?? item;
+
+        return {
+            intent: { noteId: arrived.note.noteId },
+            done: sendCardsToColumn(carried, target)
+        };
+    }
+
+    // Where the cards stand in the column, which they can only be reordered as one if they stand
+    // together in it. A selection reaching into another column, or one with cards between its own,
+    // has no single place to be moved to and the key is answered with nothing.
+    const places = moving.map((card) =>
+        items.findIndex((candidate) => candidate.note.noteId === card.note.noteId));
+    const start = Math.min(...places);
+    const end = Math.max(...places);
+    if (places.some((place) => place < 0) || end - start !== places.length - 1) {
+        return false;
     }
 
     const last = items.length - 1;
-    // A card is placed before a position too, so moving one down means passing the one below it.
-    const to = key === "ArrowUp" && spot.item > 0 ? spot.item - 1
-        : key === "ArrowDown" && spot.item < last ? spot.item + 2
-        : key === "Home" && spot.item > 0 ? 0
-        : key === "End" && spot.item < last ? items.length
+    // A card is placed before a position too, so moving down means passing the one below the run.
+    const to = key === "ArrowUp" && start > 0 ? start - 1
+        : key === "ArrowDown" && end < last ? end + 2
+        : key === "Home" && start > 0 ? 0
+        : key === "End" && end < last ? items.length
         : null;
 
     if (to === null) return false;
 
     return {
         intent: { noteId },
-        done: api.moveWithinBoard(noteId, branchId, spot.item, to, column, column)
+        done: moveCardsWithin(carried, column, to)
     };
 }
 

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -350,7 +350,7 @@ export function useBoardKeyboard({
  * What to put focus on once a card goes: the one under it, the one over it, or the column.
  *
  * @param going the cards leaving with it, which are passed over: a whole selection can be deleted
- * at once, and the card beside the focused one may be on its way out too.
+ * at once, and the card beside the focused one can be on its way out too.
  */
 function neighbourOf(
     container: HTMLElement,

--- a/apps/client/src/widgets/collections/board/properties.spec.tsx
+++ b/apps/client/src/widgets/collections/board/properties.spec.tsx
@@ -4,7 +4,7 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type FNote from "../../../entities/fnote";
-import contextMenu, { type MenuCommandItem } from "../../../menus/context_menu";
+import dialogService from "../../../services/dialog";
 import type { PromotedAttribute } from "../promoted_attributes";
 import type { SortKey } from "../sorting";
 import BoardApi from "./api";
@@ -151,7 +151,8 @@ describe("Board properties", () => {
     describe("what the board shows", () => {
         /** Both were on the board's own menu; the inbox column is now offered only here. */
         it("draws a segment for each, reading what the board's labels say", () => {
-            const rows = general()?.querySelectorAll(".tn-card-section") ?? [];
+            const rows = general()
+                ?.querySelectorAll(".tn-card-section:not(.tn-card-section-nested)") ?? [];
 
             expect(rows.length).toBe(3);
             expect(toggleAt(0)?.classList.contains("on")).toBe(false);
@@ -187,34 +188,32 @@ describe("Board properties", () => {
             expect(picker()?.querySelector(".bx-sort-down")).toBeTruthy();
         });
 
-        it("offers a menu beside the picker for putting the columns back to it", () => {
-            const show = vi.spyOn(contextMenu, "show").mockImplementation(async () => {});
-            // The menu closes itself on any click reaching the document, so the press that opens
-            // it must not get there.
-            const onDocument = vi.fn();
-            document.addEventListener("click", onDocument);
+        it("carries a link under the picker for putting the columns back to it", async () => {
+            const confirm = vi.spyOn(dialogService, "confirm").mockResolvedValue(true);
+            const link = resetLink();
 
-            act(() => { actionsButton()?.click(); });
-            document.removeEventListener("click", onDocument);
-            expect(onDocument).not.toHaveBeenCalled();
+            expect(link?.textContent).toContain("board_view.reset-column-sorting");
 
-            const items = show.mock.calls.at(-1)?.[0].items ?? [];
-            expect(items.map(item => item && "title" in item ? item.title : ""))
-                .toEqual([ "board_view.reset-columns-to-default" ]);
+            await act(async () => { link?.click(); });
 
-            const entry = items[0];
-            if (!entry || !("handler" in entry)) throw new Error("expected a menu entry");
-            act(() => { entry.handler?.(entry as MenuCommandItem<unknown>, {} as never); });
-
+            expect(confirm).toHaveBeenCalledWith("board_view.reset-column-sorting-confirm");
             expect(sorting).toEqual([ "reset" ]);
+        });
+
+        it("leaves the orders alone when the prompt is declined", async () => {
+            vi.spyOn(dialogService, "confirm").mockResolvedValue(false);
+
+            await act(async () => { resetLink()?.click(); });
+
+            expect(sorting).toEqual([]);
         });
 
         function picker() {
             return general()?.querySelector<HTMLElement>(".board-sort-picker");
         }
 
-        function actionsButton() {
-            return general()?.querySelector<HTMLElement>(".board-sort-actions");
+        function resetLink() {
+            return general()?.querySelector<HTMLElement>(".board-sort-reset");
         }
     });
 

--- a/apps/client/src/widgets/collections/board/properties.tsx
+++ b/apps/client/src/widgets/collections/board/properties.tsx
@@ -3,9 +3,9 @@ import "./properties.css";
 import { useCallback } from "preact/hooks";
 
 import type FNote from "../../../entities/fnote";
+import dialog from "../../../services/dialog";
 import { t } from "../../../services/i18n";
-import ActionButton from "../../react/ActionButton";
-import { Card, OptionCardSection } from "../../react/Card";
+import { Card, CardSection, OptionCardSection } from "../../react/Card";
 import FormToggle from "../../react/FormToggle";
 import { useNoteLabelBoolean } from "../../react/hooks";
 import Modal from "../../react/Modal";
@@ -15,7 +15,6 @@ import type { PromotedAttribute } from "../promoted_attributes";
 import SortDropdown from "../SortDropdown";
 import { parseSortKey } from "../sorting";
 import BoardApi from "./api";
-import { openSortActionsMenu } from "./context_menu";
 import { useBoardSort } from "./sort";
 
 /** The board's settings, other than its columns and cards. */
@@ -68,6 +67,13 @@ function General({ api, note }: { api: BoardApi, note: FNote }) {
     const [ inboxShown ] = useNoteLabelBoolean(note, "enableInboxColumn");
     const [ archivedShown ] = useNoteLabelBoolean(note, "includeArchived");
     const defaultSort = useBoardSort(note);
+    // Every column at once, and a column's own order is not kept anywhere else: the reader is asked
+    // before it goes.
+    const resetColumnSorts = useCallback(async () => {
+        if (await dialog.confirm(t("board_view.reset-column-sorting-confirm"))) {
+            await api.resetColumnSortsToDefault();
+        }
+    }, [ api ]);
 
     return (
         <Card className="board-properties-general" heading={t("board_view.general")}>
@@ -94,7 +100,23 @@ function General({ api, note }: { api: BoardApi, note: FNote }) {
 
             <OptionCardSection
                 name="board-sort-cards"
-                label={t("board_view.sort-cards")}
+                label={t("board_view.default-card-order")}
+                description={t("board_view.default-card-order-description")}
+                subSectionsVisible
+                subSections={
+                    <CardSection
+                        className="board-sort-reset"
+                        href="#"
+                        noContainedNavigation
+                        onAction={(event) => {
+                            // The anchor is what makes the segment read as a link; the address
+                            // itself leads nowhere, and `goToLink` would navigate by it.
+                            event.preventDefault();
+                            event.stopPropagation();
+                            void resetColumnSorts();
+                        }}
+                    >{t("board_view.reset-column-sorting")}</CardSection>
+                }
             >
                 <SortDropdown
                     className="board-sort-picker"
@@ -107,18 +129,6 @@ function General({ api, note }: { api: BoardApi, note: FNote }) {
                     // rejects that key as well: `setDefaultSort` takes a plain sort key.
                     onSelect={(orderBy) => api.setDefaultSort(parseSortKey(orderBy))}
                     onDirectionChange={(descending) => api.setDefaultSortDirection(descending)}
-                />
-
-                <ActionButton
-                    className="board-sort-actions"
-                    icon="bx bx-dots-vertical-rounded"
-                    text={t("board_view.sort-actions")}
-                    onClick={(event) => {
-                        // The press would otherwise reach the document, where the menu closes
-                        // itself on any click outside it.
-                        event.stopPropagation();
-                        openSortActionsMenu(api, event);
-                    }}
                 />
             </OptionCardSection>
         </Card>

--- a/apps/client/src/widgets/collections/calendar/context_menu.ts
+++ b/apps/client/src/widgets/collections/calendar/context_menu.ts
@@ -1,6 +1,7 @@
+import type { CommandNames } from "../../../components/app_context";
 import FNote from "../../../entities/fnote";
 import contextMenu, { ContextMenuEvent } from "../../../menus/context_menu";
-import { getArchiveMenuItem } from "../../../menus/context_menu_utils";
+import { getArchiveMenuItems } from "../../../menus/context_menu_utils";
 import NoteColorPicker from "../../../menus/custom-items/NoteColorPicker";
 import link_context_menu from "../../../menus/link_context_menu";
 import branches from "../../../services/branches";
@@ -16,7 +17,7 @@ export function openCalendarContextMenu(e: ContextMenuEvent, note: FNote, parent
         items: [
             ...link_context_menu.getItems(e),
             { kind: "separator" },
-            getArchiveMenuItem(note),
+            ...getArchiveMenuItems<CommandNames>([ note ]),
             {
                 title: t("calendar_view.delete_note"),
                 uiIcon: "bx bx-trash",

--- a/apps/client/src/widgets/react/selection.spec.tsx
+++ b/apps/client/src/widgets/react/selection.spec.tsx
@@ -41,6 +41,19 @@ describe("SelectionStore", () => {
         expect(store.anchor).toBe("a");
     });
 
+    it("takes a whole list at once, with the anchor on its first item", () => {
+        store.toggle("e");
+        store.selectAll([ "a", "b", "c" ]);
+
+        expect(selected()).toEqual([ "a", "b", "c" ]);
+        expect(store.anchor).toBe("a");
+
+        // A column holding nothing leaves the selection empty rather than as it was.
+        store.selectAll([]);
+        expect(selected()).toEqual([]);
+        expect(store.anchor).toBeNull();
+    });
+
     it("gives up everything at once", () => {
         store.toggle("b");
         store.clear();

--- a/apps/client/src/widgets/react/selection.spec.tsx
+++ b/apps/client/src/widgets/react/selection.spec.tsx
@@ -1,0 +1,198 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { SelectionContext, SelectionStore, useIsSelected, useSelectionCount } from "./selection";
+
+const ITEMS = [ "a", "b", "c", "d", "e" ];
+
+describe("SelectionStore", () => {
+    let store: SelectionStore;
+
+    beforeEach(() => {
+        store = new SelectionStore();
+    });
+
+    const selected = () => [ ...store.keys ];
+
+    it("starts holding nothing", () => {
+        expect(selected()).toEqual([]);
+        expect(store.size).toBe(0);
+        expect(store.anchor).toBeNull();
+        expect(store.has("a")).toBe(false);
+    });
+
+    it("adds and removes one item at a time, keeping the rest", () => {
+        store.toggle("b");
+        store.toggle("d");
+        expect(selected()).toEqual([ "b", "d" ]);
+
+        store.toggle("b");
+        expect(selected()).toEqual([ "d" ]);
+        expect(store.has("b")).toBe(false);
+    });
+
+    it("takes one item on its own, dropping what was picked before", () => {
+        store.toggle("b");
+        store.toggle("d");
+        store.selectOnly("a");
+
+        expect(selected()).toEqual([ "a" ]);
+        expect(store.anchor).toBe("a");
+    });
+
+    it("gives up everything at once", () => {
+        store.toggle("b");
+        store.clear();
+
+        expect(selected()).toEqual([]);
+        expect(store.anchor).toBeNull();
+    });
+
+    describe("a range", () => {
+        it("covers everything between the anchor and the item picked, either way round", () => {
+            store.toggle("b");
+            store.selectRange(ITEMS, "d");
+            expect(selected()).toEqual([ "b", "c", "d" ]);
+
+            store.selectRange(ITEMS, "a");
+            expect(selected()).toEqual([ "a", "b" ]);
+        });
+
+        it("replaces what was picked rather than adding to it", () => {
+            store.toggle("a");
+            store.toggle("e");
+            // The anchor moved to `e` with the second pick, so the range runs from there.
+            store.selectRange(ITEMS, "c");
+
+            expect(selected()).toEqual([ "c", "d", "e" ]);
+        });
+
+        it("leaves the anchor where it stands, so a second range moves one end", () => {
+            store.toggle("b");
+            store.selectRange(ITEMS, "e");
+            store.selectRange(ITEMS, "c");
+
+            expect(store.anchor).toBe("b");
+            expect(selected()).toEqual([ "b", "c" ]);
+        });
+
+        it("takes the item alone where there is no anchor to measure from", () => {
+            store.selectRange(ITEMS, "c");
+
+            expect(selected()).toEqual([ "c" ]);
+            expect(store.anchor).toBe("c");
+        });
+
+        /**
+         * The caller decides what a range can cover, which is one column of a board. An anchor set
+         * in another column is not in the list, and the press takes the item it landed on alone.
+         */
+        it("takes the item alone where the anchor stands outside the list", () => {
+            store.toggle("elsewhere");
+            store.selectRange(ITEMS, "c");
+
+            expect(selected()).toEqual([ "c" ]);
+            expect(store.anchor).toBe("c");
+        });
+
+        it("does nothing at all for an item the list does not hold", () => {
+            store.toggle("b");
+            store.selectRange(ITEMS, "gone");
+
+            expect(selected()).toEqual([ "b" ]);
+        });
+    });
+
+    describe("pruning", () => {
+        it("drops what the collection no longer holds and keeps the rest", () => {
+            store.toggle("a");
+            store.toggle("b");
+            store.toggle("c");
+
+            store.retain(new Set([ "a", "c", "z" ]));
+            expect(selected()).toEqual([ "a", "c" ]);
+        });
+
+        it("gives the anchor up with the item it named", () => {
+            store.toggle("a");
+            store.toggle("b");
+
+            store.retain(new Set([ "a" ]));
+            expect(store.anchor).toBeNull();
+
+            store.toggle("a");
+            store.retain(new Set([ "a" ]));
+            expect(store.anchor).toBe("a");
+        });
+    });
+});
+
+describe("what a change wakes", () => {
+    let container: HTMLElement;
+    let store: SelectionStore;
+    let renders: Record<string, number>;
+
+    beforeEach(() => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        store = new SelectionStore();
+        renders = {};
+        act(() => {
+            render(
+                <SelectionContext.Provider value={store}>
+                    {ITEMS.map((key) => <Watcher key={key} item={key} />)}
+                    <Counter />
+                </SelectionContext.Provider>,
+                container);
+        });
+    });
+
+    afterEach(() => {
+        render(null, container);
+        container.remove();
+    });
+
+    it("answers each item about itself alone", () => {
+        act(() => store.toggle("b"));
+
+        expect(read("a")).toBe("-");
+        expect(read("b")).toBe("selected");
+        expect(count()).toBe("1");
+    });
+
+    it("wakes the item picked and the one dropped, and no others", () => {
+        act(() => store.toggle("b"));
+        const afterFirst = { ...renders };
+
+        act(() => store.selectOnly("e"));
+        expect(drawnSince(afterFirst)).toEqual([ "b", "e" ]);
+
+        // Picking what is already picked changes nothing, so nothing is drawn again.
+        const afterSecond = { ...renders };
+        act(() => store.selectOnly("e"));
+        expect(drawnSince(afterSecond)).toEqual([]);
+    });
+
+    function read(item: string) {
+        return container.querySelector(`[data-item="${item}"]`)?.textContent;
+    }
+
+    function count() {
+        return container.querySelector("[data-count]")?.textContent;
+    }
+
+    function drawnSince(before: Record<string, number>) {
+        return ITEMS.filter((item) => renders[item] !== before[item]);
+    }
+
+    function Watcher({ item }: { item: string }) {
+        renders[item] = (renders[item] ?? 0) + 1;
+        const isSelected = useIsSelected(item);
+        return <div data-item={item}>{isSelected ? "selected" : "-"}</div>;
+    }
+
+    function Counter() {
+        return <div data-count>{useSelectionCount()}</div>;
+    }
+});

--- a/apps/client/src/widgets/react/selection.ts
+++ b/apps/client/src/widgets/react/selection.ts
@@ -52,6 +52,17 @@ export class SelectionStore {
     }
 
     /**
+     * Selects a whole list at once, dropping whatever else was selected. Ctrl+A does this.
+     *
+     * The anchor lands on the first of them, so a Shift+Click afterwards ranges from the head of
+     * what was just taken.
+     */
+    selectAll(keys: string[]) {
+        this.anchorKey = keys[0] ?? null;
+        this.replace(new Set(keys));
+    }
+
+    /**
      * Selects everything between the anchor and `to`, dropping whatever else was selected.
      *
      * The anchor stays where it was, so a second Shift+Click grows or shrinks the same range

--- a/apps/client/src/widgets/react/selection.ts
+++ b/apps/client/src/widgets/react/selection.ts
@@ -1,0 +1,150 @@
+import { createContext } from "preact";
+import { useSyncExternalStore } from "preact/compat";
+import { useCallback, useContext } from "preact/hooks";
+
+/**
+ * Which items a collection has selected, held outside component state.
+ *
+ * Kept in a store rather than in state so that a change wakes only the items whose own answer
+ * changed. A board holds hundreds of cards, and selecting one must not redraw the rest.
+ *
+ * The keys are opaque strings the collection chooses. A board selects by `noteId`; another
+ * collection can select by whatever identifies one of its rows.
+ */
+export class SelectionStore {
+    private selected: ReadonlySet<string> = new Set();
+    private anchorKey: string | null = null;
+    private listeners = new Set<() => void>();
+
+    /** The selected keys, which keep one identity until the selection changes. */
+    get keys() {
+        return this.selected;
+    }
+
+    /** Where a range starts, which is the item last picked without Shift. */
+    get anchor() {
+        return this.anchorKey;
+    }
+
+    get size() {
+        return this.selected.size;
+    }
+
+    has(key: string) {
+        return this.selected.has(key);
+    }
+
+    /** Selects one item on its own, dropping whatever else was selected. */
+    selectOnly(key: string) {
+        this.anchorKey = key;
+        this.replace(new Set([ key ]));
+    }
+
+    /** Adds or removes one item, keeping the rest. Ctrl+Click does this. */
+    toggle(key: string) {
+        const next = new Set(this.selected);
+        if (!next.delete(key)) {
+            next.add(key);
+        }
+
+        this.anchorKey = key;
+        this.replace(next);
+    }
+
+    /**
+     * Selects everything between the anchor and `to`, dropping whatever else was selected.
+     *
+     * The anchor stays where it was, so a second Shift+Click grows or shrinks the same range
+     * rather than starting a new one.
+     *
+     * @param ordered the items a range can cover, in the order they are drawn. The caller decides
+     * what that list holds, so a board passes one column and a range never crosses into another.
+     * @param to the item that was clicked.
+     */
+    selectRange(ordered: string[], to: string) {
+        const end = ordered.indexOf(to);
+        if (end < 0) {
+            return;
+        }
+
+        // No anchor yet, or one standing outside `ordered`, such as a card in another column.
+        const start = this.anchorKey === null ? -1 : ordered.indexOf(this.anchorKey);
+        if (start < 0) {
+            this.selectOnly(to);
+            return;
+        }
+
+        this.replace(new Set(ordered.slice(Math.min(start, end), Math.max(start, end) + 1)));
+    }
+
+    clear() {
+        this.anchorKey = null;
+        this.replace(new Set());
+    }
+
+    /**
+     * Drops the keys `present` does not list, for items that have left the collection.
+     *
+     * Called when the collection redraws: a note deleted, archived out of view or moved off the
+     * board must leave the selection, or a later command acts on an item that is no longer there.
+     */
+    retain(present: ReadonlySet<string>) {
+        if ([ ...this.selected ].every((key) => present.has(key))) {
+            return;
+        }
+
+        const kept = new Set([ ...this.selected ].filter((key) => present.has(key)));
+        if (this.anchorKey !== null && !kept.has(this.anchorKey)) {
+            this.anchorKey = null;
+        }
+
+        this.replace(kept);
+    }
+
+    subscribe(listener: () => void) {
+        this.listeners.add(listener);
+        return () => { this.listeners.delete(listener); };
+    }
+
+    /** Announces the new set, and only when it differs, so an unchanged pick redraws nothing. */
+    private replace(next: ReadonlySet<string>) {
+        if (next.size === this.selected.size
+                && [ ...next ].every((key) => this.selected.has(key))) {
+            return;
+        }
+
+        this.selected = next;
+        for (const listener of [ ...this.listeners ]) {
+            listener();
+        }
+    }
+}
+
+/* v8 ignore next -- a collection always provides its own; this is what lets a consumer read it
+   with a plain useContext(), with no guard for a provider that is structurally always there. */
+export const SelectionContext = createContext(new SelectionStore());
+
+/** The store itself, for the handlers that change the selection. */
+export function useSelection() {
+    return useContext(SelectionContext);
+}
+
+/** Whether one item is selected. Redraws that item alone when its own answer changes. */
+export function useIsSelected(key: string) {
+    const store = useSelection();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribe(listener), [ store ]),
+        useCallback(() => store.has(key), [ store, key ])
+    );
+}
+
+/** How many items are selected, for the components that report the size of a selection. */
+export function useSelectionCount() {
+    const store = useSelection();
+
+    return useSyncExternalStore(
+        useCallback((listener: () => void) => store.subscribe(listener), [ store ]),
+        useCallback(() => store.size, [ store ])
+    );
+}

--- a/apps/client/src/widgets/ribbon/NoteActions.tsx
+++ b/apps/client/src/widgets/ribbon/NoteActions.tsx
@@ -98,6 +98,7 @@ export function NoteContextMenu({ note, noteContext, itemsAtStart, itemsNearNote
     const isMobile = getIsMobile();
     const hasSource = ["text", "code", "relationMap", "mermaid", "canvas", "mindMap", "spreadsheet", "llmChat"].includes(noteType) || note.isSvg();
     const isSearchOrBook = ["search", "book"].includes(noteType);
+    const isBoard = noteType === "book" && viewType === "board";
     const isHelpPage = note.noteId.startsWith("_help");
     const [syncServerHost] = useTriliumOption("syncServerHost");
     const { isReadOnly, enableEditing } = useIsNoteReadOnly(note, noteContext);
@@ -187,6 +188,9 @@ export function NoteContextMenu({ note, noteContext, itemsAtStart, itemsNearNote
                 {canBeConvertedToAttachment && <ConvertToAttachment note={note} />}
                 {note.type === "render" && <CommandItem command="renderActiveNote" icon="bx bx-extension" text={t("note_actions.re_render_note")}
                 />}
+
+                {isBoard && <CommandItem icon="bx bx-cog" text={t("board_view.properties")}
+                    command={() => parentComponent?.triggerEvent("showBoardProperties", { ntxId: noteContext?.ntxId })} />}
 
                 <FormDropdownSubmenu icon="bx bx-wrench" title={t("note_actions.advanced")} dropStart>
                     <CommandItem command="openNoteExternally" icon="bx bx-file-find" disabled={isSearchOrBook || !isElectron} text={t("note_actions.open_note_externally")} title={t("note_actions.open_note_externally_title")} />

--- a/packages/commons/src/lib/builtin_attributes.ts
+++ b/packages/commons/src/lib/builtin_attributes.ts
@@ -269,6 +269,8 @@ const BUILTIN_ATTRIBUTES = [
     { type: "label", name: "maxNestingDepth", valueType: "number", hasUserValue: true },
     { type: "label", name: "includeArchived", valueType: "boolean", hasUserValue: true },
     { type: "label", name: "enableInboxColumn", valueType: "boolean", hasUserValue: true },
+    // Carried by a card that stands in for another note: opening it navigates there instead.
+    { type: "relation", name: "boardCardRedirectTo" },
     // The order a board offers for its columns, which its properties apply to every column at once.
     { type: "label", name: "sortColumns", valueType: "text", hasUserValue: true },
     { type: "label", name: "sortColumnsDescending", valueType: "boolean", hasUserValue: true },


### PR DESCRIPTION
The Kanban board now supports working with several cards at once. Cards can be picked out with Ctrl and Shift click, gathered a whole column at a time, and then moved, edited, archived or deleted as a group, whether by dragging them, by the card menu or from the keyboard. Alongside this, cards can now be dragged out of the board entirely, onto the note tree or onto a board in another split, and a card can be made to act as a shortcut that opens a different note. The board's settings have been gathered into a dialog reachable from the note menu, and the card editor has been reworked so that opening it neither changes a card's size nor risks a stray click landing elsewhere on the board.

To create a redirection card, add the relation `boardCardRedirectTo` to the card's note and point it at the note that should open. Clicking the card, or pressing Space while it is focused, then navigates to that note in the pane the board occupies rather than opening the card's own editor. The card's title is underlined on hover to indicate that it leads elsewhere. Use Quick edit from the card's context menu to open the editor again. The relation is inherited, so setting it on a parent note applies it to every card beneath that parent.

### Multi-selection

- Add Ctrl+click to add or remove a single card from the selection, accumulating across columns.
- Add Shift+click to select the range between the anchor and the clicked card, restricted to a single column.
- Add Ctrl+A to select every card in the column that holds focus.
- Clear the selection with Escape, with a click anywhere on the board outside a card, or by right clicking a card that is not part of it.
- Apply the card context menu to the whole selection: column moves, promoted attribute values, archiving, removal from the board and deletion.
- Mark a menu entry only where every selected note holds the same value, so a selection that disagrees shows no check and picking the entry writes the value to all of them.
- Apply Delete and Shift+Delete to the whole selection rather than to the focused card alone.
- Move the whole selection between columns with Ctrl and the arrow keys, and within a column when the selected cards form a contiguous run.
- Keep the selection intact after a drop, and scroll the last card moved into view.
- Prune the selection to the cards the board still draws after a refresh.
- Draw a selected card with an inset ring, and add the selection shortcuts to the board's shortcut hints.

### Drag and drop

- Drag a selection as a single stack of cards showing how many are being carried.
- Add a native drag when Ctrl is held as the press begins, allowing cards to be dropped on the note tree, on other collections and on boards in other splits and windows.
- Carry the whole selection in the native drag payload, in the same form the note tree writes and reads.
- Move a dropped set of cards in one operation instead of one card after another, removing the visible restaging as each landed.
- Hold the board as the drop drew it until the matching entity changes arrive, so a column no longer collapses and re-expands after a drop.
- Suppress the click a completed drag produces, which previously cleared the selection.
- Make `moveToColumnEnd` and `moveWithinBoard` take a set of cards natively, and batch the attribute writes behind them.

### Redirection cards

- Add the `boardCardRedirectTo` relation, which makes clicking a card or pressing Space navigate to the target note instead of opening the card's editor.
- Navigate the note context the board is drawn in rather than the globally focused one, so a redirect in a split does not replace the note in another pane.
- Underline the title of a redirecting card on hover, leaving the card's icon undecorated.
- Register the relation as a built-in attribute, with autocompletion and an explanation in the attribute detail popup.

### Board properties and menus

- Add "Board properties" to the note menu, placed above Advanced and shown only for board notes.
- Rename the board's sort setting to "Default card order" and describe the columns it governs.
- Replace the sort actions button with a nested link that resets every column's sorting, after a confirmation prompt.
- Hide "Remove from board" and leave plain Delete unanswered while the inbox column is drawn, since clearing a card's grouping value leaves it in the inbox rather than off the board.
- Omit the Options field when creating a grouping attribute from the group-by dropdown, the board's columns being what supplies those options.
- Add a `hideTypeOptions` flag to the attribute detail popup, which leaves out the rows a chosen kind adds.

### Card editing

- Keep a card's badges visible while its title is being edited, and give both modes the same metrics so the card does not change size.
- Dim the board behind a card that is being named, lifting the edited card above the dimming.
- Stop the remaining cards answering the pointer once the dimming has faded in, so dismissing the editor cannot open or select another card.
- Apply that suppression immediately when motion is disabled, where no transition ends to trigger it.

### Fixes

- Redraw a board that shares a tab with the focused pane, instead of deferring every change until something else forces a refresh.
- Write nothing for a drop that leaves the drawn order unchanged, so a filter's hidden cards are no longer reordered behind it.
- Compare a card's column membership against the unfiltered column, so an active filter no longer causes a redundant grouping write.

### Internals

- Add a reusable `SelectionStore` in `widgets/react/selection.ts`, an external store read through `useSyncExternalStore` so that selecting a card wakes only that card.
- Add `services/note_set.ts`, holding the consensus reader `shared()` and the fan-out writers for labels and the archived state.
- Widen `buildAttributeMenuItems` and `getArchiveMenuItems` to take a list of notes, updating the calendar collection accordingly.
- Generalise `applyCardMove` into `applyCardMoves`, which places a set of cards at one index in a single pass.
