### PR TITLE
fix(export): keep the space after an inline tag the pretty-printer wraps inside of

### DIFF
--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI.html
@@ -7,9 +7,9 @@
   you pick also decides where your notes travel: a cloud API billed per use,
   a subscription you already pay for, or a model running on your own hardware,
   in which case nothing leaves the machine. See&nbsp;<a class="reference-link"
-  href="#root/_help_bkPZAMT7d2sR">Providers</a>&nbsp;for what each involves, and&nbsp;
-  <a
-  class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for exactly what gets sent.</p>
+  href="#root/_help_bkPZAMT7d2sR">Providers</a>&nbsp;for what each involves, and&nbsp;<a
+  class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for exactly
+  what gets sent.</p>
 <p>Once enabled, the assistant is available as:</p>
 <ul>
   <li>As a dedicated note type, it can read and modify notes through tools,
@@ -119,141 +119,141 @@
 class="admonition note">
   <p>Currently only the search native to the LLM provider is supported. External
     search providers such as Exa, Tavily &amp; SearXNG are not yet supported.</p>
-  </aside>
-  <h3>Note access (tools)</h3>
-  <p>Tools allow the agentic AI to understand and operate on notes directly
-    within your Trilium instance.</p>
-  <p>This feature is on by default but it can easily be disabled by clicking
-    on the model selector at the bottom of the chat and unchecking <em>Note access</em>.</p>
-  <p>Here are a few tools that Trilium provides for the LLM:</p>
-  <ul>
-    <li>At note level:
-      <ul>
-        <li>Search for notes</li>
-        <li>Get the metadata or content of a note.</li>
-        <li>Edit a note
-          <ul>
-            <li>There are multiple mechanism for the LLM to edit a note: completely by
-              re-writing it, find/replace of a text sequence or append.</li>
-            <li>Whenever the AI makes a change, a <a href="#root/_help_vZWERwf8U3nx">revision</a> is
-              saved to be able to revert any unwanted changes.</li>
-          </ul>
-        </li>
-        <li>Create a new note</li>
-        <li>Rename or delete a note.</li>
-      </ul>
-    </li>
-    <li>At attribute level:
-      <ul>
-        <li>Get the full list of attributes, or a specific attribute.</li>
-        <li>Set the value of an attribute.</li>
-        <li>Delete an attribute.</li>
-      </ul>
-    </li>
-    <li>At tree level:
-      <ul>
-        <li>Get the direct children of a note.</li>
-        <li>Get the entire subtree of a note.</li>
-        <li>Move or clone a note somewhere else.</li>
-      </ul>
-    </li>
-    <li>For&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>:
-      <ul>
-        <li>Get metadata for an attachment.</li>
-        <li>Get the content of an attachment.</li>
-      </ul>
-    </li>
-    <li>Skills (see the dedicated section).</li>
-  </ul>
-  <aside class="admonition warning">
-    <p>Currently there is <strong>no permission management</strong> implemented
-      for note tools, meaning that the LLM could potentially remove existing
-      notes or clutter the tree with notes. Generally most actions are easily
-      reversible (deleting the notes, restoring deleted notes, reverting modifications
-      to a note), but there are some that are harder to revert (e.g. setting
-      an attribute because there is no attribute history).</p>
-  </aside>
-  <aside class="admonition note">
-    <p>Gemini has a special case in which <em>Note access</em> and <em>Web search</em> can't
-      be both enabled at the same time.</p>
-  </aside>
-  <h3>Attachments</h3>
-  <p>Since Trilium v0.140.0,&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;allow
-    for multi-modal chat:</p>
-  <ul>
-    <li>Raster image (sent as vision input, except for SVGs) with the following
-      supported formats: PNG, JPEG, GIF, WebP.</li>
-    <li>PDFs, sent natively to the provider (supported by Anthropic, OpenAI and
-      Google).</li>
-    <li>SVG images (sent as raw HTML).</li>
-    <li>Text files.</li>
-  </ul>
-  <p>To upload an attachment:</p>
-  <ul>
-    <li>Press the dedicated <em>Attach</em> button (paperclip icon) underneath the
-      text box.</li>
-    <li>Paste an image directly from clipboard using Ctrl+V.</li>
-  </ul>
-  <p>Once one or more attachments are uploaded, they will appear directly above
-    the text box:</p>
-  <ul>
-    <li>Images have a small thumbnail for easy identifications.</li>
-    <li>Every attachment can be deleted by pressing their corresponding X button.</li>
-  </ul>
-  <p>When an attachment is present, the LLM is instructed to consider the attachment
-    with priority, even if it has access to the current note.</p>
-  <aside class="admonition note">
-    <p>Currently Trilium doesn't pre-process the attachments (e.g. via&nbsp;
-      <a
-      class="reference-link" href="#root/_help_TiQbQDgP8L5t">Text Extraction (OCR)</a>) before sending them to the LLM provider.</p>
-  </aside>
-  <h3>Mentions</h3>
-  <p>Mentions are a way to insert references to notes other than the current
-    note, using the same mechanism as&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>.
-    To refer to another note, simply type @ followed by the name of the note
-    to reference.</p>
-  <p>This feature is mostly helpful when note tools are enabled, otherwise
-    the LLM will have no way to access the given note.</p>
-  <h3>Skills</h3>
-  <p>Skills in Trilium are specialized instruction sets that help the AI be
-    more productive by understanding how Trilium.</p>
-  <p>These skills are not loaded by default to avoid an increased consumption
-    of tokens, but the AI can load them on-demand if <em>Note tools</em> are
-    enabled.</p>
-  <p>The following skills are built-in:</p>
-  <ul>
-    <li>Search syntax: understands the full syntax of&nbsp;<a class="reference-link"
-      href="#root/_help_eIg8jdvaoNNd">Search</a>.</li>
-    <li>Backend scripting: to be able to write proper&nbsp;<a class="reference-link"
-      href="#root/_help_SPirpZypehBG">Backend scripts</a>.</li>
-    <li>Frontend scripting: to be able to write proper <a href="#root/_help_yIhgI5H7A2Sm">front-end scripts</a> (basic
-      scripts, widgets,&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>).</li>
-  </ul>
-  <p>When <em>Note tools</em> are enabled the skills will automatically be made
-    available to the AI, so no user interaction is required.</p>
-  <aside class="admonition note">
-    <p>Custom skills are currently not supported but they are planned.</p>
-  </aside>
-  <h3>MCP</h3>
-  <p>Trilium comes with a built-in MCP server which allows you to use an external
-    agent such as Claude Code have access to your database. See the dedicated&nbsp;
-    <a
-    class="reference-link" href="#root/_help_KOWBFgsZXJAD">MCP</a>&nbsp;page for more details.</p>
-  <h2>History</h2>
-  <h3>Removal in v0.102.0</h3>
-  <p>Starting with version v0.102.0, AI/LLM integration has been removed from
-    the Trilium Notes core.</p>
-  <p>While a significant amount of effort went into developing this feature,
-    maintaining and supporting it long-term proved to be unsustainable.</p>
-  <p>When upgrading to v0.102.0, your Chat notes will be preserved, but instead
-    of the dedicated chat window they will be turned to a normal&nbsp;<a class="reference-link"
-    href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note, revealing the underlying
-    JSON of the conversation.</p>
-  <h3>Reintroduction in v0.103.0</h3>
-  <p>Given the recent advancements of the AI scene, we decided to give the
-    LLM integration another try. v0.103.0 introduces a completely new chat
-    system.</p>
-  <p>One of the key changes that lead to the reimplementation is that now we
-    are using a library (<a href="https://github.com/vercel/ai">Vercel AI</a>)
-    to manage the inner mechanism and the differences between LLM providers
-    instead of having to implement it on our own.</p>
+</aside>
+<h3>Note access (tools)</h3>
+<p>Tools allow the agentic AI to understand and operate on notes directly
+  within your Trilium instance.</p>
+<p>This feature is on by default but it can easily be disabled by clicking
+  on the model selector at the bottom of the chat and unchecking <em>Note access</em>.</p>
+<p>Here are a few tools that Trilium provides for the LLM:</p>
+<ul>
+  <li>At note level:
+    <ul>
+      <li>Search for notes</li>
+      <li>Get the metadata or content of a note.</li>
+      <li>Edit a note
+        <ul>
+          <li>There are multiple mechanism for the LLM to edit a note: completely by
+            re-writing it, find/replace of a text sequence or append.</li>
+          <li>Whenever the AI makes a change, a <a href="#root/_help_vZWERwf8U3nx">revision</a> is
+            saved to be able to revert any unwanted changes.</li>
+        </ul>
+      </li>
+      <li>Create a new note</li>
+      <li>Rename or delete a note.</li>
+    </ul>
+  </li>
+  <li>At attribute level:
+    <ul>
+      <li>Get the full list of attributes, or a specific attribute.</li>
+      <li>Set the value of an attribute.</li>
+      <li>Delete an attribute.</li>
+    </ul>
+  </li>
+  <li>At tree level:
+    <ul>
+      <li>Get the direct children of a note.</li>
+      <li>Get the entire subtree of a note.</li>
+      <li>Move or clone a note somewhere else.</li>
+    </ul>
+  </li>
+  <li>For&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>:
+    <ul>
+      <li>Get metadata for an attachment.</li>
+      <li>Get the content of an attachment.</li>
+    </ul>
+  </li>
+  <li>Skills (see the dedicated section).</li>
+</ul>
+<aside class="admonition warning">
+  <p>Currently there is <strong>no permission management</strong> implemented
+    for note tools, meaning that the LLM could potentially remove existing
+    notes or clutter the tree with notes. Generally most actions are easily
+    reversible (deleting the notes, restoring deleted notes, reverting modifications
+    to a note), but there are some that are harder to revert (e.g. setting
+    an attribute because there is no attribute history).</p>
+</aside>
+<aside class="admonition note">
+  <p>Gemini has a special case in which <em>Note access</em> and <em>Web search</em> can't
+    be both enabled at the same time.</p>
+</aside>
+<h3>Attachments</h3>
+<p>Since Trilium v0.140.0,&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;allow
+  for multi-modal chat:</p>
+<ul>
+  <li>Raster image (sent as vision input, except for SVGs) with the following
+    supported formats: PNG, JPEG, GIF, WebP.</li>
+  <li>PDFs, sent natively to the provider (supported by Anthropic, OpenAI and
+    Google).</li>
+  <li>SVG images (sent as raw HTML).</li>
+  <li>Text files.</li>
+</ul>
+<p>To upload an attachment:</p>
+<ul>
+  <li>Press the dedicated <em>Attach</em> button (paperclip icon) underneath the
+    text box.</li>
+  <li>Paste an image directly from clipboard using Ctrl+V.</li>
+</ul>
+<p>Once one or more attachments are uploaded, they will appear directly above
+  the text box:</p>
+<ul>
+  <li>Images have a small thumbnail for easy identifications.</li>
+  <li>Every attachment can be deleted by pressing their corresponding X button.</li>
+</ul>
+<p>When an attachment is present, the LLM is instructed to consider the attachment
+  with priority, even if it has access to the current note.</p>
+<aside class="admonition note">
+  <p>Currently Trilium doesn't pre-process the attachments (e.g. via&nbsp;<a
+    class="reference-link" href="#root/_help_TiQbQDgP8L5t">Text Extraction (OCR)</a>)
+    before sending them to the LLM provider.</p>
+</aside>
+<h3>Mentions</h3>
+<p>Mentions are a way to insert references to notes other than the current
+  note, using the same mechanism as&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>.
+  To refer to another note, simply type @ followed by the name of the note
+  to reference.</p>
+<p>This feature is mostly helpful when note tools are enabled, otherwise
+  the LLM will have no way to access the given note.</p>
+<h3>Skills</h3>
+<p>Skills in Trilium are specialized instruction sets that help the AI be
+  more productive by understanding how Trilium.</p>
+<p>These skills are not loaded by default to avoid an increased consumption
+  of tokens, but the AI can load them on-demand if <em>Note tools</em> are
+  enabled.</p>
+<p>The following skills are built-in:</p>
+<ul>
+  <li>Search syntax: understands the full syntax of&nbsp;<a class="reference-link"
+    href="#root/_help_eIg8jdvaoNNd">Search</a>.</li>
+  <li>Backend scripting: to be able to write proper&nbsp;<a class="reference-link"
+    href="#root/_help_SPirpZypehBG">Backend scripts</a>.</li>
+  <li>Frontend scripting: to be able to write proper <a href="#root/_help_yIhgI5H7A2Sm">front-end scripts</a> (basic
+    scripts, widgets,&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>).</li>
+</ul>
+<p>When <em>Note tools</em> are enabled the skills will automatically be made
+  available to the AI, so no user interaction is required.</p>
+<aside class="admonition note">
+  <p>Custom skills are currently not supported but they are planned.</p>
+</aside>
+<h3>MCP</h3>
+<p>Trilium comes with a built-in MCP server which allows you to use an external
+  agent such as Claude Code have access to your database. See the dedicated&nbsp;<a
+  class="reference-link" href="#root/_help_KOWBFgsZXJAD">MCP</a>&nbsp;page for
+  more details.</p>
+<h2>History</h2>
+<h3>Removal in v0.102.0</h3>
+<p>Starting with version v0.102.0, AI/LLM integration has been removed from
+  the Trilium Notes core.</p>
+<p>While a significant amount of effort went into developing this feature,
+  maintaining and supporting it long-term proved to be unsustainable.</p>
+<p>When upgrading to v0.102.0, your Chat notes will be preserved, but instead
+  of the dedicated chat window they will be turned to a normal&nbsp;<a class="reference-link"
+  href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note, revealing the underlying
+  JSON of the conversation.</p>
+<h3>Reintroduction in v0.103.0</h3>
+<p>Given the recent advancements of the AI scene, we decided to give the
+  LLM integration another try. v0.103.0 introduces a completely new chat
+  system.</p>
+<p>One of the key changes that lead to the reimplementation is that now we
+  are using a library (<a href="https://github.com/vercel/ai">Vercel AI</a>)
+  to manage the inner mechanism and the differences between LLM providers
+  instead of having to implement it on our own.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/MCP.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/MCP.html
@@ -18,12 +18,10 @@
   authentication. Generally MCP servers need to support OAuth for authentication,
   but Trilium uses a simpler mechanism using Bearer tokens.</p>
 <p>To configure authentication, first create an&nbsp;<a class="reference-link"
-  href="#root/_help_pgxEVkzLl1OP">ETAPI (REST API)</a>&nbsp;token by going to&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>ETAPI</em>. Then follow the instructions in&nbsp;
-    <a
-    class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>AI / LLM</em>, by looking at the <em>How to connect an assistant</em> section
-      under MCP.</p>
+  href="#root/_help_pgxEVkzLl1OP">ETAPI (REST API)</a>&nbsp;token by going to&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>ETAPI</em>.
+  Then follow the instructions in&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>AI / LLM</em>,
+  by looking at the <em>How to connect an assistant</em> section under MCP.</p>
 <h2>Third-party alternatives</h2>
 <p>The following are alternatives to Trilium's built-in MCP feature. Since
   Trilium's AI implementation is still experimental, its tooling might not

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Privacy.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Privacy.html
@@ -133,10 +133,10 @@
 <h2>Telemetry &amp; security</h2>
 <p>Trilium itself collects no telemetry from the AI integration.</p>
 <p>Your API key is stored in your database, sent only to the provider it
-  belongs to, and is write-only through the options API so that a malevolent&nbsp;
-  <a
-  class="reference-link" href="#root/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;cannot access it. If you have backend or SQL console
-    access enabled, a malevolent script <strong>could potentially exfiltrate your API keys</strong>.</p>
+  belongs to, and is write-only through the options API so that a malevolent&nbsp;<a
+  class="reference-link" href="#root/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;cannot
+  access it. If you have backend or SQL console access enabled, a malevolent
+  script <strong>could potentially exfiltrate your API keys</strong>.</p>
 <p>The built-in MCP server is off by default. When enabled, every request
   must carry an ETAPI token, which grants the same full read and write access
   to your notes as the REST API; treat one like a password. On desktop it

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/AI/Providers.html
@@ -56,10 +56,9 @@
   <li>By looking for <code spellcheck="false">claude</code> in your PATH, generally
     works in most circumstances.</li>
   <li>By asking your login shell for its <code spellcheck="false">PATH</code> which
-    lets a desktop install find a CLI installed through <code spellcheck="false">nvm</code>,
-    <code
-    spellcheck="false">fnm</code>, <code spellcheck="false">asdf</code> or Homebrew, since a GUI-launched
-      app doesn't inherit your terminal's environment.</li>
+    lets a desktop install find a CLI installed through <code spellcheck="false">nvm</code>, <code
+    spellcheck="false">fnm</code>, <code spellcheck="false">asdf</code> or Homebrew,
+    since a GUI-launched app doesn't inherit your terminal's environment.</li>
 </ul>
 <p>After your provider is set up, you'll benefit from the same features as
   an API key (note tools, web search, extended thinking, image/PDF attachments,
@@ -111,9 +110,9 @@
 <p>This allows you to set the base URL to an OpenAI-compatible API, with
   an optional API key if required by the service.</p>
 <p>Enter the base URL exactly as the service documents it, including its
-  version path, such as <code spellcheck="false">https://api.groq.com/openai/v1</code>
-  or <code spellcheck="false">https://open.bigmodel.cn/api/paas/v4</code>. Only
-  a bare host such as <code spellcheck="false">http://localhost:8080</code> is
+  version path, such as <code spellcheck="false">https://api.groq.com/openai/v1</code> or <code
+  spellcheck="false">https://open.bigmodel.cn/api/paas/v4</code>. Only a
+  bare host such as <code spellcheck="false">http://localhost:8080</code> is
   completed with <code spellcheck="false">/v1</code>.</p>
 <p>For custom endpoints, the pricing of the models is not known so the cost
   of a conversation will not be displayed; this is especially relevant for

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases.html
@@ -1,7 +1,6 @@
-<p>Trilium offers advanced functionality through <a href="#root/_help_CdNpE2pqjmI6">Scripts</a> and
-  <a
-  href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>. To illustrate these features, we've prepared
-    several showcases available in the <a href="#root/_help_wX4HbRucYSDD">demo notes</a>:</p>
+<p>Trilium offers advanced functionality through <a href="#root/_help_CdNpE2pqjmI6">Scripts</a> and <a
+  href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>. To illustrate these
+  features, we've prepared several showcases available in the <a href="#root/_help_wX4HbRucYSDD">demo notes</a>:</p>
 <ul>
   <li><a href="#root/_help_iRwzGnHPzonm">Relation Map</a>
   </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Day Notes.html
@@ -28,13 +28,12 @@
   where you can track your daily weight. This data is then used in <a href="#root/_help_R7abl2fc6Mxi">Weight tracker</a>.</p>
 <h2>Week Note and Quarter Note</h2>
 <p>Week and quarter notes are disabled by default, since it might be too
-  much for some people. To enable them, you need to set <code spellcheck="false">#enableWeekNote</code> and
-  <code
-  spellcheck="false">#enableQuarterNote</code>attributes on the root calendar note, which is
-    identified by <code spellcheck="false">#calendarRoot</code> label. Week note
-    is affected by the first week of year option. Be careful when you already
-    have some week notes created, it will not automatically change the existing
-    week notes and might lead to some duplicates.</p>
+  much for some people. To enable them, you need to set <code spellcheck="false">#enableWeekNote</code> and <code
+  spellcheck="false">#enableQuarterNote</code> attributes on the root calendar
+  note, which is identified by <code spellcheck="false">#calendarRoot</code> label.
+  Week note is affected by the first week of year option. Be careful when
+  you already have some week notes created, it will not automatically change
+  the existing week notes and might lead to some duplicates.</p>
 <h2>Templates</h2>
 <p>Trilium provides <a href="#root/_help_KC1HB96bqqHX">template</a> functionality,
   and it could be used together with day notes.</p>
@@ -49,39 +48,34 @@
   <li>dateTemplate</li>
 </ul>
 <p>All of these are relations. When Trilium creates a new note for year or
-  month or date, it will take a look at the root and attach a corresponding
-  <code
-  spellcheck="false">~template</code>relation to the newly created role. Using this, you can
-    e.g. create your daily template with e.g. checkboxes for daily routine
-    etc.</p>
+  month or date, it will take a look at the root and attach a corresponding <code
+  spellcheck="false">~template</code> relation to the newly created role.
+  Using this, you can e.g. create your daily template with e.g. checkboxes
+  for daily routine etc.</p>
 <h3>Migrate from old template usage</h3>
 <p>If you have been using Journal prior to version v0.93.0, the previous
   template pattern likely used was <code spellcheck="false">~child:template=</code>.
   <br>To transition to the new system:</p>
 <ol>
   <li>Set up the new template pattern in the Calendar root note.</li>
-  <li>Use <a href="#root/_help_ivYnonVFBxbQ">Bulk Actions</a> to remove <code spellcheck="false">child:template</code> and
-    <code
-    spellcheck="false">child:child:template</code>from all notes under the Journal (calendar
-      root).</li>
+  <li>Use <a href="#root/_help_ivYnonVFBxbQ">Bulk Actions</a> to remove <code spellcheck="false">child:template</code> and <code
+    spellcheck="false">child:child:template</code> from all notes under the
+    Journal (calendar root).</li>
   <li>Ensure that all old template patterns are fully removed to prevent conflicts
     with the new setup.</li>
 </ol>
 <h2>Naming pattern</h2>
-<p>You can customize the title of generated journal notes by defining a
-  <code
-  spellcheck="false">#datePattern</code>, <code spellcheck="false">#weekPattern</code>,
-    <code
-    spellcheck="false">#monthPattern</code>, <code spellcheck="false">#quarterPattern</code> and
-      <code
-      spellcheck="false">#yearPattern</code>attribute on a root calendar note (identified by
-        <code
-        spellcheck="false">#calendarRoot</code>label). The naming pattern replacements follow a level-up
-          compatibility - each level can use replacements from itself and all levels
-          above it. For example, <code spellcheck="false">#monthPattern</code> can
-          use month, quarter and year replacements, while <code spellcheck="false">#weekPattern</code> can
-          use week, month, quarter and year replacements. But it is not possible
-          to use week replacements in <code spellcheck="false">#monthPattern</code>.</p>
+<p>You can customize the title of generated journal notes by defining a <code
+  spellcheck="false">#datePattern</code>, <code spellcheck="false">#weekPattern</code>, <code
+  spellcheck="false">#monthPattern</code>, <code spellcheck="false">#quarterPattern</code> and <code
+  spellcheck="false">#yearPattern</code> attribute on a root calendar note
+  (identified by <code spellcheck="false">#calendarRoot</code> label). The
+  naming pattern replacements follow a level-up compatibility - each level
+  can use replacements from itself and all levels above it. For example, <code
+  spellcheck="false">#monthPattern</code> can use month, quarter and year
+  replacements, while <code spellcheck="false">#weekPattern</code> can use
+  week, month, quarter and year replacements. But it is not possible to use
+  week replacements in <code spellcheck="false">#monthPattern</code>.</p>
 <h3>Date pattern</h3>
 <p>It's possible to customize the title of generated date notes by defining
   a <code spellcheck="false">#datePattern</code> attribute on a root calendar
@@ -90,14 +84,12 @@
 <ul>
   <li><code spellcheck="false">{isoDate}</code> results in an ISO 8061 formatted
     date (e.g. "2025-03-09" for March 9, 2025)</li>
-  <li><code spellcheck="false">{dateNumber}</code> results in a number like
-    <code
-    spellcheck="false">9</code>for the 9th day of the month, <code spellcheck="false">11</code> for
-      the 11th day of the month</li>
+  <li><code spellcheck="false">{dateNumber}</code> results in a number like <code
+    spellcheck="false">9</code> for the 9th day of the month, <code spellcheck="false">11</code> for
+    the 11th day of the month</li>
   <li><code spellcheck="false">{dateNumberPadded}</code> results in a number
-    like <code spellcheck="false">09</code> for the 9th day of the month,
-    <code
-    spellcheck="false">11</code>for the 11th day of the month</li>
+    like <code spellcheck="false">09</code> for the 9th day of the month, <code
+    spellcheck="false">11</code> for the 11th day of the month</li>
   <li><code spellcheck="false">{ordinal}</code> is replaced with the ordinal
     date (e.g. 1st, 2nd, 3rd) etc.</li>
   <li><code spellcheck="false">{weekDay}</code> results in the full day name
@@ -114,22 +106,18 @@
   the <code spellcheck="false">#weekPattern</code> attribute on the root calendar
   note. The options are:</p>
 <ul>
-  <li><code spellcheck="false">{weekNumber}</code> results in a number like
-    <code
-    spellcheck="false">9</code>for the 9th week of the year, <code spellcheck="false">11</code> for
-      the 11th week of the year</li>
+  <li><code spellcheck="false">{weekNumber}</code> results in a number like <code
+    spellcheck="false">9</code> for the 9th week of the year, <code spellcheck="false">11</code> for
+    the 11th week of the year</li>
   <li><code spellcheck="false">{weekNumberPadded}</code> results in a number
-    like <code spellcheck="false">09</code> for the 9th week of the year,
-    <code
-    spellcheck="false">11</code>for the 11th week of the year</li>
+    like <code spellcheck="false">09</code> for the 9th week of the year, <code
+    spellcheck="false">11</code> for the 11th week of the year</li>
   <li><code spellcheck="false">{shortWeek}</code> results in a short week string
-    like <code spellcheck="false">W9</code> for the 9th week of the year,
-    <code
-    spellcheck="false">W11</code>for the 11th week of the year</li>
+    like <code spellcheck="false">W9</code> for the 9th week of the year, <code
+    spellcheck="false">W11</code> for the 11th week of the year</li>
   <li><code spellcheck="false">{shortWeek3}</code> results in a short week string
-    like <code spellcheck="false">W09</code> for the 9th week of the year,
-    <code
-    spellcheck="false">W11</code>for the 11th week of the year</li>
+    like <code spellcheck="false">W09</code> for the 9th week of the year, <code
+    spellcheck="false">W11</code> for the 11th week of the year</li>
 </ul>
 <p>The default is <code spellcheck="false">Week {weekNumber}</code>
 </p>
@@ -140,9 +128,9 @@
 <ul>
   <li><code spellcheck="false">{isoMonth}</code> results in an ISO 8061 formatted
     month (e.g. "2025-03" for March 2025)</li>
-  <li><code spellcheck="false">{monthNumber}</code> results in a number like
-    <code
-    spellcheck="false">9</code>for September, and <code spellcheck="false">11</code> for November</li>
+  <li><code spellcheck="false">{monthNumber}</code> results in a number like <code
+    spellcheck="false">9</code> for September, and <code spellcheck="false">11</code> for
+    November</li>
   <li><code spellcheck="false">{monthNumberPadded}</code> results in a number
     like <code spellcheck="false">09</code> for September, and <code spellcheck="false">11</code> for
     November</li>
@@ -160,9 +148,8 @@
   through the <code spellcheck="false">#quarterPattern</code> attribute on
   the root calendar note. The options are:</p>
 <ul>
-  <li><code spellcheck="false">{quarterNumber}</code> results in a number like
-    <code
-    spellcheck="false">1</code>for the 1st quarter of the year</li>
+  <li><code spellcheck="false">{quarterNumber}</code> results in a number like <code
+    spellcheck="false">1</code> for the 1st quarter of the year</li>
   <li><code spellcheck="false">{shortQuarter}</code> results in a short quarter
     string like <code spellcheck="false">Q1</code> for the 1st quarter of the
     year</li>
@@ -174,8 +161,7 @@
   the <code spellcheck="false">#yearPattern</code> attribute on the root calendar
   note. The options are:</p>
 <ul>
-  <li><code spellcheck="false">{year}</code> results in the full year (e.g.
-    <code
+  <li><code spellcheck="false">{year}</code> results in the full year (e.g. <code
     spellcheck="false">2025</code>)</li>
 </ul>
 <p>The default is <code spellcheck="false">{year}</code>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Task Manager.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Task Manager.html
@@ -1,5 +1,4 @@
-<p>Task Manager is a <a href="#root/_help_OFXdgB2nNk1F">promoted attributes</a> and
-  <a
+<p>Task Manager is a <a href="#root/_help_OFXdgB2nNk1F">promoted attributes</a> and <a
   href="#root/_help_CdNpE2pqjmI6">scripts</a>showcase present in the <a href="#root/_help_wX4HbRucYSDD">demo notes</a>.</p>
 <h2>Demo</h2>
 <p>
@@ -14,10 +13,9 @@
   note and doneDate note (with <a href="#root/_help_kBrnXNG3Hplm">prefix</a> of either
   "TODO" or "DONE").</p>
 <h2>Implementation</h2>
-<p>New tasks are created in the TODO note which has <code spellcheck="false">~child:template</code> 
-  <a
+<p>New tasks are created in the TODO note which has <code spellcheck="false">~child:template</code>  <a
   href="#root/_help_zEY4DaJG4YT5">relation</a>(see <a href="#root/_help_bwZpz2ajCEwO">attribute inheritance</a>)
-    pointing to the task template.</p>
+  pointing to the task template.</p>
 <h3>Attributes</h3>
 <p>Task template defines several <a href="#root/_help_OFXdgB2nNk1F">promoted attributes</a> -
   todoDate, doneDate, tags, location. Importantly it also defines <code spellcheck="false">~runOnAttributeChange</code> relation
@@ -56,10 +54,9 @@
 span.fancytree-node.done .fancytree-title {
     color: green !important;
 }</code></pre>
-<p>This <a href="#root/_help_6f9hih2hXXZk">code note</a> has <code spellcheck="false">#appCss</code> 
-  <a
-  href="#root/_help_zEY4DaJG4YT5">label</a>which is recognized by Trilium on startup and loaded as CSS into
-    the application.</p>
+<p>This <a href="#root/_help_6f9hih2hXXZk">code note</a> has <code spellcheck="false">#appCss</code>  <a
+  href="#root/_help_zEY4DaJG4YT5">label</a>which is recognized by Trilium on startup
+  and loaded as CSS into the application.</p>
 <p>Second part of this functionality is based in event handler described
   above which assigns <code spellcheck="false">#cssClass</code> label to the
   task to either "done" or "todo" based on the task status.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Weight Tracker.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Advanced Showcases/Weight Tracker.html
@@ -16,13 +16,12 @@
   In this example, it's the <code spellcheck="false">Weight Tracker</code>'s
   child <code spellcheck="false">Implementation</code>. The Implementation
   consists of two <a href="#root/_help_6f9hih2hXXZk">code notes</a> that contain
-  some HTML and JavaScript respectively, which load all the notes with a
-  <code
-  spellcheck="false">weight</code>attribute and display their values in a chart.</p>
-<p>To actually render the chart, we're using a third party library called
-  <a
-  href="https://www.chartjs.org/">chart.js</a>which is imported as an attachment, since it's not built into
-    Trilium.</p>
+  some HTML and JavaScript respectively, which load all the notes with a <code
+  spellcheck="false">weight</code> attribute and display their values in a
+  chart.</p>
+<p>To actually render the chart, we're using a third party library called <a
+  href="https://www.chartjs.org/">chart.js</a>which is imported as an attachment,
+  since it's not built into Trilium.</p>
 <h3>Code</h3>
 <p>Here's the content of the script which is placed in a <a href="#root/_help_6f9hih2hXXZk">code note</a> of
   type <code spellcheck="false">JS Frontend</code>:</p><pre><code class="language-text-x-trilium-auto">async function getChartData() {

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes.html
@@ -16,8 +16,7 @@
     <p><a class="reference-link" href="#root/_help_Cq5X6iKQop6R">Relations</a>&nbsp;define
       connections between notes, similar to links. These can be used for metadata
       and scripting purposes.</p>
-    <p>For more information, including a list of predefined relations, see&nbsp;
-      <a
+    <p>For more information, including a list of predefined relations, see&nbsp;<a
       class="reference-link" href="#root/_help_Cq5X6iKQop6R">Relations</a>.</p>
   </li>
 </ol>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Attribute Inheritance.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Attribute Inheritance.html
@@ -3,16 +3,14 @@
   generally in parent-child relations (or anywhere if using templates).</p>
 <h2>Standard Inheritance</h2>
 <p>In Trilium, attributes can be automatically inherited by child notes if
-  they have the <code spellcheck="false">isInheritable</code> flag set to
-  <code
-  spellcheck="false">true</code>. This means the attribute (a key-value pair) is applied to
-    the note and all its descendants.</p>
-<p>To make an attribute inheritable, simply use the visual editor for&nbsp;
-  <a
-  class="reference-link" href="#root/_help_HI6GBBIduIgv">Labels</a>&nbsp;or&nbsp;<a class="reference-link" href="#root/_help_Cq5X6iKQop6R">Relations</a>.
-    Alternatively, the attribute can be manually defined where <code spellcheck="false">#myLabel=value</code> becomes
-    <code
-    spellcheck="false">#myLabel(inheritable)=value</code>when inheritable.</p>
+  they have the <code spellcheck="false">isInheritable</code> flag set to <code
+  spellcheck="false">true</code>. This means the attribute (a key-value pair)
+  is applied to the note and all its descendants.</p>
+<p>To make an attribute inheritable, simply use the visual editor for&nbsp;<a
+  class="reference-link" href="#root/_help_HI6GBBIduIgv">Labels</a>&nbsp;or&nbsp;<a
+  class="reference-link" href="#root/_help_Cq5X6iKQop6R">Relations</a>. Alternatively,
+  the attribute can be manually defined where <code spellcheck="false">#myLabel=value</code> becomes <code
+  spellcheck="false">#myLabel(inheritable)=value</code> when inheritable.</p>
 <p>As an example, the <code spellcheck="false">archived</code> label can be
   set to be inheritable, allowing you to hide a whole subtree of notes from
   searches and other dialogs by applying this label at the top level.</p>
@@ -21,12 +19,11 @@
   to have some notes not inherit one of the labels, then <em>copying inheritance</em> or <em>template inheritance</em> needs
   to be used instead.</p>
 <h2>Copying Inheritance</h2>
-<p>Copying inheritance differs from standard inheritance by using a
-  <code
-  spellcheck="false">child:</code>prefix in the attribute name. This prefix causes new child
-    notes to automatically receive specific attributes from the parent note.
-    These attributes are independent of the parent and will persist even if
-    the note is moved elsewhere.</p>
+<p>Copying inheritance differs from standard inheritance by using a <code
+  spellcheck="false">child:</code> prefix in the attribute name. This prefix
+  causes new child notes to automatically receive specific attributes from
+  the parent note. These attributes are independent of the parent and will
+  persist even if the note is moved elsewhere.</p>
 <p>If a parent note has the label <code spellcheck="false">#child:exampleAttribute</code>,
   all newly created child notes (one level deep) will inherit the <code spellcheck="false">#exampleAttribute</code> label.
   This can be useful for setting default properties for notes in a specific
@@ -36,9 +33,9 @@
   infinitely within a hierarchy. For that use case, consider using either
   standard inheritance or templates.</p>
 <h3>Chained inheritance</h3>
-<p>It is possible to define labels across multiple levels of depth. For example,
-  <code
-  spellcheck="false">#child:child:child:foo</code>applied to a root note would create:</p>
+<p>It is possible to define labels across multiple levels of depth. For example, <code
+  spellcheck="false">#child:child:child:foo</code> applied to a root note
+  would create:</p>
 <ul>
   <li><code spellcheck="false">#child:child:foo</code> on the first-level children.</li>
   <li><code spellcheck="false">#child:foo</code> on the second-level children.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Labels.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Labels.html
@@ -3,11 +3,10 @@
 <h2>Common use cases</h2>
 <ul>
   <li><strong>Metadata for personal use</strong>: Assign labels with optional
-    values for categorization, such as <code spellcheck="false">#year=1999</code>,
-    <code
+    values for categorization, such as <code spellcheck="false">#year=1999</code>, <code
     spellcheck="false">#genre="sci-fi"</code>, or <code spellcheck="false">#author="Neal Stephenson"</code>.
-      This can be combined with&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;to
-      make their display more user-friendly.</li>
+    This can be combined with&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;to
+    make their display more user-friendly.</li>
   <li><strong>Configuration</strong>: Labels can configure advanced features
     or settings (see reference below).</li>
   <li><strong>Scripts and Plugins</strong>: Used to tag notes with special metadata,
@@ -95,8 +94,7 @@
         <td>Excludes this note and its children when exporting.</td>
       </tr>
       <tr>
-        <td><code spellcheck="false">run</code>, <code spellcheck="false">runOnInstance</code>,
-          <code
+        <td><code spellcheck="false">run</code>, <code spellcheck="false">runOnInstance</code>, <code
           spellcheck="false">runAtHour</code>
         </td>
         <td>See&nbsp;<a class="reference-link" href="#root/_help_GPERMystNGTB">Backend Events</a>.</td>
@@ -107,11 +105,10 @@
         <td>Scripts with this label won't be included into parent script execution.</td>
       </tr>
       <tr>
-        <td><code spellcheck="false">sorted</code>, <code spellcheck="false">sortDirection</code>,
-          <code
-          spellcheck="false">sortFoldersFirst</code>, <code spellcheck="false">sortNatural</code>,
-            <code
-            spellcheck="false">sortLocale</code>, <code spellcheck="false">top</code>, <code spellcheck="false">bottom</code>
+        <td><code spellcheck="false">sorted</code>, <code spellcheck="false">sortDirection</code>, <code
+          spellcheck="false">sortFoldersFirst</code>, <code spellcheck="false">sortNatural</code>, <code
+          spellcheck="false">sortLocale</code>, <code spellcheck="false">top</code>, <code
+          spellcheck="false">bottom</code>
         </td>
         <td>Manages automatic/permanent sorting. See&nbsp;<a class="reference-link"
           href="#root/_help_aGlEvb9hyDhS">Sorting Notes</a>.</td>
@@ -204,8 +201,7 @@
       <tr>
         <td><code spellcheck="false">searchHome</code>
         </td>
-        <td>New search notes will be created as children of this note (see&nbsp;
-          <a
+        <td>New search notes will be created as children of this note (see&nbsp;<a
           class="reference-link" href="#root/_help_m523cpzocqaD">Saved Search</a>).</td>
       </tr>
       <tr>
@@ -344,28 +340,23 @@
       <tr>
         <td><code spellcheck="false">printPageSize</code>
         </td>
-        <td>When exporting to PDF, changes the size of the page. Supported values:
-          <code
-          spellcheck="false">A0</code>, <code spellcheck="false">A1</code>, <code spellcheck="false">A2</code>,
-            <code
-            spellcheck="false">A3</code>, <code spellcheck="false">A4</code>, <code spellcheck="false">A5</code>,
-              <code
-              spellcheck="false">A6</code>, <code spellcheck="false">Legal</code>, <code spellcheck="false">Letter</code>,
-                <code
-                spellcheck="false">Tabloid</code>, <code spellcheck="false">Ledger</code>.</td>
+        <td>When exporting to PDF, changes the size of the page. Supported values: <code
+          spellcheck="false">A0</code>, <code spellcheck="false">A1</code>, <code spellcheck="false">A2</code>, <code
+          spellcheck="false">A3</code>, <code spellcheck="false">A4</code>, <code spellcheck="false">A5</code>, <code
+          spellcheck="false">A6</code>, <code spellcheck="false">Legal</code>, <code
+          spellcheck="false">Letter</code>, <code spellcheck="false">Tabloid</code>, <code
+          spellcheck="false">Ledger</code>.</td>
       </tr>
       <tr>
         <td><code spellcheck="false">printScale</code>, <code spellcheck="false">printMargins</code>
         </td>
-        <td>Additional printing options, generally configured through the&nbsp;
-          <a
+        <td>Additional printing options, generally configured through the&nbsp;<a
           class="reference-link" href="#root/_help_NRnIZmSMc5sj">Printing &amp; Exporting as PDF</a>&nbsp;dialog.</td>
       </tr>
       <tr>
         <td><code spellcheck="false">geolocation</code>
         </td>
-        <td>Indicates the latitude and longitude of a note, to be displayed in a&nbsp;
-          <a
+        <td>Indicates the latitude and longitude of a note, to be displayed in a&nbsp;<a
           class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>.</td>
       </tr>
       <tr>
@@ -390,19 +381,16 @@
         <td>Defines the URL of the&nbsp;<a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>.</td>
       </tr>
       <tr>
-        <td><code spellcheck="false">tabWidth</code>, <code spellcheck="false">indentWithTabs</code>,
-          <code
+        <td><code spellcheck="false">tabWidth</code>, <code spellcheck="false">indentWithTabs</code>, <code
           spellcheck="false">wrapLines</code>
         </td>
         <td>Per-note Code editor settings: indentation width, indent with tabs vs.
           spaces, and word wrapping. See&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>.</td>
       </tr>
       <tr>
-        <td><code spellcheck="false">datePattern</code>, <code spellcheck="false">weekPattern</code>,
-          <code
-          spellcheck="false">monthPattern</code>, <code spellcheck="false">quarterPattern</code>,
-            <code
-            spellcheck="false">yearPattern</code>
+        <td><code spellcheck="false">datePattern</code>, <code spellcheck="false">weekPattern</code>, <code
+          spellcheck="false">monthPattern</code>, <code spellcheck="false">quarterPattern</code>, <code
+          spellcheck="false">yearPattern</code>
         </td>
         <td>Customizes the title naming pattern of day / week / month / quarter /
           year notes. See&nbsp;<a class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>.</td>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Promoted Attributes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Promoted Attributes.html
@@ -96,8 +96,7 @@
 </ol>
 <h2>How attribute definitions actually work</h2>
 <p>When a new promoted attribute definition is created, it creates a corresponding
-  label prefixed with either <code spellcheck="false">label</code> or
-  <code
+  label prefixed with either <code spellcheck="false">label</code> or <code
   spellcheck="false">relation</code>, depending on the definition type:</p><pre><code class="language-text-x-trilium-auto">#label:myColor(inheritable)="promoted,alias=Color,multi,color"</code></pre>
 <p>The only purpose of the attribute definition is to set up a template.
   If the attribute was marked as promoted, then it's also displayed to the
@@ -157,9 +156,9 @@
     </ul>
   </li>
   <li>The Trilium documentation (which is edited in Trilium) uses a promoted
-    attribute to be able to easily edit the <code spellcheck="false">#shareAlias</code> (see&nbsp;
-    <a
-    class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>) in order to form clean URLs.</li>
+    attribute to be able to easily edit the <code spellcheck="false">#shareAlias</code> (see&nbsp;<a
+    class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>) in order
+    to form clean URLs.</li>
   <li>If you always edit a particular system attribute such as <code spellcheck="false">#color</code>,
     simply create a promoted attribute for it to make it easier.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Relations.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Attributes/Relations.html
@@ -6,11 +6,11 @@
     linking a book note to an author note.
     <br>This can be combined with&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;to
     make their display more user-friendly.</li>
-  <li><strong>Configuration</strong>: For configuring some notes such as&nbsp;
-    <a
-    class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>, or configuring&nbsp;<a class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>&nbsp;or&nbsp;
-      <a
-      class="reference-link" href="#root/_help_KC1HB96bqqHX">Templates</a>&nbsp;(see the list below).</li>
+  <li><strong>Configuration</strong>: For configuring some notes such as&nbsp;<a
+    class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>, or configuring&nbsp;<a
+    class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>&nbsp;or&nbsp;<a
+    class="reference-link" href="#root/_help_KC1HB96bqqHX">Templates</a>&nbsp;(see
+    the list below).</li>
   <li><strong>Scripting</strong>: Attaching scripts to events or conditions
     related to the note.</li>
 </ul>
@@ -46,14 +46,12 @@
       <li>Type the title of the note to point to and press <kbd>Enter</kbd> to confirm
         (or click the desired note).</li>
       <li>Alternatively copy a note from the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;and
-        paste it after the <code spellcheck="false">=</code> sign (without the
-        <code
+        paste it after the <code spellcheck="false">=</code> sign (without the <code
         spellcheck="false">@</code> , in this case).</li>
     </ul>
   </li>
   <li>To create an inheritable relation, follow the same steps as previously
-    described but instead of <code spellcheck="false">~myRelation</code> write
-    <code
+    described but instead of <code spellcheck="false">~myRelation</code> write <code
     spellcheck="false">~myRelation(inheritable)</code>.</li>
 </ul>
 <h2>Predefined relations</h2>
@@ -114,9 +112,8 @@ class="table">
         <td><code spellcheck="false">shareCss</code>
         </td>
         <td>CSS note which will be injected into the share page. CSS note must be
-          in the shared sub-tree as well. Consider using <code spellcheck="false">shareHiddenFromTree</code> and
-          <code
-          spellcheck="false">shareOmitDefaultCss</code>as well.</td>
+          in the shared sub-tree as well. Consider using <code spellcheck="false">shareHiddenFromTree</code> and <code
+          spellcheck="false">shareOmitDefaultCss</code> as well.</td>
       </tr>
       <tr>
         <td><code spellcheck="false">shareJs</code>
@@ -135,8 +132,7 @@ class="table">
         <td><code spellcheck="false">shareTemplate</code>
         </td>
         <td>Embedded JavaScript note that will be used as the template for displaying
-          the shared note. Falls back to the default template. Consider using
-          <code
+          the shared note. Falls back to the default template. Consider using <code
           spellcheck="false">shareHiddenFromTree</code>.</td>
       </tr>
       <tr>
@@ -148,4 +144,4 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
+</figure>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Bulk Actions.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Bulk Actions.html
@@ -112,15 +112,14 @@
     <ul>
       <li>For each note, it will change the title of the note to the given one.</li>
       <li>As a more advanced use case, the note can be a “template string” which
-        allows for dynamic values with access to the note information via&nbsp;
-        <a
+        allows for dynamic values with access to the note information via&nbsp;<a
         class="reference-link" href="#root/_help_habiZ3HU8Kw8">FNote</a>, for example:
-          <ul>
-            <li><code spellcheck="false">NEW: ${note.title}</code> will prefix all notes
-              with <code spellcheck="false">NEW:</code> .</li>
-            <li><code spellcheck="false">${note.dateCreatedObj.format('MM-DD:')}: ${note.title}</code> will
-              prefix the note titles with each note's creation date (in month-day format).</li>
-          </ul>
+        <ul>
+          <li><code spellcheck="false">NEW: ${note.title}</code> will prefix all notes
+            with <code spellcheck="false">NEW:</code> .</li>
+          <li><code spellcheck="false">${note.dateCreatedObj.format('MM-DD:')}: ${note.title}</code> will
+            prefix the note titles with each note's creation date (in month-day format).</li>
+        </ul>
       </li>
     </ul>
   </li>
@@ -137,14 +136,13 @@
       <li>This allows a note to be converted from one type to another:
         <ul>
           <li><strong>Text Notes → Markdown Notes</strong> — each&nbsp;<a class="reference-link"
-            href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note is converted to a&nbsp;
-            <a
-            class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;note. Since Markdown does not support all the formatting
-              capabilities of Text Notes, some formatting may be lost and some unsupported
-              elements may even be dropped.</li>
+            href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note is converted to a&nbsp;<a
+            class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;note.
+            Since Markdown does not support all the formatting capabilities of Text
+            Notes, some formatting may be lost and some unsupported elements may even
+            be dropped.</li>
           <li><strong>Markdown Notes → Text Notes</strong> — each&nbsp;<a class="reference-link"
-            href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;note is converted to a&nbsp;
-            <a
+            href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;note is converted to a&nbsp;<a
             class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;Note.</li>
         </ul>
       </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Configuration (config.ini or environment variables).html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Configuration (config.ini or environment variables).html
@@ -3,10 +3,10 @@
   for all configuration options.</p>
 <h2>Location of the configuration file</h2>
 <p>The configuration file is not located in the same directory as the application.
-  Instead, the <code spellcheck="false">config.ini</code> is located in the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_tAassRL4RSQL">Data directory</a>. As such, the configuration file is only available
-    after starting the application and creating a database.</p>
+  Instead, the <code spellcheck="false">config.ini</code> is located in the&nbsp;<a
+  class="reference-link" href="#root/_help_tAassRL4RSQL">Data directory</a>. As
+  such, the configuration file is only available after starting the application
+  and creating a database.</p>
 <h2>Configuration Precedence</h2>
 <p>Configuration values are loaded in the following order of precedence (highest
   to lowest):</p>
@@ -25,8 +25,7 @@
 <ul>
   <li><code spellcheck="false">SECTION</code> is the INI section name in UPPERCASE</li>
   <li><code spellcheck="false">KEY</code> is the camelCase configuration key
-    converted to UPPERCASE (e.g., <code spellcheck="false">instanceName</code> →
-    <code
+    converted to UPPERCASE (e.g., <code spellcheck="false">instanceName</code> → <code
     spellcheck="false">INSTANCENAME</code>)</li>
 </ul>
 <p>Additionally, shorter aliases are available for common configurations
@@ -290,8 +289,7 @@
 </ul>
 <h3>Sync Variables</h3>
 <ul>
-  <li><code spellcheck="false">TRILIUM_SYNC_SERVER_HOST</code> (alternative to
-    <code
+  <li><code spellcheck="false">TRILIUM_SYNC_SERVER_HOST</code> (alternative to <code
     spellcheck="false">TRILIUM_SYNC_SYNCSERVERHOST</code>)</li>
   <li><code spellcheck="false">TRILIUM_SYNC_SERVER_TIMEOUT</code> (alternative
     to <code spellcheck="false">TRILIUM_SYNC_SYNCSERVERTIMEOUT</code>)</li>
@@ -300,11 +298,9 @@
 </ul>
 <h3>OAuth/MFA Variables</h3>
 <ul>
-  <li><code spellcheck="false">TRILIUM_OAUTH_BASE_URL</code> (alternative to
-    <code
+  <li><code spellcheck="false">TRILIUM_OAUTH_BASE_URL</code> (alternative to <code
     spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHBASEURL</code>)</li>
-  <li><code spellcheck="false">TRILIUM_OAUTH_CLIENT_ID</code> (alternative to
-    <code
+  <li><code spellcheck="false">TRILIUM_OAUTH_CLIENT_ID</code> (alternative to <code
     spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHCLIENTID</code>)</li>
   <li><code spellcheck="false">TRILIUM_OAUTH_CLIENT_SECRET</code> (alternative
     to <code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHCLIENTSECRET</code>)</li>
@@ -316,8 +312,7 @@
     to <code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHISSUERICON</code>)</li>
   <li><code spellcheck="false">TRILIUM_OAUTH_HTTP_TIMEOUT</code> (alternative
     to <code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHHTTPTIMEOUT</code>)</li>
-  <li><code spellcheck="false">TRILIUM_OAUTH_SCOPE</code> (alternative to
-    <code
+  <li><code spellcheck="false">TRILIUM_OAUTH_SCOPE</code> (alternative to <code
     spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE</code>)</li>
 </ul>
 <h3>Logging Variables</h3>
@@ -328,12 +323,10 @@
 <h2>Boolean Values</h2>
 <p>Boolean environment variables accept the following values:</p>
 <ul>
-  <li><strong>True</strong>: <code spellcheck="false">"true"</code>, <code spellcheck="false">"1"</code>,
-    <code
+  <li><strong>True</strong>: <code spellcheck="false">"true"</code>, <code spellcheck="false">"1"</code>, <code
     spellcheck="false">1</code>
   </li>
-  <li><strong>False</strong>: <code spellcheck="false">"false"</code>, <code spellcheck="false">"0"</code>,
-    <code
+  <li><strong>False</strong>: <code spellcheck="false">"false"</code>, <code spellcheck="false">"0"</code>, <code
     spellcheck="false">0</code>
   </li>
   <li>Any other value defaults to <code spellcheck="false">false</code>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Custom Request Handler.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Custom Request Handler.html
@@ -24,8 +24,7 @@ else {
 }</code></pre>
 <p>This script note has also following two attributes:</p>
 <ul>
-  <li>label <code spellcheck="false">#customRequestHandler</code> with value
-    <code
+  <li>label <code spellcheck="false">#customRequestHandler</code> with value <code
     spellcheck="false">create-note</code>
   </li>
   <li>relation <code spellcheck="false">~targetNote</code> pointing to a note
@@ -42,21 +41,19 @@ Content-Type: application/json
 }+++++++++++++++++++++++++++++++++++++++++++++++</code></pre>
 <p>Notice the <code spellcheck="false">/custom</code> part in the request path
   - Trilium considers any request with this prefix as "custom" and tries
-  to find a matching handler by looking at all notes which have <code spellcheck="false">customRequestHandler</code> 
-  <a
-  href="#root/_help_zEY4DaJG4YT5">label</a>. Value of this label then contains a regular expression which
-    will match the request path (in our case trivial regex "create-note").</p>
-<p>Trilium will then find our code note created above and execute it.
-  <code
-  spellcheck="false">api.req</code>, <code spellcheck="false">api.res</code> are set to <a href="https://expressjs.com/en/api.html#req">request</a> and
-    <a
-    href="https://expressjs.com/en/api.html#res">response</a>objects from which we can get details of the request and also
-      respond.</p>
+  to find a matching handler by looking at all notes which have <code spellcheck="false">customRequestHandler</code>  <a
+  href="#root/_help_zEY4DaJG4YT5">label</a>. Value of this label then contains
+  a regular expression which will match the request path (in our case trivial
+  regex "create-note").</p>
+<p>Trilium will then find our code note created above and execute it. <code
+  spellcheck="false">api.req</code>, <code spellcheck="false">api.res</code> are
+  set to <a href="https://expressjs.com/en/api.html#req">request</a> and <a
+  href="https://expressjs.com/en/api.html#res">response</a>objects from which
+  we can get details of the request and also respond.</p>
 <p>In the code note we check the request method and then use trivial authentication
   - keep in mind that these endpoints are by default totally unauthenticated,
   and you need to take care of this yourself.</p>
-<p>Once we pass these checks we will just create the desired note using
-  <a
+<p>Once we pass these checks we will just create the desired note using <a
   href="#root/_help_GLks18SNjxmC">Script API</a>.</p>
 <h2>Custom resource provider</h2>
 <p>Another common use case is that you want to just expose a file note -
@@ -70,9 +67,8 @@ Content-Type: application/json
 <h3>Parameters</h3>
 <p>REST request paths often contain parameters in the URL, e.g.:</p><pre><code class="language-text-x-trilium-auto">http://your-trilium-server/custom/notes/123</code></pre>
 <p>The last part is dynamic so the matching of the URL must also be dynamic
-  - for this reason the matching is done with regular expressions. Following
-  <code
-  spellcheck="false">customRequestHandler</code>value would match it:</p><pre><code class="language-text-x-trilium-auto">notes/([0-9]+)</code></pre>
+  - for this reason the matching is done with regular expressions. Following <code
+  spellcheck="false">customRequestHandler</code> value would match it:</p><pre><code class="language-text-x-trilium-auto">notes/([0-9]+)</code></pre>
 <p>Additionally, this also defines a matching group with the use of parenthesis
   which then makes it easier to extract the value. The matched groups are
   available in <code spellcheck="false">api.pathParams</code>:</p><pre><code class="language-text-x-trilium-auto">const noteId = api.pathParams[0];</code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Custom Resource Providers.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Custom Resource Providers.html
@@ -7,14 +7,12 @@
   <li>Import a file such as an image or a font into Trilium by drag &amp; drop.</li>
   <li>Select the file and go to the <em>Owned Attributes</em> section.</li>
   <li>Add the label <code spellcheck="false">#customResourceProvider=hello</code>.</li>
-  <li>To test if it is working, use a browser to navigate to <code spellcheck="false">&lt;protocol&gt;://&lt;host&gt;/custom/hello</code> (where
-    <code
-    spellcheck="false">&lt;protocol&gt;</code>is either <code spellcheck="false">http</code> or
-      <code
-      spellcheck="false">https</code>based on your setup, and <code spellcheck="false">&lt;host&gt;</code> is
-        the host or IP to your Trilium server instance). If you are running the
-        TriliumNext application without a server, use <code spellcheck="false">http://localhost:37840</code> as
-        the base URL.</li>
+  <li>To test if it is working, use a browser to navigate to <code spellcheck="false">&lt;protocol&gt;://&lt;host&gt;/custom/hello</code> (where <code
+    spellcheck="false">&lt;protocol&gt;</code> is either <code spellcheck="false">http</code> or <code
+    spellcheck="false">https</code> based on your setup, and <code spellcheck="false">&lt;host&gt;</code> is
+    the host or IP to your Trilium server instance). If you are running the
+    TriliumNext application without a server, use <code spellcheck="false">http://localhost:37840</code> as
+    the base URL.</li>
   <li>If everything went well, at the previous step the browser should have
     downloaded the file uploaded in the first step.</li>
 </ol>
@@ -24,8 +22,7 @@
     would be accessible via <code spellcheck="false">&lt;host&gt;/custom/fonts/Roboto.ttf</code>.</li>
   <li>As a more advanced use case, a regular expression to match multiple routes,
     such as <code spellcheck="false">hello/.*</code> which will be accessible
-    via <code spellcheck="false">/custom/hello/1</code>, <code spellcheck="false">/custom/hello/2</code>,
-    <code
+    via <code spellcheck="false">/custom/hello/1</code>, <code spellcheck="false">/custom/hello/2</code>, <code
     spellcheck="false">/custom/hello/world</code>, etc.</li>
 </ul>
 <h2>Using it in a theme</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Customizing to-do task states.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Customizing to-do task states.html
@@ -21,10 +21,10 @@
     only letters, digits, "<code spellcheck="false">-</code>" and "<code spellcheck="false">_</code>".
     It is stored as metadata in the note's markup and used to identify the
     task state. Two task states cannot share the same identifier.
-    <br>Prefix the identifiers of your custom task states with an underscore "
-    <code
-    spellcheck="false">_</code>" or a hyphen "<code spellcheck="false">-</code>" to avoid clashes
-      with task states that may be introduced in future versions of Trilium.</li>
+    <br>Prefix the identifiers of your custom task states with an underscore "<code
+    spellcheck="false">_</code>" or a hyphen "<code spellcheck="false">-</code>"
+    to avoid clashes with task states that may be introduced in future versions
+    of Trilium.</li>
   <li><strong>Markdown symbol</strong>: A single character used to represent
     the state in Markdown syntax. For example, "<code spellcheck="false">#</code>"
     creates a task state that can be applied in Markdown using " <code spellcheck="false">- [#]</code> ".

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database.html
@@ -44,6 +44,5 @@
   in the <code spellcheck="false">config.ini</code> file, you can just delete
   all of the <a href="#root/_help_tAassRL4RSQL">data directory's</a> contents to
   fully restore the application to its original state. You can also review
-  the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file to provide all
-  <code
-  spellcheck="false">config.ini</code>values as environment variables instead.</p>
+  the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file to provide all <code
+  spellcheck="false">config.ini</code> values as environment variables instead.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database/Manually altering the database.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database/Manually altering the database.html
@@ -31,8 +31,7 @@
 <h3>Using the SQLite CLI</h3>
 <p>First, start the SQLite 3 CLI by specifying the path to the database:</p><pre><code class="language-text-x-trilium-auto">sqlite3 ~/.local/share/trilium-data/document.db</code></pre>
 <ul>
-  <li>In the prompt simply type the statement and make sure it ends with a
-    <code
-    spellcheck="false">;</code>character.</li>
+  <li>In the prompt simply type the statement and make sure it ends with a <code
+    spellcheck="false">;</code> character.</li>
   <li>To exit, simply type <code spellcheck="false">.quit</code> and enter.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database/Manually altering the database/SQL Console.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Database/Manually altering the database/SQL Console.html
@@ -40,8 +40,7 @@
 <p>To do so, simply write the query and press the
   <img src="1_SQL Console_image.png">button. Once saved, the note will appear in&nbsp;<a class="reference-link"
   href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;by default. It is possible
-  to change the default location of saved queries by assigning a <code spellcheck="false">#sqlConsoleHome</code> 
-  <a
+  to change the default location of saved queries by assigning a <code spellcheck="false">#sqlConsoleHome</code>  <a
   href="#root/_help_HI6GBBIduIgv">label</a>.</p>
 <p>The note can be locked for editing by pressing the <em>Lock</em> button
   in the note actions section near the title bar (on the&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Default Note Title.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Default Note Title.html
@@ -1,13 +1,12 @@
 <p>When a new note is created, its name is by default "new note". In some
   cases, it can be desirable to have a different or even a dynamic default
   note title.</p>
-<p>For this use case, Trilium (since v0.52) supports <code spellcheck="false">#titleTemplate</code> 
-  <a
-  href="#root/_help_zEY4DaJG4YT5">label</a>. You can create such a label for a given note, assign it a value,
-    and this value will be used as a default title when creating child notes.
-    As with other labels, you can make it inheritable to apply recursively,
-    and you can even place it on the root note to have it applied globally
-    everywhere.</p>
+<p>For this use case, Trilium (since v0.52) supports <code spellcheck="false">#titleTemplate</code>  <a
+  href="#root/_help_zEY4DaJG4YT5">label</a>. You can create such a label for a
+  given note, assign it a value, and this value will be used as a default
+  title when creating child notes. As with other labels, you can make it
+  inheritable to apply recursively, and you can even place it on the root
+  note to have it applied globally everywhere.</p>
 <p>As an example use case, imagine you collect books you've read in a given
   year like this:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/ETAPI (REST API).html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/ETAPI (REST API).html
@@ -13,8 +13,7 @@
 <h2>Obtaining a token</h2>
 <p>All operations with the REST API have to be authenticated using a token.
   You can get this token either from Options -&gt; ETAPI or programmatically
-  using the <code spellcheck="false">/auth/login</code> REST call (see the
-  <a
+  using the <code spellcheck="false">/auth/login</code> REST call (see the <a
   href="https://github.com/TriliumNext/Trilium/blob/master/src/etapi/etapi.openapi.yaml">spec</a>).</p>
 <h2>Authentication</h2>
 <h3>Via the <code spellcheck="false">Authorization</code> header</h3><pre><code class="language-text-x-trilium-auto">GET https://myserver.com/etapi/app-info

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Hidden Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Hidden Notes.html
@@ -108,9 +108,9 @@ class="table">
         <td><a class="reference-link" href="#root/_hidden/_lbTplRoot">Launch Bar Templates</a>
         </td>
         <td>
-          <p>This section contains the templates for the creation of launchers in the&nbsp;
-            <a
-            class="reference-link" href="#root/_help_xYmIYSP6wE3F">Launch Bar</a>. It is not possible to create child notes here.</p>
+          <p>This section contains the templates for the creation of launchers in the&nbsp;<a
+            class="reference-link" href="#root/_help_xYmIYSP6wE3F">Launch Bar</a>. It is
+            not possible to create child notes here.</p>
           <p>Theoretically some of the notes here can be customized, but there's not
             much benefit to be had in doing so.</p>
         </td>
@@ -177,4 +177,4 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
+</figure>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Note ID.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Note ID.html
@@ -9,16 +9,16 @@
   for all the notes. This also includes other entities that are part of the
   import/export process such as&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</p>
 <h2>Note collisions</h2>
-<p>Since the Note ID is a fixed-width randomly generated number, due to the
-  <a
-  href="https://en.wikipedia.org/wiki/Pigeonhole_principle">pigeonhole principle</a>, there is a possibility that a newly created
-    note will have the same ID as an existing note.</p>
-<p>Since the note ID is alphanumeric and the length is 12 we have&nbsp;
-  <span
-  class="math-tex">\(62^{12}\)</span>&nbsp;unique IDs. However since we are generating them
-    randomly, we can use a collision calculator such as the one for <a href="https://alex7kom.github.io/nano-nanoid-cc/?alphabet=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz&amp;size=12&amp;speed=1000&amp;speedUnit=hour">Nano ID</a> to
-    determine that we'd need to create 1000 notes per hour every hour for 9
-    centuries in order to have at least 1% probability of a note collision.</p>
+<p>Since the Note ID is a fixed-width randomly generated number, due to the <a
+  href="https://en.wikipedia.org/wiki/Pigeonhole_principle">pigeonhole principle</a>,
+  there is a possibility that a newly created note will have the same ID
+  as an existing note.</p>
+<p>Since the note ID is alphanumeric and the length is 12 we have&nbsp;<span
+  class="math-tex">\(62^{12}\)</span>&nbsp;unique IDs. However since we are
+  generating them randomly, we can use a collision calculator such as the
+  one for <a href="https://alex7kom.github.io/nano-nanoid-cc/?alphabet=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz&amp;size=12&amp;speed=1000&amp;speedUnit=hour">Nano ID</a> to
+  determine that we'd need to create 1000 notes per hour every hour for 9
+  centuries in order to have at least 1% probability of a note collision.</p>
 <p>As such, Trilium does not take any explicit action against potential note
   collisions, similar to other software that makes uses of unique hashes
   such as <a href="https://stackoverflow.com/questions/10434326/hash-collision-in-git">Git</a>.

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Note source.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Note source.html
@@ -13,9 +13,9 @@
   <li><a class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>&nbsp;notes
     contain only minimal information (viewport, zoom) as a JSON.</li>
   <li><a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;notes
-    are represented as JSON, with Trilium's own information alongside with&nbsp;
-    <a
-    href="#root/_help_1YeN2MzFUluU">Excalidraw</a>'s internal JSON representation format.</li>
+    are represented as JSON, with Trilium's own information alongside with&nbsp;<a
+    href="#root/_help_1YeN2MzFUluU">Excalidraw</a>'s internal JSON representation
+    format.</li>
   <li><a class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>&nbsp;notes
     are represented as JSON, with the internal format of&nbsp;<a href="#root/_help_1YeN2MzFUluU">MindElixir</a>.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Safe mode.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Safe mode.html
@@ -1,19 +1,15 @@
 <p>Safe mode is triggered by setting the <code spellcheck="false">TRILIUM_SAFE_MODE</code> environment
   variable to a truthy value, usually <code spellcheck="false">1</code>.</p>
-<p>In each artifact there is a <code spellcheck="false">trilium-safe-mode.sh</code> (or
-  <code
+<p>In each artifact there is a <code spellcheck="false">trilium-safe-mode.sh</code> (or <code
   spellcheck="false">.bat</code>) script to enable it.</p>
 <p>What it does:</p>
 <ul>
-  <li>Disables <code spellcheck="false">customWidget</code> launcher types in
-    <code
+  <li>Disables <code spellcheck="false">customWidget</code> launcher types in <code
     spellcheck="false">app/widgets/containers/launcher.js</code>.</li>
-  <li>Disables the running of <code spellcheck="false">mobileStartup</code> or
-    <code
-    spellcheck="false">frontendStartup</code>scripts.</li>
+  <li>Disables the running of <code spellcheck="false">mobileStartup</code> or <code
+    spellcheck="false">frontendStartup</code> scripts.</li>
   <li>Displays the root note instead of the previously saved session.</li>
-  <li>Disables the running of <code spellcheck="false">backendStartup</code>,
-    <code
-    spellcheck="false">hourly</code>, <code spellcheck="false">daily</code> scripts and checks
-      for the hidden subtree.</li>
+  <li>Disables the running of <code spellcheck="false">backendStartup</code>, <code
+    spellcheck="false">hourly</code>, <code spellcheck="false">daily</code> scripts
+    and checks for the hidden subtree.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing.html
@@ -5,532 +5,518 @@
 class="image">
   <img style="aspect-ratio:1144/660;" src="Sharing_image.png"
   width="1144" height="660">
-  </figure>
-  <h2>Features, interaction and limitations</h2>
-  <ul>
-    <li>Searching by note title.</li>
-    <li>Automatic dark/light mode based on the user's browser settings.</li>
-    <li>Mobile-friendly layout, with sidebar.</li>
-    <li>Collapsible tree with the same note icons as the application.</li>
-    <li>Customizable logo.</li>
-    <li>Toggle button for dark/light mode, which also stores the user preferences.</li>
-    <li>Quick navigation buttons (previous and next note).</li>
-    <li>Displaying the date of the last update of the note.</li>
-  </ul>
-  <h3>By note type</h3>
-  <figure class="table">
-    <table class="ck-table-resized">
-      <colgroup>
-        <col style="width:19.92%;">
-          <col style="width:41.66%;">
-            <col style="width:38.42%;">
-      </colgroup>
-      <thead>
-        <tr>
-          <th>&nbsp;</th>
-          <th>Supported features</th>
-          <th>Limitations</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>
-          </th>
-          <td>
-            <ul>
-              <li>Table of contents.</li>
-              <li>Syntax highlight of code blocks, provided a language is selected (does
-                not work if “Auto-detected” is enabled).</li>
-              <li>Rendering for math equations.</li>
-              <li><a href="#root/_help_nBAXQFj20hS1">Including notes</a> (only if the included
-                notes are also shared).</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>Inline Mermaid diagrams are not rendered.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>
-          </th>
-          <td>
-            <ul>
-              <li>Basic support (displaying the contents of the note in a monospace font).</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>No syntax highlight.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_m523cpzocqaD">Saved Search</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_bdUJEHsAPYQR">Note Map</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>
-          </th>
-          <td>
-            <ul>
-              <li>The child notes are displayed in a fixed format.&nbsp;</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>More advanced view types such as the calendar view are not supported.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>
-          </th>
-          <td>
-            <ul>
-              <li>The diagram is displayed as a vector image.</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>No further interaction supported.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>
-          </th>
-          <td>
-            <ul>
-              <li>The diagram is displayed as a vector image.</li>
-            </ul>
-          </td>
-          <td>
-            <ul>
-              <li>No further interaction supported.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>
-          </th>
-          <td>The diagram is displayed as a vector image.</td>
-          <td>
-            <ul>
-              <li>No further interaction supported.</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>
-          </th>
-          <td>Not supported.</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <th><a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>
-          </th>
-          <td>Basic interaction (downloading the file).</td>
-          <td>
-            <ul>
-              <li>No further interaction supported.</li>
-            </ul>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </figure>
-  <p>While the sharing feature is powerful, it has some limitations:</p>
-  <ul>
-    <li><strong>Code Notes</strong>: No syntax highlighting.</li>
-    <li><strong>Static Note Tree</strong>
-    </li>
-    <li><strong>Protected Notes</strong>: Cannot be shared.</li>
-    <li><strong>Include Notes</strong>: Not supported.</li>
-  </ul>
-  <p>Some of these limitations may be addressed in future updates.</p>
-  <h2>Prerequisites</h2>
-  <p>To use the sharing feature, you must have a&nbsp;<a class="reference-link"
-    href="#root/_help_WOcw2SLH6tbX">Server Installation</a>&nbsp;of Trilium. This
-    is necessary because the notes will be hosted from the server.</p>
-  <h2>Sharing a note</h2>
-  <ol>
-    <li>
-      <p><strong>Enable Sharing</strong>: To share a note, toggle the <code spellcheck="false">Shared</code> switch
-        within the note's interface. Once sharing is enabled, an URL will appear,
-        which you can click to access the shared note.</p>
-      <p>
-        <img src="Sharing_share-single-note.png" alt="Share Note">
-      </p>
-    </li>
-    <li>
-      <p><strong>Access the Shared Note</strong>: The link provided will open the
-        note in your browser. If your server is not configured with a public IP,
-        the URL will refer to <code spellcheck="false">localhost (127.0.0.1)</code>.</p>
-    </li>
-  </ol>
-  <h2>Sharing a note subtree</h2>
-  <p>When you share a note, you actually share the entire subtree of notes
-    beneath it. If the note has child notes, they will also be included in
-    the shared content. For example, sharing the "Formatting" subtree will
-    display a page with basic navigation for exploring all the notes within
-    that subtree.</p>
-  <h2>Viewing and managing shared notes</h2>
-  <p>You can view a list of all shared notes by clicking on "Show Shared Notes
-    Subtree" in the&nbsp;<a class="reference-link" href="#root/_help_x3i7MxGccDuM">Global menu</a>.
-    This allows you to manage and navigate through all the notes you have made
-    public.</p>
-  <h2>Security considerations</h2>
-  <ul>
-    <li>Shared notes are published on the open internet and can be accessed by
-      anyone with the URL unless the notes are password-protected.</li>
-    <li>The URL's randomness does not provide security, so it is crucial not to
-      share sensitive information through this feature.</li>
-    <li>Trilium takes precautions to protect your publicly shared instance from
-      leaking information for non-shared notes, including opening a separate
-      read-only connection to the&nbsp;<a class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>.
-      Depending on your threat model, it might make more sense to use&nbsp;
-      <a
-      class="reference-link" href="#root/_help_ycBFjKrrwE9p">Exporting static HTML for web publishing</a>&nbsp;and use battle-tested
-        web servers such as Nginx or Apache to serve static content.</li>
-  </ul>
-  <h3>Password protection</h3>
-  <p>To protect shared notes with a username and password, you can use the
-    <code
-    spellcheck="false">#shareCredentials</code>attribute. Add this label to the note with the
-      format <code spellcheck="false">#shareCredentials="username:password"</code>.
-      To protect an entire subtree, make sure the label is <a href="#root/_help_bwZpz2ajCEwO">inheritable</a>.</p>
-  <h2>Advanced sharing options</h2>
-  <h3>Customizing the appearance of shared notes</h3>
-  <p>The default design should be a good starting point, but you can customize
-    it using your own CSS:</p>
-  <ul>
-    <li><strong>Custom CSS</strong>: Link a CSS&nbsp;<a class="reference-link"
-      href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note to the shared page by adding
-      a <code spellcheck="false">~shareCss</code> relation to the note. If you
-      want this style to apply to the entire subtree, make the label inheritable.
-      You can hide the CSS code note from the tree navigation by adding the
-      <code
-      spellcheck="false">#shareHiddenFromTree</code>label.</li>
-    <li><strong>Omitting Default CSS</strong>: For extensive styling changes,
-      use the <code spellcheck="false">#shareOmitDefaultCss</code> label to avoid
-      conflicts with Trilium's <a href="#root/_help_Wy267RK4M69c">default stylesheet</a>.</li>
-  </ul>
-  <h3>Adding JavaScript</h3>
-  <p>You can inject custom JavaScript into the shared note using the <code spellcheck="false">~shareJs</code> relation.
-    This allows you to access note attributes or traverse the note tree using
-    the <code spellcheck="false">fetchNote()</code> API, which retrieves note
-    data based on its ID.</p>
-  <h3>Adding custom HTML</h3>
-  <p>You can inject custom HTML snippets into specific locations of the shared
-    page using the <code spellcheck="false">~shareHtml</code> relation. The HTML
-    note should contain the raw HTML content you want to inject, and you can
-    control where it appears by adding the <code spellcheck="false">#shareHtmlLocation</code> label
-    to the HTML snippet note itself.</p>
-  <p>The <code spellcheck="false">#shareHtmlLocation</code> label accepts values
-    in the format <code spellcheck="false">location:position</code>:</p>
-  <ul>
-    <li><strong>Locations</strong>: <code spellcheck="false">head</code>,
-      <code
-      spellcheck="false">body</code>, <code spellcheck="false">content</code>
-    </li>
-    <li><strong>Positions</strong>: <code spellcheck="false">start</code>,
-      <code
-      spellcheck="false">end</code>
-    </li>
-  </ul>
-  <p>For example:</p>
-  <ul>
-    <li><code spellcheck="false">#shareHtmlLocation=head:start</code> - Injects
-      HTML at the beginning of the <code spellcheck="false">&lt;head&gt;</code> section</li>
-    <li><code spellcheck="false">#shareHtmlLocation=head:end</code> - Injects HTML
-      at the end of the <code spellcheck="false">&lt;head&gt;</code> section (default)</li>
-    <li><code spellcheck="false">#shareHtmlLocation=body:start</code> - Injects
-      HTML at the beginning of the <code spellcheck="false">&lt;body&gt;</code> section</li>
-    <li><code spellcheck="false">#shareHtmlLocation=content:start</code> - Injects
-      HTML at the beginning of the content area</li>
-    <li><code spellcheck="false">#shareHtmlLocation=content:end</code> - Injects
-      HTML at the end of the content area</li>
-  </ul>
-  <p>If no location is specified, the HTML will be injected at <code spellcheck="false">content:end</code> by
-    default.</p>
-  <p>Example:</p><pre><code class="language-text-javascript">const currentNote = await fetchNote();
+</figure>
+<h2>Features, interaction and limitations</h2>
+<ul>
+  <li>Searching by note title.</li>
+  <li>Automatic dark/light mode based on the user's browser settings.</li>
+  <li>Mobile-friendly layout, with sidebar.</li>
+  <li>Collapsible tree with the same note icons as the application.</li>
+  <li>Customizable logo.</li>
+  <li>Toggle button for dark/light mode, which also stores the user preferences.</li>
+  <li>Quick navigation buttons (previous and next note).</li>
+  <li>Displaying the date of the last update of the note.</li>
+</ul>
+<h3>By note type</h3>
+<figure class="table">
+  <table class="ck-table-resized">
+    <colgroup>
+      <col style="width:19.92%;">
+        <col style="width:41.66%;">
+          <col style="width:38.42%;">
+    </colgroup>
+    <thead>
+      <tr>
+        <th>&nbsp;</th>
+        <th>Supported features</th>
+        <th>Limitations</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>
+        </th>
+        <td>
+          <ul>
+            <li>Table of contents.</li>
+            <li>Syntax highlight of code blocks, provided a language is selected (does
+              not work if “Auto-detected” is enabled).</li>
+            <li>Rendering for math equations.</li>
+            <li><a href="#root/_help_nBAXQFj20hS1">Including notes</a> (only if the included
+              notes are also shared).</li>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <li>Inline Mermaid diagrams are not rendered.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>
+        </th>
+        <td>
+          <ul>
+            <li>Basic support (displaying the contents of the note in a monospace font).</li>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <li>No syntax highlight.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_m523cpzocqaD">Saved Search</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_bdUJEHsAPYQR">Note Map</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>
+        </th>
+        <td>
+          <ul>
+            <li>The child notes are displayed in a fixed format.&nbsp;</li>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <li>More advanced view types such as the calendar view are not supported.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>
+        </th>
+        <td>
+          <ul>
+            <li>The diagram is displayed as a vector image.</li>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <li>No further interaction supported.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>
+        </th>
+        <td>
+          <ul>
+            <li>The diagram is displayed as a vector image.</li>
+          </ul>
+        </td>
+        <td>
+          <ul>
+            <li>No further interaction supported.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>
+        </th>
+        <td>The diagram is displayed as a vector image.</td>
+        <td>
+          <ul>
+            <li>No further interaction supported.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>
+        </th>
+        <td>Not supported.</td>
+        <td>&nbsp;</td>
+      </tr>
+      <tr>
+        <th><a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>
+        </th>
+        <td>Basic interaction (downloading the file).</td>
+        <td>
+          <ul>
+            <li>No further interaction supported.</li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<p>While the sharing feature is powerful, it has some limitations:</p>
+<ul>
+  <li><strong>Code Notes</strong>: No syntax highlighting.</li>
+  <li><strong>Static Note Tree</strong>
+  </li>
+  <li><strong>Protected Notes</strong>: Cannot be shared.</li>
+  <li><strong>Include Notes</strong>: Not supported.</li>
+</ul>
+<p>Some of these limitations may be addressed in future updates.</p>
+<h2>Prerequisites</h2>
+<p>To use the sharing feature, you must have a&nbsp;<a class="reference-link"
+  href="#root/_help_WOcw2SLH6tbX">Server Installation</a>&nbsp;of Trilium. This
+  is necessary because the notes will be hosted from the server.</p>
+<h2>Sharing a note</h2>
+<ol>
+  <li>
+    <p><strong>Enable Sharing</strong>: To share a note, toggle the <code spellcheck="false">Shared</code> switch
+      within the note's interface. Once sharing is enabled, an URL will appear,
+      which you can click to access the shared note.</p>
+    <p>
+      <img src="Sharing_share-single-note.png" alt="Share Note">
+    </p>
+  </li>
+  <li>
+    <p><strong>Access the Shared Note</strong>: The link provided will open the
+      note in your browser. If your server is not configured with a public IP,
+      the URL will refer to <code spellcheck="false">localhost (127.0.0.1)</code>.</p>
+  </li>
+</ol>
+<h2>Sharing a note subtree</h2>
+<p>When you share a note, you actually share the entire subtree of notes
+  beneath it. If the note has child notes, they will also be included in
+  the shared content. For example, sharing the "Formatting" subtree will
+  display a page with basic navigation for exploring all the notes within
+  that subtree.</p>
+<h2>Viewing and managing shared notes</h2>
+<p>You can view a list of all shared notes by clicking on "Show Shared Notes
+  Subtree" in the&nbsp;<a class="reference-link" href="#root/_help_x3i7MxGccDuM">Global menu</a>.
+  This allows you to manage and navigate through all the notes you have made
+  public.</p>
+<h2>Security considerations</h2>
+<ul>
+  <li>Shared notes are published on the open internet and can be accessed by
+    anyone with the URL unless the notes are password-protected.</li>
+  <li>The URL's randomness does not provide security, so it is crucial not to
+    share sensitive information through this feature.</li>
+  <li>Trilium takes precautions to protect your publicly shared instance from
+    leaking information for non-shared notes, including opening a separate
+    read-only connection to the&nbsp;<a class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>.
+    Depending on your threat model, it might make more sense to use&nbsp;<a
+    class="reference-link" href="#root/_help_ycBFjKrrwE9p">Exporting static HTML for web publishing</a>&nbsp;and
+    use battle-tested web servers such as Nginx or Apache to serve static content.</li>
+</ul>
+<h3>Password protection</h3>
+<p>To protect shared notes with a username and password, you can use the <code
+  spellcheck="false">#shareCredentials</code> attribute. Add this label to
+  the note with the format <code spellcheck="false">#shareCredentials="username:password"</code>.
+  To protect an entire subtree, make sure the label is <a href="#root/_help_bwZpz2ajCEwO">inheritable</a>.</p>
+<h2>Advanced sharing options</h2>
+<h3>Customizing the appearance of shared notes</h3>
+<p>The default design should be a good starting point, but you can customize
+  it using your own CSS:</p>
+<ul>
+  <li><strong>Custom CSS</strong>: Link a CSS&nbsp;<a class="reference-link"
+    href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note to the shared page by adding
+    a <code spellcheck="false">~shareCss</code> relation to the note. If you
+    want this style to apply to the entire subtree, make the label inheritable.
+    You can hide the CSS code note from the tree navigation by adding the <code
+    spellcheck="false">#shareHiddenFromTree</code> label.</li>
+  <li><strong>Omitting Default CSS</strong>: For extensive styling changes,
+    use the <code spellcheck="false">#shareOmitDefaultCss</code> label to avoid
+    conflicts with Trilium's <a href="#root/_help_Wy267RK4M69c">default stylesheet</a>.</li>
+</ul>
+<h3>Adding JavaScript</h3>
+<p>You can inject custom JavaScript into the shared note using the <code spellcheck="false">~shareJs</code> relation.
+  This allows you to access note attributes or traverse the note tree using
+  the <code spellcheck="false">fetchNote()</code> API, which retrieves note
+  data based on its ID.</p>
+<h3>Adding custom HTML</h3>
+<p>You can inject custom HTML snippets into specific locations of the shared
+  page using the <code spellcheck="false">~shareHtml</code> relation. The HTML
+  note should contain the raw HTML content you want to inject, and you can
+  control where it appears by adding the <code spellcheck="false">#shareHtmlLocation</code> label
+  to the HTML snippet note itself.</p>
+<p>The <code spellcheck="false">#shareHtmlLocation</code> label accepts values
+  in the format <code spellcheck="false">location:position</code>:</p>
+<ul>
+  <li><strong>Locations</strong>: <code spellcheck="false">head</code>, <code
+    spellcheck="false">body</code>, <code spellcheck="false">content</code>
+  </li>
+  <li><strong>Positions</strong>: <code spellcheck="false">start</code>, <code
+    spellcheck="false">end</code>
+  </li>
+</ul>
+<p>For example:</p>
+<ul>
+  <li><code spellcheck="false">#shareHtmlLocation=head:start</code> - Injects
+    HTML at the beginning of the <code spellcheck="false">&lt;head&gt;</code> section</li>
+  <li><code spellcheck="false">#shareHtmlLocation=head:end</code> - Injects HTML
+    at the end of the <code spellcheck="false">&lt;head&gt;</code> section (default)</li>
+  <li><code spellcheck="false">#shareHtmlLocation=body:start</code> - Injects
+    HTML at the beginning of the <code spellcheck="false">&lt;body&gt;</code> section</li>
+  <li><code spellcheck="false">#shareHtmlLocation=content:start</code> - Injects
+    HTML at the beginning of the content area</li>
+  <li><code spellcheck="false">#shareHtmlLocation=content:end</code> - Injects
+    HTML at the end of the content area</li>
+</ul>
+<p>If no location is specified, the HTML will be injected at <code spellcheck="false">content:end</code> by
+  default.</p>
+<p>Example:</p><pre><code class="language-text-javascript">const currentNote = await fetchNote();
 const parentNote = await fetchNote(currentNote.parentNoteIds[0]);
 
 for (const attr of parentNote.attributes) {
     console.log(attr.type, attr.name, attr.value);
 }</code></pre>
-  <h3>Custom share templates</h3>
-  <p>To completely redesign the share, it is possible to create or use an existing
-    <a
-    href="#root/_help_Ad7Ku5gOHrDU">custom share template</a>.</p>
-  <h3>Creating human-readable URL aliases</h3>
-  <p>Shared notes typically have URLs like <code spellcheck="false">http://domain.tld/share/knvU8aJy4dJ7</code>,
-    where the last part is the note's ID. You can make these URLs more user-friendly
-    by adding the <code spellcheck="false">#shareAlias</code> label to individual
-    notes (e.g., <code spellcheck="false">#shareAlias=highlighting</code>).
-    This will change the URL to <code spellcheck="false">http://domain.tld/share/highlighting</code>.</p>
-  <p><strong>Important</strong>:</p>
-  <ol>
-    <li>Ensure that aliases are unique.</li>
-    <li>Using slashes (<code spellcheck="false">/</code>) within aliases to create
-      subpaths is not supported.</li>
-  </ol>
-  <aside class="admonition tip">
-    <ul>
-      <li>To easily identify pages that don't have a share alias, run a&nbsp;
-        <a
-        class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;with <code spellcheck="false">#!shareAlias</code>.</li>
-      <li>To be able to enter the share alias faster, consider using&nbsp;<a class="reference-link"
-        href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;(for example
-        <code
-        spellcheck="false">#label:shareAlias(inheritable)="promoted,alias=Slug,single,text"</code>).</li>
-    </ul>
-  </aside>
-  <h3>Setting a custom favicon</h3>
-  <p>To customize the favicon for your shared pages, create a relation
-    <code
-    spellcheck="false">~shareFavicon</code>pointing to a file note containing the favicon (e.g.,
-      in <code spellcheck="false">.ico</code> format).</p>
-  <h3>Sharing a note as the root</h3>
-  <p>You can designate a specific note or folder as the root of your shared
-    content by adding the <code spellcheck="false">#shareRoot</code> label. This
-    note will be linked when visiting <code spellcheck="false">[http://domain.tld/share](http://domain/share)</code>,
-    making it easier to use Trilium as a fully-fledged website.</p>
-  <aside class="admonition tip">
-    <p>Consider combining this with the <code spellcheck="false">#shareIndex</code> label,
-      which will display a list of all shared notes.</p>
-  </aside>
-  <h3>Displaying an index of shared notes</h3>
-  <p>When accessing a share, the sub-notes will be displayed in a tree on the
-    left. But since multiple note trees can be shared, it might be useful to
-    display a list of all the different share trees.</p>
-  <p>To do so, create a shared text note and apply the <code spellcheck="false">shareIndex</code> label.
-    When viewed, the list of shared roots will be displayed at the bottom of
-    the note.</p>
-  <h3>Linking to an external website</h3>
-  <p>Sometimes it's useful to include a link to an external website alongside
-    your shared notes — for example in the shared navigation or in an index.
-    To do so, add the <code spellcheck="false">#shareExternalLink</code> label
-    to a note, with the target URL as its value (e.g. <code spellcheck="false">#shareExternalLink="https://example.com"</code>).</p>
-  <p>Any link pointing to this note will then redirect to the external website
-    and open in a new browser tab, instead of opening the note's own shared
-    page. This applies to:</p>
+<h3>Custom share templates</h3>
+<p>To completely redesign the share, it is possible to create or use an existing <a
+  href="#root/_help_Ad7Ku5gOHrDU">custom share template</a>.</p>
+<h3>Creating human-readable URL aliases</h3>
+<p>Shared notes typically have URLs like <code spellcheck="false">http://domain.tld/share/knvU8aJy4dJ7</code>,
+  where the last part is the note's ID. You can make these URLs more user-friendly
+  by adding the <code spellcheck="false">#shareAlias</code> label to individual
+  notes (e.g., <code spellcheck="false">#shareAlias=highlighting</code>).
+  This will change the URL to <code spellcheck="false">http://domain.tld/share/highlighting</code>.</p>
+<p><strong>Important</strong>:</p>
+<ol>
+  <li>Ensure that aliases are unique.</li>
+  <li>Using slashes (<code spellcheck="false">/</code>) within aliases to create
+    subpaths is not supported.</li>
+</ol>
+<aside class="admonition tip">
   <ul>
-    <li>the listing produced by the <code spellcheck="false">#shareIndex</code> label;</li>
-    <li>the "Subpages" list shown under a parent note;</li>
-    <li>inline links to this note from within other shared notes.</li>
+    <li>To easily identify pages that don't have a share alias, run a&nbsp;<a
+      class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;with <code
+      spellcheck="false">#!shareAlias</code>.</li>
+    <li>To be able to enter the share alias faster, consider using&nbsp;<a class="reference-link"
+      href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;(for example <code
+      spellcheck="false">#label:shareAlias(inheritable)="promoted,alias=Slug,single,text"</code>).</li>
   </ul>
-  <p>The URL must be absolute and include the scheme (e.g. <code spellcheck="false">https://</code>).</p>
-  <aside
-  class="admonition note">
-    <p>The note still exists in the share tree and its own page remains reachable
-      by its direct URL — the label only changes how links to it behave.</p>
-    </aside>
-    <h2>Attribute reference</h2>
-    <figure class="table">
-      <table class="ck-table-resized">
-        <colgroup>
-          <col style="width:18.38%;">
-            <col style="width:81.62%;">
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Attribute</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">#shareHiddenFromTree</code>
-            </td>
-            <td>this note is hidden from left navigation tree, but still accessible with
-              its URL</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareExternalLink</code>
-            </td>
-            <td>when a link points to this note (from the share index, a subpage list,
-              or an inline link in another shared note), it redirects to the given external
-              URL in a new tab instead of the note's shared page. Value is the absolute
-              URL, e.g. <code spellcheck="false">https://example.com</code>.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareAlias</code>
-            </td>
-            <td>define an alias using which the note will be available under <code spellcheck="false">https://your_trilium_host/share/[your_alias]</code>
-            </td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareOmitDefaultCss</code>
-            </td>
-            <td>default share page CSS will be omitted. Use when you make extensive styling
-              changes.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareRoot</code>
-            </td>
-            <td>marks note which is served on /share root.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareDescription</code>
-            </td>
-            <td>define text to be added to the HTML meta tag for description</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareRaw</code>
-            </td>
-            <td>Note will be served in its raw format, without HTML wrapper. See also&nbsp;
-              <a
-              class="reference-link" href="#root/_help_Qjt68inQ2bRj">Serving directly the content of a note</a>&nbsp;for an alternative method
-                without setting an attribute.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareDisallowRobotIndexing</code>
-            </td>
-            <td>
-              <p>Indicates to web crawlers that the page should not be indexed of this
-                note by:</p>
-              <ul>
-                <li>Setting the <code spellcheck="false">X-Robots-Tag: noindex</code> HTTP header.</li>
-                <li>Setting the <code spellcheck="false">noindex, follow</code> meta tag.</li>
-              </ul>
-            </td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareCredentials</code>
-            </td>
-            <td>require credentials to access this shared note. Value is expected to be
-              in format <code spellcheck="false">username:password</code>. Don't forget
-              to make this inheritable to apply to child-notes/images.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareIndex</code>
-            </td>
-            <td>Note with this label will list all roots of shared notes.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareHtmlLocation</code>
-            </td>
-            <td>defines where custom HTML injected via <code spellcheck="false">~shareHtml</code> relation
-              should be placed. Applied to the HTML snippet note itself. Format:
-              <code
-              spellcheck="false">location:position</code>where location is <code spellcheck="false">head</code>,
-                <code
-                spellcheck="false">body</code>, or <code spellcheck="false">content</code> and position is
-                  <code
-                  spellcheck="false">start</code>or <code spellcheck="false">end</code>. Defaults to <code spellcheck="false">content:end</code>.</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h3>Customizing logo</h3>
-    <p>It's possible to adjust the logo which is displayed on the top-left of
-      the left pane.</p>
-    <figure class="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Attribute</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">~shareLogo</code>
-            </td>
-            <td>Relation set to an image to use as logo. The image must be part of the
-              share tree (it can be hidden if needed).</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareLogoWidth</code>
-            </td>
-            <td>The width (in pixels, without unit) to set for the logo. Default is
-              <code
-              spellcheck="false">53</code>.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareLogoHeight</code>
-            </td>
-            <td>The height (in pixels, without unit) to set for the logo. Default is
-              <code
-              spellcheck="false">40</code>.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareRootLink</code>
-            </td>
-            <td>URL to navigate to when the logo is pressed.</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h3>Customizing OpenGraph</h3>
-    <figure class="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Attribute</th>
-            <th>Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">#shareOpenGraphColor</code>
-            </td>
-            <td>This adjusts the <code spellcheck="false">theme-color</code> meta-property.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareOpenGraphURL</code>
-            </td>
-            <td>This adjusts the <code spellcheck="false">og:url</code> and <code spellcheck="false">twitter:url</code> meta-properties.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareOpenGraphDomain</code>
-            </td>
-            <td>Adjusts the <code spellcheck="false">twitter:domain</code> meta-property.</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#shareOpenGraphImage</code>&nbsp;
-              <br><code spellcheck="false">~shareOpenGraphImage</code>
-            </td>
-            <td>Can be either a label, case in which the value is passed on as-is, or
-              it can be a relation to an image&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>.
-              This controls the <code spellcheck="false">og:image</code> meta-property.</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h2>Credits</h2>
-    <p>Since v0.95.0, a new theme was introduced (and enabled by default) which
-      greatly improves the visual aspect of the Share feature, as well as its
-      functionality (such as mobile support, dark/light mode, collapsible tree,
-      etc.). This theme is an adaptation of the <a href="https://github.com/zerebos/trilium.rocks">Trilium Rocks!</a> by
-      <a
-      href="https://github.com/zerebos">zerebos</a>.</p>
+</aside>
+<h3>Setting a custom favicon</h3>
+<p>To customize the favicon for your shared pages, create a relation <code
+  spellcheck="false">~shareFavicon</code> pointing to a file note containing
+  the favicon (e.g., in <code spellcheck="false">.ico</code> format).</p>
+<h3>Sharing a note as the root</h3>
+<p>You can designate a specific note or folder as the root of your shared
+  content by adding the <code spellcheck="false">#shareRoot</code> label. This
+  note will be linked when visiting <code spellcheck="false">[http://domain.tld/share](http://domain/share)</code>,
+  making it easier to use Trilium as a fully-fledged website.</p>
+<aside class="admonition tip">
+  <p>Consider combining this with the <code spellcheck="false">#shareIndex</code> label,
+    which will display a list of all shared notes.</p>
+</aside>
+<h3>Displaying an index of shared notes</h3>
+<p>When accessing a share, the sub-notes will be displayed in a tree on the
+  left. But since multiple note trees can be shared, it might be useful to
+  display a list of all the different share trees.</p>
+<p>To do so, create a shared text note and apply the <code spellcheck="false">shareIndex</code> label.
+  When viewed, the list of shared roots will be displayed at the bottom of
+  the note.</p>
+<h3>Linking to an external website</h3>
+<p>Sometimes it's useful to include a link to an external website alongside
+  your shared notes — for example in the shared navigation or in an index.
+  To do so, add the <code spellcheck="false">#shareExternalLink</code> label
+  to a note, with the target URL as its value (e.g. <code spellcheck="false">#shareExternalLink="https://example.com"</code>).</p>
+<p>Any link pointing to this note will then redirect to the external website
+  and open in a new browser tab, instead of opening the note's own shared
+  page. This applies to:</p>
+<ul>
+  <li>the listing produced by the <code spellcheck="false">#shareIndex</code> label;</li>
+  <li>the "Subpages" list shown under a parent note;</li>
+  <li>inline links to this note from within other shared notes.</li>
+</ul>
+<p>The URL must be absolute and include the scheme (e.g. <code spellcheck="false">https://</code>).</p>
+<aside
+class="admonition note">
+  <p>The note still exists in the share tree and its own page remains reachable
+    by its direct URL — the label only changes how links to it behave.</p>
+</aside>
+<h2>Attribute reference</h2>
+<figure class="table">
+  <table class="ck-table-resized">
+    <colgroup>
+      <col style="width:18.38%;">
+        <col style="width:81.62%;">
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">#shareHiddenFromTree</code>
+        </td>
+        <td>this note is hidden from left navigation tree, but still accessible with
+          its URL</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareExternalLink</code>
+        </td>
+        <td>when a link points to this note (from the share index, a subpage list,
+          or an inline link in another shared note), it redirects to the given external
+          URL in a new tab instead of the note's shared page. Value is the absolute
+          URL, e.g. <code spellcheck="false">https://example.com</code>.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareAlias</code>
+        </td>
+        <td>define an alias using which the note will be available under <code spellcheck="false">https://your_trilium_host/share/[your_alias]</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareOmitDefaultCss</code>
+        </td>
+        <td>default share page CSS will be omitted. Use when you make extensive styling
+          changes.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareRoot</code>
+        </td>
+        <td>marks note which is served on /share root.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareDescription</code>
+        </td>
+        <td>define text to be added to the HTML meta tag for description</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareRaw</code>
+        </td>
+        <td>Note will be served in its raw format, without HTML wrapper. See also&nbsp;<a
+          class="reference-link" href="#root/_help_Qjt68inQ2bRj">Serving directly the content of a note</a>&nbsp;for
+          an alternative method without setting an attribute.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareDisallowRobotIndexing</code>
+        </td>
+        <td>
+          <p>Indicates to web crawlers that the page should not be indexed of this
+            note by:</p>
+          <ul>
+            <li>Setting the <code spellcheck="false">X-Robots-Tag: noindex</code> HTTP header.</li>
+            <li>Setting the <code spellcheck="false">noindex, follow</code> meta tag.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareCredentials</code>
+        </td>
+        <td>require credentials to access this shared note. Value is expected to be
+          in format <code spellcheck="false">username:password</code>. Don't forget
+          to make this inheritable to apply to child-notes/images.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareIndex</code>
+        </td>
+        <td>Note with this label will list all roots of shared notes.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareHtmlLocation</code>
+        </td>
+        <td>defines where custom HTML injected via <code spellcheck="false">~shareHtml</code> relation
+          should be placed. Applied to the HTML snippet note itself. Format: <code
+          spellcheck="false">location:position</code> where location is <code spellcheck="false">head</code>, <code
+          spellcheck="false">body</code>, or <code spellcheck="false">content</code> and
+          position is <code spellcheck="false">start</code> or <code spellcheck="false">end</code>.
+          Defaults to <code spellcheck="false">content:end</code>.</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Customizing logo</h3>
+<p>It's possible to adjust the logo which is displayed on the top-left of
+  the left pane.</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">~shareLogo</code>
+        </td>
+        <td>Relation set to an image to use as logo. The image must be part of the
+          share tree (it can be hidden if needed).</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareLogoWidth</code>
+        </td>
+        <td>The width (in pixels, without unit) to set for the logo. Default is <code
+          spellcheck="false">53</code>.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareLogoHeight</code>
+        </td>
+        <td>The height (in pixels, without unit) to set for the logo. Default is <code
+          spellcheck="false">40</code>.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareRootLink</code>
+        </td>
+        <td>URL to navigate to when the logo is pressed.</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Customizing OpenGraph</h3>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">#shareOpenGraphColor</code>
+        </td>
+        <td>This adjusts the <code spellcheck="false">theme-color</code> meta-property.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareOpenGraphURL</code>
+        </td>
+        <td>This adjusts the <code spellcheck="false">og:url</code> and <code spellcheck="false">twitter:url</code> meta-properties.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareOpenGraphDomain</code>
+        </td>
+        <td>Adjusts the <code spellcheck="false">twitter:domain</code> meta-property.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#shareOpenGraphImage</code>&nbsp;
+          <br><code spellcheck="false">~shareOpenGraphImage</code>
+        </td>
+        <td>Can be either a label, case in which the value is passed on as-is, or
+          it can be a relation to an image&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>.
+          This controls the <code spellcheck="false">og:image</code> meta-property.</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h2>Credits</h2>
+<p>Since v0.95.0, a new theme was introduced (and enabled by default) which
+  greatly improves the visual aspect of the Share feature, as well as its
+  functionality (such as mobile support, dark/light mode, collapsible tree,
+  etc.). This theme is an adaptation of the <a href="https://github.com/zerebos/trilium.rocks">Trilium Rocks!</a> by <a
+  href="https://github.com/zerebos">zerebos</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing/Custom share template.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing/Custom share template.html
@@ -10,24 +10,21 @@
 <ol>
   <li>Create a&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note
     with the language <em>Embedded JavaScript</em> (EJS).</li>
-  <li>For a shared note to apply the newly created template, apply the
-    <code
-    spellcheck="false">~shareTemplate</code>relation pointing to the note created at step (1).
-      Make use of&nbsp;<a class="reference-link" href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>&nbsp;to
-      apply it to multiple shared notes.</li>
+  <li>For a shared note to apply the newly created template, apply the <code
+    spellcheck="false">~shareTemplate</code> relation pointing to the note created
+    at step (1). Make use of&nbsp;<a class="reference-link" href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>&nbsp;to
+    apply it to multiple shared notes.</li>
 </ol>
 <p>There are two important constraints to be aware of:</p>
 <ul>
   <li>Because EJS templates execute arbitrary server-side JavaScript, <code spellcheck="false">~shareTemplate</code> only
-    takes effect when backend scripting is enabled. If it is disabled (see&nbsp;
-    <a
-    class="reference-link" href="#root/_help_fiHicjpHjIRJ">Security</a>), the relation is ignored and the default template is used.
-      For the same reason, <strong>only apply templates from notes you trust</strong>.</li>
-  <li>The template note must be part of the shared subtree (just like <code spellcheck="false">~shareCss</code>,
-    <code
-    spellcheck="false">~shareJs</code>) in order for it to be loaded. To prevent it from being
-      shown in the navigation, apply <code spellcheck="false">#shareHiddenFromTree</code> to
-      it.</li>
+    takes effect when backend scripting is enabled. If it is disabled (see&nbsp;<a
+    class="reference-link" href="#root/_help_fiHicjpHjIRJ">Security</a>), the relation
+    is ignored and the default template is used. For the same reason, <strong>only apply templates from notes you trust</strong>.</li>
+  <li>The template note must be part of the shared subtree (just like <code spellcheck="false">~shareCss</code>, <code
+    spellcheck="false">~shareJs</code>) in order for it to be loaded. To prevent
+    it from being shown in the navigation, apply <code spellcheck="false">#shareHiddenFromTree</code> to
+    it.</li>
 </ul>
 <h2>Content of the share template</h2>
 <p>Use the <a href="https://github.com/TriliumNext/Notes/blob/develop/packages/share-theme/src/templates/page.ejs">original template</a> as
@@ -47,8 +44,7 @@
       <tr>
         <td><code spellcheck="false">note</code>
         </td>
-        <td>The note being rendered. Use it to read attributes (<code spellcheck="false">note.getLabelValue(...)</code>),
-          <code
+        <td>The note being rendered. Use it to read attributes (<code spellcheck="false">note.getLabelValue(...)</code>), <code
           spellcheck="false">note.title</code>, child notes, etc.</td>
       </tr>
       <tr>
@@ -88,9 +84,8 @@
       <tr>
         <td><code spellcheck="false">isStatic</code>
         </td>
-        <td><code spellcheck="false">true</code> during a static HTML export,
-          <code
-          spellcheck="false">false</code>for a live server render.</td>
+        <td><code spellcheck="false">true</code> during a static HTML export, <code
+          spellcheck="false">false</code> for a live server render.</td>
       </tr>
       <tr>
         <td><code spellcheck="false">t</code>
@@ -100,8 +95,7 @@
       <tr>
         <td><code spellcheck="false">utils</code>
         </td>
-        <td>Helper utilities such as <code spellcheck="false">slugify()</code> and
-          <code
+        <td>Helper utilities such as <code spellcheck="false">slugify()</code> and <code
           spellcheck="false">stripTags()</code>.</td>
       </tr>
     </tbody>
@@ -113,9 +107,9 @@
   takes the shared page down.</p>
 <h2>Splitting a template into partials</h2>
 <p>A template can pull in other EJS notes as partials. Create them as <strong>child notes</strong> of
-  the template note (each also a <code spellcheck="false">code</code> /
-  <code
-  spellcheck="false">application/x-ejs</code>note) and reference them by title:</p><pre><code class="language-text-x-trilium-auto">&lt;%- include("header") %&gt;
+  the template note (each also a <code spellcheck="false">code</code> / <code
+  spellcheck="false">application/x-ejs</code> note) and reference them by
+  title:</p><pre><code class="language-text-x-trilium-auto">&lt;%- include("header") %&gt;
 
 &lt;main&gt;
     &lt;h1&gt;&lt;%= note.title %&gt;&lt;/h1&gt;

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing/Reverse proxy configuration.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Sharing/Reverse proxy configuration.html
@@ -6,10 +6,8 @@
   reverse_proxy /share http://localhost:8080/share
 }</code></pre>
 <p>This is for newer versions where the share functionality is isolated,
-  for older versions it's required to also include <code spellcheck="false">/assets</code>.
-  <a
-  href="#fn2b8mg20aol8"><sup>[1]</sup>
-    </a>
+  for older versions it's required to also include <code spellcheck="false">/assets</code>.<a
+  href="#fn2b8mg20aol8"><sup>[1]</sup></a>
 </p>
 <ol>
   <li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Technologies used.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Technologies used.html
@@ -1,7 +1,6 @@
-<p>One core aspect of Trilium that allows it to have support for multiple&nbsp;
-  <a
-  href="#root/_help_KSZ04uQ2D1St">Note Types</a>&nbsp;is the fact that it makes use of various off-the-shelf
-    or reusable libraries.</p>
+<p>One core aspect of Trilium that allows it to have support for multiple&nbsp;<a
+  href="#root/_help_KSZ04uQ2D1St">Note Types</a>&nbsp;is the fact that it makes
+  use of various off-the-shelf or reusable libraries.</p>
 <p>This page showcases some of the technologies used, for a better understanding
   of how Trilium works but also to credit the developers of that particular
   technology.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Templates.html
@@ -35,21 +35,21 @@
   <img src="Templates_template-create-instance-note.png"
   alt="show child note templates">
 </p>
-<p>For the template to appear in the menu, the template note must have the
-  <code
-  spellcheck="false">#template</code>label. Do not confuse this with the <code spellcheck="false">~template</code> relation,
-    which links the instance note to the template note. If you use <a href="#root/_help_9sRHySam5fXb">workspaces</a>,
-    you can also mark templates with <code spellcheck="false">#workspaceTemplate</code> to
-    display them only in the workspace.</p>
+<p>For the template to appear in the menu, the template note must have the <code
+  spellcheck="false">#template</code> label. Do not confuse this with the <code
+  spellcheck="false">~template</code> relation, which links the instance note
+  to the template note. If you use <a href="#root/_help_9sRHySam5fXb">workspaces</a>,
+  you can also mark templates with <code spellcheck="false">#workspaceTemplate</code> to
+  display them only in the workspace.</p>
 <p>Templates can also be added or changed after note creation by creating
   a <code spellcheck="false">~template</code> relation pointing to the desired
   template note.&nbsp;</p>
 <p>To specify a template for child notes, you can use a <code spellcheck="false">~child:template</code> relation
   pointing to the appropriate template note. There is no limit to the depth
-  of the hierarchy — you can use <code spellcheck="false">~child:child:template</code>,
-  <code
+  of the hierarchy — you can use <code spellcheck="false">~child:child:template</code>, <code
   spellcheck="false">~child:child:child:template</code>, and so on.</p>
-<aside class="admonition important">
+<aside
+class="admonition important">
   <p>Changing the template hierarchy after the parent note is created will
     not retroactively apply to newly created child notes.
     <br>For example, if you initially use <code spellcheck="false">~child:template</code> and
@@ -59,11 +59,10 @@
 </aside>
 <h2>Default parent for new notes</h2>
 <p>A template can gather the notes created from it in one place, instead
-  of having them land wherever they happen to be created. To do so, add a
-  <code
-  spellcheck="false">~template:newNoteDefaultParent</code>relation to the template note, pointing
-    at the note that should hold the instances, for example a <em>Person</em> template
-    pointing to a <em>People</em> note.</p>
+  of having them land wherever they happen to be created. To do so, add a <code
+  spellcheck="false">~template:newNoteDefaultParent</code> relation to the
+  template note, pointing at the note that should hold the instances, for
+  example a <em>Person</em> template pointing to a <em>People</em> note.</p>
 <p>Adding the relation several times places the new note in every target,
   as&nbsp;<a class="reference-link" href="#root/_help_IakOLONlIfGI">Cloning Notes</a>.
   The relation can also be inherited (e.g. from a folder holding several
@@ -92,10 +91,9 @@
   to a template of a different type (e.g. a Code note), the behavior depends
   on how the new note is created:</p>
 <ul>
-  <li>If no note type is explicitly chosen (e.g. the + button in the&nbsp;
-    <a
-    class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>), the template is applied and the new note takes the type
-      and content of the template.</li>
+  <li>If no note type is explicitly chosen (e.g. the + button in the&nbsp;<a
+    class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>), the template
+    is applied and the new note takes the type and content of the template.</li>
   <li>If a note type is explicitly selected (e.g.&nbsp;<a class="reference-link"
     href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;→ <em>Insert note after</em> / <em>Insert child note</em>):
     <ul>
@@ -108,14 +106,13 @@
 <p>Selecting a specific template from the creation menu always takes precedence
   over <code spellcheck="false">child:template</code>.</p>
 <h2>Additional Notes</h2>
-<p>From a visual perspective, templates can define <code spellcheck="false">#iconClass</code> and
-  <code
-  spellcheck="false">#cssClass</code>attributes, allowing all instance notes (e.g., books)
-    to display a specific icon and CSS style.</p>
+<p>From a visual perspective, templates can define <code spellcheck="false">#iconClass</code> and <code
+  spellcheck="false">#cssClass</code> attributes, allowing all instance notes
+  (e.g., books) to display a specific icon and CSS style.</p>
 <p>Explore the concept further in the&nbsp;<a class="reference-link" href="#root/_help_6tZeKvSHEUiB">Demo Notes</a>,
-  including examples like the&nbsp;<a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>,&nbsp;
-  <a
-  class="reference-link" href="#root/_help_xYjQUYhpbUEW">Task Manager</a>, and&nbsp;<a class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>.</p>
+  including examples like the&nbsp;<a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>,&nbsp;<a
+  class="reference-link" href="#root/_help_xYjQUYhpbUEW">Task Manager</a>, and&nbsp;<a
+  class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>.</p>
 <p>Additionally, see&nbsp;<a class="reference-link" href="#root/_help_47ZrP6FNuoG8">Default Note Title</a>&nbsp;for
   creating title templates. Note templates and title templates can be combined
   by creating a <code spellcheck="false">#titleTemplate</code> for a template

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Text Extraction (OCR).html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Advanced Usage/Text Extraction (OCR).html
@@ -58,9 +58,9 @@
   <li><a href="https://en.wikipedia.org/wiki/EPUB">EPUB</a>, since v0.104.1.</li>
 </ul>
 <h2>Configuring and triggering OCR</h2>
-<p>The OCR can be configured by going to&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→&nbsp;
-  <a
-  class="reference-link" href="#root/_hidden/_options/_optionsMedia">Media</a>&nbsp;and looking for the <em>Text Extraction (OCR)</em> section.</p>
+<p>The OCR can be configured by going to&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→&nbsp;<a
+  class="reference-link" href="#root/_hidden/_options/_optionsMedia">Media</a>&nbsp;and
+  looking for the <em>Text Extraction (OCR)</em> section.</p>
 <p>There are three ways to trigger the OCR:</p>
 <ul>
   <li>By enabling <em>Auto-process new files</em> which will process only the
@@ -83,46 +83,45 @@
   work correctly. The reason is that each language has its own data which
   needs to be downloaded, and accents or other symbols will not be supported
   by the default language.</p>
-<p>To configure the languages that are supported by the OCR, simply go to&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→&nbsp;<a class="reference-link" href="#root/_hidden/_options/_optionsLocalization">Language &amp; Region</a>&nbsp;and
-    adjust the <em>Content languages</em>.</p>
+<p>To configure the languages that are supported by the OCR, simply go to&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→&nbsp;<a
+  class="reference-link" href="#root/_hidden/_options/_optionsLocalization">Language &amp; Region</a>&nbsp;and
+  adjust the <em>Content languages</em>.</p>
 <p>When there are no content languages defined, the user interface <em>Language</em> is
   used instead.</p>
 <p>After making this change, the automatic processing or manual reprocessing
   will take into consideration the new languages.</p>
 <p>To enforce the detection in a particular language for a given note, use
   the <code spellcheck="false">language</code>  <a href="#root/_help_zEY4DaJG4YT5">attribute</a>,
-  similar to <a href="#root/_help_veGu4faJErEM">text content language</a>. For&nbsp;
-  <a
-  class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>, it's not possible to manually adjust the language.</p>
-<aside
-class="admonition note">
+  similar to <a href="#root/_help_veGu4faJErEM">text content language</a>. For&nbsp;<a
+  class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>, it's
+  not possible to manually adjust the language.</p>
+<aside class="admonition note">
   <p>The trained data for each language is not packaged with Trilium, as that
     would require a significant amount of space that might not be otherwise
     needed. As such, when the trained data will be downloaded automatically
     via <a href="https://github.com/naptha/tesseract.js/">Tesseract.js</a>.</p>
   <p>The downloaded trained data is located in the&nbsp;<a class="reference-link"
     href="#root/_help_tAassRL4RSQL">Data directory</a>, in the <code spellcheck="false">ocr-cache</code> directory.</p>
-  </aside>
-  <h2>Viewing extracted content for a single note</h2>
-  <p>To access the extracted content of a note:</p>
-  <ul>
-    <li>For&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>&nbsp;notes,
-      go to the&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Advanced</em> → <em>View OCR Text</em>.</li>
-    <li>For&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;(e.g.&nbsp;
-      <a
-      class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;in&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes),
-        double-click the attachment to view the details, press the […] button at
-        the left and select <em>View extracted text (OCR)</em>.</li>
-  </ul>
-  <p>This section allows:</p>
-  <ul>
-    <li>Viewing the extracted text, which can be copied elsewhere if needed or
-      just to check the quality of the extraction.</li>
-    <li>If the note has not been extracted yet, pressing <em>Process OCR</em> will
-      process it in the background. If the extraction confidence is lower than
-      the minimum confidence, there will be a notification.</li>
-    <li>Similarly, if the minimum confidence was changed in settings, it is possible
-      to press the <em>Process OCR</em> button again to extract the text again.</li>
-  </ul>
+</aside>
+<h2>Viewing extracted content for a single note</h2>
+<p>To access the extracted content of a note:</p>
+<ul>
+  <li>For&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>&nbsp;notes,
+    go to the&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Advanced</em> → <em>View OCR Text</em>.</li>
+  <li>For&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;(e.g.&nbsp;<a
+    class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;in&nbsp;<a
+    class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes),
+    double-click the attachment to view the details, press the […] button at
+    the left and select <em>View extracted text (OCR)</em>.</li>
+</ul>
+<p>This section allows:</p>
+<ul>
+  <li>Viewing the extracted text, which can be copied elsewhere if needed or
+    just to check the quality of the extraction.</li>
+  <li>If the note has not been extracted yet, pressing <em>Process OCR</em> will
+    process it in the background. If the extraction confidence is lower than
+    the minimum confidence, there will be a notification.</li>
+  <li>Similarly, if the minimum confidence was changed in settings, it is possible
+    to press the <em>Process OCR</em> button again to extract the text again.</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Active content.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Active content.html
@@ -7,10 +7,9 @@
   then imported into Trilium.</p>
 <p>When <a href="#root/_help_mHbBMPDPkVV5">importing</a> .zip archives into Trilium, <em>safe mode</em> is
   active by default which will try to prevent untrusted code from executing.
-  For example, a <a href="#root/_help_MgibgPcfeuGz">custom widget</a> needs the
-  <code
-  spellcheck="false">#widget</code> <a href="#root/_help_HI6GBBIduIgv">label</a> in order to function;
-    safe import works by renaming that label to <code spellcheck="false">#disabled:widget</code>.</p>
+  For example, a <a href="#root/_help_MgibgPcfeuGz">custom widget</a> needs the <code
+  spellcheck="false">#widget</code>  <a href="#root/_help_HI6GBBIduIgv">label</a> in
+  order to function; safe import works by renaming that label to <code spellcheck="false">#disabled:widget</code>.</p>
 <h2>Safe mode</h2>
 <p>Sometimes active content can cause issues with the UI or the server, preventing
   it from functioning properly.&nbsp;<a class="reference-link" href="#root/_help_64ZTlUPgEPtW">Safe mode</a>&nbsp;allows

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export.html
@@ -4,8 +4,7 @@
   <li>HTML:
     <ul>
       <li>This is the main format used by Trilium, where standard tags are used
-        to represent basic formatting and layout (e.g. <code spellcheck="false">&lt;strong&gt;</code>,
-        <code
+        to represent basic formatting and layout (e.g. <code spellcheck="false">&lt;strong&gt;</code>, <code
         spellcheck="false">&lt;table&gt;</code>, <code spellcheck="false">&lt;pre&gt;</code>).</li>
       <li>Note that HTML is not a standardized format so some more specific features
         such as admonitions or&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;might
@@ -102,9 +101,9 @@
   </table>
 </figure>
 <aside class="admonition tip">
-  <p>Instead of exporting full ZIPs (including the root note), consider using
-    <a
-    href="#root/_help_ODY7qQn5m2FT">backups</a>instead. Backups always contain the entire structure, as well
-      as additional information a ZIP export does not have: maintains note IDs,
-      contains the options/tokens and handle&nbsp;<a class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>&nbsp;better.</p>
+  <p>Instead of exporting full ZIPs (including the root note), consider using <a
+    href="#root/_help_ODY7qQn5m2FT">backups</a> instead. Backups always contain the
+    entire structure, as well as additional information a ZIP export does not
+    have: maintains note IDs, contains the options/tokens and handle&nbsp;<a
+    class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>&nbsp;better.</p>
 </aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Anytype.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Anytype.html
@@ -144,15 +144,13 @@
       </tr>
       <tr>
         <td>Checkbox</td>
-        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/
-          <code
+        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/<code
           spellcheck="false">false</code>).</td>
       </tr>
       <tr>
         <td>URL / Email / Phone</td>
-        <td><code spellcheck="false">url</code> label (<code spellcheck="false">mailto:</code>,
-          <code
-          spellcheck="false">tel:</code>prefix)</td>
+        <td><code spellcheck="false">url</code> label (<code spellcheck="false">mailto:</code>, <code
+          spellcheck="false">tel:</code> prefix)</td>
       </tr>
     </tbody>
   </table>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Evernote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Evernote.html
@@ -70,8 +70,7 @@
   <li>The hierarchy of headings (these are shifted to start with H2 because
     H1 is reserved for note title, see&nbsp;<a href="#root/_help_Gr6xFaF6ioJ5">Headings</a>)</li>
   <li>To-do lists. The new task format is collapsed to standard to-do lists</li>
-  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
-    <a
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;<a
     class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>
   </li>
   <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>&nbsp;(with
@@ -103,8 +102,7 @@
 </ul>
 <h3>Links to other notes</h3>
 <p>Since v0.104.0, the ENEX importer tries to recreate links to other notes
-  automatically by converting their Evernote-specific URLs to Trilium's&nbsp;
-  <a
+  automatically by converting their Evernote-specific URLs to Trilium's&nbsp;<a
   class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>.</p>
 <p>Since the ENEX format does not provide the unique ID of notes, the note
   references are determined via their note title.</p>
@@ -125,8 +123,7 @@
     it should also allow finding links between two different imports.</p>
 </aside>
 <p>If you want to restore the internal links in Trilium after you import
-  all of your ENEX files, you can use or adapt this custom script:&nbsp;
-  <a
+  all of your ENEX files, you can use or adapt this custom script:&nbsp;<a
   class="reference-link" href="#root/_help_dj3j8dG4th4l">Process internal links by title</a>
 </p>
 <p>The script does the following:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Google Keep.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Google Keep.html
@@ -40,8 +40,7 @@
     </ul>
   </li>
   <li>To-do lists</li>
-  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
-    <a
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;<a
     class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
   <li>Creation and modification dates are preserved.</li>
 </ul>
@@ -61,9 +60,9 @@
   <li>A sample of the note is required to better understand what happened.
     <ul>
       <li>Because Google Keep has no per-note export, extract the Google Takeout
-        ZIP and copy the files corresponding to the problematic note (<code spellcheck="false">.html</code>,
-        <code
-        spellcheck="false">.json</code>and any attachments if you are able to identify them).</li>
+        ZIP and copy the files corresponding to the problematic note (<code spellcheck="false">.html</code>, <code
+        spellcheck="false">.json</code> and any attachments if you are able to identify
+        them).</li>
     </ul>
   </li>
   <li>A screenshot with how it originally looked like before the import and

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Microsoft OneNote.html
@@ -92,10 +92,9 @@
   timeout on their side or other issues. Trilium will try to refetch pages
   in order to avoid that but sometimes pages cannot be retrieved even after
   multiple retries. In that case, the importer will still create a corresponding
-  note in Trilium but with an error report instead of a content. This preserves&nbsp;
-  <a
-  class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;and makes it easy to identify and
-    manually fix the pages that failed.</p>
+  note in Trilium but with an error report instead of a content. This preserves&nbsp;<a
+  class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;and
+  makes it easy to identify and manually fix the pages that failed.</p>
 <p>At the end of the import, the top-level note called <em>OneNote</em>  <em>import</em> will
   contain information about how the import went:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Notion.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Notion.html
@@ -55,8 +55,7 @@
   <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>
   </li>
   <li>To-do lists</li>
-  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
-    <a
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;<a
     class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
   <li>Toggle sections
     <ul>
@@ -131,9 +130,8 @@
       </tr>
       <tr>
         <td>URL / Email / Phone</td>
-        <td><code spellcheck="false">url</code> label (<code spellcheck="false">mailto:</code>,
-          <code
-          spellcheck="false">tel:</code>prefix)</td>
+        <td><code spellcheck="false">url</code> label (<code spellcheck="false">mailto:</code>, <code
+          spellcheck="false">tel:</code> prefix)</td>
       </tr>
       <tr>
         <td>Date</td>
@@ -147,8 +145,7 @@
       </tr>
       <tr>
         <td>Checkbox</td>
-        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/
-          <code
+        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/<code
           spellcheck="false">false</code>).</td>
       </tr>
       <tr>
@@ -177,11 +174,10 @@
       <tr>
         <td>Formulas / Rollup</td>
         <td>
-          <p>A <code spellcheck="false">text</code>, <code spellcheck="false">number</code> or
-            <code
-            spellcheck="false">boolean</code>label depending on the value. Dates are rendered as
-              <code
-              spellcheck="false">text</code>because the export doesn't offer any type information.</p>
+          <p>A <code spellcheck="false">text</code>, <code spellcheck="false">number</code> or <code
+            spellcheck="false">boolean</code> label depending on the value. Dates are
+            rendered as <code spellcheck="false">text</code> because the export doesn't
+            offer any type information.</p>
           <p>The Notion export does not preserve the formula/rollup configuration itself,
             instead it just exports the value.</p>
         </td>
@@ -199,11 +195,11 @@
   <p>Every page property that can be preserved according to the table above
     is saved as a label or relation to the corresponding note (except for creation
     and modification dates which are saved at note level).</p>
-  <p>To maintain a similar UX to Notion, every property is also turned into&nbsp;
-    <a
-    class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;at collection level. This also makes the
-      columns visible in the table collection. The promoted attributes are made
-      inheritable so that they appear when navigating in the child notes as well.</p>
+  <p>To maintain a similar UX to Notion, every property is also turned into&nbsp;<a
+    class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;at
+    collection level. This also makes the columns visible in the table collection.
+    The promoted attributes are made inheritable so that they appear when navigating
+    in the child notes as well.</p>
   <p>The names of the labels are intentionally converted to <code spellcheck="false">camelCase</code> to
     match Trilium's conventions, but the full name of the column is preserved
     through the <em>Alias</em> mechanism of promoted attributes.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Obsidian.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Importing data from other applications/Obsidian.html
@@ -1,7 +1,7 @@
-<p>Although Obsidian was indirectly supported through the standard&nbsp;
-  <a
-  class="reference-link" href="#root/_help_Oau6X9rCuegd">Markdown</a>&nbsp;import, its vault structure is distinct enough to warrant
-    its own dedicated import channel.</p>
+<p>Although Obsidian was indirectly supported through the standard&nbsp;<a
+  class="reference-link" href="#root/_help_Oau6X9rCuegd">Markdown</a>&nbsp;import,
+  its vault structure is distinct enough to warrant its own dedicated import
+  channel.</p>
 <h2>Import process</h2>
 <p>The first step is to obtain a .zip of your Obsidian vault:</p>
 <ol>
@@ -32,18 +32,17 @@
   <li><a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>
   </li>
   <li>To-do lists</li>
-  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;
-    <a
+  <li><a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;and&nbsp;<a
     class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>
-      <ul>
-        <li>Non-Markdown files in the Vault are treated as attachments by default
-          if they are referenced by at least one note.</li>
-        <li>Otherwise, they will be imported as&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>&nbsp;notes.</li>
-      </ul>
+    <ul>
+      <li>Non-Markdown files in the Vault are treated as attachments by default
+        if they are referenced by at least one note.</li>
+      <li>Otherwise, they will be imported as&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>&nbsp;notes.</li>
+    </ul>
   </li>
-  <li>Transclusions are converted to&nbsp;<a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>&nbsp;or&nbsp;
-    <a
-    class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;(depending on type).</li>
+  <li>Transclusions are converted to&nbsp;<a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>&nbsp;or&nbsp;<a
+    class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>&nbsp;(depending
+    on type).</li>
   <li><a class="reference-link" href="#root/_help_YfYAtQBcfo5V">Math Equations</a>&nbsp;(inline
     or block)</li>
   <li><a class="reference-link" href="#root/_help_QxEyIjRBizuC">Code blocks</a>, with
@@ -51,11 +50,10 @@
   <li>Links between pages are converted to&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>.</li>
   <li>Callouts are converted to Trilium's <a href="#root/_help_NwBbFdNZ9h7O">Admonitions</a>.
     <ul>
-      <li>Obsidian has many more types of callouts (<code spellcheck="false">tldr</code>,
-        <code
-        spellcheck="false">question</code>, <code spellcheck="false">attention</code>), these are
-          all mapped to one of Trilium's existing admonition types (e.g. Note, Tip,
-          Important).</li>
+      <li>Obsidian has many more types of callouts (<code spellcheck="false">tldr</code>, <code
+        spellcheck="false">question</code>, <code spellcheck="false">attention</code>),
+        these are all mapped to one of Trilium's existing admonition types (e.g.
+        Note, Tip, Important).</li>
       <li>Custom titles are kept and shown as a bold line at the top of the admonition,
         since there is no concept of admonition title in Trilium.</li>
       <li>Foldable callouts are imported expanded and without a fold marker.</li>
@@ -78,15 +76,14 @@
   between the two is where the property information is stored (i.e. name
   and type): in Obsidian everything is stored at vault level and shared across
   all notes, whereas in Trilium each page can have individual promoted attributes,
-  shared through&nbsp;<a class="reference-link" href="#root/_help_KC1HB96bqqHX">Templates</a>&nbsp;or&nbsp;
-  <a
+  shared through&nbsp;<a class="reference-link" href="#root/_help_KC1HB96bqqHX">Templates</a>&nbsp;or&nbsp;<a
   class="reference-link" href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>.</p>
 <p>Another important difference is that promoted attributes in Trilium are
   always displayed, even if empty. In Obsidian, these are simply suggested
   when creating a new property.</p>
-<p>To reconcile all these differences, properties are converted to&nbsp;
-  <a
-  class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;at note level.</p>
+<p>To reconcile all these differences, properties are converted to&nbsp;<a
+  class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;at
+  note level.</p>
 <p>The following note types are supported:</p>
 <figure class="table">
   <table>
@@ -111,8 +108,7 @@
       </tr>
       <tr>
         <td>Checkbox</td>
-        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/
-          <code
+        <td><code spellcheck="false">boolean</code> label (<code spellcheck="false">true</code>/<code
           spellcheck="false">false</code>).</td>
       </tr>
       <tr>
@@ -133,15 +129,12 @@
   in Trilium as well:</p>
 <ul>
   <li><code spellcheck="false">tags</code>, where every tag is turned into its
-    own <a href="#root/_help_HI6GBBIduIgv">label</a> (e.g. <code spellcheck="false">#one</code>,
-    <code
-    spellcheck="false">#two</code>when <code spellcheck="false">tags: [ one, two ]</code>).</li>
-  <li><code spellcheck="false">aliases</code> are simply mapped to individual
-    <code
-    spellcheck="false">#alias</code>labels</li>
-  <li><code spellcheck="false">cssclasses</code>, <code spellcheck="false">publish</code>,
-    <code
-    spellcheck="false">permalink</code>are ignored.</li>
+    own <a href="#root/_help_HI6GBBIduIgv">label</a> (e.g. <code spellcheck="false">#one</code>, <code
+    spellcheck="false">#two</code> when <code spellcheck="false">tags: [ one, two ]</code>).</li>
+  <li><code spellcheck="false">aliases</code> are simply mapped to individual <code
+    spellcheck="false">#alias</code> labels</li>
+  <li><code spellcheck="false">cssclasses</code>, <code spellcheck="false">publish</code>, <code
+    spellcheck="false">permalink</code> are ignored.</li>
 </ul>
 <h2>Limitations</h2>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Markdown/Supported syntax.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Import & Export/Markdown/Supported syntax.html
@@ -13,9 +13,8 @@
 <p>Trilium internal links (that mirror a note's title and display its icon)
   are embedded as HTML in order to preserve the information on import.</p>
 <h2>Math equations</h2>
-<p>Both inline and display equations are supported, using the <code spellcheck="false">$</code> and
-  <code
-  spellcheck="false">$$</code>syntaxes.</p>
+<p>Both inline and display equations are supported, using the <code spellcheck="false">$</code> and <code
+  spellcheck="false">$$</code> syntaxes.</p>
 <h2>Admonitions</h2>
 <p>The Markdown syntax for admonitions as supported by Trilium is the one
   that GitHub uses, which is as follows:</p><pre><code class="language-text-x-trilium-auto">&gt; [!NOTE]
@@ -37,10 +36,9 @@
   <li><code spellcheck="false">[[foo/bar]]</code> will look for the <code spellcheck="false">bar.md</code> file
     in the <code spellcheck="false">foo</code> directory and turn it into an
     internal link.</li>
-  <li><code spellcheck="false">![[foo/baz.png]]</code> will look for the
-    <code
-    spellcheck="false">baz.png</code>file in the <code spellcheck="false">foo</code> directory
-      and turn it into an image.</li>
+  <li><code spellcheck="false">![[foo/baz.png]]</code> will look for the <code
+    spellcheck="false">baz.png</code> file in the <code spellcheck="false">foo</code> directory
+    and turn it into an image.</li>
 </ul>
 <p>This feature is import-only, which means that it will turn wikilinks into
   Trilium-compatible syntax, but it will not export Trilium Notes into Markdown

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Keyboard Shortcuts.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Keyboard Shortcuts.html
@@ -57,9 +57,9 @@
   <li>Moving a split left/right</li>
   <li>Focusing the split to the left/right.</li>
 </ul>
-<p>All these keyboard shortcuts do not have a default set, go to&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Shortcuts</em> and look for the <em>Split View</em> category.</p>
+<p>All these keyboard shortcuts do not have a default set, go to&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Shortcuts</em> and
+  look for the <em>Split View</em> category.</p>
 <h3>Creating notes</h3>
 <ul>
   <li><kbd>Ctrl</kbd>+<kbd>O</kbd> – creates new note after the current note</li>
@@ -70,8 +70,7 @@
 <h3>Editing notes</h3>
 <aside class="admonition note">
   <p>For keyboard shortcuts specific to&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes,
-    refer to&nbsp;<a class="reference-link" href="#root/_help_oiVPnW8QfnvS">Keyboard shortcuts</a>&nbsp;and&nbsp;
-    <a
+    refer to&nbsp;<a class="reference-link" href="#root/_help_oiVPnW8QfnvS">Keyboard shortcuts</a>&nbsp;and&nbsp;<a
     class="reference-link" href="#root/_help_QrtTYPmdd1qq">Markdown-like formatting</a>.</p>
 </aside>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Jump to & command palette.html
@@ -25,14 +25,14 @@
     note title and selecting one of two options:
     <ul>
       <li><em>Create note</em> places it in the&nbsp;<a class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>:
-        the note labelled <code spellcheck="false">#inbox</code>, today's&nbsp;<a class="reference-link"
-        href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if there is none, or the
-        top level if there is no journal either. While hoisted into a&nbsp;<a class="reference-link"
-        href="#root/_help_9sRHySam5fXb">Workspaces</a>, the workspace's own inbox
-        is used, falling back to the workspace root itself. The option names the
-        destination, so it is always visible before the note is created.</li>
-      <li><em>Create child note</em> places it under the note that is currently
-        open.</li>
+        the note labelled <code spellcheck="false">#inbox</code>, today's&nbsp;<a
+        class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if
+        there is none, or the top level if there is no journal either. While hoisted
+        into a&nbsp;<a class="reference-link" href="#root/_help_9sRHySam5fXb">Workspaces</a>,
+        the workspace's own inbox is used, falling back to the workspace root itself.
+        The option names the destination, so it is always visible before the note
+        is created.</li>
+      <li><em>Create child note</em> places it under the note that is currently open.</li>
     </ul>
   </li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Note Navigation.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Note Navigation.html
@@ -9,10 +9,9 @@
   <img src="Note Navigation_image.png">
 </p>
 <h2>Jump to note</h2>
-<p>This is useful to quickly find and view arbitrary notes - click on
-  <code
-  spellcheck="false">Jump to</code>button on the top or press <kbd>Ctrl</kbd> + <kbd>J</kbd> .
-    Then type part of the note name and autocomplete will help you pick the
-    desired note.</p>
+<p>This is useful to quickly find and view arbitrary notes - click on <code
+  spellcheck="false">Jump to</code> button on the top or press <kbd>Ctrl</kbd> + <kbd>J</kbd> .
+  Then type part of the note name and autocomplete will help you pick the
+  desired note.</p>
 <p>See&nbsp;<a class="reference-link" href="#root/_help_F1r9QtzQLZqm">Jump to Note</a>&nbsp;for
   more information.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Quick search.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Quick search.html
@@ -67,11 +67,10 @@
 </ol>
 <h2>Quick Search - Exact Match Operator</h2>
 <p>Quick Search shares the same search engine as the full <a class="reference-link"
-  href="#root/_help_eIg8jdvaoNNd">Search</a>, so the exact match operator (
-  <code
-  spellcheck="false">=</code>) behaves identically in both. Start your query with <code spellcheck="false">=</code> (no
-    space after it) to switch from the default "contains" behavior to exact
-    whole-word or phrase matching.</p>
+  href="#root/_help_eIg8jdvaoNNd">Search</a>, so the exact match operator (<code
+  spellcheck="false">=</code>) behaves identically in both. Start your query
+  with <code spellcheck="false">=</code> (no space after it) to switch from
+  the default "contains" behavior to exact whole-word or phrase matching.</p>
 <p><strong>What <code spellcheck="false">=</code> actually does:</strong> it
   finds notes where the title or content contains your term as a <strong>whole word or phrase</strong>,
   ignoring surrounding punctuation. It does <strong>not</strong> require the
@@ -125,9 +124,9 @@
   </table>
 </figure>
 <p>The search is case- and diacritic-insensitive. For the complete explanation
-  of the three matching modes, fuzzy operators and relevance ranking, see
-  <a
-  href="#root/_help_eIg8jdvaoNNd">How search matches your text</a>in the full Search documentation.</p>
+  of the three matching modes, fuzzy operators and relevance ranking, see <a
+  href="#root/_help_eIg8jdvaoNNd">How search matches your text</a> in the full Search
+  documentation.</p>
 <h3>Limitations</h3>
 <ul>
   <li>The <code spellcheck="false">=</code> operator must be at the very beginning
@@ -139,13 +138,11 @@
 </ul>
 <h3>Related Features</h3>
 <ul>
-  <li>For attribute, property, boolean and ordering queries, use the full
-    <a
-    href="#root/_help_eIg8jdvaoNNd">Search</a>functionality.</li>
-  <li>For fuzzy matching (finding results despite typos), use the <code spellcheck="false">~=</code> or
-    <code
-    spellcheck="false">~*</code>operators in the full search.</li>
-  <li>For partial matches with wildcards, use operators like <code spellcheck="false">*=*</code>,
-    <code
-    spellcheck="false">=*</code>, or <code spellcheck="false">*=</code> in the full search.</li>
+  <li>For attribute, property, boolean and ordering queries, use the full <a
+    href="#root/_help_eIg8jdvaoNNd">Search</a> functionality.</li>
+  <li>For fuzzy matching (finding results despite typos), use the <code spellcheck="false">~=</code> or <code
+    spellcheck="false">~*</code> operators in the full search.</li>
+  <li>For partial matches with wildcards, use operators like <code spellcheck="false">*=*</code>, <code
+    spellcheck="false">=*</code>, or <code spellcheck="false">*=</code> in the
+    full search.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.html
@@ -13,9 +13,7 @@
     look for the dedicated search button.</li>
   <li>To limit the search to a note and its children, select <em>Search from subtree</em> from
     the&nbsp;<a class="reference-link" href="#root/_help_YtSN43OrfzaA">Note tree contextual menu</a>&nbsp;or
-    press <kbd spellcheck="false">Ctrl</kbd>+<kbd spellcheck="false">Shift</kbd>+
-    <kbd
-    spellcheck="false">S</kbd>.</li>
+    press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>.</li>
 </ul>
 <h2>Interaction</h2>
 <p>To search for notes, click on the magnifying glass icon on the toolbar
@@ -92,9 +90,9 @@
   </li>
   <li>Debug
     <ol>
-      <li>This will print additional information in the server log (see&nbsp;
-        <a
-        class="reference-link" href="#root/_help_qzNzp9LYQyPT">Error logs</a>), regarding how the search expression was parsed.</li>
+      <li>This will print additional information in the server log (see&nbsp;<a
+        class="reference-link" href="#root/_help_qzNzp9LYQyPT">Error logs</a>), regarding
+        how the search expression was parsed.</li>
       <li>This function is especially useful after understanding the search functionality
         in detail, in order to determine why a complex search query is not working
         as expected.</li>
@@ -180,9 +178,8 @@
       <tr>
         <td><strong>Attribute / property equality</strong>
         </td>
-        <td><code spellcheck="false">=</code> inside a <code spellcheck="false">#label=value</code> or
-          <code
-          spellcheck="false">note.property=value</code>clause</td>
+        <td><code spellcheck="false">=</code> inside a <code spellcheck="false">#label=value</code> or <code
+          spellcheck="false">note.property=value</code> clause</td>
         <td>the <em>entire</em> attribute or property value, exactly</td>
         <td>No</td>
         <td>No</td>
@@ -334,18 +331,16 @@
 </figure>
 <h3>Attribute and property equality (<code spellcheck="false">=</code>, <code spellcheck="false">!=</code>)</h3>
 <p><strong>Rule:</strong> when <code spellcheck="false">=</code> compares an
-  attribute or property, as in <code spellcheck="false">#label=value</code> or
-  <code
+  attribute or property, as in <code spellcheck="false">#label=value</code> or <code
   spellcheck="false">note.title=value</code>, it is <strong>strict full-value equality</strong>:
-    the <em>whole</em> value must equal what you typed, ignoring case and diacritics.
-    This is <strong>not</strong> word matching. <code spellcheck="false">!=</code> inverts
-    it.</p>
-<p>The examples below assume four notes: <em>Austria</em> (<code spellcheck="false">#capital=Vienna</code>), <em>Somewhere</em> (
-  <code
-  spellcheck="false">#capital=Vienna Austria</code>), <em>Czech Republic</em> (<code spellcheck="false">#capital=Prague</code>)
-    and <em>Switzerland</em> (<code spellcheck="false">#capital=Zürich</code>).</p>
-<figure
-class="table">
+  the <em>whole</em> value must equal what you typed, ignoring case and diacritics.
+  This is <strong>not</strong> word matching. <code spellcheck="false">!=</code> inverts
+  it.</p>
+<p>The examples below assume four notes: <em>Austria</em> (<code spellcheck="false">#capital=Vienna</code>), <em>Somewhere</em> (<code
+  spellcheck="false">#capital=Vienna Austria</code>), <em>Czech Republic</em> (<code
+  spellcheck="false">#capital=Prague</code>) and <em>Switzerland</em> (<code
+  spellcheck="false">#capital=Zürich</code>).</p>
+<figure class="table">
   <table>
     <thead>
       <tr>
@@ -371,8 +366,7 @@ class="table">
         <td><code spellcheck="false">Vienna Austria</code>
         </td>
         <td>No</td>
-        <td>the whole value is <code spellcheck="false">Vienna Austria</code>, not
-          <code
+        <td>the whole value is <code spellcheck="false">Vienna Austria</code>, not <code
           spellcheck="false">Vienna</code>
         </td>
       </tr>
@@ -398,8 +392,7 @@ class="table">
         <td><code spellcheck="false">Prague</code>
         </td>
         <td>Yes</td>
-        <td><code spellcheck="false">!=</code> matches every value that is not
-          <code
+        <td><code spellcheck="false">!=</code> matches every value that is not <code
           spellcheck="false">Vienna</code>
         </td>
       </tr>
@@ -413,528 +406,517 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <blockquote>
-    <p><strong>Quick search relaxes this.</strong> The <a href="#root/_help_Ms1nauBra7gq">Quick search</a> bar
-      and autocomplete treat an attribute <code spellcheck="false">=</code> as
-      "contains", so <code spellcheck="false">#capital=Vienna</code> typed there
-      also matches <code spellcheck="false">Vienna Austria</code>. The strict
-      full-value equality described here applies only in the full Search.</p>
-  </blockquote>
-  <h3>Fuzzy operators (<code spellcheck="false">~=</code> and <code spellcheck="false">~*</code>)</h3>
-  <p><strong>Rule:</strong> the fuzzy operators tolerate typos. <code spellcheck="false">~=</code> (fuzzy-equals)
-    matches a value that is a close whole-word variant of your term. <code spellcheck="false">~*</code> (fuzzy-contains)
-    matches when your term appears anywhere inside the value, either as a fragment
-    or as a near-miss. Both work on note properties such as <code spellcheck="false">note.title</code> and
-    <code
-    spellcheck="false">note.content</code>, and on labels (<code spellcheck="false">#label</code>).
-      Fuzzy operators require at least 3 characters.</p>
-  <p>The examples assume a note titled <code spellcheck="false">Books</code> carrying
-    the label <code spellcheck="false">#author=Tolkien</code>, and a note whose
-    content is <code spellcheck="false">learn programming today</code>.</p>
-  <figure
-  class="table">
-    <table>
-      <thead>
-        <tr>
-          <th>Query</th>
-          <th>Example value</th>
-          <th>Matches?</th>
-          <th>Why</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code spellcheck="false">note.title ~= boks</code>
-          </td>
-          <td>title <code spellcheck="false">Books</code>
-          </td>
-          <td>Yes</td>
-          <td>one edit away from <code spellcheck="false">books</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#author ~= tolkein</code>
-          </td>
-          <td>author <code spellcheck="false">Tolkien</code>
-          </td>
-          <td>Yes</td>
-          <td><code spellcheck="false">tolkein</code> is a typo of <code spellcheck="false">tolkien</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">note.content ~* progr</code>
-          </td>
-          <td><code spellcheck="false">learn programming today</code>
-          </td>
-          <td>Yes</td>
-          <td><code spellcheck="false">progr</code> is a fragment of <code spellcheck="false">programming</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">note.content ~* programing</code>
-          </td>
-          <td><code spellcheck="false">learn programming today</code>
-          </td>
-          <td>Yes</td>
-          <td><code spellcheck="false">programing</code> is one edit from <code spellcheck="false">programming</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    </figure>
-    <h3>Fuzzy tolerance (AUTO)</h3>
-    <p><strong>Rule:</strong> how many typos are tolerated depends on the <strong>length</strong> of
-      your search term (the "AUTO" scheme popularized by Elasticsearch). Short
-      terms must match almost exactly to avoid noise; longer terms tolerate more.</p>
-    <figure
-    class="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Term length</th>
-            <th>Edits allowed</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>1–2 characters</td>
-            <td>0 (exact only)</td>
-          </tr>
-          <tr>
-            <td>3–5 characters</td>
-            <td>1</td>
-          </tr>
-          <tr>
-            <td>6+ characters</td>
-            <td>2</td>
-          </tr>
-        </tbody>
-      </table>
-      </figure>
-      <figure class="table">
-        <table>
-          <thead>
-            <tr>
-              <th>Query</th>
-              <th>Term length</th>
-              <th>Example note content</th>
-              <th>Matches?</th>
-              <th>Why</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code spellcheck="false">cat</code>
-              </td>
-              <td>3</td>
-              <td><code spellcheck="false">a bright red car</code>
-              </td>
-              <td>Yes</td>
-              <td>1 edit is within budget for 3–5 character terms</td>
-            </tr>
-            <tr>
-              <td><code spellcheck="false">ceck</code>
-              </td>
-              <td>4</td>
-              <td><code spellcheck="false">the latest tech trends</code>
-              </td>
-              <td>No</td>
-              <td><code spellcheck="false">ceck</code>→<code spellcheck="false">tech</code> needs
-                2 edits; only 1 is allowed at this length</td>
-            </tr>
-            <tr>
-              <td><code spellcheck="false">combinef</code>
-              </td>
-              <td>8</td>
-              <td><code spellcheck="false">the values were combined together</code>
-              </td>
-              <td>Yes</td>
-              <td><code spellcheck="false">combinef</code>→<code spellcheck="false">combined</code> is
-                1 edit; up to 2 are allowed at 6+ characters</td>
-            </tr>
-          </tbody>
-        </table>
-      </figure>
-      <h3>Relevance ranking</h3>
-      <p><strong>Rule:</strong> results are ordered by <em>how well</em> they match,
-        not merely whether they match. Exact whole-word and phrase matches rank
-        above substring and fuzzy matches, and a note where your words appear as
-        a consecutive phrase outranks one where they are scattered.</p>
-      <figure
-      class="table">
-        <table>
-          <thead>
-            <tr>
-              <th>Query</th>
-              <th>Ranked higher</th>
-              <th>Ranked lower</th>
-              <th>Why</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code spellcheck="false">sync</code>
-              </td>
-              <td><code spellcheck="false">please sync the folders</code>
-              </td>
-              <td><code spellcheck="false">synchronize the database now</code>
-              </td>
-              <td>exact word beats substring</td>
-            </tr>
-            <tr>
-              <td><code spellcheck="false">you and me</code>
-              </td>
-              <td><code spellcheck="false">I like you and me as a phrase</code>
-              </td>
-              <td><code spellcheck="false">the menu is here and you know it</code>
-              </td>
-              <td>consecutive phrase beats scattered words</td>
-            </tr>
-          </tbody>
-        </table>
-        </figure>
-        <h3>What is searchable</h3>
-        <p>A search looks at more than the visible body text. All of the following
-          are indexed and searchable:</p>
+</figure>
+<blockquote>
+  <p><strong>Quick search relaxes this.</strong> The <a href="#root/_help_Ms1nauBra7gq">Quick search</a> bar
+    and autocomplete treat an attribute <code spellcheck="false">=</code> as
+    "contains", so <code spellcheck="false">#capital=Vienna</code> typed there
+    also matches <code spellcheck="false">Vienna Austria</code>. The strict
+    full-value equality described here applies only in the full Search.</p>
+</blockquote>
+<h3>Fuzzy operators (<code spellcheck="false">~=</code> and <code spellcheck="false">~*</code>)</h3>
+<p><strong>Rule:</strong> the fuzzy operators tolerate typos. <code spellcheck="false">~=</code> (fuzzy-equals)
+  matches a value that is a close whole-word variant of your term. <code spellcheck="false">~*</code> (fuzzy-contains)
+  matches when your term appears anywhere inside the value, either as a fragment
+  or as a near-miss. Both work on note properties such as <code spellcheck="false">note.title</code> and <code
+  spellcheck="false">note.content</code>, and on labels (<code spellcheck="false">#label</code>).
+  Fuzzy operators require at least 3 characters.</p>
+<p>The examples assume a note titled <code spellcheck="false">Books</code> carrying
+  the label <code spellcheck="false">#author=Tolkien</code>, and a note whose
+  content is <code spellcheck="false">learn programming today</code>.</p>
+<figure
+class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Example value</th>
+        <th>Matches?</th>
+        <th>Why</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">note.title ~= boks</code>
+        </td>
+        <td>title <code spellcheck="false">Books</code>
+        </td>
+        <td>Yes</td>
+        <td>one edit away from <code spellcheck="false">books</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#author ~= tolkein</code>
+        </td>
+        <td>author <code spellcheck="false">Tolkien</code>
+        </td>
+        <td>Yes</td>
+        <td><code spellcheck="false">tolkein</code> is a typo of <code spellcheck="false">tolkien</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">note.content ~* progr</code>
+        </td>
+        <td><code spellcheck="false">learn programming today</code>
+        </td>
+        <td>Yes</td>
+        <td><code spellcheck="false">progr</code> is a fragment of <code spellcheck="false">programming</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">note.content ~* programing</code>
+        </td>
+        <td><code spellcheck="false">learn programming today</code>
+        </td>
+        <td>Yes</td>
+        <td><code spellcheck="false">programing</code> is one edit from <code spellcheck="false">programming</code>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Fuzzy tolerance (AUTO)</h3>
+<p><strong>Rule:</strong> how many typos are tolerated depends on the <strong>length</strong> of
+  your search term (the "AUTO" scheme popularized by Elasticsearch). Short
+  terms must match almost exactly to avoid noise; longer terms tolerate more.</p>
+<figure
+class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Term length</th>
+        <th>Edits allowed</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1–2 characters</td>
+        <td>0 (exact only)</td>
+      </tr>
+      <tr>
+        <td>3–5 characters</td>
+        <td>1</td>
+      </tr>
+      <tr>
+        <td>6+ characters</td>
+        <td>2</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Term length</th>
+        <th>Example note content</th>
+        <th>Matches?</th>
+        <th>Why</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">cat</code>
+        </td>
+        <td>3</td>
+        <td><code spellcheck="false">a bright red car</code>
+        </td>
+        <td>Yes</td>
+        <td>1 edit is within budget for 3–5 character terms</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">ceck</code>
+        </td>
+        <td>4</td>
+        <td><code spellcheck="false">the latest tech trends</code>
+        </td>
+        <td>No</td>
+        <td><code spellcheck="false">ceck</code>→<code spellcheck="false">tech</code> needs
+          2 edits; only 1 is allowed at this length</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">combinef</code>
+        </td>
+        <td>8</td>
+        <td><code spellcheck="false">the values were combined together</code>
+        </td>
+        <td>Yes</td>
+        <td><code spellcheck="false">combinef</code>→<code spellcheck="false">combined</code> is
+          1 edit; up to 2 are allowed at 6+ characters</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Relevance ranking</h3>
+<p><strong>Rule:</strong> results are ordered by <em>how well</em> they match,
+  not merely whether they match. Exact whole-word and phrase matches rank
+  above substring and fuzzy matches, and a note where your words appear as
+  a consecutive phrase outranks one where they are scattered.</p>
+<figure
+class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Ranked higher</th>
+        <th>Ranked lower</th>
+        <th>Why</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">sync</code>
+        </td>
+        <td><code spellcheck="false">please sync the folders</code>
+        </td>
+        <td><code spellcheck="false">synchronize the database now</code>
+        </td>
+        <td>exact word beats substring</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">you and me</code>
+        </td>
+        <td><code spellcheck="false">I like you and me as a phrase</code>
+        </td>
+        <td><code spellcheck="false">the menu is here and you know it</code>
+        </td>
+        <td>consecutive phrase beats scattered words</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>What is searchable</h3>
+<p>A search looks at more than the visible body text. All of the following
+  are indexed and searchable:</p>
+<ul>
+  <li>note titles,</li>
+  <li>note body content,</li>
+  <li>labels and relations (<a href="#root/_help_zEY4DaJG4YT5">attributes</a>),</li>
+  <li>link URLs and the titles/descriptions of link previews,</li>
+  <li>the titles of notes that a note reference-links to.</li>
+</ul>
+<p>The last point is the least obvious: if a note's only content is a reference
+  link to another note, searching for that other note's <strong>title</strong> still
+  finds the linking note.</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Setup</th>
+        <th>Matches?</th>
+        <th>Why</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">special topic</code>
+        </td>
+        <td>a note whose only content is a reference link to a note titled <code spellcheck="false">Special Topic</code>
+        </td>
+        <td>Yes, and the linked target ranks first</td>
+        <td>the target's title is indexed into the linking note's searchable text</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">special</code>
+        </td>
+        <td>the same note (only a reference link to <code spellcheck="false">Special Topic</code>)</td>
+        <td>Yes, one word from the target's title is enough</td>
+        <td>the indexed title is normalized just like body text, so even one lowercased
+          word matches</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">zurich</code>
+        </td>
+        <td>a note whose only content is a reference link to a note titled <code spellcheck="false">Zürich</code>
+        </td>
+        <td>Yes</td>
+        <td>the indexed title has its accents normalized, so the plain form matches
+          the accented title</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Diacritics</h3>
+<p><strong>Rule:</strong> accents are normalized on both sides, so an accented
+  word and its plain form match each other.</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Example note content</th>
+        <th>Matches?</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">ktory</code>
+        </td>
+        <td><code spellcheck="false">slovo ktorý znamena nieco</code>
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">ktorý</code>
+        </td>
+        <td><code spellcheck="false">the word ktory appears here</code>
+        </td>
+        <td>Yes</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Regular expressions (<code spellcheck="false">%=</code>)</h3>
+<p><strong>Rule:</strong> the <code spellcheck="false">%=</code> operator matches
+  a property or label value against a regular expression.</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Query</th>
+        <th>Example note content</th>
+        <th>Matches?</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">note.content %= 'colou?r'</code>
+        </td>
+        <td><code spellcheck="false">my favorite color of all</code>
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">note.content %= 'colou?r'</code>
+        </td>
+        <td><code spellcheck="false">my favourite colour of all</code>
+        </td>
+        <td>Yes</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Simple Note Search Examples</h3>
+<ul>
+  <li><code spellcheck="false">rings tolkien</code>: Full-text search to find
+    notes containing both "rings" and "tolkien".</li>
+  <li><code spellcheck="false">"The Lord of the Rings" Tolkien</code>: Full-text
+    search where "The Lord of the Rings" must match exactly.</li>
+  <li><code spellcheck="false">note.content *=* rings OR note.content *=* tolkien</code>:
+    Find notes containing "rings" or "tolkien" in their content.</li>
+  <li><code spellcheck="false">towers #book</code>: Combine full-text and attribute
+    search to find notes containing "towers" and having the "book" label.</li>
+  <li><code spellcheck="false">towers #book or #author</code>: Search for notes
+    containing "towers" and having either the "book" or "author" label.</li>
+  <li><code spellcheck="false">towers #!book</code>: Search for notes containing
+    "towers" and not having the "book" label.</li>
+  <li><code spellcheck="false">#book #publicationYear = 1954</code>: Find notes
+    with the "book" label and "publicationYear" set to 1954.</li>
+  <li><code spellcheck="false">#genre *=* fan</code>: Find notes with the "genre"
+    label containing the substring "fan". Additional operators include <code
+    spellcheck="false">*=*</code> for "contains", <code spellcheck="false">=*</code> for
+    "starts with", <code spellcheck="false">*=</code> for "ends with", and <code
+    spellcheck="false">!=</code> for "is not equal to".</li>
+  <li><code spellcheck="false">#book #publicationYear &gt;= 1950 #publicationYear &lt; 1960</code>:
+    Use numeric operators to find all books published in the 1950s.</li>
+  <li><code spellcheck="false">#dateNote &gt;= TODAY-30</code>: Find notes with
+    the "dateNote" label within the last 30 days. Supported date values include
+    NOW +- seconds, TODAY +- days, MONTH +- months, YEAR +- years.</li>
+  <li><code spellcheck="false">~author.title *=* Tolkien</code>: Find notes
+    related to an author whose title contains "Tolkien".</li>
+  <li><code spellcheck="false">#publicationYear %= '19[0-9]{2}'</code>: Use
+    the '%=' operator to match a regular expression (regex). This feature has
+    been available since Trilium 0.52.</li>
+  <li><code spellcheck="false">note.content %= '\\d{2}:\\d{2} (PM|AM)'</code>:
+    Find notes that mention a time. Backslashes in a regex must be escaped.</li>
+</ul>
+<h3>Advanced Use Cases</h3>
+<ul>
+  <li><code spellcheck="false">~author.relations.son.title = 'Christopher Tolkien'</code>:
+    Search for notes with an "author" relation to a note that has a "son" relation
+    to "Christopher Tolkien". This can be modeled with the following note structure:
+    <ul>
+      <li>Books
         <ul>
-          <li>note titles,</li>
-          <li>note body content,</li>
-          <li>labels and relations (<a href="#root/_help_zEY4DaJG4YT5">attributes</a>),</li>
-          <li>link URLs and the titles/descriptions of link previews,</li>
-          <li>the titles of notes that a note reference-links to.</li>
-        </ul>
-        <p>The last point is the least obvious: if a note's only content is a reference
-          link to another note, searching for that other note's <strong>title</strong> still
-          finds the linking note.</p>
-        <figure class="table">
-          <table>
-            <thead>
-              <tr>
-                <th>Query</th>
-                <th>Setup</th>
-                <th>Matches?</th>
-                <th>Why</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code spellcheck="false">special topic</code>
-                </td>
-                <td>a note whose only content is a reference link to a note titled <code spellcheck="false">Special Topic</code>
-                </td>
-                <td>Yes, and the linked target ranks first</td>
-                <td>the target's title is indexed into the linking note's searchable text</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">special</code>
-                </td>
-                <td>the same note (only a reference link to <code spellcheck="false">Special Topic</code>)</td>
-                <td>Yes, one word from the target's title is enough</td>
-                <td>the indexed title is normalized just like body text, so even one lowercased
-                  word matches</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">zurich</code>
-                </td>
-                <td>a note whose only content is a reference link to a note titled <code spellcheck="false">Zürich</code>
-                </td>
-                <td>Yes</td>
-                <td>the indexed title has its accents normalized, so the plain form matches
-                  the accented title</td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
-        <h3>Diacritics</h3>
-        <p><strong>Rule:</strong> accents are normalized on both sides, so an accented
-          word and its plain form match each other.</p>
-        <figure class="table">
-          <table>
-            <thead>
-              <tr>
-                <th>Query</th>
-                <th>Example note content</th>
-                <th>Matches?</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code spellcheck="false">ktory</code>
-                </td>
-                <td><code spellcheck="false">slovo ktorý znamena nieco</code>
-                </td>
-                <td>Yes</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">ktorý</code>
-                </td>
-                <td><code spellcheck="false">the word ktory appears here</code>
-                </td>
-                <td>Yes</td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
-        <h3>Regular expressions (<code spellcheck="false">%=</code>)</h3>
-        <p><strong>Rule:</strong> the <code spellcheck="false">%=</code> operator matches
-          a property or label value against a regular expression.</p>
-        <figure class="table">
-          <table>
-            <thead>
-              <tr>
-                <th>Query</th>
-                <th>Example note content</th>
-                <th>Matches?</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code spellcheck="false">note.content %= 'colou?r'</code>
-                </td>
-                <td><code spellcheck="false">my favorite color of all</code>
-                </td>
-                <td>Yes</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">note.content %= 'colou?r'</code>
-                </td>
-                <td><code spellcheck="false">my favourite colour of all</code>
-                </td>
-                <td>Yes</td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
-        <h3>Simple Note Search Examples</h3>
-        <ul>
-          <li><code spellcheck="false">rings tolkien</code>: Full-text search to find
-            notes containing both "rings" and "tolkien".</li>
-          <li><code spellcheck="false">"The Lord of the Rings" Tolkien</code>: Full-text
-            search where "The Lord of the Rings" must match exactly.</li>
-          <li><code spellcheck="false">note.content *=* rings OR note.content *=* tolkien</code>:
-            Find notes containing "rings" or "tolkien" in their content.</li>
-          <li><code spellcheck="false">towers #book</code>: Combine full-text and attribute
-            search to find notes containing "towers" and having the "book" label.</li>
-          <li><code spellcheck="false">towers #book or #author</code>: Search for notes
-            containing "towers" and having either the "book" or "author" label.</li>
-          <li><code spellcheck="false">towers #!book</code>: Search for notes containing
-            "towers" and not having the "book" label.</li>
-          <li><code spellcheck="false">#book #publicationYear = 1954</code>: Find notes
-            with the "book" label and "publicationYear" set to 1954.</li>
-          <li><code spellcheck="false">#genre *=* fan</code>: Find notes with the "genre"
-            label containing the substring "fan". Additional operators include
-            <code
-            spellcheck="false">*=*</code>for "contains", <code spellcheck="false">=*</code> for "starts
-              with", <code spellcheck="false">*=</code> for "ends with", and <code spellcheck="false">!=</code> for
-              "is not equal to".</li>
-          <li><code spellcheck="false">#book #publicationYear &gt;= 1950 #publicationYear &lt; 1960</code>:
-            Use numeric operators to find all books published in the 1950s.</li>
-          <li><code spellcheck="false">#dateNote &gt;= TODAY-30</code>: Find notes with
-            the "dateNote" label within the last 30 days. Supported date values include
-            NOW +- seconds, TODAY +- days, MONTH +- months, YEAR +- years.</li>
-          <li><code spellcheck="false">~author.title *=* Tolkien</code>: Find notes
-            related to an author whose title contains "Tolkien".</li>
-          <li><code spellcheck="false">#publicationYear %= '19[0-9]{2}'</code>: Use
-            the '%=' operator to match a regular expression (regex). This feature has
-            been available since Trilium 0.52.</li>
-          <li><code spellcheck="false">note.content %= '\\d{2}:\\d{2} (PM|AM)'</code>:
-            Find notes that mention a time. Backslashes in a regex must be escaped.</li>
-        </ul>
-        <h3>Advanced Use Cases</h3>
-        <ul>
-          <li><code spellcheck="false">~author.relations.son.title = 'Christopher Tolkien'</code>:
-            Search for notes with an "author" relation to a note that has a "son" relation
-            to "Christopher Tolkien". This can be modeled with the following note structure:
+          <li>Lord of the Rings
             <ul>
-              <li>Books
-                <ul>
-                  <li>Lord of the Rings
-                    <ul>
-                      <li>label: “book”</li>
-                      <li>relation: “author” points to “J. R. R. Tolkien” note</li>
-                    </ul>
-                  </li>
-                </ul>
-              </li>
-              <li>People
-                <ul>
-                  <li>J. R. R. Tolkien
-                    <ul>
-                      <li>relation: “son” points to "Christopher Tolkien" note</li>
-                      <li>Christopher Tolkien</li>
-                    </ul>
-                  </li>
-                </ul>
-              </li>
+              <li>label: “book”</li>
+              <li>relation: “author” points to “J. R. R. Tolkien” note</li>
             </ul>
           </li>
-          <li><code spellcheck="false">~author.title *= Tolkien OR (#publicationDate &gt;= 1954 AND #publicationDate &lt;= 1960)</code>:
-            Use boolean expressions and parentheses to group expressions. Note that
-            expressions starting with a parenthesis need an "expression separator sign"
-            (# or ~) prepended.</li>
-          <li><code spellcheck="false">note.parents.title = 'Books'</code>: Find notes
-            with a parent named "Books".</li>
-          <li><code spellcheck="false">note.parents.parents.title = 'Books'</code>:
-            Find notes with a grandparent named "Books".</li>
-          <li><code spellcheck="false">note.ancestors.title = 'Books'</code>: Find notes
-            with an ancestor named "Books".</li>
-          <li><code spellcheck="false">note.children.title = 'sub-note'</code>: Find
-            notes with a child named "sub-note".</li>
         </ul>
-        <h3>Search with Note Properties</h3>
-        <p>Notes have properties that can be used in searches, such as <code spellcheck="false">noteId</code>,
-          <code
-          spellcheck="false">dateModified</code>, <code spellcheck="false">dateCreated</code>,
-            <code
-            spellcheck="false">isProtected</code>, <code spellcheck="false">type</code>, <code spellcheck="false">title</code>,
-              <code
-              spellcheck="false">text</code>, <code spellcheck="false">content</code>, <code spellcheck="false">rawContent</code>,
-                <code
-                spellcheck="false">ownedLabelCount</code>, <code spellcheck="false">labelCount</code>,
-                  <code
-                  spellcheck="false">ownedRelationCount</code>, <code spellcheck="false">relationCount</code>,
-                    <code
-                    spellcheck="false">ownedRelationCountIncludingLinks</code>, <code spellcheck="false">relationCountIncludingLinks</code>,
-                      <code
-                      spellcheck="false">ownedAttributeCount</code>, <code spellcheck="false">attributeCount</code>,
-                        <code
-                        spellcheck="false">targetRelationCount</code>, <code spellcheck="false">targetRelationCountIncludingLinks</code>,
-                          <code
-                          spellcheck="false">parentCount</code>, <code spellcheck="false">childrenCount</code>,
-                            <code
-                            spellcheck="false">isArchived</code>, <code spellcheck="false">contentSize</code>, <code spellcheck="false">noteSize</code>,
-                              and <code spellcheck="false">revisionCount</code>.</p>
-        <p>These properties can be accessed via the <code spellcheck="false">note.</code> prefix,
-          e.g., <code spellcheck="false">note.type = code AND note.mime = 'application/json'</code>.</p>
-        <h3>Order by and Limit</h3><pre><code class="language-text-x-trilium-auto">#author=Tolkien orderBy #publicationDate desc, note.title limit 10</code></pre>
-        <p>This example will:</p>
-        <ol>
-          <li>Find notes with the author label "Tolkien".</li>
-          <li>Order the results by <code spellcheck="false">publicationDate</code> in
-            descending order.</li>
-          <li>Use <code spellcheck="false">note.title</code> as a secondary ordering if
-            publication dates are equal.</li>
-          <li>Limit the results to the first 10 notes.</li>
-        </ol>
-        <h3>Negation</h3>
-        <p>Some queries can only be expressed with negation:</p><pre><code class="language-text-x-trilium-auto">#book AND not(note.ancestors.title = 'Tolkien')</code></pre>
-        <p>This query finds all book notes not in the "Tolkien" subtree.</p>
-        <h2>Progressive Search Strategy</h2>
-        <p>Trilium uses a progressive search strategy that performs exact matching
-          first, then adds fuzzy matching when needed.</p>
-        <h3>How Progressive Search Works</h3>
-        <ol>
-          <li><strong>Phase 1 - Exact Matching</strong>: When you search, Trilium first
-            looks for exact matches of your search terms. This handles the vast majority
-            of searches (90%+) and returns results almost instantly.</li>
-          <li><strong>Phase 2 - Fuzzy Fallback</strong>: If Phase 1 doesn't find enough
-            high-quality results (fewer than 5 results with good relevance scores),
-            Trilium automatically adds fuzzy matching to find results with typos or
-            spelling variations.</li>
-          <li><strong>Result Ordering</strong>: Exact matches always appear before fuzzy
-            matches, regardless of individual scores. This ensures that when you search
-            for "project", notes containing the exact word "project" will appear before
-            notes containing similar words like "projects" or "projection".</li>
-        </ol>
-        <h3>Progressive Search Behavior</h3>
+      </li>
+      <li>People
         <ul>
-          <li><strong>Speed</strong>: Most searches complete using only exact matching</li>
-          <li><strong>Ordering</strong>: Exact matches appear before fuzzy matches</li>
-          <li><strong>Fallback</strong>: Fuzzy matching activates when exact matches
-            return fewer than 5 results</li>
-          <li><strong>Identification</strong>: Results indicate whether they are exact
-            or fuzzy matches</li>
+          <li>J. R. R. Tolkien
+            <ul>
+              <li>relation: “son” points to "Christopher Tolkien" note</li>
+              <li>Christopher Tolkien</li>
+            </ul>
+          </li>
         </ul>
-        <h3>Search Performance</h3>
-        <p>Search system specifications:</p>
-        <ul>
-          <li>Content size limit: 10MB per note (previously 50KB)</li>
-          <li>Edit distance calculations for fuzzy matching</li>
-          <li>Infinite scrolling in Quick Search</li>
-        </ul>
-        <h2>Under the Hood</h2>
-        <h3>Label and Relation Shortcuts</h3>
-        <p>The "full" syntax for searching by labels is:</p><pre><code class="language-text-x-trilium-auto">note.labels.publicationYear = 1954</code></pre>
-        <p>For relations:</p><pre><code class="language-text-x-trilium-auto">note.relations.author.title *=* Tolkien</code></pre>
-        <p>However, common label and relation searches have shortcut syntax:</p><pre><code class="language-text-x-trilium-auto">#publicationYear = 1954
+      </li>
+    </ul>
+  </li>
+  <li><code spellcheck="false">~author.title *= Tolkien OR (#publicationDate &gt;= 1954 AND #publicationDate &lt;= 1960)</code>:
+    Use boolean expressions and parentheses to group expressions. Note that
+    expressions starting with a parenthesis need an "expression separator sign"
+    (# or ~) prepended.</li>
+  <li><code spellcheck="false">note.parents.title = 'Books'</code>: Find notes
+    with a parent named "Books".</li>
+  <li><code spellcheck="false">note.parents.parents.title = 'Books'</code>:
+    Find notes with a grandparent named "Books".</li>
+  <li><code spellcheck="false">note.ancestors.title = 'Books'</code>: Find notes
+    with an ancestor named "Books".</li>
+  <li><code spellcheck="false">note.children.title = 'sub-note'</code>: Find
+    notes with a child named "sub-note".</li>
+</ul>
+<h3>Search with Note Properties</h3>
+<p>Notes have properties that can be used in searches, such as <code spellcheck="false">noteId</code>, <code
+  spellcheck="false">dateModified</code>, <code spellcheck="false">dateCreated</code>, <code
+  spellcheck="false">isProtected</code>, <code spellcheck="false">type</code>, <code
+  spellcheck="false">title</code>, <code spellcheck="false">text</code>, <code
+  spellcheck="false">content</code>, <code spellcheck="false">rawContent</code>, <code
+  spellcheck="false">ownedLabelCount</code>, <code spellcheck="false">labelCount</code>, <code
+  spellcheck="false">ownedRelationCount</code>, <code spellcheck="false">relationCount</code>, <code
+  spellcheck="false">ownedRelationCountIncludingLinks</code>, <code spellcheck="false">relationCountIncludingLinks</code>, <code
+  spellcheck="false">ownedAttributeCount</code>, <code spellcheck="false">attributeCount</code>, <code
+  spellcheck="false">targetRelationCount</code>, <code spellcheck="false">targetRelationCountIncludingLinks</code>, <code
+  spellcheck="false">parentCount</code>, <code spellcheck="false">childrenCount</code>, <code
+  spellcheck="false">isArchived</code>, <code spellcheck="false">contentSize</code>, <code
+  spellcheck="false">noteSize</code>, and <code spellcheck="false">revisionCount</code>.</p>
+<p>These properties can be accessed via the <code spellcheck="false">note.</code> prefix,
+  e.g., <code spellcheck="false">note.type = code AND note.mime = 'application/json'</code>.</p>
+<h3>Order by and Limit</h3><pre><code class="language-text-x-trilium-auto">#author=Tolkien orderBy #publicationDate desc, note.title limit 10</code></pre>
+<p>This example will:</p>
+<ol>
+  <li>Find notes with the author label "Tolkien".</li>
+  <li>Order the results by <code spellcheck="false">publicationDate</code> in
+    descending order.</li>
+  <li>Use <code spellcheck="false">note.title</code> as a secondary ordering if
+    publication dates are equal.</li>
+  <li>Limit the results to the first 10 notes.</li>
+</ol>
+<h3>Negation</h3>
+<p>Some queries can only be expressed with negation:</p><pre><code class="language-text-x-trilium-auto">#book AND not(note.ancestors.title = 'Tolkien')</code></pre>
+<p>This query finds all book notes not in the "Tolkien" subtree.</p>
+<h2>Progressive Search Strategy</h2>
+<p>Trilium uses a progressive search strategy that performs exact matching
+  first, then adds fuzzy matching when needed.</p>
+<h3>How Progressive Search Works</h3>
+<ol>
+  <li><strong>Phase 1 - Exact Matching</strong>: When you search, Trilium first
+    looks for exact matches of your search terms. This handles the vast majority
+    of searches (90%+) and returns results almost instantly.</li>
+  <li><strong>Phase 2 - Fuzzy Fallback</strong>: If Phase 1 doesn't find enough
+    high-quality results (fewer than 5 results with good relevance scores),
+    Trilium automatically adds fuzzy matching to find results with typos or
+    spelling variations.</li>
+  <li><strong>Result Ordering</strong>: Exact matches always appear before fuzzy
+    matches, regardless of individual scores. This ensures that when you search
+    for "project", notes containing the exact word "project" will appear before
+    notes containing similar words like "projects" or "projection".</li>
+</ol>
+<h3>Progressive Search Behavior</h3>
+<ul>
+  <li><strong>Speed</strong>: Most searches complete using only exact matching</li>
+  <li><strong>Ordering</strong>: Exact matches appear before fuzzy matches</li>
+  <li><strong>Fallback</strong>: Fuzzy matching activates when exact matches
+    return fewer than 5 results</li>
+  <li><strong>Identification</strong>: Results indicate whether they are exact
+    or fuzzy matches</li>
+</ul>
+<h3>Search Performance</h3>
+<p>Search system specifications:</p>
+<ul>
+  <li>Content size limit: 10MB per note (previously 50KB)</li>
+  <li>Edit distance calculations for fuzzy matching</li>
+  <li>Infinite scrolling in Quick Search</li>
+</ul>
+<h2>Under the Hood</h2>
+<h3>Label and Relation Shortcuts</h3>
+<p>The "full" syntax for searching by labels is:</p><pre><code class="language-text-x-trilium-auto">note.labels.publicationYear = 1954</code></pre>
+<p>For relations:</p><pre><code class="language-text-x-trilium-auto">note.relations.author.title *=* Tolkien</code></pre>
+<p>However, common label and relation searches have shortcut syntax:</p><pre><code class="language-text-x-trilium-auto">#publicationYear = 1954
 ~author.title *=* Tolkien</code></pre>
-        <h3>Separating Full-Text and Attribute Parts</h3>
-        <p>Search syntax allows combining full-text search with attribute-based search.
-          For example, <code spellcheck="false">tolkien #book</code> contains:</p>
-        <ol>
-          <li>Full-text tokens - <code spellcheck="false">tolkien</code>
-          </li>
-          <li>Attribute expressions - <code spellcheck="false">#book</code>
-          </li>
-        </ol>
-        <p>Trilium detects the separation between full text search and attribute/property
-          search by looking for certain special characters or words that denote attributes
-          and properties (e.g., #, ~, note.). If you need to include these in full-text
-          search, escape them with a backslash so they are processed as regular text:</p><pre><code class="language-text-x-trilium-auto">"note.txt" 
+<h3>Separating Full-Text and Attribute Parts</h3>
+<p>Search syntax allows combining full-text search with attribute-based search.
+  For example, <code spellcheck="false">tolkien #book</code> contains:</p>
+<ol>
+  <li>Full-text tokens - <code spellcheck="false">tolkien</code>
+  </li>
+  <li>Attribute expressions - <code spellcheck="false">#book</code>
+  </li>
+</ol>
+<p>Trilium detects the separation between full text search and attribute/property
+  search by looking for certain special characters or words that denote attributes
+  and properties (e.g., #, ~, note.). If you need to include these in full-text
+  search, escape them with a backslash so they are processed as regular text:</p><pre><code class="language-text-x-trilium-auto">"note.txt" 
 \#hash 
 #myLabel = 'Say "Hello World"'</code></pre>
-        <h3>Escaping Special Characters</h3>
-        <p>Special characters can be enclosed in quotes or escaped with a backslash
-          to be used in full-text search:</p><pre><code class="language-text-x-trilium-auto">"note.txt"
+<h3>Escaping Special Characters</h3>
+<p>Special characters can be enclosed in quotes or escaped with a backslash
+  to be used in full-text search:</p><pre><code class="language-text-x-trilium-auto">"note.txt"
 \#hash
 #myLabel = 'Say "Hello World"'</code></pre>
-        <p>Three types of quotes are supported: single, double, and backtick.</p>
-        <h3>Type Coercion</h3>
-        <p>Label values are technically strings but can be coerced for numeric comparisons:</p><pre><code class="language-text-x-trilium-auto">note.dateCreated =* '2019-05'</code></pre>
-        <p>This finds notes created in May 2019. Numeric operators like <code spellcheck="false">#publicationYear &gt;= 1960</code> convert
-          string values to numbers for comparison.</p>
-        <h2>Auto-Trigger Search from URL</h2>
-        <p>You can open Trilium and automatically trigger a search by including the
-          search <a href="https://meyerweb.com/eric/tools/dencoder/">url encoded</a> string
-          in the URL:</p>
-        <p><code spellcheck="false">http://localhost:8080/#?searchString=abc</code>
-        </p>
-        <h2>Search Configuration</h2>
-        <h3>Parameters</h3>
-        <figure class="table">
-          <table>
-            <thead>
-              <tr>
-                <th>Parameter</th>
-                <th>Value</th>
-                <th>Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code spellcheck="false">MIN_FUZZY_TOKEN_LENGTH</code>
-                </td>
-                <td>3</td>
-                <td>Minimum characters for fuzzy matching</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">MAX_EDIT_DISTANCE</code>
-                </td>
-                <td>2</td>
-                <td>Ceiling on character changes, reached only by 6+ character terms; shorter
-                  terms allow fewer. See the <em>Fuzzy tolerance (AUTO)</em> section above</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">RESULT_SUFFICIENCY_THRESHOLD</code>
-                </td>
-                <td>5</td>
-                <td>Minimum exact results before fuzzy fallback</td>
-              </tr>
-              <tr>
-                <td><code spellcheck="false">MAX_CONTENT_SIZE</code>
-                </td>
-                <td>10MB</td>
-                <td>Maximum note content size for search processing</td>
-              </tr>
-            </tbody>
-          </table>
-        </figure>
-        <h3>Limits</h3>
-        <ul>
-          <li>Searched note content is limited to 10MB per note to prevent performance
-            issues</li>
-          <li>Notes exceeding this limit will still be included in title and attribute
-            searches</li>
-          <li>Fuzzy matching requires tokens of at least 3 characters</li>
-        </ul>
+<p>Three types of quotes are supported: single, double, and backtick.</p>
+<h3>Type Coercion</h3>
+<p>Label values are technically strings but can be coerced for numeric comparisons:</p><pre><code class="language-text-x-trilium-auto">note.dateCreated =* '2019-05'</code></pre>
+<p>This finds notes created in May 2019. Numeric operators like <code spellcheck="false">#publicationYear &gt;= 1960</code> convert
+  string values to numbers for comparison.</p>
+<h2>Auto-Trigger Search from URL</h2>
+<p>You can open Trilium and automatically trigger a search by including the
+  search <a href="https://meyerweb.com/eric/tools/dencoder/">url encoded</a> string
+  in the URL:</p>
+<p><code spellcheck="false">http://localhost:8080/#?searchString=abc</code>
+</p>
+<h2>Search Configuration</h2>
+<h3>Parameters</h3>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Value</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">MIN_FUZZY_TOKEN_LENGTH</code>
+        </td>
+        <td>3</td>
+        <td>Minimum characters for fuzzy matching</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">MAX_EDIT_DISTANCE</code>
+        </td>
+        <td>2</td>
+        <td>Ceiling on character changes, reached only by 6+ character terms; shorter
+          terms allow fewer. See the <em>Fuzzy tolerance (AUTO)</em> section above</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">RESULT_SUFFICIENCY_THRESHOLD</code>
+        </td>
+        <td>5</td>
+        <td>Minimum exact results before fuzzy fallback</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">MAX_CONTENT_SIZE</code>
+        </td>
+        <td>10MB</td>
+        <td>Maximum note content size for search processing</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Limits</h3>
+<ul>
+  <li>Searched note content is limited to 10MB per note to prevent performance
+    issues</li>
+  <li>Notes exceeding this limit will still be included in title and attribute
+    searches</li>
+  <li>Fuzzy matching requires tokens of at least 3 characters</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Tree Concepts.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Navigation/Tree Concepts.html
@@ -1,8 +1,7 @@
 <p>This page explains the basic concepts related to the tree structure of
   notes in TriliumNext.</p>
 <h2>Note</h2>
-<p>A note is the central entity in TriliumNext. For more details, see&nbsp;
-  <a
+<p>A note is the central entity in TriliumNext. For more details, see&nbsp;<a
   class="reference-link" href="#root/_help_BFs8mudNFgCS">Notes</a>.</p>
 <h2>Branch</h2>
 <p>A branch describes the placement of a note within the note tree. Essentially,
@@ -10,8 +9,7 @@
   indicating that the given note is placed as a child under the specified
   parent note.</p>
 <p>Each note can have multiple branches, meaning any note can be placed in
-  multiple locations within the tree. This concept is referred to as&nbsp;
-  <a
+  multiple locations within the tree. This concept is referred to as&nbsp;<a
   class="reference-link" href="#root/_help_IakOLONlIfGI">Cloning Notes</a>.</p>
 <h2>Prefix</h2>
 <p>A prefix is a branch-specific title modifier for a note. If you place

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes.html
@@ -2,9 +2,9 @@
   content.</p>
 <h3>Note types</h3>
 <p>The main note type is a rich-text note type called&nbsp;<a class="reference-link"
-  href="#root/_help_iPIMuisry3hd">Text</a>. For diagrams and drawing there is&nbsp;
-  <a
-  class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>.</p>
+  href="#root/_help_iPIMuisry3hd">Text</a>. For diagrams and drawing there is&nbsp;<a
+  class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>.</p>
 <p>There are also more complex note types such as&nbsp;<a class="reference-link"
   href="#root/_help_m523cpzocqaD">Saved Search</a>,&nbsp;<a class="reference-link"
   href="#root/_help_HcABDtFCkbFN">Render Note</a>&nbsp;that usually go hand-in-hand

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Archived Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Archived Notes.html
@@ -1,6 +1,5 @@
-<p>Archived notes are notes which have <code spellcheck="false">archived</code> 
-  <a
-  href="#root/_help_zEY4DaJG4YT5">attribute</a>- either directly or <a href="#root/_help_bwZpz2ajCEwO">inherited</a>.</p>
+<p>Archived notes are notes which have <code spellcheck="false">archived</code>  <a
+  href="#root/_help_zEY4DaJG4YT5">attribute</a> - either directly or <a href="#root/_help_bwZpz2ajCEwO">inherited</a>.</p>
 <p>Such notes are then by default not shown in the autocomplete and in the
   full text <a href="#root/_help_eIg8jdvaoNNd">search</a>.</p>
 <p>This can be useful for notes which are no longer very useful but still

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Attachments.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Attachments.html
@@ -22,8 +22,7 @@
     be of multiple types, including:
     <ul>
       <li><a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>&nbsp;to
-        store information about views such as the column information for the&nbsp;
-        <a
+        store information about views such as the column information for the&nbsp;<a
         class="reference-link" href="#root/_help_CtBQqbwXDx1w">Kanban Board</a>.</li>
       <li>Icons and cover images for&nbsp;<a class="reference-link" href="#root/_help_UmgZAfcltxkS">Link Previews</a>.</li>
       <li>Debug information for some importers such as&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Cloning Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Cloning Notes.html
@@ -81,8 +81,7 @@
   <img src="Cloning Notes_create-clone.gif">
 </p>
 <p>In the demo, you can see how a clone can be created using the context
-  menu. It's possible to do this also using the Add Link dialog or with <kbd>Ctrl</kbd>+<kbd>C</kbd> and <kbd>Ctrl</kbd>+<kbd>V</kbd> 
-  <a
+  menu. It's possible to do this also using the Add Link dialog or with <kbd>Ctrl</kbd>+<kbd>C</kbd> and <kbd>Ctrl</kbd>+<kbd>V</kbd>  <a
   href="#root/_help_A9Oc6YKKc65v">keyboard shortcuts</a>.</p>
 <p>You can view the list of all available clones:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Cloning Notes/Branch prefix.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Cloning Notes/Branch prefix.html
@@ -1,8 +1,8 @@
 <p>Since a single note can appear into multiple places in the&nbsp;<a class="reference-link"
-  href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;via a process called&nbsp;
-  <a
-  class="reference-link" href="#root/_help_IakOLONlIfGI">Cloning Notes</a>, it's recommended to choose a generalized name that
-    fits into all locations instead of something more specific to avoid confusion.</p>
+  href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;via a process called&nbsp;<a
+  class="reference-link" href="#root/_help_IakOLONlIfGI">Cloning Notes</a>, it's
+  recommended to choose a generalized name that fits into all locations instead
+  of something more specific to avoid confusion.</p>
 <p>In some cases this isn't possible so Trilium provides "branch prefixes",
   which is shown before the note name in the tree and as such provides a
   specific kind of context.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Icons & Colors.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Icons & Colors.html
@@ -6,8 +6,7 @@
 <p>Icons are useful for distinguishing notes and are displayed near the note
   title, as well as in various places such as the&nbsp;<a class="reference-link"
   href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>,&nbsp;<a class="reference-link"
-  href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;or the&nbsp;
-  <a
+  href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;or the&nbsp;<a
   class="reference-link" href="#root/_help_F1r9QtzQLZqm">Jump to &amp; command palette</a>.</p>
 <p>While editing a note, click on the icon next to the title to bring up
   a chooser gallery.</p>
@@ -28,10 +27,8 @@
 <p>To set a custom color, right click on the note in the&nbsp;<a class="reference-link"
   href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;and select a predefined color
   from there or use the color picker (last option).</p>
-<p>Alternatively, a custom color can be set manually through the <code spellcheck="false">#color</code> 
-  <a
-  href="#root/_help_HI6GBBIduIgv">label</a>, whose value must be a valid hex color including the leading
-    <code
-    spellcheck="false">#</code>(e.g. <code spellcheck="false">#ff0000</code> for red). This color
-      can be carried over across multiple notes via&nbsp;<a class="reference-link"
-      href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>.</p>
+<p>Alternatively, a custom color can be set manually through the <code spellcheck="false">#color</code>  <a
+  href="#root/_help_HI6GBBIduIgv">label</a>, whose value must be a valid hex color
+  including the leading <code spellcheck="false">#</code> (e.g. <code spellcheck="false">#ff0000</code> for
+  red). This color can be carried over across multiple notes via&nbsp;<a
+  class="reference-link" href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.html
@@ -7,14 +7,14 @@
   <li>The global <em>Create note into inbox</em> shortcut (default <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>).</li>
   <li>The <em>New note</em> action in the <a href="#root/_help_7iwde4lsKc6O">tray icon menu</a>.</li>
   <li>The&nbsp;<a class="reference-link" href="#root/_help_MtPxeAWVAzMg">Web Clipper</a>&nbsp;extension.</li>
-  <li>The <em>Create note</em> option offered when a search finds no match, in&nbsp;<a class="reference-link"
-    href="#root/_help_F1r9QtzQLZqm">Jump to &amp; command palette</a>, in an empty
-    tab and in the <code spellcheck="false">@</code> completion of a text note.</li>
+  <li>The <em>Create note</em> option offered when a search finds no match, in&nbsp;<a
+    class="reference-link" href="#root/_help_F1r9QtzQLZqm">Jump to &amp; command palette</a>,
+    in an empty tab and in the <code spellcheck="false">@</code> completion of
+    a text note.</li>
 </ul>
 <h2>Setting a note inbox</h2>
-<p>To create a note inbox, apply the <code spellcheck="false">#inbox</code> 
-  <a
-  href="#root/_help_HI6GBBIduIgv">label</a>to it.</p>
+<p>To create a note inbox, apply the <code spellcheck="false">#inbox</code>  <a
+  href="#root/_help_HI6GBBIduIgv">label</a> to it.</p>
 <p>Only one note should carry this label. If there are multiple notes, only
   one will be used by the application.</p>
 <aside class="admonition note">

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note List.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note List.html
@@ -6,8 +6,7 @@
   of the note for easy navigation.</p>
 <h2>Configuration</h2>
 <ul>
-  <li>To hide the note list for a particular note, simply apply the <code spellcheck="false">hideChildrenOverview</code> 
-    <a
+  <li>To hide the note list for a particular note, simply apply the <code spellcheck="false">hideChildrenOverview</code>  <a
     href="#root/_help_zEY4DaJG4YT5">label</a>.</li>
   <li>For some view types, such as Grid view, only a subset of notes will be
     displayed and pagination can be used to navigate through all of them for

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Revisions.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Note Revisions.html
@@ -106,9 +106,9 @@
 <p>Time interval of taking note snapshot is configurable in the Options -&gt;
   Other dialog. This provides a trade-off between more revisions and more
   data to store.</p>
-<p>To turn off note versioning for a particular note (or sub-tree), add
-  <code
-  spellcheck="false">disableVersioning</code> <a href="#root/_help_zEY4DaJG4YT5">label</a> to the note.</p>
+<p>To turn off note versioning for a particular note (or sub-tree), add <code
+  spellcheck="false">disableVersioning</code>  <a href="#root/_help_zEY4DaJG4YT5">label</a> to
+  the note.</p>
 <h4>Maximum revisions</h4>
 <p>The limit on the number of note snapshots can be configured in the Options
   -&gt; Other dialog. The note revision snapshot number limit refers to the

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Printing & Exporting as PDF.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Printing & Exporting as PDF.html
@@ -64,8 +64,7 @@
 <aside class="admonition note">
   <p>Most of the options here (expect printer &amp; which pages to print) are
     managed at note level through&nbsp;<a class="reference-link" href="#root/_help_zEY4DaJG4YT5">Attributes</a>&nbsp;(such
-    as <code spellcheck="false">#printLandscape</code>, <code spellcheck="false">#printPageSize</code>,
-    <code
+    as <code spellcheck="false">#printLandscape</code>, <code spellcheck="false">#printPageSize</code>, <code
     spellcheck="false">#printScale</code>, <code spellcheck="false">#printMargins</code>).</p>
   <p>This means that the print settings will be restored when printing the
     same note. There are no default settings that can be configured for all
@@ -83,13 +82,12 @@
   constraints and it will be hidden.</p>
 <h2>Reporting issues with the rendering</h2>
 <p>Should you encounter any visual issues in the resulting PDF file (e.g.
-  a table does not fit properly, there is cut off text, etc.) feel free to
-  <a
-  href="#root/_help_wy8So3yZZlH9">report the issue</a>. In this case, it's best to offer a sample note (click
-    on the
-    <img src="Printing & Exporting as PDF_image.png" width="29"
-    height="31">button, select Export note → This note and all of its descendants → HTML
-    in ZIP archive). Make sure not to accidentally leak any personal information.</p>
+  a table does not fit properly, there is cut off text, etc.) feel free to <a
+  href="#root/_help_wy8So3yZZlH9">report the issue</a>. In this case, it's best
+  to offer a sample note (click on the
+  <img src="Printing & Exporting as PDF_image.png"
+  width="29" height="31">button, select Export note → This note and all of its descendants → HTML
+  in ZIP archive). Make sure not to accidentally leak any personal information.</p>
 <p>Consider adjusting font sizes and using <a href="#root/_help_CohkqWQC1iBv">page breaks</a> to
   work around the layout.</p>
 <aside class="admonition tip">
@@ -158,8 +156,7 @@
         where each slide/sub-note is displayed.
         <ul>
           <li>Most note types are supported, especially the ones that have an image
-            representation such as&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;
-            <a
+            representation such as&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;<a
             class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>.</li>
         </ul>
       </li>
@@ -191,8 +188,7 @@
   <li>Create a CSS <a href="#root/_help_6f9hih2hXXZk">code note</a>.</li>
   <li>On the note being printed, apply the <code spellcheck="false">~printCss</code> relation
     to point to the newly created CSS code note.</li>
-  <li>To apply the CSS to multiple notes, consider using <a href="#root/_help_bwZpz2ajCEwO">inheritable attributes</a> or&nbsp;
-    <a
+  <li>To apply the CSS to multiple notes, consider using <a href="#root/_help_bwZpz2ajCEwO">inheritable attributes</a> or&nbsp;<a
     class="reference-link" href="#root/_help_KC1HB96bqqHX">Templates</a>.</li>
 </ul>
 <p>For example, to change the font of the document from the one defined by
@@ -212,17 +208,16 @@
   <li>If the note pointing to the <code spellcheck="false">printCss</code> doesn't
     have the right note type or mime type, it will be ignored.</li>
   <li>If migrating from a previous version where&nbsp;<a class="reference-link"
-    href="#root/_help_AlhDUqhENtH7">Custom app-wide CSS</a>, there's no need for
-    <code
-    spellcheck="false">@media print {</code> since the style-sheet is used only for printing.</li>
+    href="#root/_help_AlhDUqhENtH7">Custom app-wide CSS</a>, there's no need for <code
+    spellcheck="false">@media print {</code>  since the style-sheet is used
+    only for printing.</li>
 </ul>
 <h2>Under the hood</h2>
 <p>Both printing and exporting as PDF use the same mechanism: a note is rendered
   individually in a separate webpage that is then sent to the browser or
   the Electron application either for printing or exporting as PDF.</p>
 <p>The webpage that renders a single note can actually be accessed in a web
-  browser. For example <code spellcheck="false">http://localhost:8080/#root/WWRGzqHUfRln/RRZsE9Al8AIZ?ntxId=0o4fzk</code> becomes
-  <code
+  browser. For example <code spellcheck="false">http://localhost:8080/#root/WWRGzqHUfRln/RRZsE9Al8AIZ?ntxId=0o4fzk</code> becomes <code
   spellcheck="false">http://localhost:8080/?print#root/WWRGzqHUfRln/RRZsE9Al8AIZ</code>.</p>
 <p>Accessing the print note in a web browser allows for easy debugging to
   understand why a particular note doesn't render well. The mechanism for

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Read-Only Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Read-Only Notes.html
@@ -1,8 +1,8 @@
-<p>Some note types such as&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;
-  <a
-  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes in Trilium can be set to read-only. When a note is
-    in read-only mode, it is presented to the user in a non-editable view,
-    with the option to switch to editing mode if needed.</p>
+<p>Some note types such as&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes in
+  Trilium can be set to read-only. When a note is in read-only mode, it is
+  presented to the user in a non-editable view, with the option to switch
+  to editing mode if needed.</p>
 <h2>Automatic read-only mode</h2>
 <p>For optimization purposes, Trilium will automatically set very large notes
   to read-only. Displaying such lengthy notes in editing mode can slow down
@@ -11,9 +11,9 @@
   of the next section.</p>
 <p>In addition, it's possible to change the number of characters at which
   the automatic read-only mode will trigger in&nbsp;<a class="reference-link"
-  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;by going to the options for&nbsp;
-  <a
-  class="reference-link" href="#root/_hidden/_options/_optionsTextNotes">Text Notes</a>&nbsp;and&nbsp;<a class="reference-link" href="#root/_hidden/_options/_optionsCodeNotes">Code Notes</a>.</p>
+  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;by going to the options for&nbsp;<a
+  class="reference-link" href="#root/_hidden/_options/_optionsTextNotes">Text Notes</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_hidden/_options/_optionsCodeNotes">Code Notes</a>.</p>
 <h2>Changing a note's read-only behavior</h2>
 <p>A note's read-only behavior can be changed via:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Sorting Notes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Sorting Notes.html
@@ -58,8 +58,7 @@
       <tr>
         <td><code spellcheck="false">#sortLocale</code>
         </td>
-        <td>The language code driving the natural sort (e.g. <code spellcheck="false">zh-CN</code>,
-          <code
+        <td>The language code driving the natural sort (e.g. <code spellcheck="false">zh-CN</code>, <code
           spellcheck="false">de</code>). Only meaningful together with <code spellcheck="false">#sortNatural</code>.</td>
       </tr>
       <tr>
@@ -98,11 +97,10 @@
         the specified property.</li>
       <li><strong>Label Sorting</strong>: If <code spellcheck="false">#sorted</code> has
         any other value, this value is treated as the name of a child note's label,
-        and sorting is based on the values of this label. For example, setting
-        <code
-        spellcheck="false">#sorted=myOrder</code>on the parent note and using <code spellcheck="false">#myOrder=001</code>,
-          <code
-          spellcheck="false">#myOrder=002</code>, etc., on child notes.</li>
+        and sorting is based on the values of this label. For example, setting <code
+        spellcheck="false">#sorted=myOrder</code> on the parent note and using <code
+        spellcheck="false">#myOrder=001</code>, <code spellcheck="false">#myOrder=002</code>,
+        etc., on child notes.</li>
     </ul>
   </li>
   <li><strong>Alphabetical Sorting</strong>: Used as a last resort when other

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Title.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Notes/Title.html
@@ -31,10 +31,9 @@
 <p>To rename a note, simply click into the title field and type. Changes
   are saved automatically as you type.</p>
 <p>You can also begin editing the title directly from the&nbsp;<a class="reference-link"
-  href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;by selecting a note and pressing <kbd>Enter</kbd> (see <em>Edit note title</em> in&nbsp;
-  <a
-  class="reference-link" href="#root/_help_A9Oc6YKKc65v">Keyboard Shortcuts</a>), which focuses the title field for the active
-    note.</p>
+  href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;by selecting a note and pressing <kbd>Enter</kbd> (see <em>Edit note title</em> in&nbsp;<a
+  class="reference-link" href="#root/_help_A9Oc6YKKc65v">Keyboard Shortcuts</a>),
+  which focuses the title field for the active note.</p>
 <aside class="admonition note">
   <p>Titles may contain any characters, including Unicode and emoji. For security,
     any HTML in the title is stripped automatically, so the title is always
@@ -50,8 +49,7 @@
 <h3>Working with new notes</h3>
 <p>When you create a new note it's given a default title (<em>new note</em>)
   which is pre-selected, so you can type a name right away to replace it.
-  The default title for new notes can be customized per-section — see&nbsp;
-  <a
+  The default title for new notes can be customized per-section — see&nbsp;<a
   class="reference-link" href="#root/_help_47ZrP6FNuoG8">Default Note Title</a>.</p>
 <p>If you decide you don't want the note after all, pressing <kbd>Escape</kbd> while
   the title of a freshly created note is still focused will discard it.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes.html
@@ -76,8 +76,7 @@ body .CodeMirror {
 <ol>
   <li>Go to "Menu" -&gt; "Options" -&gt; "Appearance."</li>
   <li>In the theme selection dropdown, you should see your custom theme listed
-    under the name you provided with the <code spellcheck="false">#appTheme</code> 
-    <a
+    under the name you provided with the <code spellcheck="false">#appTheme</code>  <a
     href="#root/_help_zEY4DaJG4YT5">label</a>.</li>
   <li>Select your custom theme to activate it.</li>
 </ol>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes/Icon Packs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes/Icon Packs.html
@@ -8,8 +8,7 @@
   scratch (see below) or imported from a ZIP file from a third-party developer.</p>
 <h2>Sample icon packs</h2>
 <p>The Trilium team maintains a few icon packs that are not shipped with
-  Trilium. These icon packs can be found on the official website on the
-  <a
+  Trilium. These icon packs can be found on the official website on the <a
   href="https://triliumnotes.org/resources">Resources page</a>.</p>
 <h2>Importing an existing icon pack</h2>
 <aside class="admonition note">
@@ -53,9 +52,8 @@
     wrong with it.</p>
   <ul>
     <li>Try checking the&nbsp;<a class="reference-link" href="#root/_help_bnyigUA2UK7s">Backend (server) logs</a>&nbsp;for
-      clues and make sure that the icon pack has the <code spellcheck="false">#iconPack</code> 
-      <a
-      href="#root/_help_HI6GBBIduIgv">label</a>with a value assigned to it (a prefix).</li>
+      clues and make sure that the icon pack has the <code spellcheck="false">#iconPack</code>  <a
+      href="#root/_help_HI6GBBIduIgv">label</a> with a value assigned to it (a prefix).</li>
     <li>Icon packs that are <a href="#root/_help_bwg0e8ewQMak">protected</a> are ignored.</li>
   </ul>
 </aside>
@@ -64,21 +62,18 @@
   href="#root/_help_R9pX4DGra2Vt">Sharing</a>&nbsp;feature, where they will be
   shown in the note tree. However, in order for an icon pack to be visible
   to the share function, the icon pack note must also be shared.</p>
-<p>If you are using a custom share theme, make sure it supports the
-  <code
-  spellcheck="false">iconPackCss</code>, otherwise icons will not show up. Check the original
-    share template source code for reference.</p>
+<p>If you are using a custom share theme, make sure it supports the <code
+  spellcheck="false">iconPackCss</code>, otherwise icons will not show up.
+  Check the original share template source code for reference.</p>
 <p>Custom icon packs will also be preserved when&nbsp;<a class="reference-link"
   href="#root/_help_ycBFjKrrwE9p">Exporting static HTML for web publishing</a>.
   In this case, there's no requirement to make the icon pack shared.</p>
 <h2>What happens if I remove an icon pack</h2>
-<p>If an icon pack is removed or disabled (by removing or altering its
-  <code
-  spellcheck="false">#iconPack</code>label), all the notes that use this icon pack will show
-    in the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;with
-    no icon. This won't cause any issues apart from looking strange.</p>
-<p>The solution is to replace the icons with some else, try using&nbsp;
-  <a
-  class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;which supports bulk actions, to identify the notes with
-    the now deleted icon pack (by looking for the prefix) and changing or removing
-    their <code spellcheck="false">iconClass</code>.</p>
+<p>If an icon pack is removed or disabled (by removing or altering its <code
+  spellcheck="false">#iconPack</code> label), all the notes that use this
+  icon pack will show in the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;with
+  no icon. This won't cause any issues apart from looking strange.</p>
+<p>The solution is to replace the icons with some else, try using&nbsp;<a
+  class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;which
+  supports bulk actions, to identify the notes with the now deleted icon
+  pack (by looking for the prefix) and changing or removing their <code spellcheck="false">iconClass</code>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes/Personalizing the font.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/Themes/Personalizing the font.html
@@ -6,8 +6,7 @@
 <ul>
   <li>Interface text, for most of the UI (menus, toolbars, dialogs).</li>
   <li><a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>.</li>
-  <li>Document text, for the actual content of the notes (especially for&nbsp;
-    <a
+  <li>Document text, for the actual content of the notes (especially for&nbsp;<a
     class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes).</li>
   <li>Monospace text, e.g. for&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes
     and&nbsp;<a class="reference-link" href="#root/_help_QxEyIjRBizuC">Code blocks</a>.</li>
@@ -19,10 +18,10 @@
 <ul>
   <li><strong>Generic fonts</strong>
     <ul>
-      <li><em>Theme defined</em> which uses the font that is embedded with the current
-        <a
-        href="#root/_help_Wy267RK4M69c">theme</a>. For example on the default modern theme, the font is <em>Inter</em>.
-          This does not require the font to be installed.</li>
+      <li><em>Theme defined</em> which uses the font that is embedded with the current <a
+        href="#root/_help_Wy267RK4M69c">theme</a>. For example on the default modern
+        theme, the font is <em>Inter</em>. This does not require the font to be
+        installed.</li>
       <li><em>System default</em> which uses a combination of fonts that works best
         for the <a href="#root/_help_poXkQfguuA0U">desktop app</a>. For example on Windows
         it will use <em>Segoe UI</em>.</li>
@@ -80,10 +79,10 @@
   <li>A font kept in a <a href="#root/_help_bwg0e8ewQMak">protected note</a> can only
     be previewed and used while the protected session is open.</li>
 </ul>
-<p>For theme authors, a font can also be embedded in a theme's CSS through&nbsp;
-  <a
-  class="reference-link" href="#root/_help_d3fAXQ2diepH">Custom Resource Providers</a>, which is the route to take when the font
-    should come with the theme rather than be chosen in the settings.</p>
+<p>For theme authors, a font can also be embedded in a theme's CSS through&nbsp;<a
+  class="reference-link" href="#root/_help_d3fAXQ2diepH">Custom Resource Providers</a>,
+  which is the route to take when the font should come with the theme rather
+  than be chosen in the settings.</p>
 <h3>Downloading from Google Fonts</h3>
 <p>A large selection of fonts can be easily retrieved from Google Fonts,
   as follows:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Content width.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Content width.html
@@ -1,16 +1,14 @@
-<p>Some note types such as&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>,&nbsp;
-  <a
-  class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>, and saved search intentionally limit the width of the
-    content.</p>
+<p>Some note types such as&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>,&nbsp;<a
+  class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>, and
+  saved search intentionally limit the width of the content.</p>
 <p>This might appear surprising at first, but the idea is to make text fit
   well on wider screens without appearing distorted. This is especially the
   case if the document contains&nbsp;<a class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>,
   tables or other width-dependent elements.</p>
 <h2>Configuring the content width and alignment</h2>
-<p>The content width is expressed in pixels and can be changed from&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Appearance</em> → <em>Content Width</em> and adjusting
-    the <em>Max content width</em> section.</p>
+<p>The content width is expressed in pixels and can be changed from&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Appearance</em> → <em>Content Width</em> and
+  adjusting the <em>Max content width</em> section.</p>
 <p>To effectively disable the content width limitation, simply set the width
   to a value larger than your screen size (e.g. 9999).</p>
 <p>By default, the content is aligned to the left, but it can be centered
@@ -24,9 +22,8 @@
   <li>Since v0.104.0 in the&nbsp;<a class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>&nbsp;only,
     go to&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;and
     toggle <em>Full width</em>.</li>
-  <li>Or manually apply the <code spellcheck="false">fullContentWidth</code> 
-    <a
-    href="#root/_help_HI6GBBIduIgv">label</a>to the note.</li>
+  <li>Or manually apply the <code spellcheck="false">fullContentWidth</code>  <a
+    href="#root/_help_HI6GBBIduIgv">label</a> to the note.</li>
 </ul>
 <aside class="admonition note">
   <p>Some <a href="#root/_help_KSZ04uQ2D1St">note types</a> are full width by default,

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Floating buttons.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Floating buttons.html
@@ -8,11 +8,10 @@
   note.</p>
 <p>For example:</p>
 <ul>
-  <li>For&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;and&nbsp;
-    <a
-    class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>, there are buttons to download the SVG representation of the
-      note, or to copy a reference to the note for pasting it a&nbsp;<a class="reference-link"
-      href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note.</li>
+  <li>For&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;and&nbsp;<a
+    class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>, there are
+    buttons to download the SVG representation of the note, or to copy a reference
+    to the note for pasting it a&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;note.</li>
   <li>For <a href="#root/_help_CoFPLs3dRlXc">read-only notes</a>, there is a button
     to temporarily edit the note for quick modifications.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Launch Bar.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Launch Bar.html
@@ -55,9 +55,9 @@
   more interaction options, including using keyboard shortcuts.</p>
 <h2>Customizing the launcher</h2>
 <ul>
-  <li>The icon of a launcher can be changed just like a normal note. See&nbsp;
-    <a
-    class="reference-link" href="#root/_help_p9kXRFAkwN4o">Note Icons</a>&nbsp;for more information.</li>
+  <li>The icon of a launcher can be changed just like a normal note. See&nbsp;<a
+    class="reference-link" href="#root/_help_p9kXRFAkwN4o">Note Icons</a>&nbsp;for
+    more information.</li>
   <li>The title of the launcher can also be changed.</li>
 </ul>
 <h3>Resetting</h3>
@@ -84,9 +84,9 @@
   </li>
   <li>
     <p><strong>Script Launcher</strong>
-      <br>An advanced launcher which will run a script upon pressing. See&nbsp;
-      <a
-      class="reference-link" href="#root/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;for more information.</p>
+      <br>An advanced launcher which will run a script upon pressing. See&nbsp;<a
+      class="reference-link" href="#root/_help_CdNpE2pqjmI6">Scripting</a>&nbsp;for
+      more information.</p>
     <ol>
       <li>Set <code spellcheck="false">script</code> to point to the desired script
         to run.</li>
@@ -97,9 +97,9 @@
   <li>
     <p><strong>Custom Widget</strong>
     </p>
-    <p>Allows defining a custom widget to be rendered inside the launcher. See&nbsp;
-      <a
-      class="reference-link" href="#root/_help_SynTBQiBsdYJ">Widget Basics</a>&nbsp;for more information.</p>
+    <p>Allows defining a custom widget to be rendered inside the launcher. See&nbsp;<a
+      class="reference-link" href="#root/_help_SynTBQiBsdYJ">Widget Basics</a>&nbsp;for
+      more information.</p>
   </li>
   <li>
     <p><strong>Spacers</strong>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/New Layout.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/New Layout.html
@@ -6,253 +6,250 @@
 <h3>Status bar</h3>
 <p>At the bottom of the window there is a new bar called the <em>Status bar</em>.
   This bar houses multiple items such as the Breadcrumb navigation and information
-  and settings about the current note, such as the <a href="#root/_help_veGu4faJErEM">content language</a> and&nbsp;
-  <a
+  and settings about the current note, such as the <a href="#root/_help_veGu4faJErEM">content language</a> and&nbsp;<a
   class="reference-link" href="#root/_help_zEY4DaJG4YT5">Attributes</a>.</p>
 <p>For more information, consult the <a href="#root/_help_AlJ73vBCjWDw">dedicated page</a>.</p>
 <figure
 class="image">
   <img style="aspect-ratio:1150/27;" src="5_New Layout_image.png"
   width="1150" height="27">
-  </figure>
-  <h3>Inline title</h3>
-  <p>In previous versions of Trilium, the title bar was fixed at all times.
-    In the new layout, there is both a fixed title bar and one that scrolls
-    with the text. The newly introduced title is called the <em>Inline title</em> and
-    it displays the title in a larger font, while also displaying additional
-    information such as the creation and the modification date.</p>
-  <p>Whenever the title is scrolled past, the fixed title is shown instead.</p>
-  <p>This only affects&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;
-    <a
-    class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes. Note types that take the entirety of the screen such
-      as&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;will
-      always have only the fixed title bar.</p>
-  <p>Depending on the note type, the inline title will also present some more
-    interactive options such as being able to switch the note type (see below).</p>
-  <figure
-  class="image">
-    <img style="aspect-ratio:899/122;" src="New Layout_image.png"
-    width="899" height="122">
-    <figcaption>The <em>Inline title</em>, which is displayed at the top of the note and
-      can be scrolled past.</figcaption>
-    </figure>
-    <figure class="image">
-      <img style="aspect-ratio:910/104;" src="4_New Layout_image.png"
-      width="910" height="104">
-      <figcaption>The fixed title bar. The title only appears after scrolling past the <em>Inline title</em>.</figcaption>
-    </figure>
-    <h3>New note type switcher</h3>
-    <p>When a new&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;
-      <a
-      class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note is created, a note type switcher will appear below
-        the <em>Inline title</em>. Apart from changing the note type, it's also
-        possible to apply a <a href="#root/_help_KC1HB96bqqHX">template</a>.</p>
-    <p>The switcher will disappear as soon as a text is entered.</p>
-    <img src="6_New Layout_image.png"
-    width="735" height="143">
-    <h3>Note badges</h3>
-    <p>Note badges appear near the fixed note title and indicate important information
-      about the note such as whether it is read-only. Some of the badges are
-      also interactive.</p>
-    <figure class="image">
-      <img style="aspect-ratio:910/49;" src="3_New Layout_image.png"
-      width="910" height="49">
-    </figure>
-    <p>The following badges are available:</p>
+</figure>
+<h3>Inline title</h3>
+<p>In previous versions of Trilium, the title bar was fixed at all times.
+  In the new layout, there is both a fixed title bar and one that scrolls
+  with the text. The newly introduced title is called the <em>Inline title</em> and
+  it displays the title in a larger font, while also displaying additional
+  information such as the creation and the modification date.</p>
+<p>Whenever the title is scrolled past, the fixed title is shown instead.</p>
+<p>This only affects&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes. Note
+  types that take the entirety of the screen such as&nbsp;<a class="reference-link"
+  href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;will always have only the fixed
+  title bar.</p>
+<p>Depending on the note type, the inline title will also present some more
+  interactive options such as being able to switch the note type (see below).</p>
+<figure
+class="image">
+  <img style="aspect-ratio:899/122;" src="New Layout_image.png"
+  width="899" height="122">
+  <figcaption>The <em>Inline title</em>, which is displayed at the top of the note and
+    can be scrolled past.</figcaption>
+</figure>
+<figure class="image">
+  <img style="aspect-ratio:910/104;" src="4_New Layout_image.png"
+  width="910" height="104">
+  <figcaption>The fixed title bar. The title only appears after scrolling past the <em>Inline title</em>.</figcaption>
+</figure>
+<h3>New note type switcher</h3>
+<p>When a new&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;<a
+  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note is
+  created, a note type switcher will appear below the <em>Inline title</em>.
+  Apart from changing the note type, it's also possible to apply a <a href="#root/_help_KC1HB96bqqHX">template</a>.</p>
+<p>The switcher will disappear as soon as a text is entered.</p>
+<img src="6_New Layout_image.png"
+width="735" height="143">
+<h3>Note badges</h3>
+<p>Note badges appear near the fixed note title and indicate important information
+  about the note such as whether it is read-only. Some of the badges are
+  also interactive.</p>
+<figure class="image">
+  <img style="aspect-ratio:910/49;" src="3_New Layout_image.png"
+  width="910" height="49">
+</figure>
+<p>The following badges are available:</p>
+<ul>
+  <li><strong>Read-only badge</strong>, which will be shown if the note is not
+    editable due to either automatic read-only or manual read-only. Clicking
+    on the badge will temporarily edit the note (similar to the Edit <a href="#root/_help_XpOYSgsLkTJy">floating button</a>).</li>
+  <li><strong>Share badge</strong>, which will indicate that the current note
+    is shared. The badge will also indicate if the share is on the local network
+    (for the desktop application without&nbsp;<a class="reference-link" href="#root/_help_cbkrhQjrkKrh">Synchronization</a>&nbsp;set
+    up) or publicly accessible (for the server).</li>
+  <li><strong>Web clip badge</strong>, which will indicate if the note was clipped
+    using the&nbsp;<a class="reference-link" href="#root/_help_MtPxeAWVAzMg">Web Clipper</a>.
+    The badge acts as a link, so it can be clicked on to navigate to the page
+    or right clicked for more options.</li>
+  <li><strong>Execute badge</strong>, for <a href="#root/_help_CdNpE2pqjmI6">scripts</a> or <a
+    href="#root/_help_YKWqdJhzi2VY">saved SQL queries</a> which have an execute button
+    or a description.</li>
+</ul>
+<p>Some of these badges replace the dedicated panels at the top of the note.</p>
+<h3>Collapsible sections</h3>
+<figure class="image">
+  <img style="aspect-ratio:496/265;" src="1_New Layout_image.png"
+  width="496" height="265">
+</figure>
+<p>The following sections have been made collapsible:</p>
+<ul>
+  <li><em>Promoted Attributes</em>
     <ul>
-      <li><strong>Read-only badge</strong>, which will be shown if the note is not
-        editable due to either automatic read-only or manual read-only. Clicking
-        on the badge will temporarily edit the note (similar to the Edit <a href="#root/_help_XpOYSgsLkTJy">floating button</a>).</li>
-      <li><strong>Share badge</strong>, which will indicate that the current note
-        is shared. The badge will also indicate if the share is on the local network
-        (for the desktop application without&nbsp;<a class="reference-link" href="#root/_help_cbkrhQjrkKrh">Synchronization</a>&nbsp;set
-        up) or publicly accessible (for the server).</li>
-      <li><strong>Web clip badge</strong>, which will indicate if the note was clipped
-        using the&nbsp;<a class="reference-link" href="#root/_help_MtPxeAWVAzMg">Web Clipper</a>.
-        The badge acts as a link, so it can be clicked on to navigate to the page
-        or right clicked for more options.</li>
-      <li><strong>Execute badge</strong>, for <a href="#root/_help_CdNpE2pqjmI6">scripts</a> or
-        <a
-        href="#root/_help_YKWqdJhzi2VY">saved SQL queries</a>which have an execute button or a description.</li>
+      <li>For full-height notes such as&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>,
+        the promoted attributes are collapsed by default to make room.</li>
+      <li>The keyboard shortcut previously used to trigger the promoted attributes
+        ribbon tab (which was no longer working) has been repurposed to toggle
+        the promoted attributes instead.</li>
     </ul>
-    <p>Some of these badges replace the dedicated panels at the top of the note.</p>
-    <h3>Collapsible sections</h3>
-    <figure class="image">
-      <img style="aspect-ratio:496/265;" src="1_New Layout_image.png"
-      width="496" height="265">
-    </figure>
-    <p>The following sections have been made collapsible:</p>
+  </li>
+  <li><em>Edited Notes</em>, which appears for&nbsp;<a class="reference-link"
+    href="#root/_help_l0tKav7yLHGF">[missing note]</a>&nbsp;is now shown underneath
+    the title.
     <ul>
-      <li><em>Promoted Attributes</em>
-        <ul>
-          <li>For full-height notes such as&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>,
-            the promoted attributes are collapsed by default to make room.</li>
-          <li>The keyboard shortcut previously used to trigger the promoted attributes
-            ribbon tab (which was no longer working) has been repurposed to toggle
-            the promoted attributes instead.</li>
-        </ul>
-      </li>
-      <li><em>Edited Notes</em>, which appears for&nbsp;<a class="reference-link"
-        href="#root/_help_l0tKav7yLHGF">[missing note]</a>&nbsp;is now shown underneath
-        the title.
-        <ul>
-          <li>Whether the section is collapsed or not depends on the choice in&nbsp;
-            <a
-            class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Appearance.</li>
-        </ul>
-      </li>
-      <li><em>Search Properties</em>, which appears for the full&nbsp;<a class="reference-link"
-        href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;and&nbsp;<a class="reference-link"
-        href="#root/_help_m523cpzocqaD">Saved Search</a>.</li>
+      <li>Whether the section is collapsed or not depends on the choice in&nbsp;<a
+        class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Appearance.</li>
     </ul>
-    <h3>Save status indicator</h3>
-    <p>
-      <img class="image-style-align-right" src="2_New Layout_image.png"
-      width="168" height="47">To the right of the note title, a temporary indicators appears after making
-      a change to the document that indicates whether the document has been saved.</p>
-    <p>It indicates the following states:</p>
+  </li>
+  <li><em>Search Properties</em>, which appears for the full&nbsp;<a class="reference-link"
+    href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;and&nbsp;<a class="reference-link"
+    href="#root/_help_m523cpzocqaD">Saved Search</a>.</li>
+</ul>
+<h3>Save status indicator</h3>
+<p>
+  <img class="image-style-align-right" src="2_New Layout_image.png"
+  width="168" height="47">To the right of the note title, a temporary indicators appears after making
+  a change to the document that indicates whether the document has been saved.</p>
+<p>It indicates the following states:</p>
+<ul>
+  <li><em>Unsaved</em>, if the changes will be saved soon.</li>
+  <li><em>Saving</em>, if the changes are being saved.</li>
+  <li><em>Saved</em>, if all the changes were successfully saved to the server.</li>
+  <li><em>Error</em>, if the changes could not be saved, for example due to
+    a communication server with the server.</li>
+</ul>
+<p>After all changes have been saved, the indicator will hide automatically
+  after a few seconds.</p>
+<h2>Changing to the existing layout</h2>
+<h3>Removal of the ribbon</h3>
+<p>The most significant change is the removal of the ribbon. All the actions
+  and options from the ribbon were integrated in other places in the application.</p>
+<p>Here's how all the different tabs that were once part of the ribbon are
+  now available in the new layout:</p>
+<ul>
+  <li>“Formatting toolbar” was relocated to the top of the page.
     <ul>
-      <li><em>Unsaved</em>, if the changes will be saved soon.</li>
-      <li><em>Saving</em>, if the changes are being saved.</li>
-      <li><em>Saved</em>, if all the changes were successfully saved to the server.</li>
-      <li><em>Error</em>, if the changes could not be saved, for example due to
-        a communication server with the server.</li>
+      <li>Instead of having one per split, now there is a single formatting toolbar
+        per tab. This allows more space for the toolbar items.</li>
     </ul>
-    <p>After all changes have been saved, the indicator will hide automatically
-      after a few seconds.</p>
-    <h2>Changing to the existing layout</h2>
-    <h3>Removal of the ribbon</h3>
-    <p>The most significant change is the removal of the ribbon. All the actions
-      and options from the ribbon were integrated in other places in the application.</p>
-    <p>Here's how all the different tabs that were once part of the ribbon are
-      now available in the new layout:</p>
+  </li>
+  <li>“Owned attributes” and “Inherited attributes” were merged and moved to
+    the status bar region (displayed one above the other).</li>
+  <li>“Basic Properties” were integrated in the&nbsp;<a class="reference-link"
+    href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;menu.
     <ul>
-      <li>“Formatting toolbar” was relocated to the top of the page.
-        <ul>
-          <li>Instead of having one per split, now there is a single formatting toolbar
-            per tab. This allows more space for the toolbar items.</li>
-        </ul>
-      </li>
-      <li>“Owned attributes” and “Inherited attributes” were merged and moved to
-        the status bar region (displayed one above the other).</li>
-      <li>“Basic Properties” were integrated in the&nbsp;<a class="reference-link"
-        href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;menu.
-        <ul>
-          <li>The only exception here is the Language combo box which can now be found
-            in the status bar (top-right of the screen).</li>
-        </ul>
-      </li>
-      <li>“File” and “Image” tabs
-        <ul>
-          <li>The buttons were moved to the right of the note title, as dedicated entries
-            in&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>.</li>
-          <li>The info section has been merged into the <em>Note info</em> section of
-            the status bar.</li>
-        </ul>
-      </li>
-      <li>Edited notes
-        <ul>
-          <li>Moved underneath the title, displayed under a collapsible area and the
-            notes are represented as badges/chips.</li>
-          <li>Whether the section is expanded or collapsed depends on the “Edited Notes
-            ribbon tab will automatically open on day notes” setting from Options →
-            Appearance.</li>
-        </ul>
-      </li>
-      <li>Search definition tab
-        <ul>
-          <li>Moved underneath the title under a collapsible area.</li>
-          <li>Expanded by default for new searches, collapsed for saved searches.</li>
-        </ul>
-      </li>
-      <li>The Note map is now available in the Note actions menu.
-        <ul>
-          <li>Instead of opening into a panel in the ribbon, the note map now opens
-            in the sidebar, in the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>&nbsp;where
-            it can also be maximized.</li>
-        </ul>
-      </li>
-      <li>“Note info” tab was moved to a small (i) icon in the status bar.</li>
-      <li>“Similar notes” tab
-        <ul>
-          <li>Instead of opening into a panel in the ribbon, the similar notes are now
-            shown in the sidebar, in the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.</li>
-        </ul>
-      </li>
-      <li>The Collection properties tab were relocated under the note title and
-        grouped into:
-        <ul>
-          <li>A combo box to quickly switch between views.</li>
-          <li>Individual settings for the current view in a submenu.</li>
-        </ul>
-      </li>
-      <li>Some smaller ribbon tabs were converted to badges that appear near the
-        note title in the breadcrumb section:
-        <ul>
-          <li>Original URL indicator for clipped web pages (<code spellcheck="false">#pageUrl</code>).</li>
-          <li>SQL and script execute buttons.</li>
-        </ul>
-      </li>
+      <li>The only exception here is the Language combo box which can now be found
+        in the status bar (top-right of the screen).</li>
     </ul>
-    <aside class="admonition note">
-      <p>The ribbon keyboard shortcuts (e.g. <code spellcheck="false">toggleRibbonTabClassicEditor</code>)
-        have been repurposed to work on the new layout, where they will toggle
-        the appropriate panel.</p>
-    </aside>
-    <h3>Removal of the floating buttons</h3>
-    <p>Most of the buttons were relocated to the right of the note title, in
-      the&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;area,
-      with the exception of:</p>
+  </li>
+  <li>“File” and “Image” tabs
     <ul>
-      <li>The Edit button is displayed near the note title, as a badge.</li>
-      <li><em>Backlinks</em> are now displayed in the sidebar, in the&nbsp;<a class="reference-link"
-        href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.
-        <ul>
-          <li>Alternatively, the backlinks count is displayed in the status bar and
-            when clicked the sidebar opens at the right section.</li>
-        </ul>
-      </li>
-      <li>Relation map zoom buttons are now part of the relation map itself.</li>
-      <li>Export image to PNG/SVG are now in the Note actions menu, in the <em>Export as image</em> option.</li>
+      <li>The buttons were moved to the right of the note title, as dedicated entries
+        in&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>.</li>
+      <li>The info section has been merged into the <em>Note info</em> section of
+        the status bar.</li>
     </ul>
-    <h3>Changes to the sidebar</h3>
-    <p>The sidebar (also known as the right pane) also received some important
-      changes.</p>
-    <p>Most importantly, v0.105.0 splits the sidebar into multiple tabs with
-      additional functionality:</p>
+  </li>
+  <li>Edited notes
     <ul>
-      <li><a class="reference-link" href="#root/_help_2dcGDhp9WFKb">[missing note]</a>,
-        which gathers the table of contents and highlights lists.</li>
-      <li><a class="reference-link" href="#root/_help_uNtgN0cUKEBc">[missing note]</a>,
-        which provides a graphical method of editing labels, relations and (promoted)
-        attribute definitions.</li>
-      <li>A dedicated&nbsp;<a class="reference-link" href="#root/_help_LrKznOtw9cQD">[missing note]</a>.</li>
-      <li><a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>,
-        which groups together the note map, note paths, backlinks and similar notes.</li>
+      <li>Moved underneath the title, displayed under a collapsible area and the
+        notes are represented as badges/chips.</li>
+      <li>Whether the section is expanded or collapsed depends on the “Edited Notes
+        ribbon tab will automatically open on day notes” setting from Options →
+        Appearance.</li>
     </ul>
-    <p>The previous iteration of the sidebar would appear contextually, depending
-      on whether there are any items to be displayed. This caused occasional
-      content shifts when moving between two panes in a split view. In the new
-      layout, the sidebar acts more like the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;pane,
-      remaining visible even if there is nothing to display.</p>
-    <p>In order to toggle the sidebar, there is a new button on the top-right
-      side of the screen, near the window buttons (on Windows and Linux).</p>
-    <p>Now each section of the sidebar (e.g. “Table of Contents”, “Highlights
-      list”) is individually collapsible and will remember whether it was collapsed.</p>
-    <p>Some sidebar items also have a contextual menu, indicated by the three
-      dots on the title. For example, the highlights filter can be adjusted directly
-      from that menu.&nbsp;</p>
-    <p>Custom widgets are still supported. For custom scripts, the three dots
-      menu allows quick navigation to the corresponding script note.</p>
-    <h2>How to toggle the new layout</h2>
-    <p>Starting with v0.101.0, this new layout is enabled by default. It is possible
-      to fall back to the old layout by going to&nbsp;<a class="reference-link"
-      href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Appearance and selecting <em>Old layout</em>.</p>
-    <aside
-    class="admonition important">
-      <p>Since a new layout was introduced, this becomes the standard one. The <em>Old layout</em> is
-        considered deprecated and will not receive new features (for example, the
-        breadcrumb) as we focus on the new one. At some point the old layout will
-        be removed entirely, as maintaining two layouts with major differences
-        creates a maintenance burden.</p>
-      </aside>
+  </li>
+  <li>Search definition tab
+    <ul>
+      <li>Moved underneath the title under a collapsible area.</li>
+      <li>Expanded by default for new searches, collapsed for saved searches.</li>
+    </ul>
+  </li>
+  <li>The Note map is now available in the Note actions menu.
+    <ul>
+      <li>Instead of opening into a panel in the ribbon, the note map now opens
+        in the sidebar, in the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>&nbsp;where
+        it can also be maximized.</li>
+    </ul>
+  </li>
+  <li>“Note info” tab was moved to a small (i) icon in the status bar.</li>
+  <li>“Similar notes” tab
+    <ul>
+      <li>Instead of opening into a panel in the ribbon, the similar notes are now
+        shown in the sidebar, in the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.</li>
+    </ul>
+  </li>
+  <li>The Collection properties tab were relocated under the note title and
+    grouped into:
+    <ul>
+      <li>A combo box to quickly switch between views.</li>
+      <li>Individual settings for the current view in a submenu.</li>
+    </ul>
+  </li>
+  <li>Some smaller ribbon tabs were converted to badges that appear near the
+    note title in the breadcrumb section:
+    <ul>
+      <li>Original URL indicator for clipped web pages (<code spellcheck="false">#pageUrl</code>).</li>
+      <li>SQL and script execute buttons.</li>
+    </ul>
+  </li>
+</ul>
+<aside class="admonition note">
+  <p>The ribbon keyboard shortcuts (e.g. <code spellcheck="false">toggleRibbonTabClassicEditor</code>)
+    have been repurposed to work on the new layout, where they will toggle
+    the appropriate panel.</p>
+</aside>
+<h3>Removal of the floating buttons</h3>
+<p>Most of the buttons were relocated to the right of the note title, in
+  the&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;area,
+  with the exception of:</p>
+<ul>
+  <li>The Edit button is displayed near the note title, as a badge.</li>
+  <li><em>Backlinks</em> are now displayed in the sidebar, in the&nbsp;<a class="reference-link"
+    href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.
+    <ul>
+      <li>Alternatively, the backlinks count is displayed in the status bar and
+        when clicked the sidebar opens at the right section.</li>
+    </ul>
+  </li>
+  <li>Relation map zoom buttons are now part of the relation map itself.</li>
+  <li>Export image to PNG/SVG are now in the Note actions menu, in the <em>Export as image</em> option.</li>
+</ul>
+<h3>Changes to the sidebar</h3>
+<p>The sidebar (also known as the right pane) also received some important
+  changes.</p>
+<p>Most importantly, v0.105.0 splits the sidebar into multiple tabs with
+  additional functionality:</p>
+<ul>
+  <li><a class="reference-link" href="#root/_help_2dcGDhp9WFKb">[missing note]</a>,
+    which gathers the table of contents and highlights lists.</li>
+  <li><a class="reference-link" href="#root/_help_uNtgN0cUKEBc">[missing note]</a>,
+    which provides a graphical method of editing labels, relations and (promoted)
+    attribute definitions.</li>
+  <li>A dedicated&nbsp;<a class="reference-link" href="#root/_help_LrKznOtw9cQD">[missing note]</a>.</li>
+  <li><a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>,
+    which groups together the note map, note paths, backlinks and similar notes.</li>
+</ul>
+<p>The previous iteration of the sidebar would appear contextually, depending
+  on whether there are any items to be displayed. This caused occasional
+  content shifts when moving between two panes in a split view. In the new
+  layout, the sidebar acts more like the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;pane,
+  remaining visible even if there is nothing to display.</p>
+<p>In order to toggle the sidebar, there is a new button on the top-right
+  side of the screen, near the window buttons (on Windows and Linux).</p>
+<p>Now each section of the sidebar (e.g. “Table of Contents”, “Highlights
+  list”) is individually collapsible and will remember whether it was collapsed.</p>
+<p>Some sidebar items also have a contextual menu, indicated by the three
+  dots on the title. For example, the highlights filter can be adjusted directly
+  from that menu.&nbsp;</p>
+<p>Custom widgets are still supported. For custom scripts, the three dots
+  menu allows quick navigation to the corresponding script note.</p>
+<h2>How to toggle the new layout</h2>
+<p>Starting with v0.101.0, this new layout is enabled by default. It is possible
+  to fall back to the old layout by going to&nbsp;<a class="reference-link"
+  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Appearance and selecting <em>Old layout</em>.</p>
+<aside
+class="admonition important">
+  <p>Since a new layout was introduced, this becomes the standard one. The <em>Old layout</em> is
+    considered deprecated and will not receive new features (for example, the
+    breadcrumb) as we focus on the new one. At some point the old layout will
+    be removed entirely, as maintaining two layouts with major differences
+    creates a maintenance burden.</p>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/New Layout/Status bar.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/New Layout/Status bar.html
@@ -21,8 +21,7 @@
   <li>If a note is placed in multiple places in the tree (cloned), the number
     of the note paths will be displayed.
     <ol>
-      <li>Clicking it will reveal the full list of note paths in the sidebar's&nbsp;
-        <a
+      <li>Clicking it will reveal the full list of note paths in the sidebar's&nbsp;<a
         class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.</li>
     </ol>
   </li>
@@ -35,8 +34,7 @@
     will be displayed.
     <ol>
       <li>Clicking on it will show the list of notes that link to this note, as
-        well as an excerpt of where the note is referenced in the sidebar's&nbsp;
-        <a
+        well as an excerpt of where the note is referenced in the sidebar's&nbsp;<a
         class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>.</li>
     </ol>
   </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree.html
@@ -12,8 +12,7 @@
 <h2>Keyboard Manipulation</h2>
 <p>
   <img src="Note Tree_move-note-with-keyboard.gif"
-  alt="Example of using keyboard keys to move a note">Trilium offers efficient keyboard-based manipulation using the following
-  <a
+  alt="Example of using keyboard keys to move a note">Trilium offers efficient keyboard-based manipulation using the following <a
   href="#root/_help_A9Oc6YKKc65v">shortcuts</a>:</p>
 <ul>
   <li><kbd>Ctrl</kbd> + <kbd><span>↑</span></kbd> and <kbd>Ctrl</kbd> +<kbd><span>↓</span></kbd>:
@@ -28,10 +27,9 @@
 </ul>
 <h2>Context Menu</h2>
 <p>You can also move notes using the familiar cut and paste functions available
-  in the context menu, or with the associated keyboard <a href="#root/_help_A9Oc6YKKc65v">shortcuts</a>:
-  <code
-  spellcheck="false">CTRL-C</code>( <a href="#root/_help_IakOLONlIfGI">copy</a>), <kbd>Ctrl</kbd> + <kbd>X</kbd> (cut)
-    and <kbd>Ctrl</kbd> + <kbd>V</kbd> (paste).</p>
+  in the context menu, or with the associated keyboard <a href="#root/_help_A9Oc6YKKc65v">shortcuts</a>: <code
+  spellcheck="false">CTRL-C</code> ( <a href="#root/_help_IakOLONlIfGI">copy</a>), <kbd>Ctrl</kbd> + <kbd>X</kbd> (cut)
+  and <kbd>Ctrl</kbd> + <kbd>V</kbd> (paste).</p>
 <p>See&nbsp;<a class="reference-link" href="#root/_help_YtSN43OrfzaA">Note tree contextual menu</a>&nbsp;for
   more information.</p>
 <h2>Tree Settings</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree/Hiding the subtree.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree/Hiding the subtree.html
@@ -52,9 +52,9 @@
 <ul>
   <li>The note position is clearly visible when using the&nbsp;<a class="reference-link"
     href="#root/_help_eIg8jdvaoNNd">Search</a>.</li>
-  <li>The note can still be operated on from the tree, such as adding a&nbsp;
-    <a
-    class="reference-link" href="#root/_help_TBwsyfadTA18">Branch prefix</a>&nbsp;or moving it outside the collection.</li>
+  <li>The note can still be operated on from the tree, such as adding a&nbsp;<a
+    class="reference-link" href="#root/_help_TBwsyfadTA18">Branch prefix</a>&nbsp;or
+    moving it outside the collection.</li>
 </ul>
 <p>The note appears in italics to indicate its temporary display. When switching
   to another note, the spotlighted note will disappear.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree/Note tree contextual menu.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note Tree/Note tree contextual menu.html
@@ -2,8 +2,7 @@
   <img style="aspect-ratio:269/608;" src="1_Note tree contextual menu_image.png"
   width="269" height="608">
 </figure>
-<p>The <em>note tree menu</em> can be accessed by right-clicking in the&nbsp;
-  <a
+<p>The <em>note tree menu</em> can be accessed by right-clicking in the&nbsp;<a
   class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>.</p>
 <h2>Interaction</h2>
 <p>The contextual menu can operate:</p>
@@ -57,9 +56,9 @@
   </li>
   <li><strong>Protect subtree</strong>
     <ul>
-      <li>Will mark this note and all of its descendents as protected. See&nbsp;
-        <a
-        class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>&nbsp;for more information.</li>
+      <li>Will mark this note and all of its descendents as protected. See&nbsp;<a
+        class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>&nbsp;for
+        more information.</li>
     </ul>
   </li>
   <li><strong>Unprotect subtree</strong>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note buttons.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note buttons.html
@@ -6,8 +6,7 @@
   <li>The Note Revisions button displays the&nbsp;<a href="#root/_help_vZWERwf8U3nx">Note Revisions</a>&nbsp;for
     that particular note.</li>
   <li>The contextual menu offers commands for the note or its subtree, such
-    as import, export, viewing the&nbsp;<a href="#root/_help_4FahAwuGTAwC">Note source code</a>&nbsp;or&nbsp;
-    <a
+    as import, export, viewing the&nbsp;<a href="#root/_help_4FahAwuGTAwC">Note source code</a>&nbsp;or&nbsp;<a
     href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
 </ul>
 <p>On the&nbsp;<a class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>,

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note types with split view.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Note types with split view.html
@@ -1,7 +1,7 @@
-<p>Split view is a feature of&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;and&nbsp;
-  <a
-  class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes which displays both the source code on one side
-    and the preview of the content on the other.</p>
+<p>Split view is a feature of&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes
+  which displays both the source code on one side and the preview of the
+  content on the other.</p>
 <p><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;also
   allow changing between a horizontal or a vertical split, to accommodate
   for the various sizes of diagrams.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Ribbon.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Ribbon.html
@@ -46,9 +46,9 @@
     content. See&nbsp;<a href="#root/_help_KC1HB96bqqHX">Template</a>&nbsp;for more
     information.</li>
   <li><em><strong>Language</strong></em> changes the main language of the current
-    note, mostly useful for spell checking or right-to-left support. See&nbsp;
-    <a
-    href="#root/_help_veGu4faJErEM">Content language &amp; Right-to-left support</a>&nbsp;for more information.</li>
+    note, mostly useful for spell checking or right-to-left support. See&nbsp;<a
+    href="#root/_help_veGu4faJErEM">Content language &amp; Right-to-left support</a>&nbsp;for
+    more information.</li>
 </ul>
 <h3>Owned Attributes</h3>
 <p>This section allows editing the labels and relations of a note. For more
@@ -57,10 +57,9 @@
   and relations, via a graphical input. From this menu, it's also possible
   to define label and relation definitions (see&nbsp;<a href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>).</p>
 <h3>Inherited Attributes</h3>
-<p>This section displays the attributes which are applied to this note via&nbsp;
-  <a
-  href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>. It is not possible to alter the attributes
-    from this section.</p>
+<p>This section displays the attributes which are applied to this note via&nbsp;<a
+  href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>. It is not possible
+  to alter the attributes from this section.</p>
 <h3>Note Paths</h3>
 <p>This section displays all the places where the current note has been cloned
   to. Here the current note can also be cloned to a new location (similar
@@ -86,6 +85,6 @@
 <h3>Edited notes</h3>
 <p>This section pops automatically when entering a <a href="#root/_help_l0tKav7yLHGF">day note</a> and
   shows the notes that were edited that day.</p>
-<p>It is possible to disable this behavior from settings, by going to&nbsp;
-  <a
-  class="reference-link" href="#root/_hidden/_options/_optionsAppearance">Appearance</a>&nbsp;settings and looking for the <em>Ribbon widgets</em> section.</p>
+<p>It is possible to disable this behavior from settings, by going to&nbsp;<a
+  class="reference-link" href="#root/_hidden/_options/_optionsAppearance">Appearance</a>&nbsp;settings
+  and looking for the <em>Ribbon widgets</em> section.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Attributes tab.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Attributes tab.html
@@ -10,9 +10,9 @@
     to this note.</li>
   <li><em>Inherited attributes</em> are attributes that apply to the current
     note but come through&nbsp;<a class="reference-link" href="#root/_help_bwZpz2ajCEwO">Attribute Inheritance</a>.</li>
-  <li><em>Definitions</em> describe the type of attributes and are used in&nbsp;
-    <a
-    class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;and&nbsp;<a class="reference-link" href="#root/_help_2FvYrpmOXm29">Table</a>&nbsp;collections.</li>
+  <li><em>Definitions</em> describe the type of attributes and are used in&nbsp;<a
+    class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;and&nbsp;<a
+    class="reference-link" href="#root/_help_2FvYrpmOXm29">Table</a>&nbsp;collections.</li>
 </ul>
 <h2>Owned attributes</h2>
 <p>Every item is structured as such:</p>
@@ -95,9 +95,8 @@
         of it.</li>
     </ul>
   </li>
-  <li>The name indicates the name of the attribute it defines (without the
-    <code
-    spellcheck="false">label:</code>or <code spellcheck="false">relation:</code> prefix).</li>
+  <li>The name indicates the name of the attribute it defines (without the <code
+    spellcheck="false">label:</code> or <code spellcheck="false">relation:</code> prefix).</li>
   <li>To the right of the name a short summary is displayed which indicates
     the display name (alias), whether it has multiple values or an inverse
     relation.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Connections tab.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Connections tab.html
@@ -10,47 +10,47 @@ class="admonition note">
     of the sections have to retrieve additional data that might not otherwise
     be needed. While collapsed, the sections do not retrieve any additional
     data.</p>
-  </aside>
-  <h2>Note map</h2>
-  <p>The note map displays a graph which shows the relation between the current
-    notes and other notes on the hierarchy. There are two types of visualizations,
-    which can be selected from the top-right part of the section:</p>
-  <ul>
-    <li>The <em>Link map</em>, which displays the <a href="#root/_help_Cq5X6iKQop6R">relations</a> between
-      notes.</li>
-    <li>The <em>Tree map</em>, which displays the hierarchical structure.</li>
-  </ul>
-  <p>The sidebar will remember which visualization is selected, as a global
-    option. Note that note maps also have a <code spellcheck="false">#mapType</code> which
-    describes which visualization to use, but the sidebar deliberately ignores
-    that to keep consistency when switching between notes.</p>
-  <p>The map can also be expanded by pressing the button in the top-right of
-    the section. When expanded, the map is displayed in a separate dialog.
-    Alternatively, all other sections can be collapsed, which will make the
-    note map taller and the sidebar can be dragged to make for more lateral
-    space.</p>
-  <p>The note map view inside the sidebar is deliberately more compact in order
-    to fit the space: the link map would also show notes that don't have a
-    link to the current note from the hierarchy (creating a cloud of dots)
-    but this is only shown while the map is expanded. Similarly, the link strength
-    and pin configuration buttons are not displayed here.</p>
-  <p>See also:</p>
-  <ul>
-    <li>The&nbsp;<a class="reference-link" href="#root/_help_bdUJEHsAPYQR">Note Map</a>&nbsp;note
-      type</li>
-    <li><a class="reference-link" href="#root/_help_BCkXAVs63Ttv">Note Map (Link map, Tree map)</a>&nbsp;for
-      more information on the concept as a whole.</li>
-  </ul>
-  <h2>Note paths</h2>
-  <p>The note paths section displays the locations in which the current note
-    is <a href="#root/_help_IakOLONlIfGI">cloned</a>. Each segment of the note path
-    is clickable, in order to navigate to that note or clone.</p>
-  <p>A new clone can be created from the top-right button.</p>
-  <h2>Backlinks</h2>
-  <p>Backlinks list the notes that refer to the current note, as well as a
-    preview of the content where the reference to the note is made.</p>
-  <p>For more information, see&nbsp;<a class="reference-link" href="#root/_help_wfGXLmm7x27z">Backlinks</a>.</p>
-  <h2>Similar notes</h2>
-  <p>Displays a list of notes that appear similar based on the content of the
-    notes and their attributes. For more information, see&nbsp;<a class="reference-link"
-    href="#root/_help_xWtq5NUHOwql">Similar Notes</a>.</p>
+</aside>
+<h2>Note map</h2>
+<p>The note map displays a graph which shows the relation between the current
+  notes and other notes on the hierarchy. There are two types of visualizations,
+  which can be selected from the top-right part of the section:</p>
+<ul>
+  <li>The <em>Link map</em>, which displays the <a href="#root/_help_Cq5X6iKQop6R">relations</a> between
+    notes.</li>
+  <li>The <em>Tree map</em>, which displays the hierarchical structure.</li>
+</ul>
+<p>The sidebar will remember which visualization is selected, as a global
+  option. Note that note maps also have a <code spellcheck="false">#mapType</code> which
+  describes which visualization to use, but the sidebar deliberately ignores
+  that to keep consistency when switching between notes.</p>
+<p>The map can also be expanded by pressing the button in the top-right of
+  the section. When expanded, the map is displayed in a separate dialog.
+  Alternatively, all other sections can be collapsed, which will make the
+  note map taller and the sidebar can be dragged to make for more lateral
+  space.</p>
+<p>The note map view inside the sidebar is deliberately more compact in order
+  to fit the space: the link map would also show notes that don't have a
+  link to the current note from the hierarchy (creating a cloud of dots)
+  but this is only shown while the map is expanded. Similarly, the link strength
+  and pin configuration buttons are not displayed here.</p>
+<p>See also:</p>
+<ul>
+  <li>The&nbsp;<a class="reference-link" href="#root/_help_bdUJEHsAPYQR">Note Map</a>&nbsp;note
+    type</li>
+  <li><a class="reference-link" href="#root/_help_BCkXAVs63Ttv">Note Map (Link map, Tree map)</a>&nbsp;for
+    more information on the concept as a whole.</li>
+</ul>
+<h2>Note paths</h2>
+<p>The note paths section displays the locations in which the current note
+  is <a href="#root/_help_IakOLONlIfGI">cloned</a>. Each segment of the note path
+  is clickable, in order to navigate to that note or clone.</p>
+<p>A new clone can be created from the top-right button.</p>
+<h2>Backlinks</h2>
+<p>Backlinks list the notes that refer to the current note, as well as a
+  preview of the content where the reference to the note is made.</p>
+<p>For more information, see&nbsp;<a class="reference-link" href="#root/_help_wfGXLmm7x27z">Backlinks</a>.</p>
+<h2>Similar notes</h2>
+<p>Displays a list of notes that appear similar based on the content of the
+  notes and their attributes. For more information, see&nbsp;<a class="reference-link"
+  href="#root/_help_xWtq5NUHOwql">Similar Notes</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Outline tab.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Right Sidebar/Outline tab.html
@@ -124,9 +124,9 @@
   </li>
   <li>Attachments
     <ul>
-      <li>If the PDF has its own attachments (not to be confused with Trilium's&nbsp;
-        <a
-        class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>), they will be displayed in a list.</li>
+      <li>If the PDF has its own attachments (not to be confused with Trilium's&nbsp;<a
+        class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>), they
+        will be displayed in a list.</li>
       <li>Some information such as the name and size of the attachment are displayed.</li>
       <li>It's possible to download the attachment by clicking on the download button.</li>
     </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Split View.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Split View.html
@@ -3,87 +3,87 @@
 class="image image-style-align-center">
   <img style="aspect-ratio:1398/1015;" src="Split View_2_Split View_image.png"
   width="1398" height="1015">
-  </figure>
-  <h2>Interactions</h2>
-  <ul>
-    <li>Press the
-      <img src="Split View_Split View_image.png">button to the right of a note's title to open a new split to the right
-      of it.
-      <ul>
-        <li>It is possible to have as many splits as desired, simply press again the
-          button.</li>
-        <li>Only horizontal splits are possible, vertical or drag &amp; dropping is
-          not supported.</li>
-      </ul>
-    </li>
-    <li>When at least one split is open, press the
-      <img src="Split View_3_Split View_image.png">button next to it to close it.</li>
-    <li>Use the
-      <img src="Split View_4_Split View_image.png">or the
-      <img src="Split View_1_Split View_image.png">button to move around the splits.</li>
-    <li>Creating, closing and moving a split can also be triggered from a <a href="#root/_help_A9Oc6YKKc65v">keyboard shortcut</a> (<em>Create New Split</em>, <em>Close Active Split</em>, <em>Move Split Left</em> and <em>Move Split Right</em>,
-      all unassigned by default) or through the <a href="#root/_help_F1r9QtzQLZqm">command palette</a>.</li>
-    <li>The focus can be moved from one split to the one next to it with the <em>Focus Split to the Left</em> and <em>Focus Split to the Right</em> actions,
-      which stop at either end of the tab instead of continuing into the next
-      tab. They are unassigned by default as well.</li>
-    <li>Each <a href="#root/_help_3seOhtN8uLIY">tab</a> has its own split view configuration
-      (e.g. one tab can have two notes in a split view, whereas the others are
-      one-note views).
-      <ul>
-        <li>The tab's title will indicate all the note titles, in the order of the
-          splits from the left to right and separated by a bullet symbol.</li>
-        <li>The tab's icon will indicate the icon of the last active split, which
-          will be automatically focused when clicking on the tab.</li>
-      </ul>
-    </li>
-  </ul>
-  <h2>Splits and the note tree &amp; hoisting</h2>
-  <p>Clicking on the content of a split will focus that split. While focused,
-    the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;will
-    also indicate the note that is being edited.</p>
-  <p>It is possible for each of the splits to have their own&nbsp;<a class="reference-link"
-    href="#root/_help_OR8WJ7Iz9K4U">Note Hoisting</a>.</p>
-  <p>When a new split is created, it will share the same note hoisting as the
-    previous one. An easy solution to this is to simply hoist the notes after
-    the split is created.</p>
-  <p>This is generally quite useful for reorganizing notes from one place to
-    the other, by hoisting the old place in the first split and hoisting the
-    new place to the second one. This will allow easy cut and paste without
-    the tree jumping around from switching between notes.</p>
-  <h2>Mobile support</h2>
-  <p>Since v0.100.0, it's possible to have a split view on the mobile view
-    as well, with the following differences from the desktop version of the
-    split:</p>
-  <ul>
-    <li>On smartphones, the split views are laid out vertically (one on the top
-      and one on the bottom), instead of horizontally as on the desktop.</li>
-    <li>There can be only one split open per tab.</li>
-    <li>It's not possible to resize the two split panes.</li>
-    <li>When the keyboard is opened, the active note will be “maximized”, thus
-      allowing for more space even when a split is open. When the keyboard is
-      closed, the splits become equal in size again.</li>
-  </ul>
-  <p>Interaction:</p>
-  <ul>
-    <li>To create a new split, click the three dots button on the right of the
-      note title and select <em>Create new split</em>.
-      <ul>
-        <li>This option will only be available if there is no split already open in
-          the current tab.</li>
-      </ul>
-    </li>
-    <li>To close a split, click the three dots button on the right of the note
-      title and select <em>Close this pane</em>.
-      <ul>
-        <li>Note that this option will only be available on the second note in the
-          split (the one at the bottom on smartphones, the one on the right on tablets).</li>
-      </ul>
-    </li>
-    <li>When long-pressing a link, a contextual menu will show up with an option
-      to <em>Open note in a new split</em>.
-      <ul>
-        <li>If there's already a split, the option will replace the existing split
-          instead.</li>
-      </ul>
-    </li>
-  </ul>
+</figure>
+<h2>Interactions</h2>
+<ul>
+  <li>Press the
+    <img src="Split View_Split View_image.png">button to the right of a note's title to open a new split to the right
+    of it.
+    <ul>
+      <li>It is possible to have as many splits as desired, simply press again the
+        button.</li>
+      <li>Only horizontal splits are possible, vertical or drag &amp; dropping is
+        not supported.</li>
+    </ul>
+  </li>
+  <li>When at least one split is open, press the
+    <img src="Split View_3_Split View_image.png">button next to it to close it.</li>
+  <li>Use the
+    <img src="Split View_4_Split View_image.png">or the
+    <img src="Split View_1_Split View_image.png">button to move around the splits.</li>
+  <li>Creating, closing and moving a split can also be triggered from a <a href="#root/_help_A9Oc6YKKc65v">keyboard shortcut</a> (<em>Create New Split</em>, <em>Close Active Split</em>, <em>Move Split Left</em> and <em>Move Split Right</em>,
+    all unassigned by default) or through the <a href="#root/_help_F1r9QtzQLZqm">command palette</a>.</li>
+  <li>The focus can be moved from one split to the one next to it with the <em>Focus Split to the Left</em> and <em>Focus Split to the Right</em> actions,
+    which stop at either end of the tab instead of continuing into the next
+    tab. They are unassigned by default as well.</li>
+  <li>Each <a href="#root/_help_3seOhtN8uLIY">tab</a> has its own split view configuration
+    (e.g. one tab can have two notes in a split view, whereas the others are
+    one-note views).
+    <ul>
+      <li>The tab's title will indicate all the note titles, in the order of the
+        splits from the left to right and separated by a bullet symbol.</li>
+      <li>The tab's icon will indicate the icon of the last active split, which
+        will be automatically focused when clicking on the tab.</li>
+    </ul>
+  </li>
+</ul>
+<h2>Splits and the note tree &amp; hoisting</h2>
+<p>Clicking on the content of a split will focus that split. While focused,
+  the&nbsp;<a class="reference-link" href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;will
+  also indicate the note that is being edited.</p>
+<p>It is possible for each of the splits to have their own&nbsp;<a class="reference-link"
+  href="#root/_help_OR8WJ7Iz9K4U">Note Hoisting</a>.</p>
+<p>When a new split is created, it will share the same note hoisting as the
+  previous one. An easy solution to this is to simply hoist the notes after
+  the split is created.</p>
+<p>This is generally quite useful for reorganizing notes from one place to
+  the other, by hoisting the old place in the first split and hoisting the
+  new place to the second one. This will allow easy cut and paste without
+  the tree jumping around from switching between notes.</p>
+<h2>Mobile support</h2>
+<p>Since v0.100.0, it's possible to have a split view on the mobile view
+  as well, with the following differences from the desktop version of the
+  split:</p>
+<ul>
+  <li>On smartphones, the split views are laid out vertically (one on the top
+    and one on the bottom), instead of horizontally as on the desktop.</li>
+  <li>There can be only one split open per tab.</li>
+  <li>It's not possible to resize the two split panes.</li>
+  <li>When the keyboard is opened, the active note will be “maximized”, thus
+    allowing for more space even when a split is open. When the keyboard is
+    closed, the splits become equal in size again.</li>
+</ul>
+<p>Interaction:</p>
+<ul>
+  <li>To create a new split, click the three dots button on the right of the
+    note title and select <em>Create new split</em>.
+    <ul>
+      <li>This option will only be available if there is no split already open in
+        the current tab.</li>
+    </ul>
+  </li>
+  <li>To close a split, click the three dots button on the right of the note
+    title and select <em>Close this pane</em>.
+    <ul>
+      <li>Note that this option will only be available on the second note in the
+        split (the one at the bottom on smartphones, the one on the right on tablets).</li>
+    </ul>
+  </li>
+  <li>When long-pressing a link, a contextual menu will show up with an option
+    to <em>Open note in a new split</em>.
+    <ul>
+      <li>If there's already a split, the option will replace the existing split
+        instead.</li>
+    </ul>
+  </li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Tabs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Basic Concepts and Features/UI Elements/Tabs.html
@@ -61,4 +61,4 @@ class="admonition note">
     The decision to use a more mobile-like tab switcher was taken because the
     original tab bar could not support many tabs at once and the new design
     better aligns with how mobile applications handle tabs.</p>
-  </aside>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections.html
@@ -108,9 +108,9 @@
   of the note.</p>
 <h2>Archived notes</h2>
 <p>By default, <a href="#root/_help_MKmLg5x6xkor">archived notes</a> will not be
-  shown in collections. This behavior can be changed by going to&nbsp;
-  <a
-  class="reference-link" href="#root/_help_CssoWBu8I7jF">Collection Properties</a>&nbsp;and checking <em>Show archived notes</em>.</p>
+  shown in collections. This behavior can be changed by going to&nbsp;<a
+  class="reference-link" href="#root/_help_CssoWBu8I7jF">Collection Properties</a>&nbsp;and
+  checking <em>Show archived notes</em>.</p>
 <p>Archived notes will be generally indicated by being greyed out as opposed
   to the normal ones.</p>
 <h2>Hiding the child notes from the note tree</h2>
@@ -155,9 +155,9 @@
 <p>By default, new collections use predefined&nbsp;<a class="reference-link"
   href="#root/_help_KC1HB96bqqHX">Templates</a>&nbsp;that are stored safely in
   the&nbsp;<a class="reference-link" href="#root/_help_2mUhVmZK8RF3">Hidden Notes</a>&nbsp;to
-  define some basic configuration such as the type of view, but also some&nbsp;
-  <a
-  class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;to make editing easier.</p>
+  define some basic configuration such as the type of view, but also some&nbsp;<a
+  class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;to
+  make editing easier.</p>
 <p>Collections don't store their configuration (e.g. the position on the
   map, the hidden columns in a table) in the content of the note itself,
   but as attachments.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Calendar.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Calendar.html
@@ -201,375 +201,369 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <p>In addition, the first day of the week can be either Sunday or Monday
-    and can be adjusted from the application settings.</p>
-  <h2>Configuring the calendar events using attributes</h2>
-  <p>For each note of the calendar, the following attributes can be used:</p>
-  <figure
-  class="table">
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code spellcheck="false">#startDate</code>
-          </td>
-          <td>The date the event starts, which will display it in the calendar. The
-            format is <code spellcheck="false">YYYY-MM-DD</code> (year, month and day
-            separated by a minus sign).</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#endDate</code>
-          </td>
-          <td>Similar to <code spellcheck="false">startDate</code>, mentions the end
-            date if the event spans across multiple days. The date is inclusive, so
-            the end day is also considered. The attribute can be missing for single-day
-            events.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#startTime</code>
-          </td>
-          <td>The time the event starts at. If this value is missing, then the event
-            is considered a full-day event. The format is <code spellcheck="false">HH:MM</code> (hours
-            in 24-hour format and minutes).</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#endTime</code>
-          </td>
-          <td>Similar to <code spellcheck="false">startTime</code>, it mentions the time
-            at which the event ends (in relation with <code spellcheck="false">endDate</code> if
-            present, or <code spellcheck="false">startDate</code>).</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#recurrence</code>
-          </td>
-          <td>This is an optional CalDAV <code spellcheck="false">RRULE</code> string
-            that if present, determines whether a task should repeat or not. Note that
-            it does not include the <code spellcheck="false">DTSTART</code> attribute,
-            which is derived from the <code spellcheck="false">#startDate</code> and
-            <code
-            spellcheck="false">#startTime</code>directly. For examples of valid <code spellcheck="false">RRULE</code> strings
-              see <a href="https://icalendar.org/rrule-tool.html">https://icalendar.org/rrule-tool.html</a>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#color</code>
-          </td>
-          <td>Displays the event with a specified color (named such as <code spellcheck="false">red</code>,
-            <code
-            spellcheck="false">gray</code>or hex such as <code spellcheck="false">#FF0000</code>). This
-              will also change the color of the note in other places such as the note
-              tree.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:color</code>
-          </td>
-          <td><strong>❌️ Removed since v0.100.0. Use</strong>  <code spellcheck="false">#color</code>  <strong>instead.</strong>&nbsp;&nbsp;&nbsp;&nbsp;
-            <br>
-            <br>Similar to <code spellcheck="false">#color</code>, but applies the color
-            only for the event in the calendar and not for other places such as the
-            note tree.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#iconClass</code>
-          </td>
-          <td>If present, the icon of the note will be displayed to the left of the
-            event title.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:title</code>
-          </td>
-          <td>Changes the title of an event to point to an attribute of the note other
-            than the title, can either a label or a relation (without the <code spellcheck="false">#</code> or
-            <code
-            spellcheck="false">~</code>symbol). See <em>Use-cases</em> for more information.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:displayedAttributes</code>
-          </td>
-          <td>Allows displaying the value of one or more attributes in the calendar
-            like this:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <br>
-            <br>
-            <img src="6_Calendar_image.png">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <br>
-            <br><code spellcheck="false">#weight="70" #Mood="Good" #calendar:displayedAttributes="weight,Mood"</code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <br>
-            <br>It can also be used with relations, case in which it will display the
-            title of the target note:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-            <br>
-            <br><code spellcheck="false">~assignee=@My assignee #calendar:displayedAttributes="assignee"</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:startDate</code>
-          </td>
-          <td>Allows using a different label to represent the start date, other than
-            <code
-            spellcheck="false">startDate</code>(e.g. <code spellcheck="false">expiryDate</code>). The
-              label name <strong>must not be</strong> prefixed with <code spellcheck="false">#</code>.
-              If the label is not defined for a note, the default will be used instead.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:endDate</code>
-          </td>
-          <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
-            changing the attribute which is being used to read the end date.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:startTime</code>
-          </td>
-          <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
-            changing the attribute which is being used to read the start time.</td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">#calendar:endTime</code>
-          </td>
-          <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
-            changing the attribute which is being used to read the end time.</td>
-        </tr>
-      </tbody>
-    </table>
-    </figure>
-    <h2>How the calendar works</h2>
-    <p>
-      <img src="8_Calendar_image.png">
-    </p>
-    <p>The calendar displays all the child notes of the Collection that have
-      a <code spellcheck="false">#startDate</code>. An <code spellcheck="false">#endDate</code> can
-      optionally be added.</p>
-    <p>The start date &amp; end date can easily be edited from the calendar collection
-      itself by clicking on the event. To edit the date while in the event note
-      itself, the following attributes can be added to the Collection note:</p><pre><code class="language-text-x-trilium-auto">#viewType=calendar #label:startDate(inheritable)="promoted,alias=Start Date,single,date"
+</figure>
+<p>In addition, the first day of the week can be either Sunday or Monday
+  and can be adjusted from the application settings.</p>
+<h2>Configuring the calendar events using attributes</h2>
+<p>For each note of the calendar, the following attributes can be used:</p>
+<figure
+class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">#startDate</code>
+        </td>
+        <td>The date the event starts, which will display it in the calendar. The
+          format is <code spellcheck="false">YYYY-MM-DD</code> (year, month and day
+          separated by a minus sign).</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#endDate</code>
+        </td>
+        <td>Similar to <code spellcheck="false">startDate</code>, mentions the end
+          date if the event spans across multiple days. The date is inclusive, so
+          the end day is also considered. The attribute can be missing for single-day
+          events.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#startTime</code>
+        </td>
+        <td>The time the event starts at. If this value is missing, then the event
+          is considered a full-day event. The format is <code spellcheck="false">HH:MM</code> (hours
+          in 24-hour format and minutes).</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#endTime</code>
+        </td>
+        <td>Similar to <code spellcheck="false">startTime</code>, it mentions the time
+          at which the event ends (in relation with <code spellcheck="false">endDate</code> if
+          present, or <code spellcheck="false">startDate</code>).</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#recurrence</code>
+        </td>
+        <td>This is an optional CalDAV <code spellcheck="false">RRULE</code> string
+          that if present, determines whether a task should repeat or not. Note that
+          it does not include the <code spellcheck="false">DTSTART</code> attribute,
+          which is derived from the <code spellcheck="false">#startDate</code> and <code
+          spellcheck="false">#startTime</code> directly. For examples of valid <code
+          spellcheck="false">RRULE</code> strings see <a href="https://icalendar.org/rrule-tool.html">https://icalendar.org/rrule-tool.html</a>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#color</code>
+        </td>
+        <td>Displays the event with a specified color (named such as <code spellcheck="false">red</code>, <code
+          spellcheck="false">gray</code> or hex such as <code spellcheck="false">#FF0000</code>).
+          This will also change the color of the note in other places such as the
+          note tree.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:color</code>
+        </td>
+        <td><strong>❌️ Removed since v0.100.0. Use</strong>  <code spellcheck="false">#color</code>  <strong>instead.</strong>&nbsp;&nbsp;&nbsp;&nbsp;
+          <br>
+          <br>Similar to <code spellcheck="false">#color</code>, but applies the color
+          only for the event in the calendar and not for other places such as the
+          note tree.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#iconClass</code>
+        </td>
+        <td>If present, the icon of the note will be displayed to the left of the
+          event title.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:title</code>
+        </td>
+        <td>Changes the title of an event to point to an attribute of the note other
+          than the title, can either a label or a relation (without the <code spellcheck="false">#</code> or <code
+          spellcheck="false">~</code> symbol). See <em>Use-cases</em> for more information.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:displayedAttributes</code>
+        </td>
+        <td>Allows displaying the value of one or more attributes in the calendar
+          like this:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <br>
+          <br>
+          <img src="6_Calendar_image.png">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <br>
+          <br><code spellcheck="false">#weight="70" #Mood="Good" #calendar:displayedAttributes="weight,Mood"</code>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <br>
+          <br>It can also be used with relations, case in which it will display the
+          title of the target note:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+          <br>
+          <br><code spellcheck="false">~assignee=@My assignee #calendar:displayedAttributes="assignee"</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:startDate</code>
+        </td>
+        <td>Allows using a different label to represent the start date, other than <code
+          spellcheck="false">startDate</code> (e.g. <code spellcheck="false">expiryDate</code>).
+          The label name <strong>must not be</strong> prefixed with <code spellcheck="false">#</code>.
+          If the label is not defined for a note, the default will be used instead.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:endDate</code>
+        </td>
+        <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
+          changing the attribute which is being used to read the end date.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:startTime</code>
+        </td>
+        <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
+          changing the attribute which is being used to read the start time.</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:endTime</code>
+        </td>
+        <td>Similar to <code spellcheck="false">#calendar:startDate</code>, allows
+          changing the attribute which is being used to read the end time.</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h2>How the calendar works</h2>
+<p>
+  <img src="8_Calendar_image.png">
+</p>
+<p>The calendar displays all the child notes of the Collection that have
+  a <code spellcheck="false">#startDate</code>. An <code spellcheck="false">#endDate</code> can
+  optionally be added.</p>
+<p>The start date &amp; end date can easily be edited from the calendar collection
+  itself by clicking on the event. To edit the date while in the event note
+  itself, the following attributes can be added to the Collection note:</p><pre><code class="language-text-x-trilium-auto">#viewType=calendar #label:startDate(inheritable)="promoted,alias=Start Date,single,date"
 #label:endDate(inheritable)="promoted,alias=End Date,single,date"
 #hidePromotedAttributes </code></pre>
-    <p>This will result in:</p>
-    <p>
-      <img src="7_Calendar_image.png">
-    </p>
-    <p>When not used in a Journal, the calendar is recursive. That is, it will
-      look for events not just in its child notes but also in the children of
-      these child notes.</p>
-    <h2>Recurrence</h2>
-    <p>The built in calendar view also supports repeating tasks (e.g. every week,
-      every month as well as more complex recurrency rules).</p>
-    <p>Starting with v0.105.0, recurrence can be directly edited from the calendar
-      by clicking on an event and then selecting the <em>Repeats</em> option.</p>
-    <h3>Custom recurrence using a subset of RRULE</h3>
-    <p>If the existing recurrence editor from the event popup is not sufficient,
-      more complex rules can be manually set via the <code spellcheck="false">#recurrence</code> label.</p>
-    <p>For example, to make a note repeat on the calendar:</p>
-    <ul>
-      <li>Every Day - <code spellcheck="false">#recurrence="FREQ=DAILY;INTERVAL=1"</code>
-      </li>
-      <li>Every 3 days - <code spellcheck="false">#recurrence="FREQ=DAILY;INTERVAL=3"</code>
-      </li>
-      <li>Every week - <code spellcheck="false">#recurrence="FREQ=WEEKLY;INTERVAL=1"</code>
-      </li>
-      <li>Every 2 weeks on Monday, Wednesday and Friday - <code spellcheck="false">#recurrence="FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"</code>
-      </li>
-      <li>Every 3 months - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=3"</code>
-      </li>
-      <li>Every 2 months on the First Sunday - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=2;BYDAY=1SU"</code>
-      </li>
-      <li>Every month on the Last Friday - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=1;BYDAY=-1FR"</code>
-      </li>
-    </ul>
-    <p>For other examples of valid <code spellcheck="false">RRULE</code> strings
-      see <a href="https://icalendar.org/rrule-tool.html">https://icalendar.org/rrule-tool.html</a>
-    </p>
-    <p>Note that the recurrence string does not include the <code spellcheck="false">DTSTART</code> attribute
-      as defined in the iCAL specifications. This is derived directly from the
-      <code
-      spellcheck="false">startDate</code>and <code spellcheck="false">startTime</code> attributes</p>
-    <p>If you want to override the label the calendar uses to fetch the recurrence
-      string, you can use the <code spellcheck="false">#calendar:recurrence</code> attribute.
-      For example, you can set <code spellcheck="false">#calendar:recurrence=taskRepeats</code>.
-      Then you can set your recurrence string like <code spellcheck="false">#taskRepeats="FREQ=DAILY;INTERVAL=1"</code>
-    </p>
-    <p>Also note that the recurrence label can be made promoted as with the start
-      and end dates.&nbsp;</p>
-    <aside class="admonition warning">
-      <p>If the recurrence string is not valid, a toast will be shown with the
-        note ID and title of the note with the erroneous recurrence message. This
-        note will not be added to the calendar</p>
-    </aside>
-    <h2>Slot Duration &amp; Slot Label Interval</h2>
-    <p>Trilium's calendar view is powered by FullCalendar, which gives you fine-grained
-      control over how the time grid looks and behaves for day and week views.
-      Two labels you can use to configure these views are <code spellcheck="false">#calendar:slotDuration</code> and
-      <code
-      spellcheck="false">#calendar:slotLabelInterval</code>. Understanding what each one does —
-        and how they interact — lets you tailor the calendar to match your workflow,
-        whether you're scheduling in 15-minute increments or planning out your
-        day in broad hourly blocks.</p>
-    <p>These settings can also be adjusted from the <em>Collections</em> tab in
-      the&nbsp;<a class="reference-link" href="#root/_help_BlN9DFI679QC">Ribbon</a>.</p>
-    <h3>Slot duration</h3>
-    <p>Controls how tall each time slot is on the calendar — essentially the
-      smallest unit of time the grid is divided into. A shorter duration means
-      more rows and finer granularity; a longer one means fewer, chunkier rows.
-      The default is one row every 15 minutes.</p>
-    <p><strong>Examples:</strong>
-    </p>
-    <figure class="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Value</th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">#calendar:slotDuration="00:15:00"</code>
-            </td>
-            <td>One row every 15 minutes</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#calendar:slotDuration="00:30:00"</code>
-            </td>
-            <td>One row every 30 minutes</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#calendar:slotDuration="01:00:00"</code>
-            </td>
-            <td>One row every hour</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h3>Label interval</h3>
-    <p>Controls how often a time label appears on the left-hand axis. This is
-      independent of the slot size — you can have very small slots but only label
-      every hour to keep the axis readable. The default is a time label shown
-      every hour.</p>
-    <p><strong>Examples:</strong>
-    </p>
-    <figure class="table">
-      <table>
-        <thead>
-          <tr>
-            <th>Value</th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">#calendar:slotLabelInterval="00:30:00"</code>
-            </td>
-            <td>Show a time label every 30 minutes</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">#calendar:slotLabelInterval="01:00:00"</code>
-            </td>
-            <td>Show a time label every hour</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h3>Useful combinations</h3>
-    <figure class="table">
-      <table>
-        <thead>
-          <tr>
-            <th><code spellcheck="false">#calendar:slotDuration</code>
-            </th>
-            <th><code spellcheck="false">#calendar:slotLabelInterval</code>
-            </th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code spellcheck="false">00:15:00</code>
-            </td>
-            <td><code spellcheck="false">01:00:00</code>
-            </td>
-            <td>Fine grid, clean axis — good for busy schedules</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">00:30:00</code>
-            </td>
-            <td><code spellcheck="false">01:00:00</code>
-            </td>
-            <td>Standard calendar feel</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">01:00:00</code>
-            </td>
-            <td><code spellcheck="false">01:00:00</code>
-            </td>
-            <td>Simple hourly grid — good for day planning</td>
-          </tr>
-          <tr>
-            <td><code spellcheck="false">00:15:00</code>
-            </td>
-            <td><code spellcheck="false">00:30:00</code>
-            </td>
-            <td>Fine grid, labels every 30 min — balanced detail</td>
-          </tr>
-        </tbody>
-      </table>
-    </figure>
-    <h3>Format</h3>
-    <p>Both values use <code spellcheck="false">HH:mm:ss</code> format. Hours can
-      go up to <code spellcheck="false">24</code> (<code spellcheck="false">24:00:00</code>),
-      while minutes and seconds must be between <code spellcheck="false">00</code> and
-      <code
-      spellcheck="false">59</code>. The minimum meaningful duration is 1 minute (<code spellcheck="false">00:01:00</code>).</p>
-    <h2>Use-cases</h2>
-    <h3>Using with the Journal / calendar</h3>
-    <p>It is possible to integrate the calendar view into the Journal with day
-      notes. In order to do so change the note type of the Journal note (calendar
-      root) to Collection and then select the Calendar View.</p>
-    <p>While in journal mode, the popup editor will not show dates, recurrence,
-      colors or removal, since day notes aren't editable events.</p>
-    <p>Based on the <code spellcheck="false">#calendarRoot</code> (or <code spellcheck="false">#workspaceCalendarRoot</code>)
-      attribute, the calendar will know that it's in a calendar and apply the
-      following:</p>
-    <ul>
-      <li>The calendar events are now rendered based on their <code spellcheck="false">dateNote</code> attribute
-        rather than <code spellcheck="false">startDate</code>.</li>
-      <li>Interactive editing such as dragging over an empty era or resizing an
-        event is no longer possible.</li>
-      <li>Clicking on the empty space on a date will automatically open that day's
-        note or create it if it does not exist.</li>
-      <li>Direct children of a day note will be displayed on the calendar despite
-        not having a <code spellcheck="false">dateNote</code> attribute. Children
-        of the child notes will not be displayed.</li>
-    </ul>
-    <img src="5_Calendar_image.png" width="1217" height="724">
-    <h3>Using a different attribute as event title</h3>
-    <p>
-      <img class="image-style-align-right" src="2_Calendar_image.png"
-      width="445" height="124">By default, events are displayed on the calendar by their note title.
-      However, it is possible to configure a different attribute to be displayed
-      instead.</p>
-    <p>To do so, assign <code spellcheck="false">#calendar:title</code> to the
-      child note (not the calendar/Collection note), with the value being
-      <code
-      spellcheck="false">name</code>where <code spellcheck="false">name</code> can be any label (make
-        not to add the <code spellcheck="false">#</code> prefix). The attribute can
-        also come through inheritance such as a template attribute. If the note
-        does not have the requested label, the title of the note will be used instead.</p><pre><code class="language-text-x-trilium-auto">#startDate=2025-02-11 #endDate=2025-02-13 #name="My vacation" #calendar:title="name"</code></pre>
-    <h3>Using a relation attribute as event title</h3>
-    <p>
-      <img class="image-style-align-right image_resized" style="aspect-ratio:294/151;width:21.22%;"
-      src="3_Calendar_image.png" width="294" height="151">Similarly to using an attribute, use <code spellcheck="false">#calendar:title</code> and
-      set it to <code spellcheck="false">name</code> where <code spellcheck="false">name</code> is
-      the name of the relation to use.</p>
-    <p>Moreover, if there are more relations of the same name, they will be displayed
-      as multiple events coming from the same note.</p><pre><code class="language-text-x-trilium-auto">#startDate=2025-02-14 #endDate=2025-02-15 ~for=@John Smith ~for=@Jane Doe #calendar:title="for"</code></pre>
-    <p>
-      <img class="image-style-align-left" src="Calendar_image.png"
-      width="296" height="150">Note that it's even possible to have a <code spellcheck="false">#calendar:title</code> on
-      the target note (e.g. “John Smith”) which will try to render an attribute
-      of it. Note that it's not possible to use a relation here as well for safety
-      reasons (an accidental recursion &nbsp;of attributes could cause the application
-      to loop infinitely).</p><pre><code class="language-text-x-trilium-auto">#calendar:title="shortName" #shortName="John S."</code></pre>
+<p>This will result in:</p>
+<p>
+  <img src="7_Calendar_image.png">
+</p>
+<p>When not used in a Journal, the calendar is recursive. That is, it will
+  look for events not just in its child notes but also in the children of
+  these child notes.</p>
+<h2>Recurrence</h2>
+<p>The built in calendar view also supports repeating tasks (e.g. every week,
+  every month as well as more complex recurrency rules).</p>
+<p>Starting with v0.105.0, recurrence can be directly edited from the calendar
+  by clicking on an event and then selecting the <em>Repeats</em> option.</p>
+<h3>Custom recurrence using a subset of RRULE</h3>
+<p>If the existing recurrence editor from the event popup is not sufficient,
+  more complex rules can be manually set via the <code spellcheck="false">#recurrence</code> label.</p>
+<p>For example, to make a note repeat on the calendar:</p>
+<ul>
+  <li>Every Day - <code spellcheck="false">#recurrence="FREQ=DAILY;INTERVAL=1"</code>
+  </li>
+  <li>Every 3 days - <code spellcheck="false">#recurrence="FREQ=DAILY;INTERVAL=3"</code>
+  </li>
+  <li>Every week - <code spellcheck="false">#recurrence="FREQ=WEEKLY;INTERVAL=1"</code>
+  </li>
+  <li>Every 2 weeks on Monday, Wednesday and Friday - <code spellcheck="false">#recurrence="FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"</code>
+  </li>
+  <li>Every 3 months - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=3"</code>
+  </li>
+  <li>Every 2 months on the First Sunday - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=2;BYDAY=1SU"</code>
+  </li>
+  <li>Every month on the Last Friday - <code spellcheck="false">#recurrence="FREQ=MONTHLY;INTERVAL=1;BYDAY=-1FR"</code>
+  </li>
+</ul>
+<p>For other examples of valid <code spellcheck="false">RRULE</code> strings
+  see <a href="https://icalendar.org/rrule-tool.html">https://icalendar.org/rrule-tool.html</a>
+</p>
+<p>Note that the recurrence string does not include the <code spellcheck="false">DTSTART</code> attribute
+  as defined in the iCAL specifications. This is derived directly from the <code
+  spellcheck="false">startDate</code> and <code spellcheck="false">startTime</code> attributes</p>
+<p>If you want to override the label the calendar uses to fetch the recurrence
+  string, you can use the <code spellcheck="false">#calendar:recurrence</code> attribute.
+  For example, you can set <code spellcheck="false">#calendar:recurrence=taskRepeats</code>.
+  Then you can set your recurrence string like <code spellcheck="false">#taskRepeats="FREQ=DAILY;INTERVAL=1"</code>
+</p>
+<p>Also note that the recurrence label can be made promoted as with the start
+  and end dates.&nbsp;</p>
+<aside class="admonition warning">
+  <p>If the recurrence string is not valid, a toast will be shown with the
+    note ID and title of the note with the erroneous recurrence message. This
+    note will not be added to the calendar</p>
+</aside>
+<h2>Slot Duration &amp; Slot Label Interval</h2>
+<p>Trilium's calendar view is powered by FullCalendar, which gives you fine-grained
+  control over how the time grid looks and behaves for day and week views.
+  Two labels you can use to configure these views are <code spellcheck="false">#calendar:slotDuration</code> and <code
+  spellcheck="false">#calendar:slotLabelInterval</code>. Understanding what
+  each one does — and how they interact — lets you tailor the calendar to
+  match your workflow, whether you're scheduling in 15-minute increments
+  or planning out your day in broad hourly blocks.</p>
+<p>These settings can also be adjusted from the <em>Collections</em> tab in
+  the&nbsp;<a class="reference-link" href="#root/_help_BlN9DFI679QC">Ribbon</a>.</p>
+<h3>Slot duration</h3>
+<p>Controls how tall each time slot is on the calendar — essentially the
+  smallest unit of time the grid is divided into. A shorter duration means
+  more rows and finer granularity; a longer one means fewer, chunkier rows.
+  The default is one row every 15 minutes.</p>
+<p><strong>Examples:</strong>
+</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Value</th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">#calendar:slotDuration="00:15:00"</code>
+        </td>
+        <td>One row every 15 minutes</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:slotDuration="00:30:00"</code>
+        </td>
+        <td>One row every 30 minutes</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:slotDuration="01:00:00"</code>
+        </td>
+        <td>One row every hour</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Label interval</h3>
+<p>Controls how often a time label appears on the left-hand axis. This is
+  independent of the slot size — you can have very small slots but only label
+  every hour to keep the axis readable. The default is a time label shown
+  every hour.</p>
+<p><strong>Examples:</strong>
+</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th>Value</th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">#calendar:slotLabelInterval="00:30:00"</code>
+        </td>
+        <td>Show a time label every 30 minutes</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">#calendar:slotLabelInterval="01:00:00"</code>
+        </td>
+        <td>Show a time label every hour</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Useful combinations</h3>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th><code spellcheck="false">#calendar:slotDuration</code>
+        </th>
+        <th><code spellcheck="false">#calendar:slotLabelInterval</code>
+        </th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">00:15:00</code>
+        </td>
+        <td><code spellcheck="false">01:00:00</code>
+        </td>
+        <td>Fine grid, clean axis — good for busy schedules</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">00:30:00</code>
+        </td>
+        <td><code spellcheck="false">01:00:00</code>
+        </td>
+        <td>Standard calendar feel</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">01:00:00</code>
+        </td>
+        <td><code spellcheck="false">01:00:00</code>
+        </td>
+        <td>Simple hourly grid — good for day planning</td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">00:15:00</code>
+        </td>
+        <td><code spellcheck="false">00:30:00</code>
+        </td>
+        <td>Fine grid, labels every 30 min — balanced detail</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<h3>Format</h3>
+<p>Both values use <code spellcheck="false">HH:mm:ss</code> format. Hours can
+  go up to <code spellcheck="false">24</code> (<code spellcheck="false">24:00:00</code>),
+  while minutes and seconds must be between <code spellcheck="false">00</code> and <code
+  spellcheck="false">59</code>. The minimum meaningful duration is 1 minute
+  (<code spellcheck="false">00:01:00</code>).</p>
+<h2>Use-cases</h2>
+<h3>Using with the Journal / calendar</h3>
+<p>It is possible to integrate the calendar view into the Journal with day
+  notes. In order to do so change the note type of the Journal note (calendar
+  root) to Collection and then select the Calendar View.</p>
+<p>While in journal mode, the popup editor will not show dates, recurrence,
+  colors or removal, since day notes aren't editable events.</p>
+<p>Based on the <code spellcheck="false">#calendarRoot</code> (or <code spellcheck="false">#workspaceCalendarRoot</code>)
+  attribute, the calendar will know that it's in a calendar and apply the
+  following:</p>
+<ul>
+  <li>The calendar events are now rendered based on their <code spellcheck="false">dateNote</code> attribute
+    rather than <code spellcheck="false">startDate</code>.</li>
+  <li>Interactive editing such as dragging over an empty era or resizing an
+    event is no longer possible.</li>
+  <li>Clicking on the empty space on a date will automatically open that day's
+    note or create it if it does not exist.</li>
+  <li>Direct children of a day note will be displayed on the calendar despite
+    not having a <code spellcheck="false">dateNote</code> attribute. Children
+    of the child notes will not be displayed.</li>
+</ul>
+<img src="5_Calendar_image.png" width="1217" height="724">
+<h3>Using a different attribute as event title</h3>
+<p>
+  <img class="image-style-align-right" src="2_Calendar_image.png"
+  width="445" height="124">By default, events are displayed on the calendar by their note title.
+  However, it is possible to configure a different attribute to be displayed
+  instead.</p>
+<p>To do so, assign <code spellcheck="false">#calendar:title</code> to the
+  child note (not the calendar/Collection note), with the value being <code
+  spellcheck="false">name</code> where <code spellcheck="false">name</code> can
+  be any label (make not to add the <code spellcheck="false">#</code> prefix).
+  The attribute can also come through inheritance such as a template attribute.
+  If the note does not have the requested label, the title of the note will
+  be used instead.</p><pre><code class="language-text-x-trilium-auto">#startDate=2025-02-11 #endDate=2025-02-13 #name="My vacation" #calendar:title="name"</code></pre>
+<h3>Using a relation attribute as event title</h3>
+<p>
+  <img class="image-style-align-right image_resized" style="aspect-ratio:294/151;width:21.22%;"
+  src="3_Calendar_image.png" width="294" height="151">Similarly to using an attribute, use <code spellcheck="false">#calendar:title</code> and
+  set it to <code spellcheck="false">name</code> where <code spellcheck="false">name</code> is
+  the name of the relation to use.</p>
+<p>Moreover, if there are more relations of the same name, they will be displayed
+  as multiple events coming from the same note.</p><pre><code class="language-text-x-trilium-auto">#startDate=2025-02-14 #endDate=2025-02-15 ~for=@John Smith ~for=@Jane Doe #calendar:title="for"</code></pre>
+<p>
+  <img class="image-style-align-left" src="Calendar_image.png"
+  width="296" height="150">Note that it's even possible to have a <code spellcheck="false">#calendar:title</code> on
+  the target note (e.g. “John Smith”) which will try to render an attribute
+  of it. Note that it's not possible to use a relation here as well for safety
+  reasons (an accidental recursion &nbsp;of attributes could cause the application
+  to loop infinitely).</p><pre><code class="language-text-x-trilium-auto">#calendar:title="shortName" #shortName="John S."</code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Collection Properties.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Collection Properties.html
@@ -4,12 +4,11 @@
 </figure>
 <p>The <em>Collection Properties</em> is a toolbar that is displayed at the
   top of every <a href="#root/_help_GTwFsgaA0lCt">collection note</a>.</p>
-<p>For versions prior to v0.102.0, this feature was only available for the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>. Starting with this version, the collection properties
-    are enabled for the Old layout as well, and&nbsp;<a class="reference-link"
-    href="#root/_help_BlN9DFI679QC">Ribbon</a>&nbsp;no longer contains a dedicated
-    tab for collection properties.</p>
+<p>For versions prior to v0.102.0, this feature was only available for the&nbsp;<a
+  class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>. Starting
+  with this version, the collection properties are enabled for the Old layout
+  as well, and&nbsp;<a class="reference-link" href="#root/_help_BlN9DFI679QC">Ribbon</a>&nbsp;no
+  longer contains a dedicated tab for collection properties.</p>
 <p>The collection properties has:</p>
 <ul>
   <li>A quick selector for the view type (e.g. grid, calendar, board).</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Dashboard.html
@@ -30,12 +30,11 @@
   href="#root/_help_0ESUbbAxVnoK">Note List</a>, which means every note can be
   rendered, such as:</p>
 <ul>
-  <li>Static content, via&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;
-    <a
+  <li>Static content, via&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;<a
     class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>.</li>
-  <li>Images via&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>,&nbsp;
-    <a
-    class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,&nbsp;<a class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>.</li>
+  <li>Images via&nbsp;<a class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>,&nbsp;<a
+    class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,&nbsp;<a
+    class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>.</li>
   <li>Interactive widgets via&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>.</li>
   <li>Web pages can be displayed via&nbsp;<a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>&nbsp;and
     refreshed via the context menu.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Geo Map.html
@@ -24,8 +24,8 @@
   an error message will appear instead of the map (<em>This map can't be drawn because WebGL isn't available…</em>).</p>
 <p>The button that shows your location is offered only when Trilium is reached
   over HTTPS, in the desktop application or in the mobile application. Browsers
-  refuse to share the location of a device with a page served over plain HTTP,
-  so on such a server the button does not appear.</p>
+  refuse to share the location of a device with a page served over plain
+  HTTP, so on such a server the button does not appear.</p>
 <h2>Interaction</h2>
 <ul>
   <li>At the top-left there is the search bar. It searches the notes already
@@ -68,10 +68,10 @@
   When you add markers yourself you have already moved the map to reach the
   place you are marking, and that movement saves a position.</p>
 <h2>Going to your location</h2>
-<p>Press the <em>Show your location</em> button at the bottom-right of the map,
-  beside the zoom buttons. The first time, the browser or the operating system
-  asks whether Trilium may know where the device is. In the desktop application
-  the operating system's location settings decide.</p>
+<p>Press the <em>Show your location</em> button at the bottom-right of the
+  map, beside the zoom buttons. The first time, the browser or the operating
+  system asks whether Trilium may know where the device is. In the desktop
+  application the operating system's location settings decide.</p>
 <p>The map then moves to where the device is and marks it with a blue dot.
   A lighter circle around the dot shows how accurate the position is: a phone
   with GPS gives a dot on the street, while a computer located through its
@@ -80,20 +80,20 @@
 <p>Dragging the map stops it from following. The dot stays and keeps moving,
   and pressing the button again brings the map back to it. Pressing the button
   while the map is following turns the dot off.</p>
-<p>Click the dot to see its coordinates in the panel a searched place is shown
-  in. From there the position can be kept as a marker (see <em>Keeping a place as a marker</em>).
+<p>Click the dot to see its coordinates in the panel a searched place is
+  shown in. From there the position can be kept as a marker (see <em>Keeping a place as a marker</em>).
   Clicking the lighter circle around the dot is a click on the map.</p>
 <p>If the position cannot be found, a message says so and the button keeps
-  waiting for one; press it again to stop. If you refuse the permission, the
-  button is disabled until the map is opened again. To allow it after all,
-  change the permission for Trilium in the browser or in the system's location
-  settings.</p>
+  waiting for one; press it again to stop. If you refuse the permission,
+  the button is disabled until the map is opened again. To allow it after
+  all, change the permission for Trilium in the browser or in the system's
+  location settings.</p>
 <p>Your position is not stored in the note, and Trilium does not send it
   anywhere on its own. Moving the map there does what any other pan or zoom
-  does: the tile provider behind the map's style sees the coordinates of the
-  area now on screen. The map does remember where you left it, as it does
-  after any other movement, so a map you have taken to your location opens
-  there the next time.</p>
+  does: the tile provider behind the map's style sees the coordinates of
+  the area now on screen. The map does remember where you left it, as it
+  does after any other movement, so a map you have taken to your location
+  opens there the next time.</p>
 <h2>Searching the map</h2>
 <p>The search bar at the top-left of the map searches in two places. It always
   searches the notes that are already on the map. It can also search for
@@ -301,268 +301,265 @@
 class="admonition note">
   <p>If the map is locked for editing (see below), the map needs to be unlocked
     before moving the marker.</p>
-  </aside>
-  <h2>Interaction with the markers</h2>
-  <ul>
-    <li>Hovering over a marker will display a&nbsp;<a class="reference-link" href="#root/_help_lgKX7r3aL30x">Note Tooltip</a>&nbsp;with
-      the content of the note it belongs to.
-      <ul>
-        <li>Clicking on the note title in the tooltip will navigate to the note in
-          the current view.</li>
-      </ul>
-    </li>
-    <li>Right-clicking the marker will open a contextual menu (as described below).</li>
-    <li>Clicking a marker will focus on the marker and display a dedicated popup
-      with the details. This works regardless of whether the map is editable
-      or not.</li>
-  </ul>
-  <h3>Popup view</h3>
-  <p>When a marker or a track is clicked, a popup will open to the right which
-    contains the following information:</p>
-  <ul>
-    <li>The title and icon of the marker, both editable.</li>
-    <li>An indicator for the coordinates; clicking it will copy the coordinates
-      to clipboard.</li>
-    <li>A button to maximize the popup.</li>
-    <li>Buttons to interact with the markers:
-      <ul>
-        <li>Open the marker in the same pane, new tab, etc.</li>
-        <li>A button to open the location in a dedicated application (e.g. Google
-          Maps on mobile).</li>
-        <li>Color picker to change the color of the marker.</li>
-        <li>Button to remove the marker from the map, which can optionally delete
-          its corresponding note. Removing a marker without deleting the note will
-          only remove its <code spellcheck="false">#geolocation</code> attribute (case
-          in which the coordinates have to be manually added back in in order to
-          get the note to show on the map again).</li>
-      </ul>
-    </li>
-    <li>The&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;of
-      the marker, if any.</li>
-    <li>The note's content which can be edited directly from the panel.</li>
-  </ul>
-  <p>To dismiss the popup:</p>
-  <ul>
-    <li>Press the X button at the top-right of the popup.</li>
-    <li>In the map, press anywhere outside the popup.</li>
-    <li>Or simply press the Escape key.</li>
-  </ul>
-  <p>When a marker is clicked, the map will automatically adjust the viewport
-    so that the marker is still visible with the popup open. The currently
-    selected marker is shown slightly bigger.</p>
-  <p>It is possible to switch between markers by clicking on them even when
-    the popup view is already open.</p>
-  <p>Markers can have&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;between
-    them and clicking on such a link will automatically adjust the viewport
-    and the popup view to the new note.</p>
-  <h3>Contextual menu</h3>
-  <p>It's possible to press the right mouse button to display a contextual
-    menu.</p>
-  <ol>
-    <li>If right-clicking an empty section of the map (not on a marker), it allows
-      to:
-      <ol>
-        <li>Displays the latitude and longitude. Clicking this option will copy them
-          to the clipboard.</li>
-        <li>Open the location using an external application (if the operating system
-          supports it).</li>
-        <li>Adding a new marker at that location.</li>
-      </ol>
-    </li>
-    <li>If right-clicking on a marker, it allows to:
-      <ol>
-        <li>Displays the latitude and longitude. Clicking this option will copy them
-          to the clipboard.</li>
-        <li>Open the location using an external application (if the operating system
-          supports it).</li>
-        <li>Open the note in a new tab, split or window.</li>
-        <li>Button to remove the marker from the map, which can optionally delete
-          its corresponding note. Removing a marker without deleting the note will
-          only remove its <code spellcheck="false">#geolocation</code> attribute (case
-          in which the coordinates have to be manually added back in in order to
-          get the note to show on the map again).</li>
-      </ol>
-    </li>
-  </ol>
-  <h3>Icon and color of the markers</h3>
-  <figure class="image image-style-align-right image_resized" style="width:47.42%;">
-    <img style="aspect-ratio:885/321;" src="3_Geo Map_image.png"
-    width="885" height="321">
-  </figure>
-  <p>The markers will have the same icon as the note.</p>
-  <p>It's possible to add a custom color to a marker by assigning them a
-    <code
-    spellcheck="false">#color</code>attribute such as <code spellcheck="false">#color=green</code>.</p>
-  <h3>Adding the coordinates manually</h3>
-  <p>Searching for the place is usually quicker (see <em>Searching the map</em> above).
-    The steps below remain useful for a coordinate that is already to hand,
-    or for a place the search cannot find.</p>
-  <p>In a nutshell, create a child note and set the <code spellcheck="false">#geolocation</code> attribute
-    to the coordinates.</p>
-  <p>The value of the attribute is made up of the latitude and longitude separated
-    by a comma.</p>
-  <h4>Adding from Google Maps</h4>
-  <ol>
-    <li>In Google Maps, on the web:
-      <ol>
-        <li>Look for a desired location, right click on it and a context menu will
-          show up.</li>
-        <li>Simply click on the first item displaying the coordinates and they will
-          be copied to clipboard.</li>
-      </ol>
-    </li>
-    <li>In Trilium, create a child note under the map.</li>
-    <li>Then paste the value inside the text box into the <code spellcheck="false">#geolocation</code> attribute
-      of a child note of the map (don't forget to surround the value with a
-      <code
-      spellcheck="false">"</code>character).</li>
-  </ol>
-  <h4>Adding from OpenStreetMap</h4>
-  <p>Similarly to the Google Maps approach:</p>
-  <ol>
-    <li>Go to any location on openstreetmap.org and right click to bring up the
-      context menu. Select the <em>Show address</em> item.</li>
-    <li>The address will be visible in the top-left of the screen, in the place
-      of the search bar.&nbsp;Select the coordinates and copy them into the clipboard.</li>
-    <li>Simply paste the value inside the text box into the <code spellcheck="false">#geolocation</code> attribute
-      of a child note of the map and then it should be displayed on the map.</li>
-  </ol>
-  <h2>Adding GPS tracks (.gpx)</h2>
-  <figure class="image">
-    <img style="aspect-ratio:1566/1155;" src="1_Geo Map_image.png"
-    width="1566" height="1155">
-  </figure>
-  <p>Trilium can display GPS tracks on the geo map, in the form of <code spellcheck="false">.gpx</code> files.</p>
-  <p>To add a track, either:</p>
-  <ol>
-    <li>Drag &amp; drop a <code spellcheck="false">.gpx</code> file inside the geo
-      map in the note tree.
-      <ol>
-        <li>In order for the file to be recognized as a GPS track, it needs to show
-          up as <code spellcheck="false">application/gpx+xml</code> in the <em>File type</em> field.</li>
-      </ol>
-    </li>
-    <li>Press the <em>Add a GPS track from a GPX file</em> which will directly prompt
-      for a GPX file and import it as a subnote of the collection.</li>
-  </ol>
-  <p>When going back to the map, the track should now be visible.</p>
-  <p>The starting point of the track will be displayed as a marker, with the
-    name of the note underneath. The start marker will also respect the icon
-    and the <code spellcheck="false">color</code> of the note. The end marker
-    is displayed with a distinct icon.</p>
-  <p>If the track file contains multiple tracks, they will all be displayed
-    as well as markers. Trilium will also split a single track that happens
-    to have non-continuous points.</p>
-  <p>If the GPX contains waypoints, they will also be displayed, including
-    their names.</p>
-  <p>When the track is clicked, the entire route is brought into view, as well
-    as the right popup will indicate details about the track such as distance,
-    duration and the elevation map. This information is also displayed when
-    clicking the <code spellcheck="false">.gpx</code> note itself.</p>
-  <p>When clicking on the markers of a track (whether it's the start or stop
-    builtin markers, or custom markers that are part of the track), only that
-    marker is brought into view, as opposed to the entire route.</p>
-  <h2>Read-only mode</h2>
-  <p>When a map is <a href="#root/_help_CoFPLs3dRlXc">read-only</a> all editing features
-    will be disabled such as:</p>
-  <ul>
-    <li>The add button at the bottom of the map.</li>
-    <li>Repositioning markers.</li>
-    <li>Editing from the contextual menu (removing locations or adding new items).</li>
-    <li>Keeping a place as a marker, whether you found it by searching or clicked
-      it on the map. You can still search and click, and you can still look at
-      a place and copy its coordinates.</li>
-  </ul>
-  <p>To set a map as read-only, go to&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Editable</em> → <em>Read-only</em> (on
-    the new layout, or in Basic Properties on the&nbsp;<a class="reference-link"
-    href="#root/_help_BlN9DFI679QC">Ribbon</a>&nbsp;for the old layout).</p>
-  <h2>Configuration</h2>
-  <h3>Map Style</h3>
-  <p>The styling of the map can be adjusted in the&nbsp;<a class="reference-link"
-    href="#root/_help_CssoWBu8I7jF">Collection Properties</a>&nbsp;or manually via
-    the <code spellcheck="false">#map:style</code> attribute.</p>
-  <p>The geo map comes with two different types of styles:</p>
-  <ul>
-    <li>Raster styles
-      <ul>
-        <li>For these styles the map is represented as a grid of images at different
-          zoom levels. This is the traditional way OpenStreetMap used to work.</li>
-        <li>Zoom is slightly restricted.</li>
-        <li>Currently, the only raster theme is the original OpenStreetMap style.</li>
-      </ul>
-    </li>
-    <li>Vector styles
-      <ul>
-        <li>Vector styles are not represented as images, but as geometrical shapes.
-          This makes the rendering much smoother, especially when zooming and looking
-          at the building edges, for example.</li>
-        <li>The map can be zoomed in much further.</li>
-        <li>These come in various styles that are both light (Colorful, Graybeard,
-          Neutrino) and dark (Eclipse, Shadow).</li>
-        <li>The vector styles come from <a href="https://versatiles.org/">VersaTiles</a>,
-          a free and open-source project providing map tiles based on OpenStreetMap.</li>
-        <li>The VersaTiles layers also provide 3D building information (see below).</li>
-      </ul>
-    </li>
-  </ul>
-  <p>The default theme is Versatiles Colorful (vector).</p>
-  <h4>3D view with buildings</h4>
-  <figure class="image">
-    <img style="aspect-ratio:2727/1642;" src="2_Geo Map_image.png"
-    width="2727" height="1642">
-  </figure>
-  <p>Trilium v0.105.0 introduces a 3D view, courtesy of MapLibre GL. To enter
-    3D mode, simply press the corresponding button at the bottom-right of the
-    map or press Ctrl and drag across the map.</p>
-  <p>The buildings will only appear from zoom 14 onwards to avoid lag.</p>
-  <aside
-  class="admonition note">
-    <p>To get 3D buildings, make sure you are using the <em>VersaTiles</em> styles
-      which provide the building informatia via the <code spellcheck="false">versatiles-shortbread</code> source.</p>
-    </aside>
-    <h3>Custom map style / tiles</h3>
-    <p>Starting with v0.102.0 it is possible to use custom tile sets, but only
-      in raster format.</p>
-    <p>To do so, manually set the <code spellcheck="false">#map:style</code> 
-      <a
-      href="#root/_help_HI6GBBIduIgv">label</a>to the URL of the tile set. For example, to use Esri.NatGeoWorldMap,
-        set the value to <a href="https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/%7Bz%7D/%7By%7D/%7Bx%7D."><code spellcheck="false">https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}</code>.</a>
-    </p>
-    <p>Additionally:</p>
+</aside>
+<h2>Interaction with the markers</h2>
+<ul>
+  <li>Hovering over a marker will display a&nbsp;<a class="reference-link" href="#root/_help_lgKX7r3aL30x">Note Tooltip</a>&nbsp;with
+    the content of the note it belongs to.
     <ul>
-      <li>Hi-DPI tiles are supported via the <code spellcheck="false">{r}</code> placeholder.</li>
-      <li>To mark the custom style as dark (which affects the styling of the UI),
-        apply the <code spellcheck="false">map:darkStyle</code> label. This attribute
-        also overrides builtin themes.</li>
+      <li>Clicking on the note title in the tooltip will navigate to the note in
+        the current view.</li>
     </ul>
-    <aside class="admonition note">
-      <p>For a list of tile sets, see the <a href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers preview</a> page.
-        Select a desired tile set and just copy the URL from the <em>Plain JavaScript</em> example.</p>
-    </aside>
-    <p>Custom vector map support is planned, but not yet implemented.</p>
-    <h3>Other options</h3>
-    <p>The following options can be configured either via the&nbsp;<a class="reference-link"
-      href="#root/_help_CssoWBu8I7jF">Collection Properties</a>, by clicking on the
-      settings (Gear icon). Alternatively, each of these options also have a
-      corresponding <a href="#root/_help_HI6GBBIduIgv">label</a> that can be set manually.</p>
+  </li>
+  <li>Right-clicking the marker will open a contextual menu (as described below).</li>
+  <li>Clicking a marker will focus on the marker and display a dedicated popup
+    with the details. This works regardless of whether the map is editable
+    or not.</li>
+</ul>
+<h3>Popup view</h3>
+<p>When a marker or a track is clicked, a popup will open to the right which
+  contains the following information:</p>
+<ul>
+  <li>The title and icon of the marker, both editable.</li>
+  <li>An indicator for the coordinates; clicking it will copy the coordinates
+    to clipboard.</li>
+  <li>A button to maximize the popup.</li>
+  <li>Buttons to interact with the markers:
     <ul>
-      <li>Scale, which illustrates the scale of the map in either kilometers or
-        miles in the bottom-left of the map.
-        <ul>
-          <li>The unit is determined by the <em>Formatting locale</em> option in <em>Language &amp; Region</em>.</li>
-        </ul>
-      </li>
-      <li>The name of the markers is displayed by default underneath the pin on
-        the map. Since v0.102.0, it is possible to hide these labels which increases
-        the performance and decreases clutter when there are many markers on the
-        map.</li>
-      <li>v0.105.0 also introduces a feature called <em>Group nearby markers</em> which
-        will cluster multiple markers together at low zoom.
-        <ul>
-          <li>The clusters display the number of items they contain. The color also
-            changes based on the count.</li>
-          <li>Clicking on a cluster will automatically zoom in so that the individual
-            markers that make up the cluster are now visible.</li>
-        </ul>
-      </li>
+      <li>Open the marker in the same pane, new tab, etc.</li>
+      <li>A button to open the location in a dedicated application (e.g. Google
+        Maps on mobile).</li>
+      <li>Color picker to change the color of the marker.</li>
+      <li>Button to remove the marker from the map, which can optionally delete
+        its corresponding note. Removing a marker without deleting the note will
+        only remove its <code spellcheck="false">#geolocation</code> attribute (case
+        in which the coordinates have to be manually added back in in order to
+        get the note to show on the map again).</li>
     </ul>
+  </li>
+  <li>The&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>&nbsp;of
+    the marker, if any.</li>
+  <li>The note's content which can be edited directly from the panel.</li>
+</ul>
+<p>To dismiss the popup:</p>
+<ul>
+  <li>Press the X button at the top-right of the popup.</li>
+  <li>In the map, press anywhere outside the popup.</li>
+  <li>Or simply press the Escape key.</li>
+</ul>
+<p>When a marker is clicked, the map will automatically adjust the viewport
+  so that the marker is still visible with the popup open. The currently
+  selected marker is shown slightly bigger.</p>
+<p>It is possible to switch between markers by clicking on them even when
+  the popup view is already open.</p>
+<p>Markers can have&nbsp;<a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;between
+  them and clicking on such a link will automatically adjust the viewport
+  and the popup view to the new note.</p>
+<h3>Contextual menu</h3>
+<p>It's possible to press the right mouse button to display a contextual
+  menu.</p>
+<ol>
+  <li>If right-clicking an empty section of the map (not on a marker), it allows
+    to:
+    <ol>
+      <li>Displays the latitude and longitude. Clicking this option will copy them
+        to the clipboard.</li>
+      <li>Open the location using an external application (if the operating system
+        supports it).</li>
+      <li>Adding a new marker at that location.</li>
+    </ol>
+  </li>
+  <li>If right-clicking on a marker, it allows to:
+    <ol>
+      <li>Displays the latitude and longitude. Clicking this option will copy them
+        to the clipboard.</li>
+      <li>Open the location using an external application (if the operating system
+        supports it).</li>
+      <li>Open the note in a new tab, split or window.</li>
+      <li>Button to remove the marker from the map, which can optionally delete
+        its corresponding note. Removing a marker without deleting the note will
+        only remove its <code spellcheck="false">#geolocation</code> attribute (case
+        in which the coordinates have to be manually added back in in order to
+        get the note to show on the map again).</li>
+    </ol>
+  </li>
+</ol>
+<h3>Icon and color of the markers</h3>
+<figure class="image image-style-align-right image_resized" style="width:47.42%;">
+  <img style="aspect-ratio:885/321;" src="3_Geo Map_image.png"
+  width="885" height="321">
+</figure>
+<p>The markers will have the same icon as the note.</p>
+<p>It's possible to add a custom color to a marker by assigning them a <code
+  spellcheck="false">#color</code> attribute such as <code spellcheck="false">#color=green</code>.</p>
+<h3>Adding the coordinates manually</h3>
+<p>Searching for the place is usually quicker (see <em>Searching the map</em> above).
+  The steps below remain useful for a coordinate that is already to hand,
+  or for a place the search cannot find.</p>
+<p>In a nutshell, create a child note and set the <code spellcheck="false">#geolocation</code> attribute
+  to the coordinates.</p>
+<p>The value of the attribute is made up of the latitude and longitude separated
+  by a comma.</p>
+<h4>Adding from Google Maps</h4>
+<ol>
+  <li>In Google Maps, on the web:
+    <ol>
+      <li>Look for a desired location, right click on it and a context menu will
+        show up.</li>
+      <li>Simply click on the first item displaying the coordinates and they will
+        be copied to clipboard.</li>
+    </ol>
+  </li>
+  <li>In Trilium, create a child note under the map.</li>
+  <li>Then paste the value inside the text box into the <code spellcheck="false">#geolocation</code> attribute
+    of a child note of the map (don't forget to surround the value with a <code
+    spellcheck="false">"</code> character).</li>
+</ol>
+<h4>Adding from OpenStreetMap</h4>
+<p>Similarly to the Google Maps approach:</p>
+<ol>
+  <li>Go to any location on openstreetmap.org and right click to bring up the
+    context menu. Select the <em>Show address</em> item.</li>
+  <li>The address will be visible in the top-left of the screen, in the place
+    of the search bar.&nbsp;Select the coordinates and copy them into the clipboard.</li>
+  <li>Simply paste the value inside the text box into the <code spellcheck="false">#geolocation</code> attribute
+    of a child note of the map and then it should be displayed on the map.</li>
+</ol>
+<h2>Adding GPS tracks (.gpx)</h2>
+<figure class="image">
+  <img style="aspect-ratio:1566/1155;" src="1_Geo Map_image.png"
+  width="1566" height="1155">
+</figure>
+<p>Trilium can display GPS tracks on the geo map, in the form of <code spellcheck="false">.gpx</code> files.</p>
+<p>To add a track, either:</p>
+<ol>
+  <li>Drag &amp; drop a <code spellcheck="false">.gpx</code> file inside the geo
+    map in the note tree.
+    <ol>
+      <li>In order for the file to be recognized as a GPS track, it needs to show
+        up as <code spellcheck="false">application/gpx+xml</code> in the <em>File type</em> field.</li>
+    </ol>
+  </li>
+  <li>Press the <em>Add a GPS track from a GPX file</em> which will directly prompt
+    for a GPX file and import it as a subnote of the collection.</li>
+</ol>
+<p>When going back to the map, the track should now be visible.</p>
+<p>The starting point of the track will be displayed as a marker, with the
+  name of the note underneath. The start marker will also respect the icon
+  and the <code spellcheck="false">color</code> of the note. The end marker
+  is displayed with a distinct icon.</p>
+<p>If the track file contains multiple tracks, they will all be displayed
+  as well as markers. Trilium will also split a single track that happens
+  to have non-continuous points.</p>
+<p>If the GPX contains waypoints, they will also be displayed, including
+  their names.</p>
+<p>When the track is clicked, the entire route is brought into view, as well
+  as the right popup will indicate details about the track such as distance,
+  duration and the elevation map. This information is also displayed when
+  clicking the <code spellcheck="false">.gpx</code> note itself.</p>
+<p>When clicking on the markers of a track (whether it's the start or stop
+  builtin markers, or custom markers that are part of the track), only that
+  marker is brought into view, as opposed to the entire route.</p>
+<h2>Read-only mode</h2>
+<p>When a map is <a href="#root/_help_CoFPLs3dRlXc">read-only</a> all editing features
+  will be disabled such as:</p>
+<ul>
+  <li>The add button at the bottom of the map.</li>
+  <li>Repositioning markers.</li>
+  <li>Editing from the contextual menu (removing locations or adding new items).</li>
+  <li>Keeping a place as a marker, whether you found it by searching or clicked
+    it on the map. You can still search and click, and you can still look at
+    a place and copy its coordinates.</li>
+</ul>
+<p>To set a map as read-only, go to&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Editable</em> → <em>Read-only</em> (on
+  the new layout, or in Basic Properties on the&nbsp;<a class="reference-link"
+  href="#root/_help_BlN9DFI679QC">Ribbon</a>&nbsp;for the old layout).</p>
+<h2>Configuration</h2>
+<h3>Map Style</h3>
+<p>The styling of the map can be adjusted in the&nbsp;<a class="reference-link"
+  href="#root/_help_CssoWBu8I7jF">Collection Properties</a>&nbsp;or manually via
+  the <code spellcheck="false">#map:style</code> attribute.</p>
+<p>The geo map comes with two different types of styles:</p>
+<ul>
+  <li>Raster styles
+    <ul>
+      <li>For these styles the map is represented as a grid of images at different
+        zoom levels. This is the traditional way OpenStreetMap used to work.</li>
+      <li>Zoom is slightly restricted.</li>
+      <li>Currently, the only raster theme is the original OpenStreetMap style.</li>
+    </ul>
+  </li>
+  <li>Vector styles
+    <ul>
+      <li>Vector styles are not represented as images, but as geometrical shapes.
+        This makes the rendering much smoother, especially when zooming and looking
+        at the building edges, for example.</li>
+      <li>The map can be zoomed in much further.</li>
+      <li>These come in various styles that are both light (Colorful, Graybeard,
+        Neutrino) and dark (Eclipse, Shadow).</li>
+      <li>The vector styles come from <a href="https://versatiles.org/">VersaTiles</a>,
+        a free and open-source project providing map tiles based on OpenStreetMap.</li>
+      <li>The VersaTiles layers also provide 3D building information (see below).</li>
+    </ul>
+  </li>
+</ul>
+<p>The default theme is Versatiles Colorful (vector).</p>
+<h4>3D view with buildings</h4>
+<figure class="image">
+  <img style="aspect-ratio:2727/1642;" src="2_Geo Map_image.png"
+  width="2727" height="1642">
+</figure>
+<p>Trilium v0.105.0 introduces a 3D view, courtesy of MapLibre GL. To enter
+  3D mode, simply press the corresponding button at the bottom-right of the
+  map or press Ctrl and drag across the map.</p>
+<p>The buildings will only appear from zoom 14 onwards to avoid lag.</p>
+<aside
+class="admonition note">
+  <p>To get 3D buildings, make sure you are using the <em>VersaTiles</em> styles
+    which provide the building informatia via the <code spellcheck="false">versatiles-shortbread</code> source.</p>
+</aside>
+<h3>Custom map style / tiles</h3>
+<p>Starting with v0.102.0 it is possible to use custom tile sets, but only
+  in raster format.</p>
+<p>To do so, manually set the <code spellcheck="false">#map:style</code>  <a
+  href="#root/_help_HI6GBBIduIgv">label</a> to the URL of the tile set. For example,
+  to use Esri.NatGeoWorldMap, set the value to <a href="https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/%7Bz%7D/%7By%7D/%7Bx%7D."><code spellcheck="false">https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}</code>.</a>
+</p>
+<p>Additionally:</p>
+<ul>
+  <li>Hi-DPI tiles are supported via the <code spellcheck="false">{r}</code> placeholder.</li>
+  <li>To mark the custom style as dark (which affects the styling of the UI),
+    apply the <code spellcheck="false">map:darkStyle</code> label. This attribute
+    also overrides builtin themes.</li>
+</ul>
+<aside class="admonition note">
+  <p>For a list of tile sets, see the <a href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers preview</a> page.
+    Select a desired tile set and just copy the URL from the <em>Plain JavaScript</em> example.</p>
+</aside>
+<p>Custom vector map support is planned, but not yet implemented.</p>
+<h3>Other options</h3>
+<p>The following options can be configured either via the&nbsp;<a class="reference-link"
+  href="#root/_help_CssoWBu8I7jF">Collection Properties</a>, by clicking on the
+  settings (Gear icon). Alternatively, each of these options also have a
+  corresponding <a href="#root/_help_HI6GBBIduIgv">label</a> that can be set manually.</p>
+<ul>
+  <li>Scale, which illustrates the scale of the map in either kilometers or
+    miles in the bottom-left of the map.
+    <ul>
+      <li>The unit is determined by the <em>Formatting locale</em> option in <em>Language &amp; Region</em>.</li>
+    </ul>
+  </li>
+  <li>The name of the markers is displayed by default underneath the pin on
+    the map. Since v0.102.0, it is possible to hide these labels which increases
+    the performance and decreases clutter when there are many markers on the
+    map.</li>
+  <li>v0.105.0 also introduces a feature called <em>Group nearby markers</em> which
+    will cluster multiple markers together at low zoom.
+    <ul>
+      <li>The clusters display the number of items they contain. The color also
+        changes based on the count.</li>
+      <li>Clicking on a cluster will automatically zoom in so that the individual
+        markers that make up the cluster are now visible.</li>
+    </ul>
+  </li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Kanban Board.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Kanban Board.html
@@ -132,10 +132,9 @@
 </ul>
 <h3>Grouping by another label</h3>
 <p>By default, the label used to group the notes is <code spellcheck="false">#status</code>.
-  It is possible to use a different label if needed by defining a label named
-  <code
-  spellcheck="false">#board:groupBy</code>with the value being the attribute to use (with or
-    without <code spellcheck="false">#</code> attribute prefix).</p>
+  It is possible to use a different label if needed by defining a label named <code
+  spellcheck="false">#board:groupBy</code> with the value being the attribute
+  to use (with or without <code spellcheck="false">#</code> attribute prefix).</p>
 <h3>Grouping by relations</h3>
 <figure class="image image-style-align-right">
   <img style="aspect-ratio:535/245;" src="1_Kanban Board_image.png"
@@ -170,8 +169,7 @@
   </li>
   <li>
     <p>Set <code spellcheck="false">#board:groupBy</code> to the name of a relation
-      to group by, <strong>including the</strong>  <code spellcheck="false">~</code>  <strong>prefix</strong> (e.g.
-      <code
+      to group by, <strong>including the</strong>  <code spellcheck="false">~</code>  <strong>prefix</strong> (e.g. <code
       spellcheck="false">~status</code>).</p>
   </li>
   <li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Presentation.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Collections/Presentation.html
@@ -95,11 +95,10 @@
 </ul>
 <p>At slide level:</p>
 <ul>
-  <li>It's possible to adjust the background color of a slide by using the
-    <a
-    href="#root/_help_OFXdgB2nNk1F">predefined promoted attribute</a>for the color or manually setting
-      <code
-      spellcheck="false">#slide:background</code>to a hex color.</li>
+  <li>It's possible to adjust the background color of a slide by using the <a
+    href="#root/_help_OFXdgB2nNk1F">predefined promoted attribute</a> for the color
+    or manually setting <code spellcheck="false">#slide:background</code> to
+    a hex color.</li>
   <li>More complex backgrounds can be achieved via gradients. There's no UI
     for it; it has to be set via <code spellcheck="false">#slide:background</code> to
     a CSS gradient definition such as: <code spellcheck="false">linear-gradient(to bottom, #283b95, #17b2c3)</code>.</li>
@@ -110,29 +109,29 @@
     and background colors) and font size. Code blocks and tables also work.</li>
   <li>Try using more than just text notes, the presentation uses the same mechanism
     as <a href="#root/_help_R9pX4DGra2Vt">shared notes</a> and&nbsp;<a class="reference-link"
-    href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;so it should be able to display&nbsp;
-    <a
-    class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,&nbsp;<a class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;
-      <a
-      class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>&nbsp;in full-screen (without the interactivity).
-        <ul>
-          <li>
-            <p>Consider using a transparent background for&nbsp;<a class="reference-link"
-              href="#root/_help_grjYqerjn243">Canvas</a>, if the slides have a custom background
-              (go to the hamburger menu in the Canvas, press the button select a custom
-              color and write <code spellcheck="false">transparent</code>).</p>
-          </li>
-          <li>
-            <p>For&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,
-              some of them have a predefined background which can be changed via the
-              frontmatter. For example, for XY-charts:</p><pre><code class="language-text-x-trilium-auto">---
+    href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;so it should be able to display&nbsp;<a
+    class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,&nbsp;<a
+    class="reference-link" href="#root/_help_grjYqerjn243">Canvas</a>&nbsp;and&nbsp;<a
+    class="reference-link" href="#root/_help_gBbsAeiuUxI5">Mind Map</a>&nbsp;in full-screen
+    (without the interactivity).
+    <ul>
+      <li>
+        <p>Consider using a transparent background for&nbsp;<a class="reference-link"
+          href="#root/_help_grjYqerjn243">Canvas</a>, if the slides have a custom background
+          (go to the hamburger menu in the Canvas, press the button select a custom
+          color and write <code spellcheck="false">transparent</code>).</p>
+      </li>
+      <li>
+        <p>For&nbsp;<a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>,
+          some of them have a predefined background which can be changed via the
+          frontmatter. For example, for XY-charts:</p><pre><code class="language-text-x-trilium-auto">---
 config:
     themeVariables:
         xyChart:
             backgroundColor: transparent
 ---</code></pre>
-          </li>
-        </ul>
+      </li>
+    </ul>
   </li>
 </ul>
 <h2>Under the hood</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/FAQ.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/FAQ.html
@@ -33,21 +33,20 @@
   <li>given its size it would probably pivot the attention away from my main
     focus which is a personal note-taking</li>
   <li>the assumption that only single person has access to the app simplifies
-    many things, or just outright makes them possible. In multi-user app, our
-    <a
-    href="#root/_help_CdNpE2pqjmI6">scripting</a>support would be a XSS security hole, while with the single
-      user assumption it's an endless customizable tool.</li>
+    many things, or just outright makes them possible. In multi-user app, our <a
+    href="#root/_help_CdNpE2pqjmI6">scripting</a>support would be a XSS security
+    hole, while with the single user assumption it's an endless customizable
+    tool.</li>
 </ul>
 <h2>How to open multiple documents in one Trilium instance</h2>
 <p>This is normally not supported - one Trilium process can open only a single
   instance of a <a href="#root/_help_wX4HbRucYSDD">database</a>. However, you can
   run two Trilium processes (from one installation), each connected to a
-  separate document. To achieve this, you need to set a location for the
-  <a
-  href="#root/_help_tAassRL4RSQL">data directory</a>in the <code spellcheck="false">TRILIUM_DATA_DIR</code> environment
-    variable and separate port on <code spellcheck="false">TRILIUM_PORT</code> environment
-    variable. How to do that depends on the platform, in Unix-based systems
-    you can achieve that by running command such as this:</p><pre><code class="language-text-x-sh">TRILIUM_DATA_DIR=/home/me/path/to/data/dir TRILIUM_PORT=12345 trilium </code></pre>
+  separate document. To achieve this, you need to set a location for the <a
+  href="#root/_help_tAassRL4RSQL">data directory</a> in the <code spellcheck="false">TRILIUM_DATA_DIR</code> environment
+  variable and separate port on <code spellcheck="false">TRILIUM_PORT</code> environment
+  variable. How to do that depends on the platform, in Unix-based systems
+  you can achieve that by running command such as this:</p><pre><code class="language-text-x-sh">TRILIUM_DATA_DIR=/home/me/path/to/data/dir TRILIUM_PORT=12345 trilium </code></pre>
 <p>You can save this command into a <code spellcheck="false">.sh</code> script
   file or make an alias. Do this similarly for a second instance with different
   data directory and port.</p>
@@ -89,11 +88,10 @@
 <h3>Why does search sometimes find results with typos?</h3>
 <p>Trilium uses a progressive search strategy that includes fuzzy matching
   when exact matches return fewer than 5 results. This finds notes despite
-  minor typos in your search query. You can use fuzzy search operators (
-  <code
-  spellcheck="false">~=</code>for fuzzy exact match and <code spellcheck="false">~*</code> for
-    fuzzy contains). See the&nbsp;<a class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;documentation
-    for details.</p>
+  minor typos in your search query. You can use fuzzy search operators (<code
+  spellcheck="false">~=</code> for fuzzy exact match and <code spellcheck="false">~*</code> for
+  fuzzy contains). See the&nbsp;<a class="reference-link" href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;documentation
+  for details.</p>
 <h3>How can I search for notes when I'm not sure of the exact spelling?</h3>
 <p>Use the fuzzy search operators:</p>
 <ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Backup.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Backup.html
@@ -1,6 +1,6 @@
-<p>Trilium supports simple backup scheme where it saves copy of the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>&nbsp;on these events:</p>
+<p>Trilium supports simple backup scheme where it saves copy of the&nbsp;<a
+  class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>&nbsp;on these
+  events:</p>
 <ul>
   <li>once a day</li>
   <li>once a week</li>
@@ -85,12 +85,10 @@
   <li>find <code spellcheck="false">~/trilium-data/backup/backup-weekly.db</code> -
     this is the&nbsp;<a class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>&nbsp;backup.</li>
   <li>at this point stop/kill Trilium</li>
-  <li>delete <code spellcheck="false">~/trilium-data/document.db</code>,
-    <code
-    spellcheck="false">~/trilium-data/document.db-wal</code>and <code spellcheck="false">~/trilium-data/document.db-shm</code> (latter
-      two files are auto generated)</li>
-  <li>copy and rename this <code spellcheck="false">~/trilium-data/backup/backup-weekly.db</code> to
-    <code
+  <li>delete <code spellcheck="false">~/trilium-data/document.db</code>, <code
+    spellcheck="false">~/trilium-data/document.db-wal</code> and <code spellcheck="false">~/trilium-data/document.db-shm</code> (latter
+    two files are auto generated)</li>
+  <li>copy and rename this <code spellcheck="false">~/trilium-data/backup/backup-weekly.db</code> to <code
     spellcheck="false">~/trilium-data/document.db</code>
   </li>
   <li>make sure that the file is writable, e.g. with <code spellcheck="false">chmod 600 document.db</code>
@@ -153,32 +151,31 @@ class="admonition note">
   <p>On some systems, a keyring may not be available for Trilium to securely
     store the encryption password. In such cases, the encryption option is
     disabled.</p>
-  </aside>
-  <h2>Backup compression</h2>
-  <p>Database backups can be optionally compressed to minimize storage footprint.
-    This method is effective primarily when the database consists largely of
-    text content. However, media files (images, videos, audio), along with
-    PDF, ODF, and DOCX files, are already compressed in their original formats
-    and won't benefit from further compression.</p>
-  <p>Compressed backups are stored using the Trilium Backup Container (.tnbackup),
-    employing RFC 1952 GZIP compression.</p>
-  <aside class="admonition warning">
-    <p><strong>Note:</strong> Compression increases the time required for backup
-      creation and restoration. It may also lead to higher CPU usage during automatic
-      backups, potentially draining the battery faster on battery-powered devices.
-      Enable this option only if necessary.</p>
-  </aside>
-  <h3>Enabling Backup Compression (Desktop Only)</h3>
-  <p>To enable compression for new automatic and manual backups, navigate to <strong>Settings → Backup → Backup Options</strong> and
-    toggle <strong>Enable Compression</strong> to on.</p>
-  <h2>Disabling backup</h2>
-  <p>Although this is not recommended, it is possible to disable backup in
-    <code
-    spellcheck="false">config.ini</code>in the <a href="#root/_help_tAassRL4RSQL">data directory</a>:</p><pre><code class="language-text-x-trilium-auto">[General]
+</aside>
+<h2>Backup compression</h2>
+<p>Database backups can be optionally compressed to minimize storage footprint.
+  This method is effective primarily when the database consists largely of
+  text content. However, media files (images, videos, audio), along with
+  PDF, ODF, and DOCX files, are already compressed in their original formats
+  and won't benefit from further compression.</p>
+<p>Compressed backups are stored using the Trilium Backup Container (.tnbackup),
+  employing RFC 1952 GZIP compression.</p>
+<aside class="admonition warning">
+  <p><strong>Note:</strong> Compression increases the time required for backup
+    creation and restoration. It may also lead to higher CPU usage during automatic
+    backups, potentially draining the battery faster on battery-powered devices.
+    Enable this option only if necessary.</p>
+</aside>
+<h3>Enabling Backup Compression (Desktop Only)</h3>
+<p>To enable compression for new automatic and manual backups, navigate to <strong>Settings → Backup → Backup Options</strong> and
+  toggle <strong>Enable Compression</strong> to on.</p>
+<h2>Disabling backup</h2>
+<p>Although this is not recommended, it is possible to disable backup in <code
+  spellcheck="false">config.ini</code> in the <a href="#root/_help_tAassRL4RSQL">data directory</a>:</p><pre><code class="language-text-x-trilium-auto">[General]
 ... some other configs
 # set to true to disable backups (e.g. because of limited space on server)
 noBackup=true</code></pre>
-  <p>You can also review the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file
-    to provide all <code spellcheck="false">config.ini</code> values as environment
-    variables instead.</p>
-  <p>See <a href="https://github.com/TriliumNext/Trilium/blob/master/config-sample.ini">sample config</a>.</p>
+<p>You can also review the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file
+  to provide all <code spellcheck="false">config.ini</code> values as environment
+  variables instead.</p>
+<p>See <a href="https://github.com/TriliumNext/Trilium/blob/master/config-sample.ini">sample config</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Data directory.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Data directory.html
@@ -46,9 +46,9 @@
 </ol>
 <h4>Linux</h4><pre><code class="language-text-x-trilium-auto">export TRILIUM_DATA_DIR=/home/myuser/data/my-trilium-data</code></pre>
 <h4>Mac OS X</h4>
-<p>You need to create a <code spellcheck="false">.plist</code> file under
-  <code
-  spellcheck="false">~/Library/LaunchAgents</code>to load it properly each login.</p>
+<p>You need to create a <code spellcheck="false">.plist</code> file under <code
+  spellcheck="false">~/Library/LaunchAgents</code> to load it properly each
+  login.</p>
 <p>To load it manually, you need to use <code spellcheck="false">launchctl setenv TRILIUM_DATA_DIR &lt;yourpath&gt;</code>
 </p>
 <p>Here is a pre-defined template, where you just need to add your path to:</p><pre><code class="language-text-x-trilium-auto">        Label
@@ -77,12 +77,11 @@
   (e.g. <code spellcheck="false">%APPDATA%</code> on Windows), which may be
   undesirable in corporate environments with roaming profiles or when running
   in portable mode.</p>
-<p>To keep Electron data out of the system's roaming profile, set the
-  <code
-  spellcheck="false">TRILIUM_ELECTRON_DATA_DIR</code>environment variable to an explicit path.
-    The <code spellcheck="false">trilium-portable</code> script does this automatically,
-    pointing it to <code spellcheck="false">trilium-electron-data/</code> next
-    to the application.</p>
+<p>To keep Electron data out of the system's roaming profile, set the <code
+  spellcheck="false">TRILIUM_ELECTRON_DATA_DIR</code> environment variable
+  to an explicit path. The <code spellcheck="false">trilium-portable</code> script
+  does this automatically, pointing it to <code spellcheck="false">trilium-electron-data/</code> next
+  to the application.</p>
 <h2>Fine-grained directory/path location</h2>
 <p>Apart from the data directory, some of the subdirectories of it can be
   moved elsewhere by changing an environment variable:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation.html
@@ -5,9 +5,8 @@
     GitHub.</li>
   <li><strong>Extract the Package</strong>: Unzip the downloaded package to
     a location of your choice.</li>
-  <li><strong>Run the Application</strong>: Launch Trilium by executing the
-    <code
-    spellcheck="false">trilium</code>executable found within the unzipped folder.</li>
+  <li><strong>Run the Application</strong>: Launch Trilium by executing the <code
+    spellcheck="false">trilium</code> executable found within the unzipped folder.</li>
 </ol>
 <h2>Startup Scripts</h2>
 <p>Trilium offers various startup scripts to customize your experience:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Network Access.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Network Access.html
@@ -50,4 +50,4 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
+</figure>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Nix flake.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Nix flake.html
@@ -7,8 +7,7 @@
 <p>Using <a href="https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-run.html">nix run</a>,
   the desktop app can be started as: <code spellcheck="false">nix run github:TriliumNext/Trilium/v0.95.0</code>
 </p>
-<p>Running the server requires explicitly specifying the desired package:
-  <code
+<p>Running the server requires explicitly specifying the desired package: <code
   spellcheck="false">nix run github:TriliumNext/Trilium/v0.95.0#server</code>
 </p>
 <p>Instead of a version (<code spellcheck="false">v0.95.0</code> above), you

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Tray icon & automatic startup.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Tray icon & automatic startup.html
@@ -10,8 +10,7 @@
 </figure>
 <p>The desktop application has native integration with the system tray on
   all operating systems.</p>
-<p>The tray icon is enabled by default, but it can be toggled from&nbsp;
-  <a
+<p>The tray icon is enabled by default, but it can be toggled from&nbsp;<a
   class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Desktop</em>.</p>
 <p>The tray icon has the following functionality:</p>
 <ul>
@@ -22,10 +21,10 @@
       <li>Each window can be individually shown or hidden, identified by their active
         note.</li>
       <li>New windows can be opened.</li>
-      <li>A new note can be created directly, which will be created in the&nbsp;
-        <a
-        class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(or&nbsp;<a class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if
-          an inbox is not available).</li>
+      <li>A new note can be created directly, which will be created in the&nbsp;<a
+        class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(or&nbsp;<a
+        class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;if
+        an inbox is not available).</li>
       <li>Today's day note can be opened.</li>
       <li>Bookmarks and recent notes are displayed in a sub-menu and clicking them
         navigates to that note.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Using the desktop application as a server.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Desktop Installation/Using the desktop application as a server.html
@@ -12,33 +12,33 @@ class="admonition note">
     the desktop application itself is running. So closing the application will
     also close the server. To overcome this, you can try hiding the application
     in the system tray.</p>
-  </aside>
-  <h2>Mobile interface</h2>
-  <p>By default, this will display the desktop user interface, even on mobile.
-    To switch to the mobile version, simply go to the&nbsp;<a class="reference-link"
-    href="#root/_help_x3i7MxGccDuM">Global menu</a>&nbsp;and select “Switch to the
-    mobile version”.</p>
-  <h2>Allowing the port externally on Windows with Windows Defender Firewall</h2>
-  <p>First, find out the IP of your desktop server by running <code spellcheck="false">ipconfig</code> in
-    your local terminal. Then try accessing <code spellcheck="false">http://&lt;ip&gt;:37840/login</code> on
-    another device. If it doesn't work, then most likely the port is blocked
-    by your operating system's firewall.</p>
-  <p>If you use Windows Defender Firewall:</p>
-  <ol>
-    <li>Go to Windows's start menu and look for “Windows Defender Firewall with
-      Advanced Security”.</li>
-    <li>Go to “Inbound Rules” on the left tree, and select “New Rule” in the “Actions”
-      sidebar on the right.</li>
-    <li>Select “Port” and press “Next”.</li>
-    <li>Type in <code spellcheck="false">37840</code> in the “Specific local ports”
-      section and then press “Next”.</li>
-    <li>Leave “Allow the connection” checked and press “Next”.</li>
-    <li>Configure the networks to apply to (check all if unsure) and then press
-      “Next”.</li>
-    <li>Add an appropriate name to the rule (e.g. “Trilium Notes”) and press “Finish”.</li>
-  </ol>
-  <aside class="admonition warning">
-    <p>Since v0.104.0, the port used by Trilium is accessible only on <code spellcheck="false">localhost</code>.
-      To enable across the local network, see&nbsp;<a class="reference-link"
-      href="#root/_help_swSFivWk6KkA">Network Access</a>.</p>
-  </aside>
+</aside>
+<h2>Mobile interface</h2>
+<p>By default, this will display the desktop user interface, even on mobile.
+  To switch to the mobile version, simply go to the&nbsp;<a class="reference-link"
+  href="#root/_help_x3i7MxGccDuM">Global menu</a>&nbsp;and select “Switch to the
+  mobile version”.</p>
+<h2>Allowing the port externally on Windows with Windows Defender Firewall</h2>
+<p>First, find out the IP of your desktop server by running <code spellcheck="false">ipconfig</code> in
+  your local terminal. Then try accessing <code spellcheck="false">http://&lt;ip&gt;:37840/login</code> on
+  another device. If it doesn't work, then most likely the port is blocked
+  by your operating system's firewall.</p>
+<p>If you use Windows Defender Firewall:</p>
+<ol>
+  <li>Go to Windows's start menu and look for “Windows Defender Firewall with
+    Advanced Security”.</li>
+  <li>Go to “Inbound Rules” on the left tree, and select “New Rule” in the “Actions”
+    sidebar on the right.</li>
+  <li>Select “Port” and press “Next”.</li>
+  <li>Type in <code spellcheck="false">37840</code> in the “Specific local ports”
+    section and then press “Next”.</li>
+  <li>Leave “Allow the connection” checked and press “Next”.</li>
+  <li>Configure the networks to apply to (check all if unsure) and then press
+    “Next”.</li>
+  <li>Add an appropriate name to the rule (e.g. “Trilium Notes”) and press “Finish”.</li>
+</ol>
+<aside class="admonition warning">
+  <p>Since v0.104.0, the port used by Trilium is accessible only on <code spellcheck="false">localhost</code>.
+    To enable across the local network, see&nbsp;<a class="reference-link"
+    href="#root/_help_swSFivWk6KkA">Network Access</a>.</p>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Mobile Frontend.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Mobile Frontend.html
@@ -121,10 +121,9 @@
   To access it go to <code spellcheck="false">http://&lt;ip&gt;:37840/login?mobile</code> .</p>
 <h2>Forcing mobile/desktop frontend</h2>
 <p>Trilium decides automatically whether to use mobile or desktop front-end.
-  If this is not appropriate, you can use <code spellcheck="false">?mobile</code> or
-  <code
-  spellcheck="false">?desktop</code>query param on <strong>login</strong> page (Note: you might
-    need to log out).</p>
+  If this is not appropriate, you can use <code spellcheck="false">?mobile</code> or <code
+  spellcheck="false">?desktop</code> query param on <strong>login</strong> page
+  (Note: you might need to log out).</p>
 <p>Alternatively, simply select <em>Switch to Mobile/Desktop Version</em> in
   the&nbsp;<a class="reference-link" href="#root/_help_x3i7MxGccDuM">Global menu</a>.</p>
 <h2>Scripting</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation.html
@@ -36,9 +36,8 @@
 <h3>Config Location</h3>
 <p>By default, <code spellcheck="false">config.ini</code>, the <a href="#root/_help_wX4HbRucYSDD">database</a>,
   and other important Trilium data files are stored in the <a href="#root/_help_tAassRL4RSQL">data directory</a>.
-  If you prefer a different location, you can change it by setting the
-  <code
-  spellcheck="false">TRILIUM_DATA_DIR</code>environment variable:</p><pre><code class="language-text-x-trilium-auto">export TRILIUM_DATA_DIR=/home/myuser/data/my-trilium-data</code></pre>
+  If you prefer a different location, you can change it by setting the <code
+  spellcheck="false">TRILIUM_DATA_DIR</code> environment variable:</p><pre><code class="language-text-x-trilium-auto">export TRILIUM_DATA_DIR=/home/myuser/data/my-trilium-data</code></pre>
 <h3>Disabling Authentication</h3>
 <p>See&nbsp;<a class="reference-link" href="#root/_help_0hzsNCP31IAB">Authentication</a>.</p>
 <h2>Reverse Proxy Setup</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Manually.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Manually.html
@@ -1,8 +1,7 @@
 <aside class="admonition warning">
-  <p>This page describes manually installing Trilium on your server. <strong>Note that this is a not well supported way to install Trilium, problems may appear, information laid out here is quite out of date. It is recommended to use either</strong>&nbsp;
-    <a
-    class="reference-link" href="#root/_help_rWX5eY045zbE">Docker Server Installation</a>&nbsp;<strong>or</strong>&nbsp;<a class="reference-link"
-      href="#root/_help_3tW6mORuTHnB">Packaged server installation</a><strong>.</strong>
+  <p>This page describes manually installing Trilium on your server. <strong>Note that this is a not well supported way to install Trilium, problems may appear, information laid out here is quite out of date. It is recommended to use either</strong>&nbsp;<a
+    class="reference-link" href="#root/_help_rWX5eY045zbE">Docker Server Installation</a>&nbsp;<strong>or</strong>&nbsp;<a
+    class="reference-link" href="#root/_help_3tW6mORuTHnB">Packaged server installation</a><strong>.</strong>
   </p>
 </aside>
 <h2>Requirements</h2>
@@ -20,9 +19,8 @@
 <h2>Installation</h2>
 <h3>Download</h3>
 <p>You can either download source code zip/tar from <a href="https://github.com/TriliumNext/Trilium/releases/latest">https://github.com/TriliumNext/Trilium/releases/latest</a>.</p>
-<p>For the latest version including betas, clone Git repository <strong>from</strong> 
-  <code
-  spellcheck="false">main</code> <strong>branch</strong> with:</p><pre><code class="language-text-x-trilium-auto">git clone -b main https://github.com/triliumnext/trilium.git</code></pre>
+<p>For the latest version including betas, clone Git repository <strong>from</strong>  <code
+  spellcheck="false">main</code>  <strong>branch</strong> with:</p><pre><code class="language-text-x-trilium-auto">git clone -b main https://github.com/triliumnext/trilium.git</code></pre>
 <h2>Installation</h2><pre><code class="language-text-x-trilium-auto">cd trilium
 
 # download all node dependencies

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Multiple server instances.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Multiple server instances.html
@@ -4,10 +4,10 @@
 <p>To allow multiple server instances on a single physical server:</p>
 <ul>
   <li>
-    <p>For&nbsp;<a class="reference-link" href="#root/_help_3tW6mORuTHnB">Packaged version for Linux</a>&nbsp;or&nbsp;
-      <a
-      class="reference-link" href="#root/_help_J1Bb6lVlwU5T">Manually</a>, if starting the server manually just specify a different
-        port and data directory per instance:</p><pre><code class="language-text-x-trilium-auto">TRILIUM_NETWORK_PORT=8080 TRILIUM_DATA_DIR=/path/to/your/data-dir-A /opt/trilium/trilium.sh</code></pre>
+    <p>For&nbsp;<a class="reference-link" href="#root/_help_3tW6mORuTHnB">Packaged version for Linux</a>&nbsp;or&nbsp;<a
+      class="reference-link" href="#root/_help_J1Bb6lVlwU5T">Manually</a>, if starting
+      the server manually just specify a different port and data directory per
+      instance:</p><pre><code class="language-text-x-trilium-auto">TRILIUM_NETWORK_PORT=8080 TRILIUM_DATA_DIR=/path/to/your/data-dir-A /opt/trilium/trilium.sh</code></pre>
     <p>For a second instance:</p><pre><code class="language-text-x-trilium-auto">TRILIUM_NETWORK_PORT=8081 TRILIUM_DATA_DIR=/path/to/your/data-dir-B /opt/trilium/trilium.sh</code></pre>
     <p>If using <code spellcheck="false">systemd</code>, then set the <a href="https://serverfault.com/questions/413397/how-to-set-environment-variable-in-systemd-service">environment variables in the service configuration</a>.</p>
   </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Packaged version for Linux.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Packaged version for Linux.html
@@ -19,10 +19,10 @@
 <p>The problem with above steps is that once you close the SSH connection,
   the Trilium process is terminated. To avoid that, you have two options:</p>
 <ul>
-  <li>Kill it (with e.g. <kbd>Ctrl</kbd> + <kbd>C</kbd>) and run again like this:
-    <code
-    spellcheck="false">nohup ./trilium.sh &amp;</code>. (nohup keeps the process running in the
-      background, <code spellcheck="false">&amp;</code> runs it in the background)</li>
+  <li>Kill it (with e.g. <kbd>Ctrl</kbd> + <kbd>C</kbd>) and run again like this: <code
+    spellcheck="false">nohup ./trilium.sh &amp;</code>. (nohup keeps the process
+    running in the background, <code spellcheck="false">&amp;</code> runs it
+    in the background)</li>
   <li>Configure systemd to automatically run Trilium in the background on every
     boot</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Using Docker.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Using Docker.html
@@ -1,5 +1,4 @@
-<p>Official docker images are published on docker hub for <strong>AMD64</strong>, <strong>ARMv7</strong> and <strong>ARM64/v8</strong>:
-  <a
+<p>Official docker images are published on docker hub for <strong>AMD64</strong>, <strong>ARMv7</strong> and <strong>ARM64/v8</strong>: <a
   href="https://hub.docker.com/r/triliumnext/trilium/">https://hub.docker.com/r/triliumnext/trilium/</a>
 </p>
 <h2>Prerequisites</h2>
@@ -9,11 +8,10 @@
 <p><strong>Note:</strong> Trilium's Docker container requires root privileges
   to operate correctly.</p>
 <aside class="admonition warning">
-  <p>If you're using a SMB/CIFS share or folder as your Trilium data directory,
-    <a
-    href="https://github.com/TriliumNext/Notes/issues/415#issuecomment-2344824400">you'll need</a>to add the mount options of <code spellcheck="false">nobrl</code> and
-      <code
-      spellcheck="false">noperm</code>when mounting your SMB share.</p>
+  <p>If you're using a SMB/CIFS share or folder as your Trilium data directory, <a
+    href="https://github.com/TriliumNext/Notes/issues/415#issuecomment-2344824400">you'll need</a> to
+    add the mount options of <code spellcheck="false">nobrl</code> and <code spellcheck="false">noperm</code> when
+    mounting your SMB share.</p>
 </aside>
 <h2>Running with Docker Compose</h2>
 <h3>Grab the latest docker-compose.yml:</h3><pre><code class="language-text-x-trilium-auto">wget https://raw.githubusercontent.com/TriliumNext/Trilium/master/docker-compose.yml</code></pre>
@@ -27,8 +25,7 @@
 <h3>Pulling the Docker Image</h3>
 <p>To pull the image, use the following command, replacing <code spellcheck="false">[VERSION]</code> with
   the desired version or tag, such as <code spellcheck="false">v0.91.6</code> or
-  just <code spellcheck="false">latest</code>. (See published tag names at
-  <a
+  just <code spellcheck="false">latest</code>. (See published tag names at <a
   href="https://hub.docker.com/r/triliumnext/trilium/tags">https://hub.docker.com/r/triliumnext/trilium/tags</a>.):</p><pre><code class="language-text-x-trilium-auto">docker pull triliumnext/trilium:v0.91.6</code></pre>
 <p><strong>Warning:</strong> Avoid using the "latest" tag, as it may automatically
   upgrade your instance to a new minor version, potentially disrupting sync
@@ -149,9 +146,8 @@ docker run -d --name trilium -p 8080:8080 --user $(id -u):$(id -g) -v ~/trilium-
 <ol>
   <li>The host directory has appropriate permissions for the UID/GID you're
     using</li>
-  <li>You're setting both <code spellcheck="false">TRILIUM_UID</code> and
-    <code
-    spellcheck="false">TRILIUM_GID</code>to match the owner of the host directory</li>
+  <li>You're setting both <code spellcheck="false">TRILIUM_UID</code> and <code
+    spellcheck="false">TRILIUM_GID</code> to match the owner of the host directory</li>
 </ol><pre><code class="language-text-x-trilium-auto"># For example, if your data directory is owned by UID 1001 and GID 1001:
 TRILIUM_UID=1001 TRILIUM_GID=1001 docker-compose -f docker-compose.rootless.yml up -d
 </code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Using Kubernetes.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/1. Installing the server/Using Kubernetes.html
@@ -20,8 +20,7 @@
   you don't have to use an init container.</p>
 <h2>Helm Charts</h2>
 <p><a href="https://github.com/TriliumNext/helm-charts">Official Helm chart</a> from
-  TriliumNext Unofficial helm chart by <a href="https://github.com/ohdearaugustin">ohdearaugustin</a>:
-  <a
+  TriliumNext Unofficial helm chart by <a href="https://github.com/ohdearaugustin">ohdearaugustin</a>: <a
   href="https://github.com/ohdearaugustin/charts">https://github.com/ohdearaugustin/charts</a>
 </p>
 <h2>Adding a Helm repository</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/2. Reverse proxy.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/2. Reverse proxy.html
@@ -18,10 +18,9 @@
 <p>Regardless of the proxy you choose, make sure of the following:</p>
 <ul>
   <li><strong>Forward the WebSocket upgrade.</strong> Trilium uses a WebSocket
-    for synchronization and live UI updates. Your proxy must pass the
-    <code
-    spellcheck="false">Upgrade</code>and <code spellcheck="false">Connection</code> headers through,
-      otherwise the client will appear to load but never receive updates.</li>
+    for synchronization and live UI updates. Your proxy must pass the <code
+    spellcheck="false">Upgrade</code> and <code spellcheck="false">Connection</code> headers
+    through, otherwise the client will appear to load but never receive updates.</li>
   <li><strong>Configure the trusted proxy.</strong> So that Trilium sees the
     real client IP (for rate limiting, logging, and secure cookies) rather
     than the proxy's address. See&nbsp;<a class="reference-link" href="#root/_help_LLzSMXACKhUs">Trusted proxy</a>.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/2. Reverse proxy/Traefik.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/2. Reverse proxy/Traefik.html
@@ -1,6 +1,6 @@
-<p>The goal of this article is to configure Traefik proxy and HTTPS. See
-  <a
-  href="https://github.com/TriliumNext/Trilium/issues/7768#issuecomment-3539165814">#7768</a>for reference.</p>
+<p>The goal of this article is to configure Traefik proxy and HTTPS. See <a
+  href="https://github.com/TriliumNext/Trilium/issues/7768#issuecomment-3539165814">#7768</a> for
+  reference.</p>
 <h2>Breaking change in Traefik 3.6.4</h2>
 <p>Traefik 3.6.4 introduced a <a href="https://doc.traefik.io/traefik/migrate/v3/#encoded-characters-in-request-path">breaking change</a> regarding
   how percent-encoded characters are handled in URLs. More specifically some

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Authentication/Resetting your password.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Authentication/Resetting your password.html
@@ -32,8 +32,7 @@ UPDATE options SET value = 'Eb8af1/T57b89lCRuS97tPEl4CwxsAWAU7YNJ77oY+s=' WHERE 
 UPDATE options SET value = 'QpC8XoiYYeqHPtHKRtbNxfTHsk+pEBqVBODYp0FkPBa22tlBBKBMigdLu5GNX8Uu' WHERE name = 'encryptedDataKey';</code></pre>
   </li>
   <li>
-    <p>After executing the changes, commit/write the changes. <strong>This sets the password to</strong> 
-      <code
+    <p>After executing the changes, commit/write the changes. <strong>This sets the password to</strong>  <code
       spellcheck="false">**password**</code><strong>, allowing you to log in again.</strong>
     </p>
   </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/HTTPS (TLS).html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/HTTPS (TLS).html
@@ -6,22 +6,22 @@ class="admonition tip">
     use a <a href="#root/_help_vcjrb3VVYPZI">reverse proxy</a> instead with TLS termination.
     You can follow a <a href="https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-20-04">guide like this</a> for
     such setups.</p>
-  </aside>
-  <h2>Obtaining a TLS Certificate</h2>
-  <p>You have two options for obtaining a TLS certificate:</p>
-  <ul>
-    <li><strong>Recommended</strong>: Obtain a TLS certificate signed by a root
-      certificate authority. For personal use, <a href="https://letsencrypt.org">Let's Encrypt</a> is
-      an excellent choice. It is free, automated, and straightforward. Certbot
-      can facilitate automatic TLS setup.</li>
-    <li>Generate a self-signed certificate. This option is not recommended due
-      to the additional complexity of importing the certificate into all machines
-      connecting to the server.</li>
-  </ul>
-  <h2>Modifying <code spellcheck="false">config.ini</code></h2>
-  <p>Once you have your certificate, modify the <code spellcheck="false">config.ini</code> file
-    in the <a href="#root/_help_tAassRL4RSQL">data directory</a> to configure Trilium
-    to use it:</p><pre><code class="language-text-x-trilium-auto">[Network]
+</aside>
+<h2>Obtaining a TLS Certificate</h2>
+<p>You have two options for obtaining a TLS certificate:</p>
+<ul>
+  <li><strong>Recommended</strong>: Obtain a TLS certificate signed by a root
+    certificate authority. For personal use, <a href="https://letsencrypt.org">Let's Encrypt</a> is
+    an excellent choice. It is free, automated, and straightforward. Certbot
+    can facilitate automatic TLS setup.</li>
+  <li>Generate a self-signed certificate. This option is not recommended due
+    to the additional complexity of importing the certificate into all machines
+    connecting to the server.</li>
+</ul>
+<h2>Modifying <code spellcheck="false">config.ini</code></h2>
+<p>Once you have your certificate, modify the <code spellcheck="false">config.ini</code> file
+  in the <a href="#root/_help_tAassRL4RSQL">data directory</a> to configure Trilium
+  to use it:</p><pre><code class="language-text-x-trilium-auto">[Network]
 port=8080
 # Set to true for TLS/SSL/HTTPS (secure), false for HTTP (insecure).
 https=true
@@ -29,25 +29,25 @@ https=true
 # Relevant only if https=true
 certPath=/[username]/.acme.sh/[hostname]/fullchain.cer
 keyPath=/[username]/.acme.sh/[hostname]/example.com.key</code></pre>
-  <p>You can also review the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file
-    to provide all <code spellcheck="false">config.ini</code> values as environment
-    variables instead. For example, you can configure TLS using environment
-    variables:</p><pre><code class="language-text-x-trilium-auto">export TRILIUM_NETWORK_HTTPS=true
+<p>You can also review the <a href="#root/_help_Gzjqa934BdH4">configuration</a> file
+  to provide all <code spellcheck="false">config.ini</code> values as environment
+  variables instead. For example, you can configure TLS using environment
+  variables:</p><pre><code class="language-text-x-trilium-auto">export TRILIUM_NETWORK_HTTPS=true
 export TRILIUM_NETWORK_CERTPATH=/path/to/cert.pem
 export TRILIUM_NETWORK_KEYPATH=/path/to/key.pem</code></pre>
-  <p>The above example shows how this is set up in an environment where the
-    certificate was generated using Let's Encrypt's ACME utility. Your paths
-    may differ. For Docker installations, ensure these paths are within a volume
-    or another directory accessible by the Docker container, such as <code spellcheck="false">/home/node/trilium-data/[DIR IN DATA DIRECTORY]</code>.</p>
-  <p>After configuring <code spellcheck="false">config.ini</code>, restart Trilium
-    and access the hostname using "https".</p>
-  <h2>Self-Signed Certificate</h2>
-  <p>If you opt to use a self-signed certificate for your server instance,
-    note that the desktop instance will not trust it by default.</p>
-  <p>To bypass this, disable certificate validation by setting the following
-    environment variable (for Linux):</p><pre><code class="language-text-x-trilium-auto">export NODE_TLS_REJECT_UNAUTHORIZED=0
+<p>The above example shows how this is set up in an environment where the
+  certificate was generated using Let's Encrypt's ACME utility. Your paths
+  may differ. For Docker installations, ensure these paths are within a volume
+  or another directory accessible by the Docker container, such as <code spellcheck="false">/home/node/trilium-data/[DIR IN DATA DIRECTORY]</code>.</p>
+<p>After configuring <code spellcheck="false">config.ini</code>, restart Trilium
+  and access the hostname using "https".</p>
+<h2>Self-Signed Certificate</h2>
+<p>If you opt to use a self-signed certificate for your server instance,
+  note that the desktop instance will not trust it by default.</p>
+<p>To bypass this, disable certificate validation by setting the following
+  environment variable (for Linux):</p><pre><code class="language-text-x-trilium-auto">export NODE_TLS_REJECT_UNAUTHORIZED=0
 trilium</code></pre>
-  <p>Trilium provides scripts to start in this mode, such as <code spellcheck="false">trilium-no-cert-check.bat</code> for
-    Windows.</p>
-  <p><strong>Warning</strong>: Disabling TLS certificate validation is insecure.
-    Proceed only if you fully understand the implications.</p>
+<p>Trilium provides scripts to start in this mode, such as <code spellcheck="false">trilium-no-cert-check.bat</code> for
+  Windows.</p>
+<p><strong>Warning</strong>: Disabling TLS certificate validation is insecure.
+  Proceed only if you fully understand the implications.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Multi-factor authentication with TOTP.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Multi-factor authentication with TOTP.html
@@ -38,8 +38,8 @@
 <p>To use a recovery code, simply login with your password and use the recovery
   code as the security token.</p>
 <p>The initial set of recovery codes is generated when setting up your TOTP
-  for the first time. They can be regenerated at any time by going to &nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Password &amp; Auth</em> and pressing the <em>Regenerate recovery codes</em> button.
-    This will generate a new set of recovery codes while at the same time disabling
-    the previous ones.</p>
+  for the first time. They can be regenerated at any time by going to &nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Password &amp; Auth</em> and
+  pressing the <em>Regenerate recovery codes</em> button. This will generate
+  a new set of recovery codes while at the same time disabling the previous
+  ones.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect.html
@@ -68,10 +68,10 @@
             </td>
             <td><code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHCLIENTAUTHMETHOD</code>
             </td>
-            <td>Token-endpoint auth method: <code spellcheck="false">client_secret_basic</code> or
-              <code
-              spellcheck="false">client_secret_post</code>. Empty auto-detects. &nbsp;Only needed if sign-in
-                fails with a <code spellcheck="false">WWW-Authenticate</code> or <code spellcheck="false">invalid_client</code> error.</td>
+            <td>Token-endpoint auth method: <code spellcheck="false">client_secret_basic</code> or <code
+              spellcheck="false">client_secret_post</code>. Empty auto-detects. &nbsp;Only
+              needed if sign-in fails with a <code spellcheck="false">WWW-Authenticate</code> or <code
+              spellcheck="false">invalid_client</code> error.</td>
           </tr>
           <tr>
             <td>ID token algorithm</td>
@@ -79,27 +79,24 @@
             </td>
             <td><code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHIDTOKENSIGNINGALG</code>
             </td>
-            <td><span style="color:rgb(32,32,32);">The algorithm your provider signs ID tokens with, e.g.</span> 
-              <code
-              spellcheck="false">RS256</code><span style="color:rgb(32,32,32);">,</span>  <code spellcheck="false">EdDSA</code>
-                <span
-                style="color:rgb(32,32,32);">,</span> <code spellcheck="false">ES256</code><span style="color:rgb(32,32,32);">. Empty auto-detects from the provider. Only needed if sign-in fails with an</span> 
-                  <code
-                  spellcheck="false">unexpected JWT alg</code> <span style="color:rgb(32,32,32);">error.</span>
+            <td><span style="color:rgb(32,32,32);">The algorithm your provider signs ID tokens with, e.g.</span>  <code
+              spellcheck="false">RS256</code><span style="color:rgb(32,32,32);">,</span>  <code
+              spellcheck="false">EdDSA</code><span style="color:rgb(32,32,32);">,</span>  <code
+              spellcheck="false">ES256</code><span style="color:rgb(32,32,32);">. Empty auto-detects from the provider. Only needed if sign-in fails with an</span>  <code
+              spellcheck="false">unexpected JWT alg</code>  <span style="color:rgb(32,32,32);">error.</span>
             </td>
           </tr>
         </tbody>
       </table>
-      </figure>
-      <p>Asterisk (*) marks a required field</p>
+    </figure>
+    <p>Asterisk (*) marks a required field</p>
   </li>
   <li>
     <p>The default OAuth issuer is Google. To use other services such as Authentik
-      or Auth0, you can configure the settings via <code spellcheck="false">oauthIssuerBaseUrl</code>,
-      <code
+      or Auth0, you can configure the settings via <code spellcheck="false">oauthIssuerBaseUrl</code>, <code
       spellcheck="false">oauthIssuerName</code>, and <code spellcheck="false">oauthIssuerIcon</code> in
-        the <code spellcheck="false">config.ini</code> file. Alternatively, these
-        values can be set using environment variables:</p>
+      the <code spellcheck="false">config.ini</code> file. Alternatively, these
+      values can be set using environment variables:</p>
     <figure class="table">
       <table>
         <thead>
@@ -120,15 +117,12 @@
             <td>Either the issuer itself (<code spellcheck="false">https://auth.example.com</code>)
               or a full discovery URL (<code spellcheck="false">https://auth.example.com/.well-known/openid-configuration</code>).
               <br>
-              <br>A URL containing <code spellcheck="false">/.well-known/</code> is used as-is
-              <span
-              style="color:rgb(32,32,32);">, which is convenient when your provider hands you a discovery URL to
-                copy. A trailing slash may be included or omitted; Trilium matches whichever
-                spelling the provider advertises.</span>
-                <br>
-                <br>Use the full form when your provider advertises an issuer that differs
-                from the path serving its discovery document, such as Authentik in "global"
-                issuer mode.</td>
+              <br>A URL containing <code spellcheck="false">/.well-known/</code> is used as-is<span
+              style="color:rgb(32,32,32);">, which is convenient when your provider hands you a discovery URL to copy. A trailing slash may be included or omitted; Trilium matches whichever spelling the provider advertises.</span> 
+              <br>
+              <br>Use the full form when your provider advertises an issuer that differs
+              from the path serving its discovery document, such as Authentik in "global"
+              issuer mode.</td>
           </tr>
           <tr>
             <td>Issuer name</td>
@@ -184,10 +178,9 @@
             </td>
             <td><code spellcheck="false">TRILIUM_MULTIFACTORAUTHENTICATION_OAUTHSCOPE</code>
             </td>
-            <td>Space-separated list of OIDC scopes requested at login. Defaults to
-              <code
-              spellcheck="false">openid profile email</code>. <code spellcheck="false">openid</code> is required
-                and is prepended automatically if you omit it.</td>
+            <td>Space-separated list of OIDC scopes requested at login. Defaults to <code
+              spellcheck="false">openid profile email</code>. <code spellcheck="false">openid</code> is
+              required and is prepended automatically if you omit it.</td>
           </tr>
         </tbody>
       </table>
@@ -203,16 +196,12 @@
   </li>
 </ol>
 <aside class="admonition note">
-  <p>Legacy environment variables are also supported: <code spellcheck="false">TRILIUM_OAUTH_BASE_URL</code>,
-    <code
+  <p>Legacy environment variables are also supported: <code spellcheck="false">TRILIUM_OAUTH_BASE_URL</code>, <code
     spellcheck="false">TRILIUM_OAUTH_CLIENT_ID</code>, <code spellcheck="false">TRILIUM_OAUTH_CLIENT_SECRET</code>,
-      and for customizing the provider: <code spellcheck="false">TRILIUM_OAUTH_ISSUER_BASE_URL</code>,
-      <code
-      spellcheck="false">TRILIUM_OAUTH_ISSUER_NAME</code>, <code spellcheck="false">TRILIUM_OAUTH_ISSUER_ICON</code>,
-        <code
-        spellcheck="false">TRILIUM_OAUTH_HTTP_TIMEOUT</code>, <code spellcheck="false">TRILIUM_OAUTH_SCOPE</code>,
-          <code
-          spellcheck="false">TRILIUM_OAUTH_CLIENT_AUTH_METHOD</code>, <code spellcheck="false">TRILIUM_OAUTH_ID_TOKEN_SIGNING_ALG</code>.</p>
+    and for customizing the provider: <code spellcheck="false">TRILIUM_OAUTH_ISSUER_BASE_URL</code>, <code
+    spellcheck="false">TRILIUM_OAUTH_ISSUER_NAME</code>, <code spellcheck="false">TRILIUM_OAUTH_ISSUER_ICON</code>, <code
+    spellcheck="false">TRILIUM_OAUTH_HTTP_TIMEOUT</code>, <code spellcheck="false">TRILIUM_OAUTH_SCOPE</code>, <code
+    spellcheck="false">TRILIUM_OAUTH_CLIENT_AUTH_METHOD</code>, <code spellcheck="false">TRILIUM_OAUTH_ID_TOKEN_SIGNING_ALG</code>.</p>
 </aside>
 <h2>Connecting to the authentication provider</h2>
 <p>Once the server has been configured at the previous step, the next step
@@ -269,27 +258,23 @@
 <h2>Troubleshooting</h2>
 <h3>Setup fails with a <code spellcheck="false">WWW-Authenticate</code> or <code spellcheck="false">invalid_client</code> error</h3>
 <p>Your provider disagrees with Trilium about how client credentials should
-  be sent to the token endpoint. Set <code spellcheck="false">oauthClientAuthMethod</code> to
-  <code
-  spellcheck="false">client_secret_post</code>(or <code spellcheck="false">client_secret_basic</code> if
-    it's already set to post) and restart. Providers vary: some reject
-    <code
-    spellcheck="false">client_secret_post</code>outright because the method is fixed when the
-      client is registered (e.g. Authelia), so if one value doesn't work, try
-      the other.</p>
+  be sent to the token endpoint. Set <code spellcheck="false">oauthClientAuthMethod</code> to <code
+  spellcheck="false">client_secret_post</code> (or <code spellcheck="false">client_secret_basic</code> if
+  it's already set to post) and restart. Providers vary: some reject <code
+  spellcheck="false">client_secret_post</code> outright because the method
+  is fixed when the client is registered (e.g. Authelia), so if one value
+  doesn't work, try the other.</p>
 <h3>Setup fails with <code spellcheck="false">invalid user</code></h3>
 <p>If you are running behind a <a href="#root/_help_vcjrb3VVYPZI">reverse proxy</a>,
-  a buffer overflow can also cause this issue. Here is a sample fix for&nbsp;
-  <a
+  a buffer overflow can also cause this issue. Here is a sample fix for&nbsp;<a
   class="reference-link" href="#root/_help_ud6MShXL4WpO">Nginx</a>: </p><pre><code class="language-text-x-trilium-auto">proxy_buffer_size 128k;
 proxy_buffers 4 256k;
 proxy_busy_buffers_size 256k;</code></pre>
 <h3>Setup fails with an <code spellcheck="false">unexpected JWT alg</code> error</h3>
-<p>Depending on your version the message reads <code spellcheck="false">unexpected JWT "alg" header parameter</code> or
-  <code
-  spellcheck="false">unexpected JWT alg received, expected RS256, got: EdDSA</code>. Both mean
-    the same thing: your provider signs ID tokens with an algorithm other than
-    RS256. Pocket ID (Ed25519) and Kanidm (ES256) do this.</p>
+<p>Depending on your version the message reads <code spellcheck="false">unexpected JWT "alg" header parameter</code> or <code
+  spellcheck="false">unexpected JWT alg received, expected RS256, got: EdDSA</code>.
+  Both mean the same thing: your provider signs ID tokens with an algorithm
+  other than RS256. Pocket ID (Ed25519) and Kanidm (ES256) do this.</p>
 <p>From v0.104.2 Trilium detects the algorithm from your provider automatically,
   and the log records the outcome (<code spellcheck="false">OAuth: the issuer does not sign ID tokens with RS256; expecting ES256</code>).
   If detection can't reach the provider it falls back to RS256, so check

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect/Setting up with various providers.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/Signing in with OpenID Connect/Setting up with various providers.html
@@ -10,15 +10,13 @@
   <li>
     <p>Generate a client secret:</p><pre><code class="language-text-x-trilium-auto">authelia crypto hash generate pbkdf2 --variant sha512 --random --random.length 72 --random.charset rfc3986
 </code></pre>
-    <p><code spellcheck="false">Random Password</code> goes to Trilium, <code spellcheck="false">Digest</code> (the
-      <code
-      spellcheck="false">$pbkdf2-sha512$…</code>string) goes to Authelia.</p>
+    <p><code spellcheck="false">Random Password</code> goes to Trilium, <code spellcheck="false">Digest</code> (the <code
+      spellcheck="false">$pbkdf2-sha512$…</code> string) goes to Authelia.</p>
   </li>
   <li>
     <p>Add a client under <code spellcheck="false">identity_providers.oidc.clients</code> in
-      Authelia's <code spellcheck="false">configuration.yml</code>, replacing
-      <code
-      spellcheck="false">&lt;server&gt;</code>with the URL of your Trilium instance:</p><pre><code class="language-text-x-yaml">identity_providers:
+      Authelia's <code spellcheck="false">configuration.yml</code>, replacing <code
+      spellcheck="false">&lt;server&gt;</code> with the URL of your Trilium instance:</p><pre><code class="language-text-x-yaml">identity_providers:
   oidc:
     clients:
       - client_id: 'trilium'
@@ -67,11 +65,10 @@ oauthIssuerName=Authelia</code></pre>
     should be near the end).</li>
   <li>Save the application and copy the <em>Application ID</em> and <em>Secret</em>.</li>
 </ol>
-<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing
-  <code
-  spellcheck="false">&lt;ApplicationId&gt;</code>and <code spellcheck="false">&lt;Secret&gt;</code> with
-    the values from the last step as well as the <code spellcheck="false">&lt;server&gt;</code> with
-    a URL to your Trilium instance.</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
+<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing <code
+  spellcheck="false">&lt;ApplicationId&gt;</code> and <code spellcheck="false">&lt;Secret&gt;</code> with
+  the values from the last step as well as the <code spellcheck="false">&lt;server&gt;</code> with
+  a URL to your Trilium instance.</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
 oauthBaseUrl=https://&lt;server&gt;
 oauthClientId=&lt;ApplicationId&gt;
 oauthClientSecret=&lt;Secret&gt;
@@ -80,10 +77,9 @@ oauthIssuerName=GitLab
 oauthClientAuthMethod=client_secret_post
 </code></pre>
 <aside class="admonition important">
-  <p>If you are using a self-hosted instance of GitLab, make sure to also update
-    <code
+  <p>If you are using a self-hosted instance of GitLab, make sure to also update <code
     spellcheck="false">oauthIssuerBaseUrl</code>, and keep the <code spellcheck="false">oauthClientAuthMethod</code> line
-      above.</p>
+    above.</p>
   <p>GitLab's token endpoint does not decode credentials sent via HTTP Basic,
     so without <code spellcheck="false">oauthClientAuthMethod</code>, sign-in
     fails with a <code spellcheck="false">server responded with a challenge in the WWW-Authenticate HTTP Header</code> error.
@@ -93,10 +89,10 @@ oauthClientAuthMethod=client_secret_post
 <h2>Kanidm</h2>
 <ol>
   <li>
-    <p>Create the client, add the redirect URL and grant the scopes, replacing
-      <code
-      spellcheck="false">&lt;server&gt;</code>with the URL of your Trilium instance and <code spellcheck="false">&lt;group&gt;</code> with
-        an existing Kanidm group whose members may sign in:</p><pre><code class="language-text-x-trilium-auto">kanidm system oauth2 create trilium "Trilium" "https://&lt;server&gt;"
+    <p>Create the client, add the redirect URL and grant the scopes, replacing <code
+      spellcheck="false">&lt;server&gt;</code> with the URL of your Trilium instance
+      and <code spellcheck="false">&lt;group&gt;</code> with an existing Kanidm
+      group whose members may sign in:</p><pre><code class="language-text-x-trilium-auto">kanidm system oauth2 create trilium "Trilium" "https://&lt;server&gt;"
 kanidm system oauth2 add-redirect-url trilium "https://&lt;server&gt;/callback"
 kanidm system oauth2 update-scope-map trilium &lt;group&gt; openid profile email</code></pre>
     <p>The <code spellcheck="false">openid</code> scope is mandatory; without it
@@ -106,10 +102,10 @@ kanidm system oauth2 update-scope-map trilium &lt;group&gt; openid profile email
     <p>Read the client secret:</p><pre><code class="language-text-x-trilium-auto">kanidm system oauth2 show-basic-secret trilium</code></pre>
   </li>
 </ol>
-<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing
-  <code
-  spellcheck="false">&lt;idm&gt;</code>with the URL of your Kanidm instance and <code spellcheck="false">&lt;BasicSecret&gt;</code> with
-    the value from step 2:</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
+<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing <code
+  spellcheck="false">&lt;idm&gt;</code> with the URL of your Kanidm instance
+  and <code spellcheck="false">&lt;BasicSecret&gt;</code> with the value from
+  step 2:</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
 oauthBaseUrl=https://&lt;server&gt;
 oauthClientId=trilium
 oauthClientSecret=&lt;BasicSecret&gt;
@@ -168,11 +164,10 @@ oauthIssuerName=Pocket ID</code></pre>
   <li>In <em>Authorized redirect URIs</em>, set &nbsp;<code spellcheck="false">https://&lt;server&gt;/callback</code>.</li>
   <li>Press <em>Create</em> and copy <em>Client ID</em> and <em>Client secret</em>.</li>
 </ol>
-<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing
-  <code
-  spellcheck="false">&lt;ClientID&gt;</code>and <code spellcheck="false">&lt;ClientSecret&gt;</code> with
-    the values from the last step as well as the <code spellcheck="false">&lt;server&gt;</code> with
-    a URL to your Trilium instance.</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
+<p>Adjust <code spellcheck="false">config.ini</code> as follows, replacing <code
+  spellcheck="false">&lt;ClientID&gt;</code> and <code spellcheck="false">&lt;ClientSecret&gt;</code> with
+  the values from the last step as well as the <code spellcheck="false">&lt;server&gt;</code> with
+  a URL to your Trilium instance.</p><pre><code class="language-text-x-trilium-auto">[MultiFactorAuthentication]
 oauthBaseUrl=https://&lt;server&gt;
 oauthClientId=&lt;ClientID&gt;
 oauthClientSecret=&lt;ClientSecret&gt;</code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/System Requirements.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Server Installation/System Requirements.html
@@ -3,15 +3,13 @@
   <li>Native binaries are provided for Linux x64 and ARM (<code spellcheck="false">aarch64</code>).</li>
 </ul>
 <h2>Legacy ARM support</h2>
-<p>The Docker builds also provide <code spellcheck="false">linux/arm/v7</code> and
-  <code
-  spellcheck="false">linux/arm/v8</code>platforms. These platforms are considered legacy since
-    Trilium uses Node.js version 24 which have <a href="https://github.com/nodejs/node/commit/6682861d6f">officially downgraded support</a> for
-    these platforms to “experimental”.</p>
+<p>The Docker builds also provide <code spellcheck="false">linux/arm/v7</code> and <code
+  spellcheck="false">linux/arm/v8</code> platforms. These platforms are considered
+  legacy since Trilium uses Node.js version 24 which have <a href="https://github.com/nodejs/node/commit/6682861d6f">officially downgraded support</a> for
+  these platforms to “experimental”.</p>
 <p>As a result, Trilium needs to use Node.js 22 for these versions. As soon
-  as soon Node.js 22 will no longer be compatible, support for <code spellcheck="false">armv7</code> and
-  <code
-  spellcheck="false">armv8</code>will be dropped entirely.</p>
+  as soon Node.js 22 will no longer be compatible, support for <code spellcheck="false">armv7</code> and <code
+  spellcheck="false">armv8</code> will be dropped entirely.</p>
 <p>Regardless of upstream support, these platforms are supported on a best-effort
   basis and are not officially supported by the Trilium development team.
   Bug reports are accepted but they will not be treated with priority; contributions

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Synchronization.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Synchronization.html
@@ -66,35 +66,35 @@ class="admonition warning">
   <p>Since v0.104.0, LAN access needs to be enabled to allow this sync to function.
     See&nbsp;<a class="reference-link" href="#root/_help_swSFivWk6KkA">Network Access</a>&nbsp;for
     information on how to do so.</p>
-  </aside>
-  <h2>Proxy Configuration</h2>
-  <p>Two proxy setups are supported:</p>
-  <ul>
-    <li><strong>Explicit Proxy Configuration</strong>: Set the proxy server in
-      Options / Sync. Only unauthenticated proxy servers are supported.</li>
-    <li><strong>System Proxy Settings</strong>: If no proxy server is explicitly
-      configured, Trilium will use the system proxy settings.</li>
-  </ul>
-  <h2>Troubleshooting</h2>
-  <h3>Date/Time Synchronization</h3>
-  <p>For successful synchronization, both client and server must have the same
-    date and time, with a tolerance of up to five minutes.</p>
-  <h3>Certificate Issues</h3>
-  <p>When using TLS, Trilium will verify the server certificate. If verification
-    fails (e.g., due to self-signed certificates or certain corporate proxies),
-    you can run the Trilium client with the <code spellcheck="false">NODE_TLS_REJECT_UNAUTHORIZED</code> environment
-    variable set to <code spellcheck="false">0</code>:</p><pre><code class="language-text-x-trilium-auto">export NODE_TLS_REJECT_UNAUTHORIZED=0</code></pre>
-  <p>This will disable TLS certificate verification, significantly reducing
-    security and exposing the setup to MITM attacks. It is strongly recommended
-    to use a valid signed server certificate. Newer Trilium versions include
-    a script called <code spellcheck="false">trilium-no-cert-check.sh</code> for
-    this purpose.</p>
-  <h3>Conflict Resolution</h3>
-  <p>If you edit the same note on multiple instances before synchronization,
-    Trilium resolves conflicts by retaining the newer change and discarding
-    the older one. The older version remains accessible in <a href="#root/_help_vZWERwf8U3nx">note revisions</a>,
-    allowing data recovery if needed.</p>
-  <h3>Hash Check</h3>
-  <p>After each synchronization, Trilium computes a hash of all synced data
-    on both the client and the sync server. If there is a discrepancy, Trilium
-    will automatically initiate a recovery mechanism to resolve the issue.</p>
+</aside>
+<h2>Proxy Configuration</h2>
+<p>Two proxy setups are supported:</p>
+<ul>
+  <li><strong>Explicit Proxy Configuration</strong>: Set the proxy server in
+    Options / Sync. Only unauthenticated proxy servers are supported.</li>
+  <li><strong>System Proxy Settings</strong>: If no proxy server is explicitly
+    configured, Trilium will use the system proxy settings.</li>
+</ul>
+<h2>Troubleshooting</h2>
+<h3>Date/Time Synchronization</h3>
+<p>For successful synchronization, both client and server must have the same
+  date and time, with a tolerance of up to five minutes.</p>
+<h3>Certificate Issues</h3>
+<p>When using TLS, Trilium will verify the server certificate. If verification
+  fails (e.g., due to self-signed certificates or certain corporate proxies),
+  you can run the Trilium client with the <code spellcheck="false">NODE_TLS_REJECT_UNAUTHORIZED</code> environment
+  variable set to <code spellcheck="false">0</code>:</p><pre><code class="language-text-x-trilium-auto">export NODE_TLS_REJECT_UNAUTHORIZED=0</code></pre>
+<p>This will disable TLS certificate verification, significantly reducing
+  security and exposing the setup to MITM attacks. It is strongly recommended
+  to use a valid signed server certificate. Newer Trilium versions include
+  a script called <code spellcheck="false">trilium-no-cert-check.sh</code> for
+  this purpose.</p>
+<h3>Conflict Resolution</h3>
+<p>If you edit the same note on multiple instances before synchronization,
+  Trilium resolves conflicts by retaining the newer change and discarding
+  the older one. The older version remains accessible in <a href="#root/_help_vZWERwf8U3nx">note revisions</a>,
+  allowing data recovery if needed.</p>
+<h3>Hash Check</h3>
+<p>After each synchronization, Trilium computes a hash of all synced data
+  on both the client and the sync server. If there is a discrepancy, Trilium
+  will automatically initiate a recovery mechanism to resolve the issue.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Web Clipper.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Installation & Setup/Web Clipper.html
@@ -31,8 +31,7 @@
 <p>Trilium will save these clippings as a new child note under a "clipper
   inbox" note.</p>
 <p>By default, that's the&nbsp;<a class="reference-link" href="#root/_help_l0tKav7yLHGF">Day Notes</a>&nbsp;but
-  you can override that by setting the <a href="#root/_help_zEY4DaJG4YT5">label</a> 
-  <code
+  you can override that by setting the <a href="#root/_help_zEY4DaJG4YT5">label</a>  <code
   spellcheck="false">clipperInbox</code>, on any other note.</p>
 <p>If there's multiple clippings from the same page (and on the same day),
   then they will be added to the same note.</p>
@@ -89,9 +88,8 @@
   <p>Firefox prevents installation of unsigned packages in the “retail” version.
     To be able to install extensions from disk, consider using <em>Firefox Developer Edition</em> or
     a non-branded version of Firefox (e.g. <em>GNU IceCat</em>).</p>
-  <p>One time, go to <code spellcheck="false">about:config</code> and change
-    <code
-    spellcheck="false">xpinstall.signatures.required</code>to <code spellcheck="false">false</code>.</p>
+  <p>One time, go to <code spellcheck="false">about:config</code> and change <code
+    spellcheck="false">xpinstall.signatures.required</code> to <code spellcheck="false">false</code>.</p>
 </aside>
 <ol>
   <li>Navigate to <code spellcheck="false">about:addons</code>.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Miscellaneous/Patterns of personal knowledge.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Miscellaneous/Patterns of personal knowledge.html
@@ -99,21 +99,19 @@
   notes specific to the former employer immediately lose most of its import.
   This doesn't mean I want to delete these notes though - typically I just
   want them to somehow deprioritize - in Trilium I would do that by assigning
-  an <a href="https://github.com/zadam/trilium/wiki/Attribute-inheritance">inherited</a> 
-  <a
-  href="https://github.com/zadam/trilium/wiki/Attributes">label</a> <code spellcheck="false">archived</code> to the company root note.
-    The main effect of this label is that all the notes from this sub-tree
-    are filtered out from search results (fast search via note autocomplete
-    is my main <a href="https://github.com/zadam/trilium/wiki/Note-navigation">navigation approach</a>).
-    Apart from this, I also typically move such outdated notes to some less
-    prominent place in the hierarchy.</p>
+  an <a href="https://github.com/zadam/trilium/wiki/Attribute-inheritance">inherited</a>  <a
+  href="https://github.com/zadam/trilium/wiki/Attributes">label</a>  <code
+  spellcheck="false">archived</code> to the company root note. The main effect
+  of this label is that all the notes from this sub-tree are filtered out
+  from search results (fast search via note autocomplete is my main <a href="https://github.com/zadam/trilium/wiki/Note-navigation">navigation approach</a>).
+  Apart from this, I also typically move such outdated notes to some less
+  prominent place in the hierarchy.</p>
 <p>I use archivation also for notes which are not very relevant from their
   creation - an example might be automatically imported reddit comments.</p>
 <p>Sometimes there's no clear <em>category</em> split between relevant and
-  non-relevant notes, in that case I just create "<em>OLD</em>" note with
-  <code
-  spellcheck="false">archived</code>label and move all irrelevant notes there. So my credentials
-    note might look something like this:</p>
+  non-relevant notes, in that case I just create "<em>OLD</em>" note with <code
+  spellcheck="false">archived</code> label and move all irrelevant notes there.
+  So my credentials note might look something like this:</p>
 <ul>
   <li>Credentials
     <ul>
@@ -170,8 +168,7 @@
     certain daily metrics (like weight). These are saved into one daily "data
     note" (actually JSON <a href="#root/_help_6f9hih2hXXZk">code note</a>).
     <ul>
-      <li>I have other scripts which then help me to visualize these data (see a&nbsp;
-        <a
+      <li>I have other scripts which then help me to visualize these data (see a&nbsp;<a
         class="reference-link" href="#root/_help_R7abl2fc6Mxi">Weight Tracker</a>&nbsp;example)</li>
       <li>I have a script which automatically imports all my comments from reddit
         into the day note.
@@ -237,67 +234,67 @@
 class="image">
   <img style="aspect-ratio:941/758;" src="Patterns of personal knowledge_relation-map-family.png"
   width="941" height="758">
-  </figure>
-  <h3>Books</h3>
-  <p>Of course, I keep standard "To read" list. I also keep a record on the
-    books I've read - typically one book has one subtree where the root has
-    some basic info like author, page count, publication date, date started,
-    date finished (in the form of&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>).
-    I also write a (private) review and keep list of highlights from Kindle,
-    optionally with some commentary, these are usually stored in sub notes
-    (unless they are pretty short).</p>
-  <p>To keep the list of books manageable, I sort them per year (of reading
-    them), this also gives me some basic overview of "reading performance"
-    for given year. I plan to create a <a href="#root/_help_CdNpE2pqjmI6">script</a> which
-    would show some timeline chart visualizing book attributes <code spellcheck="false">dateStarted</code> -
-    <code
-    spellcheck="false">dateFinished</code>to have nicer view of my reading sprints and trends.</p>
-  <p>Some specific authors also have their own note which contains cloned book
-    reviews, links to interviews and other related resources.</p>
-  <p>I have similar system for movies and TV shows, but not as sophisticated.</p>
-  <h3>Personal diary</h3>
-  <p>This is a place to reflect on events, experiences, new findings etc. This
-    can help you get deeper understanding of your inner self, clarify your
-    thinking and make better decisions as a result.</p>
-  <p>I sort personal diary notes directly under <em>day note</em> (explained
-    above), but it can be cloned also to e.g. "trip note" (if the diary note
-    is about given trip) or to person's profile (if the person plays a role
-    in the diary note). All my diary notes are <a href="#root/_help_bwg0e8ewQMak">protected</a> since
-    they are usually pretty sensitive.</p>
-  <h3>Documents</h3>
-  <p>I keep all my personal documents (ID, passport, education certificates
-    ...) scanned in the knowledge base. They are <a href="#root/_help_cbkrhQjrkKrh">synchronized</a> across
-    every PC which provides decent backup and makes them available everywhere.</p>
-  <p>Advantage compared to e.g. keeping them in Dropbox or Google Drive is
-    that they are not stored on some 3rd party server and they can be encrypted
-    (see&nbsp;<a class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>).</p>
-  <h3>Inventory</h3>
-  <p>Inventory contains documents and other relevant importation for my important
-    belongings - e.g. for car you can keep the registration card, maintenance
-    record, related costs etc. I also keep inventory for some items personally
-    important to me - mainly computers, phones, cameras and similar electronics.
-    This can be practical at times but also provides sentimental value.</p>
-  <h3>Topic knowledge base</h3>
-  <p>This where I store hard "knowledge" - summarized topics and findings from
-    different domains. Topics can range from traditional sciences - physics,
-    history, economy to philosophy, mental models, apps (notes about specific
-    apps I use) etc. Of course this is very subjective - given what I do, my
-    Physics sub-tree is pretty sparse compared to my Programming subtree.</p>
-  <h3>Work knowledge base</h3>
-  <p>I usually keep top level note for the company I currently work at (past
-    jobs are moved elsewhere). I track basic organization of the company (divisions,
-    business units), who is who (<a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>)
-    are again useful for visualization), projects I work at etc.</p>
-  <p>There's a number of credentials to various company services I need to
-    use. Companies usually have a bunch of complex processes and tools. I record
-    meeting minutes, link to the company wiki (which is usually difficult to
-    find relevant info). In general there's a lot of company specific information
-    I need to know or need have them at hand in a nice structure I can understand.
-    Often it's just copy pasting and reshuffling of existing information into
-    something more understandable for me.</p>
-  <p>From my experience, keeping this makes me more productive and even more
-    importantly dramatically reduces frustration and stress.</p>
-  <h2>Conclusion</h2>
-  <p>I could probably go on with more patterns (e.g. study notes, travelling),
-    but I think you get the idea. Whatever is important in your life, it probably
-    makes sense to document and track it.</p>
+</figure>
+<h3>Books</h3>
+<p>Of course, I keep standard "To read" list. I also keep a record on the
+  books I've read - typically one book has one subtree where the root has
+  some basic info like author, page count, publication date, date started,
+  date finished (in the form of&nbsp;<a class="reference-link" href="#root/_help_OFXdgB2nNk1F">Promoted Attributes</a>).
+  I also write a (private) review and keep list of highlights from Kindle,
+  optionally with some commentary, these are usually stored in sub notes
+  (unless they are pretty short).</p>
+<p>To keep the list of books manageable, I sort them per year (of reading
+  them), this also gives me some basic overview of "reading performance"
+  for given year. I plan to create a <a href="#root/_help_CdNpE2pqjmI6">script</a> which
+  would show some timeline chart visualizing book attributes <code spellcheck="false">dateStarted</code> - <code
+  spellcheck="false">dateFinished</code> to have nicer view of my reading
+  sprints and trends.</p>
+<p>Some specific authors also have their own note which contains cloned book
+  reviews, links to interviews and other related resources.</p>
+<p>I have similar system for movies and TV shows, but not as sophisticated.</p>
+<h3>Personal diary</h3>
+<p>This is a place to reflect on events, experiences, new findings etc. This
+  can help you get deeper understanding of your inner self, clarify your
+  thinking and make better decisions as a result.</p>
+<p>I sort personal diary notes directly under <em>day note</em> (explained
+  above), but it can be cloned also to e.g. "trip note" (if the diary note
+  is about given trip) or to person's profile (if the person plays a role
+  in the diary note). All my diary notes are <a href="#root/_help_bwg0e8ewQMak">protected</a> since
+  they are usually pretty sensitive.</p>
+<h3>Documents</h3>
+<p>I keep all my personal documents (ID, passport, education certificates
+  ...) scanned in the knowledge base. They are <a href="#root/_help_cbkrhQjrkKrh">synchronized</a> across
+  every PC which provides decent backup and makes them available everywhere.</p>
+<p>Advantage compared to e.g. keeping them in Dropbox or Google Drive is
+  that they are not stored on some 3rd party server and they can be encrypted
+  (see&nbsp;<a class="reference-link" href="#root/_help_bwg0e8ewQMak">Protected Notes</a>).</p>
+<h3>Inventory</h3>
+<p>Inventory contains documents and other relevant importation for my important
+  belongings - e.g. for car you can keep the registration card, maintenance
+  record, related costs etc. I also keep inventory for some items personally
+  important to me - mainly computers, phones, cameras and similar electronics.
+  This can be practical at times but also provides sentimental value.</p>
+<h3>Topic knowledge base</h3>
+<p>This where I store hard "knowledge" - summarized topics and findings from
+  different domains. Topics can range from traditional sciences - physics,
+  history, economy to philosophy, mental models, apps (notes about specific
+  apps I use) etc. Of course this is very subjective - given what I do, my
+  Physics sub-tree is pretty sparse compared to my Programming subtree.</p>
+<h3>Work knowledge base</h3>
+<p>I usually keep top level note for the company I currently work at (past
+  jobs are moved elsewhere). I track basic organization of the company (divisions,
+  business units), who is who (<a class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>)
+  are again useful for visualization), projects I work at etc.</p>
+<p>There's a number of credentials to various company services I need to
+  use. Companies usually have a bunch of complex processes and tools. I record
+  meeting minutes, link to the company wiki (which is usually difficult to
+  find relevant info). In general there's a lot of company specific information
+  I need to know or need have them at hand in a nice structure I can understand.
+  Often it's just copy pasting and reshuffling of existing information into
+  something more understandable for me.</p>
+<p>From my experience, keeping this makes me more productive and even more
+  importantly dramatically reduces frustration and stress.</p>
+<h2>Conclusion</h2>
+<p>I could probably go on with more patterns (e.g. study notes, travelling),
+  but I think you get the idea. Whatever is important in your life, it probably
+  makes sense to document and track it.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types.html
@@ -1,9 +1,9 @@
 <p>One of the core features of Trilium is that it supports multiple types
   of notes, depending on the need.</p>
 <h2>Creating a new note with a different type via the note tree</h2>
-<p>The default note type in Trilium (e.g. when creating a new note) is&nbsp;
-  <a
-  class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>, since it's for general use.</p>
+<p>The default note type in Trilium (e.g. when creating a new note) is&nbsp;<a
+  class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>, since it's for
+  general use.</p>
 <p>To create a new note of a different type, head to the&nbsp;<a class="reference-link"
   href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;and right click an existing
   note where to place the new one and select:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Canvas.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Canvas.html
@@ -7,8 +7,7 @@
   text and graphics input.</p>
 <h2>Interaction</h2>
 <ul>
-  <li>The note can be togged <a href="#root/_help_CoFPLs3dRlXc">read-only</a> from the&nbsp;
-    <a
+  <li>The note can be togged <a href="#root/_help_CoFPLs3dRlXc">read-only</a> from the&nbsp;<a
     class="reference-link" href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;section.</li>
 </ul>
 <h2>Embedding notes</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Code.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Code.html
@@ -53,8 +53,7 @@
   </li>
 </ul>
 <aside class="admonition note">
-  <p>Word wrapping can also be adjusted at note level through the <code spellcheck="false">#wrapLines</code> 
-    <a
+  <p>Word wrapping can also be adjusted at note level through the <code spellcheck="false">#wrapLines</code>  <a
     href="#root/_help_HI6GBBIduIgv">label</a>, which can also be inherited.</p>
 </aside>
 <h2>Adjusting options using the status bar</h2>
@@ -88,11 +87,10 @@
   <li>Preserves non-leading whitespace, blank lines, and content without indentation</li>
 </ul>
 <h2>Color schemes</h2>
-<p>Since Trilium 0.94.0 the colors of code notes can be customized by going&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Code Notes and looking for the <em>Appearance</em> section.</p>
-<aside
-class="admonition note">
+<p>Since Trilium 0.94.0 the colors of code notes can be customized by going&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ Code
+  Notes and looking for the <em>Appearance</em> section.</p>
+<aside class="admonition note">
   <p><strong>Why are there only a few themes whereas the code block themes for text notes have a lot?</strong>
     <br>The reason is that Code notes use a different technology than the one
     used in Text notes, and as such there is a more limited selection of themes.
@@ -100,4 +98,4 @@ class="admonition note">
     us know and we might consider adding it to the set of default themes. There
     is no possibility of adding new themes (at least for now), since the themes
     are defined in JavaScript and not at CSS level.</p>
-  </aside>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File.html
@@ -26,15 +26,14 @@
 </figure>
 <p>Interaction:</p>
 <ul>
-  <li><em>Copy reference to clipboard</em>, for embedding the image within&nbsp;
-    <a
+  <li><em>Copy reference to clipboard</em>, for embedding the image within&nbsp;<a
     class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes.
-      <ul>
-        <li>See&nbsp;<a class="reference-link" href="#root/_help_0Ofbk1aSuVRu">Image references</a>&nbsp;for
-          more information.</li>
-        <li>Alternatively, press the corresponding button from the&nbsp;<a class="reference-link"
-          href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>.</li>
-      </ul>
+    <ul>
+      <li>See&nbsp;<a class="reference-link" href="#root/_help_0Ofbk1aSuVRu">Image references</a>&nbsp;for
+        more information.</li>
+      <li>Alternatively, press the corresponding button from the&nbsp;<a class="reference-link"
+        href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>.</li>
+    </ul>
   </li>
 </ul>
 <h3>Videos</h3>
@@ -65,11 +64,11 @@
   whose content is not necessarily of interest to the user, such as third-party
   libraries or generated content, that can then be downloaded if needed.</p>
 <p>Note that generally text files will be <a href="#root/_help_mHbBMPDPkVV5">imported</a> as
-  either&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;
-  <a
-  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes. To bypass this behavior and create a <em>File</em> note
-    type, use the <em>Import into note</em> feature and uncheck <em>Import HTML, Markdown and TXT as text notes</em>,
-    as well as <em>Import recognized code files as code notes</em>.&nbsp;</p>
+  either&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;or&nbsp;<a
+  class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes. To
+  bypass this behavior and create a <em>File</em> note type, use the <em>Import into note</em> feature
+  and uncheck <em>Import HTML, Markdown and TXT as text notes</em>, as well
+  as <em>Import recognized code files as code notes</em>.&nbsp;</p>
 <p>Since one of the use cases for having files instead of notes is to display
   large files, the content preview is limited to a relatively small amount
   of characters. To view the full file, consider opening it in an external
@@ -77,68 +76,66 @@
 <h3>GPS tracks</h3>
 <p>Trilium displays information about GPS tracks in <code spellcheck="false">.gpx</code> format,
   such as the distance, duration, elevation profile, tracks, markers.</p>
-<p>When a <code spellcheck="false">.gpx</code> note is dropped in a&nbsp;
-  <a
-  class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>, the track itself will also be displayed on the map.</p>
-<figure
-class="image">
+<p>When a <code spellcheck="false">.gpx</code> note is dropped in a&nbsp;<a
+  class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>, the track
+  itself will also be displayed on the map.</p>
+<figure class="image">
   <img style="aspect-ratio:1500/807;" src="4_File_image.png"
   width="1500" height="807">
-  </figure>
-  <h3>Fonts</h3>
-  <p>Supported font formats will show an interactive preview of the font:</p>
-  <ul>
-    <li>A field to type in a custom text.</li>
-    <li>A slider to change the font size of the preview.</li>
-    <li>A preview of the text at the given size.</li>
-    <li>A sampling of various font sizes for this font.</li>
-    <li>The Latin alphabet.</li>
-  </ul>
-  <p>Additionally, enabling <em>In font picker</em> will make the font available
-    in the&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Appearance</em> font
-    selection. See&nbsp;<a class="reference-link" href="#root/_help_w4rMEhJsALlA">Personalizing the font</a>&nbsp;for
-    more information.</p>
-  <h3>Unknown file types</h3>
-  <figure class="image image-style-align-center image_resized" style="width:50%;">
-    <img style="aspect-ratio:532/240;" src="3_File_image.png"
-    width="532" height="240">
-  </figure>
-  <p>If the file could not be identified as any of the supported file types
-    from above, it will be treated as an unknown file. In this case, all the
-    default interactions will be available such as downloading or opening the
-    file externally, but there will be no preview of the content.</p>
-  <h2>Interaction</h2>
-  <ul>
-    <li>Regardless of the file type, a series of buttons will be displayed in
-      the <em>Image</em> or <em>File</em> tab in the&nbsp;<a class="reference-link"
-      href="#root/_help_BlN9DFI679QC">Ribbon</a>.
-      <ul>
-        <li><em>Download</em>, which will download the file for local use.</li>
-        <li><em>Open</em>, will will open the file with the system-default application.</li>
-        <li>Upload new revision to replace the file with a new one.</li>
-      </ul>
-    </li>
-    <li>It is <strong>not</strong> possible to change the note type of a <em>File</em> note.</li>
-    <li>Convert into an <a href="#root/_help_0vhv7lsOLy82">attachment</a> from the <a href="#root/_help_8YBEPzcpUgxw">note menu</a>.</li>
-  </ul>
-  <h2>Relation with other notes</h2>
-  <ul>
-    <li>
-      <p>Files are also displayed in the&nbsp;<a class="reference-link" href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;based
-        on their type:</p>
-      <img class="image_resized" style="aspect-ratio:853/315;width:50%;"
-      src="5_File_image.png" width="853" height="315">
-    </li>
-    <li>
-      <p>Non-image files can be embedded into text notes as read-only widgets via
-        the&nbsp;<a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>&nbsp;functionality.</p>
-    </li>
-    <li>
-      <p>Image files can be embedded into text notes like normal images via&nbsp;
-        <a
-        class="reference-link" href="#root/_help_0Ofbk1aSuVRu">Image references</a>.</p>
-    </li>
-  </ul>
-  <h2>File size limit</h2>
-  <p>An individual file cannot be bigger than 374 MiB. For more information
-    see <em>Maximum import size</em> in&nbsp;<a class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>.</p>
+</figure>
+<h3>Fonts</h3>
+<p>Supported font formats will show an interactive preview of the font:</p>
+<ul>
+  <li>A field to type in a custom text.</li>
+  <li>A slider to change the font size of the preview.</li>
+  <li>A preview of the text at the given size.</li>
+  <li>A sampling of various font sizes for this font.</li>
+  <li>The Latin alphabet.</li>
+</ul>
+<p>Additionally, enabling <em>In font picker</em> will make the font available
+  in the&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Appearance</em> font
+  selection. See&nbsp;<a class="reference-link" href="#root/_help_w4rMEhJsALlA">Personalizing the font</a>&nbsp;for
+  more information.</p>
+<h3>Unknown file types</h3>
+<figure class="image image-style-align-center image_resized" style="width:50%;">
+  <img style="aspect-ratio:532/240;" src="3_File_image.png"
+  width="532" height="240">
+</figure>
+<p>If the file could not be identified as any of the supported file types
+  from above, it will be treated as an unknown file. In this case, all the
+  default interactions will be available such as downloading or opening the
+  file externally, but there will be no preview of the content.</p>
+<h2>Interaction</h2>
+<ul>
+  <li>Regardless of the file type, a series of buttons will be displayed in
+    the <em>Image</em> or <em>File</em> tab in the&nbsp;<a class="reference-link"
+    href="#root/_help_BlN9DFI679QC">Ribbon</a>.
+    <ul>
+      <li><em>Download</em>, which will download the file for local use.</li>
+      <li><em>Open</em>, will will open the file with the system-default application.</li>
+      <li>Upload new revision to replace the file with a new one.</li>
+    </ul>
+  </li>
+  <li>It is <strong>not</strong> possible to change the note type of a <em>File</em> note.</li>
+  <li>Convert into an <a href="#root/_help_0vhv7lsOLy82">attachment</a> from the <a href="#root/_help_8YBEPzcpUgxw">note menu</a>.</li>
+</ul>
+<h2>Relation with other notes</h2>
+<ul>
+  <li>
+    <p>Files are also displayed in the&nbsp;<a class="reference-link" href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;based
+      on their type:</p>
+    <img class="image_resized" style="aspect-ratio:853/315;width:50%;"
+    src="5_File_image.png" width="853" height="315">
+  </li>
+  <li>
+    <p>Non-image files can be embedded into text notes as read-only widgets via
+      the&nbsp;<a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>&nbsp;functionality.</p>
+  </li>
+  <li>
+    <p>Image files can be embedded into text notes like normal images via&nbsp;<a
+      class="reference-link" href="#root/_help_0Ofbk1aSuVRu">Image references</a>.</p>
+  </li>
+</ul>
+<h2>File size limit</h2>
+<p>An individual file cannot be bigger than 374 MiB. For more information
+  see <em>Maximum import size</em> in&nbsp;<a class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/Audio & Video.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/Audio & Video.html
@@ -10,12 +10,12 @@
   it doesn't have to download the entire file to start playing it.</p>
 <h2>Note on large media files</h2>
 <p>Although Trilium offers support for media files, it is generally not meant
-  to be used with very large files. Uploading large media will cause the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>&nbsp;to balloon, as well as any&nbsp;<a class="reference-link"
-    href="#root/_help_ODY7qQn5m2FT">Backup</a>&nbsp;of it. In addition, there might
-    be slowdowns when first uploading the files. Otherwise, a large database
-    should not impact the general performance of Trilium significantly.</p>
+  to be used with very large files. Uploading large media will cause the&nbsp;<a
+  class="reference-link" href="#root/_help_wX4HbRucYSDD">Database</a>&nbsp;to balloon,
+  as well as any&nbsp;<a class="reference-link" href="#root/_help_ODY7qQn5m2FT">Backup</a>&nbsp;of
+  it. In addition, there might be slowdowns when first uploading the files.
+  Otherwise, a large database should not impact the general performance of
+  Trilium significantly.</p>
 <h2>Supported formats</h2>
 <p>Trilium uses the built-in media decoding mechanism of the browser (or
   Electron/Chromium when running on the desktop). Starting with v0.103.0,
@@ -75,10 +75,10 @@
   width="1395" height="145">
   <figcaption>An audio note include (configured to the "Small" size).</figcaption>
 </figure>
-<p><a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;
-  <a
-  class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes can embed an interactive media player directly
-    in the note content. To do so, include the audio or video file:</p>
+<p><a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;and&nbsp;<a
+  class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes
+  can embed an interactive media player directly in the note content. To
+  do so, include the audio or video file:</p>
 <ul>
   <li><strong>Text notes:</strong> in the formatting toolbar, click “<strong>Insert”</strong> → <strong>“Include”.</strong>
   </li>
@@ -168,4 +168,4 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
+</figure>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/Office documents.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/Office documents.html
@@ -11,9 +11,9 @@
   <li><a href="https://en.wikipedia.org/wiki/EPUB">EPUB</a> e-books.</li>
 </ul>
 <aside class="admonition note">
-  <p>Older Microsoft Office formats (<code spellcheck="false">.doc</code>,
-    <code
-    spellcheck="false">.xls</code>, <code spellcheck="false">.ppt</code>) are not supported.</p>
+  <p>Older Microsoft Office formats (<code spellcheck="false">.doc</code>, <code
+    spellcheck="false">.xls</code>, <code spellcheck="false">.ppt</code>) are
+    not supported.</p>
 </aside>
 <h2>How it works</h2>
 <p>The document is converted to a simplified representation on the server
@@ -47,11 +47,11 @@
 </ul>
 <h2>Relation with other features</h2>
 <ul>
-  <li>The same preview is used when an office document is displayed in the&nbsp;
-    <a
-    class="reference-link" href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;or embedded in a text note via&nbsp;<a class="reference-link"
-      href="#root/_help_nBAXQFj20hS1">Include Note</a>, as well as for office documents
-      stored as&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
+  <li>The same preview is used when an office document is displayed in the&nbsp;<a
+    class="reference-link" href="#root/_help_0ESUbbAxVnoK">Note List</a>&nbsp;or
+    embedded in a text note via&nbsp;<a class="reference-link" href="#root/_help_nBAXQFj20hS1">Include Note</a>,
+    as well as for office documents stored as&nbsp;<a class="reference-link"
+    href="#root/_help_0vhv7lsOLy82">Attachments</a>.</li>
   <li>Independently of the preview, the text content of office documents is
     also extracted in the background so that it can be found with&nbsp;<a class="reference-link"
     href="#root/_help_eIg8jdvaoNNd">Search</a>&nbsp;via&nbsp;<a class="reference-link"

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/PDFs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/File/PDFs.html
@@ -40,74 +40,73 @@ class="admonition tip">
   <p>Technically, the information about the scroll position and rotation is
     stored in the&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;section,
     in a dedicated attachment called <code spellcheck="false">pdfHistory.json</code>.</p>
-  </aside>
-  <h2>Annotations</h2>
-  <p>Since v0.102.0 it's possible to annotate PDFs. To do so, look for the
-    annotation buttons on the right side of the PDF toolbar (
-    <img src="1_PDFs_image.png"
-    width="120" height="32">).</p>
-  <p>Since v0.103.0:</p>
-  <ul>
-    <li>Annotations are disabled if the note is marked as&nbsp;<a class="reference-link"
-      href="#root/_help_CoFPLs3dRlXc">Read-Only Notes</a>.</li>
-    <li>Comments can also be added, which is similar to highlights but also attach
-      a text.</li>
-    <li>The&nbsp;<a class="reference-link" href="#root/_help_RnaPdbciOfeq">Right Sidebar</a>&nbsp;also
-      displays a list of annotations (highlights, comments), but only in the&nbsp;
-      <a
-      class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>.</li>
-  </ul>
-  <h3>Supported annotations</h3>
-  <p>The following annotation methods are supported:</p>
-  <ul>
-    <li><strong>Highlight</strong>
-      <br>Allows highlighting text with one of the predefined colors.
-      <ul>
-        <li>The thickness is also adjustable.</li>
-        <li>It's also possible to highlight the blank space, turning the feature more
-          into a thicker pen.</li>
-      </ul>
-    </li>
-    <li><strong>Text</strong>
-      <br>Allows adding arbitrary text, with a custom color and size.</li>
-    <li><strong>Pen</strong>
-      <br>Allows free drawing on the document, with variable color, thickness and
-      opacity.</li>
-    <li><strong>Image</strong>
-      <br>Allows inserting images from outside Trilium directly into the document.</li>
-  </ul>
-  <h3>Editing existing annotations</h3>
-  <p>Although annotations are stored in the PDF itself, they can be edited.
-    To edit an annotation, press one of the annotation buttons from the previous
-    section to enter edit mode and click on an existing annotation. This will
-    reveal a toolbar with options to customize the annotation (e.g. to change
-    a color), as well as the possibility to remove it.</p>
-  <h3>How are annotations stored</h3>
-  <p>Annotations are stored directly in the PDF. When modifications are made,
-    Trilium will replace the PDF with the new one.</p>
-  <p>Since modifications are automatically saved, there's no need to manually
-    save the document after making modifications to the annotations.</p>
-  <p>The benefit of “baked-in annotations” is that they are also accessible
-    if downloading (for external use outside Trilium) or sharing the note.</p>
-  <p>The downside is that the entire PDF needs to be sent back to the server,
-    which can slow down performance for larger documents. If you encounter
-    any issues from this system, feel free to <a href="#root/_help_wy8So3yZZlH9">report it</a>.</p>
-  <h2>Filling out forms</h2>
-  <p>Similar to annotations, forms are also supported by Trilium since v0.102.0.
-    If the document has fields that can be filled-in, they will be indicated
-    with a colored background.</p>
-  <p>Simply type text in the forms and they will be automatically saved.</p>
-  <h2>Sidebar navigation</h2>
-  <aside class="admonition note">
-    <p>This feature is only available if&nbsp;<a class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>&nbsp;is
-      enabled. If you are using the old layout, these features are still available
-      by looking for a sidebar button in the PDF viewer toolbar.</p>
-  </aside>
-  <p>See the dedicated section on PDFs in&nbsp;<a class="reference-link" href="#root/_help_2dcGDhp9WFKb">Outline tab</a>.</p>
-  <h2>Share functionality</h2>
-  <p>PDFs can also be shared using the&nbsp;<a class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>&nbsp;feature.
-    This will also use Trilium's customized PDF viewer.</p>
-  <p>If you are using a reverse proxy on your server with strict access limitations
-    for the share functionality, make sure that <code spellcheck="false">[host].com/pdfjs</code> directory
-    is accessible. Note that this directory is outside the <code spellcheck="false">/share</code> route
-    as it's common with the rest of the application.</p>
+</aside>
+<h2>Annotations</h2>
+<p>Since v0.102.0 it's possible to annotate PDFs. To do so, look for the
+  annotation buttons on the right side of the PDF toolbar (
+  <img src="1_PDFs_image.png"
+  width="120" height="32">).</p>
+<p>Since v0.103.0:</p>
+<ul>
+  <li>Annotations are disabled if the note is marked as&nbsp;<a class="reference-link"
+    href="#root/_help_CoFPLs3dRlXc">Read-Only Notes</a>.</li>
+  <li>Comments can also be added, which is similar to highlights but also attach
+    a text.</li>
+  <li>The&nbsp;<a class="reference-link" href="#root/_help_RnaPdbciOfeq">Right Sidebar</a>&nbsp;also
+    displays a list of annotations (highlights, comments), but only in the&nbsp;<a
+    class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>.</li>
+</ul>
+<h3>Supported annotations</h3>
+<p>The following annotation methods are supported:</p>
+<ul>
+  <li><strong>Highlight</strong>
+    <br>Allows highlighting text with one of the predefined colors.
+    <ul>
+      <li>The thickness is also adjustable.</li>
+      <li>It's also possible to highlight the blank space, turning the feature more
+        into a thicker pen.</li>
+    </ul>
+  </li>
+  <li><strong>Text</strong>
+    <br>Allows adding arbitrary text, with a custom color and size.</li>
+  <li><strong>Pen</strong>
+    <br>Allows free drawing on the document, with variable color, thickness and
+    opacity.</li>
+  <li><strong>Image</strong>
+    <br>Allows inserting images from outside Trilium directly into the document.</li>
+</ul>
+<h3>Editing existing annotations</h3>
+<p>Although annotations are stored in the PDF itself, they can be edited.
+  To edit an annotation, press one of the annotation buttons from the previous
+  section to enter edit mode and click on an existing annotation. This will
+  reveal a toolbar with options to customize the annotation (e.g. to change
+  a color), as well as the possibility to remove it.</p>
+<h3>How are annotations stored</h3>
+<p>Annotations are stored directly in the PDF. When modifications are made,
+  Trilium will replace the PDF with the new one.</p>
+<p>Since modifications are automatically saved, there's no need to manually
+  save the document after making modifications to the annotations.</p>
+<p>The benefit of “baked-in annotations” is that they are also accessible
+  if downloading (for external use outside Trilium) or sharing the note.</p>
+<p>The downside is that the entire PDF needs to be sent back to the server,
+  which can slow down performance for larger documents. If you encounter
+  any issues from this system, feel free to <a href="#root/_help_wy8So3yZZlH9">report it</a>.</p>
+<h2>Filling out forms</h2>
+<p>Similar to annotations, forms are also supported by Trilium since v0.102.0.
+  If the document has fields that can be filled-in, they will be indicated
+  with a colored background.</p>
+<p>Simply type text in the forms and they will be automatically saved.</p>
+<h2>Sidebar navigation</h2>
+<aside class="admonition note">
+  <p>This feature is only available if&nbsp;<a class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>&nbsp;is
+    enabled. If you are using the old layout, these features are still available
+    by looking for a sidebar button in the PDF viewer toolbar.</p>
+</aside>
+<p>See the dedicated section on PDFs in&nbsp;<a class="reference-link" href="#root/_help_2dcGDhp9WFKb">Outline tab</a>.</p>
+<h2>Share functionality</h2>
+<p>PDFs can also be shared using the&nbsp;<a class="reference-link" href="#root/_help_R9pX4DGra2Vt">Sharing</a>&nbsp;feature.
+  This will also use Trilium's customized PDF viewer.</p>
+<p>If you are using a reverse proxy on your server with strict access limitations
+  for the share functionality, make sure that <code spellcheck="false">[host].com/pdfjs</code> directory
+  is accessible. Note that this directory is outside the <code spellcheck="false">/share</code> route
+  as it's common with the rest of the application.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Markdown.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Markdown.html
@@ -36,15 +36,13 @@
     <p>All standard and GitHub-flavored syntax (basic formatting, tables, blockquotes).</p>
   </li>
   <li>
-    <p>Basic HTML is also supported (e.g. collapsible blocks using <code spellcheck="false">&lt;details&gt;</code> and
-      <code
+    <p>Basic HTML is also supported (e.g. collapsible blocks using <code spellcheck="false">&lt;details&gt;</code> and <code
       spellcheck="false">&lt;summary&gt;</code>).</p>
   </li>
   <li>
     <p>Code blocks with syntax highlight.</p>
     <ul>
-      <li>The language must be specified for syntax highlight to be applied (e.g.
-        <code
+      <li>The language must be specified for syntax highlight to be applied (e.g. <code
         spellcheck="false">```js</code>).</li>
       <li>Code blocks will respect the text wrapping from the&nbsp;<a class="reference-link"
         href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;section in&nbsp;<a class="reference-link"
@@ -60,8 +58,7 @@
       inline and block)</p>
   </li>
   <li>
-    <p><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;using
-      <code
+    <p><a class="reference-link" href="#root/_help_s1aBHPd79XYj">Mermaid Diagrams</a>&nbsp;using <code
       spellcheck="false">```mermaid</code>
     </p>
   </li>
@@ -77,8 +74,7 @@
   </li>
   <li>
     <p><a class="reference-link" href="#root/_help_hrZ1D00cLbal">Internal (reference) links</a>&nbsp;via
-      its HTML syntax, or through a <em>Wikilinks</em>-like format (only&nbsp;
-      <a
+      its HTML syntax, or through a <em>Wikilinks</em>-like format (only&nbsp;<a
       class="reference-link" href="#root/_help_m1lbrzyKDaRB">Note ID</a>):</p><pre><code class="language-text-x-trilium-auto">[[Hg8TS5ZOxti6]]</code></pre>
   </li>
   <li>
@@ -108,9 +104,9 @@
       </table>
     </figure>
     <p>Task states are customizable: you can reorder them, create new ones with
-      different colors and symbols, or delete the ones you don't need. See&nbsp;
-      <a
-      class="reference-link" href="#root/_help_i16PM6A7GXdU">Customizing to-do task states</a>&nbsp;for more details.</p>
+      different colors and symbols, or delete the ones you don't need. See&nbsp;<a
+      class="reference-link" href="#root/_help_i16PM6A7GXdU">Customizing to-do task states</a>&nbsp;for
+      more details.</p>
     <p>Note that to-do items with task states other than "None" and "Done" are
       Trilium-specific and may not work well with other Markdown software.</p>
   </li>
@@ -204,9 +200,9 @@
   <li>Inserting a collapsible block (<code spellcheck="false">/collapsible</code>).</li>
   <li>Inserting a page break for printing (<code spellcheck="false">/page-break</code>).</li>
   <li>Inserting a table (<code spellcheck="false">/table</code>).</li>
-  <li>Creating admonitions (e.g. <code spellcheck="false">/tip</code>, <code spellcheck="false">/note</code>,
-    <code
-    spellcheck="false">/important</code>, <code spellcheck="false">/caution</code>, <code spellcheck="false">/warning</code>).</li>
+  <li>Creating admonitions (e.g. <code spellcheck="false">/tip</code>, <code spellcheck="false">/note</code>, <code
+    spellcheck="false">/important</code>, <code spellcheck="false">/caution</code>, <code
+    spellcheck="false">/warning</code>).</li>
   <li>Inserting task items (<code spellcheck="false">/todo:&lt;state&gt;</code>,
     e.g. <code spellcheck="false">/todo:done</code>), one per configured task
     state.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Relation Map.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Relation Map.html
@@ -1,5 +1,4 @@
-<p>Relation map is a type of&nbsp;note&nbsp;which visualizes notes and their
-  <a
+<p>Relation map is a type of&nbsp;note&nbsp;which visualizes notes and their <a
   href="#root/_help_zEY4DaJG4YT5">relations</a>.</p>
 <h2>Interaction</h2>
 <ul>
@@ -49,9 +48,9 @@ width="934" height="667">
 width="812" height="585">
 <p>We start completely from scratch by first creating new note called "Development
   process" and changing its type to "Relation map". After that we create
-  new notes one by one and place them by clicking into the map. We also drag
-  <a
-  href="#root/_help_zEY4DaJG4YT5">relations</a>between notes and name them. That's all!</p>
+  new notes one by one and place them by clicking into the map. We also drag <a
+  href="#root/_help_zEY4DaJG4YT5">relations</a>between notes and name them. That's
+  all!</p>
 <p>Items on the map - "Specification", "Development", "Testing" and "Demo"
   are actually notes which have been created under "Development process"
   note - you can click on them and write some content. Connections between
@@ -67,13 +66,12 @@ width="812" height="585">
 <p>There are several steps here:</p>
 <ul>
   <li>we start with empty relation map and two existing notes representing Prince
-    Philip and Queen Elizabeth II. These two notes already have <code spellcheck="false">isPartnerOf</code> 
-    <a
+    Philip and Queen Elizabeth II. These two notes already have <code spellcheck="false">isPartnerOf</code>  <a
     href="#root/_help_zEY4DaJG4YT5">relations</a>defined.
-      <ul>
-        <li>There are actually two "inverse" relations (one from Philip to Elizabeth
-          and one from Elizabeth to Philip)</li>
-      </ul>
+    <ul>
+      <li>There are actually two "inverse" relations (one from Philip to Elizabeth
+        and one from Elizabeth to Philip)</li>
+    </ul>
   </li>
   <li>we drag both notes to relation map and place to suitable position. Notice
     how the existing <code spellcheck="false">isPartnerOf</code> relations are
@@ -86,11 +84,10 @@ width="812" height="585">
     <ul>
       <li>now there's something unexpected - we can also see the relation to display
         another <code spellcheck="false">hasChild</code> relation. This is because
-        there's a <a href="#root/_help_OFXdgB2nNk1F">relation definition</a> which puts
-        <code
-        spellcheck="false">isChildOf</code>as an "<a href="#root/_help_OFXdgB2nNk1F">inverse</a>" relation
-          of <code spellcheck="false">hasChildOf</code> (and vice versa) and thus it
-          is created automatically.</li>
+        there's a <a href="#root/_help_OFXdgB2nNk1F">relation definition</a> which puts <code
+        spellcheck="false">isChildOf</code> as an "<a href="#root/_help_OFXdgB2nNk1F">inverse</a>"
+        relation of <code spellcheck="false">hasChildOf</code> (and vice versa) and
+        thus it is created automatically.</li>
     </ul>
   </li>
   <li>we create another note for Princess Diana and create <code spellcheck="false">isPartnerOf</code> relation

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Saved Search.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Saved Search.html
@@ -8,8 +8,7 @@ style="width:50%;">
 </figure>
 <h2>Location</h2>
 <p>By default, saved searches are stored in the day note. However, you can
-  designate a different note to store saved searches by marking it with the
-  <code
-  spellcheck="false">#searchHome</code>label. Additionally, for <a href="#root/_help_9sRHySam5fXb">workspaces</a>,
-    you can use the <code spellcheck="false">#workspaceSearchHome</code> label
-    to specify a storage location for saved searches within that workspace.</p>
+  designate a different note to store saved searches by marking it with the <code
+  spellcheck="false">#searchHome</code> label. Additionally, for <a href="#root/_help_9sRHySam5fXb">workspaces</a>,
+  you can use the <code spellcheck="false">#workspaceSearchHome</code> label
+  to specify a storage location for saved searches within that workspace.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Spreadsheets.html
@@ -46,9 +46,9 @@
     href="#root/_help_oPVyFC7WL2Lp">Note Tree</a>&nbsp;and it will be converted into
     a spreadsheet note.
     <ul>
-      <li>To avoid this behavior (e.g. to import a .xlsx file as an actual&nbsp;
-        <a
-        class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>), uncheck the corresponding option in the <a href="#root/_help_mHbBMPDPkVV5">Import dialog</a>.</li>
+      <li>To avoid this behavior (e.g. to import a .xlsx file as an actual&nbsp;<a
+        class="reference-link" href="#root/_help_W8vYD3Q1zjCR">File</a>), uncheck the
+        corresponding option in the <a href="#root/_help_mHbBMPDPkVV5">Import dialog</a>.</li>
       <li>Multiple files can be imported at the same time, including a mixture of
         .csv and .xlsx files. Folder structure can be preserved by using a .zip
         file.</li>
@@ -57,8 +57,7 @@
   <li>Unlike importing, exporting is on a per-note basis:
     <ul>
       <li>In the&nbsp;<a class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>,
-        choose the <em>Export to Excel</em> or <em>Export to CSV</em> options for the&nbsp;
-        <a
+        choose the <em>Export to Excel</em> or <em>Export to CSV</em> options for the&nbsp;<a
         class="reference-link" href="#root/_help_IjZS7iK5EXtb">New Layout</a>.</li>
       <li>For the old layout, choose the corresponding buttons in the&nbsp;<a class="reference-link"
         href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;area.</li>
@@ -66,10 +65,10 @@
         the resulting file will be a custom <code spellcheck="false">.triliumsheet</code> file
         that preserves the spreadsheet as-is.
         <ul>
-          <li>The export is intentionally a different process than the normal&nbsp;
-            <a
-            class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>&nbsp;functionality because it does conversion
-              to multiple formats with varying degrees of compatibility.</li>
+          <li>The export is intentionally a different process than the normal&nbsp;<a
+            class="reference-link" href="#root/_help_mHbBMPDPkVV5">Import &amp; Export</a>&nbsp;functionality
+            because it does conversion to multiple formats with varying degrees of
+            compatibility.</li>
         </ul>
       </li>
     </ul>
@@ -89,8 +88,7 @@
     <ul>
       <li>The images are saved as&nbsp;<a class="reference-link" href="#root/_help_0vhv7lsOLy82">Attachments</a>&nbsp;for
         performance reasons.</li>
-      <li>The image upload respects the same compression settings as text&nbsp;
-        <a
+      <li>The image upload respects the same compression settings as text&nbsp;<a
         class="reference-link" href="#root/_help_mT0HEkOsz6i1">Images</a>.</li>
     </ul>
   </li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text.html
@@ -168,28 +168,27 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <h2>Read-Only vs. Editing Mode</h2>
-  <p>Text notes are usually opened in edit mode. However, they may open in
-    read-only mode if the note is too big or the note is explicitly marked
-    as read-only. For more information, see&nbsp;<a class="reference-link"
-    href="#root/_help_CoFPLs3dRlXc">[missing note]</a>.</p>
-  <h2>Keyboard shortcuts</h2>
-  <p>There are numerous keyboard shortcuts to format the text without having
-    to use the mouse. For a reference of all the key combinations, see&nbsp;
-    <a
-    class="reference-link" href="#root/_help_A9Oc6YKKc65v">Keyboard Shortcuts</a>. In addition, see&nbsp;<a class="reference-link"
-      href="#root/_help_QrtTYPmdd1qq">Markdown-like formatting</a>&nbsp;as an alternative
-      to the keyboard shortcuts.</p>
-  <h2>Content width</h2>
-  <p>For readability purposes on wider screens, the width of text notes is
-    limited via a configurable option. See&nbsp;<a class="reference-link" href="#root/_help_t596jLvPrqkS">[missing note]</a>&nbsp;for
-    more information.</p>
-  <h2>Converting to a Markdown note</h2>
-  <p>Text notes can be converted to&nbsp;<a class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes.
-    See&nbsp;<a class="reference-link" href="#root/_help_jludwdW7N4hg">Converting between note types</a>.</p>
-  <h2>Technical details</h2>
-  <p>For the text editing functionality, Trilium uses a commercial product
-    (with an open-source base) called&nbsp;<a class="reference-link" href="#root/_help_MI26XDLSAlCD">[missing note]</a>.
-    This brings the benefit of having a powerful WYSIWYG (What You See Is What
-    You Get) editor.</p>
+</figure>
+<h2>Read-Only vs. Editing Mode</h2>
+<p>Text notes are usually opened in edit mode. However, they may open in
+  read-only mode if the note is too big or the note is explicitly marked
+  as read-only. For more information, see&nbsp;<a class="reference-link"
+  href="#root/_help_CoFPLs3dRlXc">[missing note]</a>.</p>
+<h2>Keyboard shortcuts</h2>
+<p>There are numerous keyboard shortcuts to format the text without having
+  to use the mouse. For a reference of all the key combinations, see&nbsp;<a
+  class="reference-link" href="#root/_help_A9Oc6YKKc65v">Keyboard Shortcuts</a>.
+  In addition, see&nbsp;<a class="reference-link" href="#root/_help_QrtTYPmdd1qq">Markdown-like formatting</a>&nbsp;as
+  an alternative to the keyboard shortcuts.</p>
+<h2>Content width</h2>
+<p>For readability purposes on wider screens, the width of text notes is
+  limited via a configurable option. See&nbsp;<a class="reference-link" href="#root/_help_t596jLvPrqkS">[missing note]</a>&nbsp;for
+  more information.</p>
+<h2>Converting to a Markdown note</h2>
+<p>Text notes can be converted to&nbsp;<a class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes.
+  See&nbsp;<a class="reference-link" href="#root/_help_jludwdW7N4hg">Converting between note types</a>.</p>
+<h2>Technical details</h2>
+<p>For the text editing functionality, Trilium uses a commercial product
+  (with an open-source base) called&nbsp;<a class="reference-link" href="#root/_help_MI26XDLSAlCD">[missing note]</a>.
+  This brings the benefit of having a powerful WYSIWYG (What You See Is What
+  You Get) editor.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Automatic replacements.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Automatic replacements.html
@@ -42,22 +42,18 @@ class="table">
       <tr>
         <td>Mathematical symbols</td>
         <td>fractions such as <code spellcheck="false">1/2</code> with <code spellcheck="false">½</code>,
-          and the operators <code spellcheck="false">&lt;=</code>, <code spellcheck="false">&gt;=</code>,
-          <code
-          spellcheck="false">!=</code>, <code spellcheck="false">&lt;-</code> and <code spellcheck="false">-&gt;</code> with
-            <code
-            spellcheck="false">≤</code>, <code spellcheck="false">≥</code>, <code spellcheck="false">≠</code>,
-              <code
-              spellcheck="false">←</code>and <code spellcheck="false">→</code>
+          and the operators <code spellcheck="false">&lt;=</code>, <code spellcheck="false">&gt;=</code>, <code
+          spellcheck="false">!=</code>, <code spellcheck="false">&lt;-</code> and <code
+          spellcheck="false">-&gt;</code> with <code spellcheck="false">≤</code>, <code
+          spellcheck="false">≥</code>, <code spellcheck="false">≠</code>, <code spellcheck="false">←</code> and <code
+          spellcheck="false">→</code>
         </td>
       </tr>
       <tr>
         <td>Copyright and trademark</td>
-        <td><code spellcheck="false">(c)</code>, <code spellcheck="false">(r)</code> and
-          <code
-          spellcheck="false">(tm)</code>with <code spellcheck="false">©</code>, <code spellcheck="false">®</code> and
-            <code
-            spellcheck="false">™</code>
+        <td><code spellcheck="false">(c)</code>, <code spellcheck="false">(r)</code> and <code
+          spellcheck="false">(tm)</code> with <code spellcheck="false">©</code>, <code
+          spellcheck="false">®</code> and <code spellcheck="false">™</code>
         </td>
       </tr>
       <tr>
@@ -66,88 +62,82 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <h2>Quotation marks</h2>
-  <p>Quotation marks are configured separately from the rest, with one setting
-    for the <strong>double</strong> quote key and one for the <strong>single</strong> quote
-    key, because which pair belongs on which key differs between conventions
-    — British typography traditionally sets a quotation in <code spellcheck="false">‘…’</code> where
-    American sets it in <code spellcheck="false">“…”</code>.</p>
-  <p>Each offers:</p>
-  <ul>
-    <li><em>Based on the note's content language</em> (the default) — English gives
-      <code
-      spellcheck="false">“quote”</code>, German <code spellcheck="false">„quote“</code>, French
-        <code
-        spellcheck="false">« quote »</code>, Japanese <code spellcheck="false">「quote」</code>. See <em>Content language &amp; Right-to-left support</em> for
-          how a note's language is decided.</li>
-    <li><em>Disabled,</em> straight quotes stay straight.</li>
-    <li><em>A specific pair</em> — <code spellcheck="false">“…”</code>, <code spellcheck="false">‘…’</code>,
-      <code
-      spellcheck="false">„…“</code>, <code spellcheck="false">„…”</code>, <code spellcheck="false">«…»</code>,
-        <code
-        spellcheck="false">« … »</code>, <code spellcheck="false">‹…›</code>, <code spellcheck="false">「…」</code>,
-          <code
-          spellcheck="false">『…』</code>. Choosing one applies it to every note, whatever language it
-            is written in.</li>
-  </ul>
-  <h2>Custom replacements</h2>
-  <p>You can add your own under&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Text notes</em> → <em>Automatic replacements</em> → <em>Custom replacements</em>.
-    Type the text to replace and the replacement, then press Enter. Existing
-    ones are shown as chips and removed with the × on each.</p>
-  <p>A custom replacement is applied when the text is typed as a whole word
-    and followed by a space, so longer words that begin with it are left alone
-    — a <code spellcheck="false">TN</code> replacement does not rewrite the end
-    of <code spellcheck="false">BTN</code>, and <code spellcheck="false">TNT</code> can
-    still be typed.</p>
-  <p>Capitalisation follows what you type, unless the replacement has capitals
-    of its own:</p>
-  <figure class="table">
-    <table>
-      <thead>
-        <tr>
-          <th><strong>Replacement you defined</strong>
-          </th>
-          <th><strong>You type</strong>
-          </th>
-          <th><strong>You get</strong>
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code spellcheck="false">teh</code> → <code spellcheck="false">the</code>
-          </td>
-          <td><code spellcheck="false">teh</code> / <code spellcheck="false">Teh</code> /
-            <code
-            spellcheck="false">TEH</code>
-          </td>
-          <td><code spellcheck="false">the</code> / <code spellcheck="false">The</code> /
-            <code
-            spellcheck="false">THE</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code spellcheck="false">TN</code> → <code spellcheck="false">Trilium Notes</code>
-          </td>
-          <td><code spellcheck="false">TN</code> or <code spellcheck="false">tn</code>
-          </td>
-          <td><code spellcheck="false">Trilium Notes</code> (unchanged — it has capitals)</td>
-        </tr>
-      </tbody>
-    </table>
-  </figure>
-  <p>The text to replace is matched literally; it is not a pattern. Typing
-    a replacement whose "text to replace" already exists updates that entry
-    rather than adding a second one.</p>
-  <h2>Characters that only look replaced (ligatures)</h2>
-  <p>If you see <code spellcheck="false">!=</code> displayed as <code spellcheck="false">≠</code> or
-    <code
-    spellcheck="false">-&gt;</code>as <code spellcheck="false">→</code> inside a code block, that
-      is not a replacement — replacements never run there. It is a <em>font ligature</em>:
-      the default monospace font draws certain character pairs as a single symbol.
-      The underlying text is unchanged, and copying it out gives you back
-      <code
-      spellcheck="false">!=</code>and <code spellcheck="false">-&gt;</code>.</p>
-  <p>This can be turned off with&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a><em>→ Appearance → Fonts → Programming ligatures.</em>
-  </p>
+</figure>
+<h2>Quotation marks</h2>
+<p>Quotation marks are configured separately from the rest, with one setting
+  for the <strong>double</strong> quote key and one for the <strong>single</strong> quote
+  key, because which pair belongs on which key differs between conventions
+  — British typography traditionally sets a quotation in <code spellcheck="false">‘…’</code> where
+  American sets it in <code spellcheck="false">“…”</code>.</p>
+<p>Each offers:</p>
+<ul>
+  <li><em>Based on the note's content language</em> (the default) — English gives <code
+    spellcheck="false">“quote”</code>, German <code spellcheck="false">„quote“</code>,
+    French <code spellcheck="false">« quote »</code>, Japanese <code spellcheck="false">「quote」</code>.
+    See <em>Content language &amp; Right-to-left support</em> for how a note's
+    language is decided.</li>
+  <li><em>Disabled,</em> straight quotes stay straight.</li>
+  <li><em>A specific pair</em> — <code spellcheck="false">“…”</code>, <code spellcheck="false">‘…’</code>, <code
+    spellcheck="false">„…“</code>, <code spellcheck="false">„…”</code>, <code
+    spellcheck="false">«…»</code>, <code spellcheck="false">« … »</code>, <code
+    spellcheck="false">‹…›</code>, <code spellcheck="false">「…」</code>, <code
+    spellcheck="false">『…』</code>. Choosing one applies it to every note, whatever
+    language it is written in.</li>
+</ul>
+<h2>Custom replacements</h2>
+<p>You can add your own under&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Text notes</em> → <em>Automatic replacements</em> → <em>Custom replacements</em>.
+  Type the text to replace and the replacement, then press Enter. Existing
+  ones are shown as chips and removed with the × on each.</p>
+<p>A custom replacement is applied when the text is typed as a whole word
+  and followed by a space, so longer words that begin with it are left alone
+  — a <code spellcheck="false">TN</code> replacement does not rewrite the end
+  of <code spellcheck="false">BTN</code>, and <code spellcheck="false">TNT</code> can
+  still be typed.</p>
+<p>Capitalisation follows what you type, unless the replacement has capitals
+  of its own:</p>
+<figure class="table">
+  <table>
+    <thead>
+      <tr>
+        <th><strong>Replacement you defined</strong>
+        </th>
+        <th><strong>You type</strong>
+        </th>
+        <th><strong>You get</strong>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code spellcheck="false">teh</code> → <code spellcheck="false">the</code>
+        </td>
+        <td><code spellcheck="false">teh</code> / <code spellcheck="false">Teh</code> / <code
+          spellcheck="false">TEH</code>
+        </td>
+        <td><code spellcheck="false">the</code> / <code spellcheck="false">The</code> / <code
+          spellcheck="false">THE</code>
+        </td>
+      </tr>
+      <tr>
+        <td><code spellcheck="false">TN</code> → <code spellcheck="false">Trilium Notes</code>
+        </td>
+        <td><code spellcheck="false">TN</code> or <code spellcheck="false">tn</code>
+        </td>
+        <td><code spellcheck="false">Trilium Notes</code> (unchanged — it has capitals)</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>
+<p>The text to replace is matched literally; it is not a pattern. Typing
+  a replacement whose "text to replace" already exists updates that entry
+  rather than adding a second one.</p>
+<h2>Characters that only look replaced (ligatures)</h2>
+<p>If you see <code spellcheck="false">!=</code> displayed as <code spellcheck="false">≠</code> or <code
+  spellcheck="false">-&gt;</code> as <code spellcheck="false">→</code> inside
+  a code block, that is not a replacement — replacements never run there.
+  It is a <em>font ligature</em>: the default monospace font draws certain
+  character pairs as a single symbol. The underlying text is unchanged, and
+  copying it out gives you back <code spellcheck="false">!=</code> and <code
+  spellcheck="false">-&gt;</code>.</p>
+<p>This can be turned off with&nbsp;<a class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a><em>→ Appearance → Fonts → Programming ligatures.</em>
+</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Block quotes & admonitions.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Block quotes & admonitions.html
@@ -14,52 +14,52 @@
 class="image image-style-align-center">
   <img style="aspect-ratio:959/547;" src="2_Block quotes & admonitions_image.png"
   width="959" height="547">
-  </figure>
-  <p>From a functional point of view, admonitions act very similarly to a block
-    quote, just with different styling. This includes the ability to insert
-    other elements in it such as headings, tables, images, etc.</p>
-  <h3>Inserting a new admonition</h3>
-  <p>In the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>:</p>
-  <p>
-    <img src="1_Block quotes & admonitions_image.png">
-  </p>
-  <p>It's possible to insert an admonition simply by typing:</p>
-  <ul>
-    <li><code spellcheck="false">!!! note</code>
-    </li>
-    <li><code spellcheck="false">!!! tip</code>
-    </li>
-    <li><code spellcheck="false">!!! important</code>
-    </li>
-    <li><code spellcheck="false">!!! caution</code>
-    </li>
-    <li><code spellcheck="false">!!! warning</code>
-    </li>
-  </ul>
-  <p>In addition to that, it's also possible to type <code spellcheck="false">!!!</code>&nbsp;
-    followed by any text, case in which a default admonition type will appear
-    (note) with the entered text inside it.</p>
-  <h3>Interaction</h3>
-  <p>By design, admonitions act very similar to block quotes.</p>
-  <ul>
-    <li>Selecting a text and pressing the admonition button will turn that text
-      into an admonition.</li>
-    <li>If selecting multiple admonitions, pressing the admonition button will
-      automatically merge them into one.</li>
-  </ul>
-  <p>Inside an admonition:</p>
-  <ul>
-    <li>Pressing <kbd>Backspace</kbd> while the admonition is empty will remove
-      it.</li>
-    <li>Pressing <kbd>Enter</kbd> will start a new paragraph. Pressing it twice
-      will exit out of the admonition.</li>
-    <li>Headings and other block content including tables can be inserted inside
-      the admonition.</li>
-  </ul>
-  <h3>Types of admonitions</h3>
-  <p>There are currently five types of admonitions: <em>Note</em>, <em>Tip</em>, <em>Important</em>, <em>Caution</em>, <em>Warning</em>.</p>
-  <p>These types were inspired by GitHub's support for this feature and there
-    are currently no plans for adjusting it or allowing the user to customize
-    them.</p>
-  <h3>Markdown support</h3>
-  <p>See&nbsp;<a class="reference-link" href="#root/_help_rJ9grSgoExl9">Supported syntax</a>.</p>
+</figure>
+<p>From a functional point of view, admonitions act very similarly to a block
+  quote, just with different styling. This includes the ability to insert
+  other elements in it such as headings, tables, images, etc.</p>
+<h3>Inserting a new admonition</h3>
+<p>In the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>:</p>
+<p>
+  <img src="1_Block quotes & admonitions_image.png">
+</p>
+<p>It's possible to insert an admonition simply by typing:</p>
+<ul>
+  <li><code spellcheck="false">!!! note</code>
+  </li>
+  <li><code spellcheck="false">!!! tip</code>
+  </li>
+  <li><code spellcheck="false">!!! important</code>
+  </li>
+  <li><code spellcheck="false">!!! caution</code>
+  </li>
+  <li><code spellcheck="false">!!! warning</code>
+  </li>
+</ul>
+<p>In addition to that, it's also possible to type <code spellcheck="false">!!!</code>&nbsp;
+  followed by any text, case in which a default admonition type will appear
+  (note) with the entered text inside it.</p>
+<h3>Interaction</h3>
+<p>By design, admonitions act very similar to block quotes.</p>
+<ul>
+  <li>Selecting a text and pressing the admonition button will turn that text
+    into an admonition.</li>
+  <li>If selecting multiple admonitions, pressing the admonition button will
+    automatically merge them into one.</li>
+</ul>
+<p>Inside an admonition:</p>
+<ul>
+  <li>Pressing <kbd>Backspace</kbd> while the admonition is empty will remove
+    it.</li>
+  <li>Pressing <kbd>Enter</kbd> will start a new paragraph. Pressing it twice
+    will exit out of the admonition.</li>
+  <li>Headings and other block content including tables can be inserted inside
+    the admonition.</li>
+</ul>
+<h3>Types of admonitions</h3>
+<p>There are currently five types of admonitions: <em>Note</em>, <em>Tip</em>, <em>Important</em>, <em>Caution</em>, <em>Warning</em>.</p>
+<p>These types were inspired by GitHub's support for this feature and there
+  are currently no plans for adjusting it or allowing the user to customize
+  them.</p>
+<h3>Markdown support</h3>
+<p>See&nbsp;<a class="reference-link" href="#root/_help_rJ9grSgoExl9">Supported syntax</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Collapsible blocks.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Collapsible blocks.html
@@ -24,4 +24,4 @@
 class="admonition tip">
   <p>Place multiple collapsible blocks one after another to create an accordion,
     where each block can be expanded or collapsed independently.</p>
-  </aside>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Developer-specific formatting/Code blocks.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Developer-specific formatting/Code blocks.html
@@ -93,8 +93,7 @@
   <img src="2_Code blocks_image.png">
 </p>
 <h2>Adjusting the list of languages</h2>
-<p>The code blocks feature shares the list of languages with the&nbsp;
-  <a
+<p>The code blocks feature shares the list of languages with the&nbsp;<a
   class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note type.</p>
 <p>The supported languages can be adjusted by going to&nbsp;<a class="reference-link"
   href="#root/_help_4TIF1oA4VQRO">Options</a>, then <em>Code Notes</em> and looking

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Formatting toolbar.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Formatting toolbar.html
@@ -1,9 +1,9 @@
 <p>Trilium allows two different editing experiences for text notes, based
   on your preference.</p>
 <p>The type of formatting toolbar can be changed by going to&nbsp;<a class="reference-link"
-  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;and then looking for the&nbsp;
-  <a
-  class="reference-link" href="#root/_options/_optionsTextNotes">Text Notes</a>&nbsp;section. In it, look for the <em>Formatting toolbar</em> category.</p>
+  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;and then looking for the&nbsp;<a
+  class="reference-link" href="#root/_options/_optionsTextNotes">Text Notes</a>&nbsp;section.
+  In it, look for the <em>Formatting toolbar</em> category.</p>
 <h2>Floating</h2>
 <p>The floating bar is a more minimalist option, in which the formatting
   is hidden behind two different popups.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/General formatting.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/General formatting.html
@@ -30,9 +30,9 @@
 <p>Unlike other text editors such as Microsoft Word, the font size is relative
   (i.e. “Tiny”, “Small” instead of a number like 12).</p>
 <p>Avoid using this feature just to simply make all text bigger. In that
-  case it's generally better to adjust the font size for all notes in&nbsp;
-  <a
-  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;or by zooming.</p>
+  case it's generally better to adjust the font size for all notes in&nbsp;<a
+  class="reference-link" href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;or by
+  zooming.</p>
 <h2>Bold, italic, underline, strike-through</h2>
 <figure class="image image-style-align-right">
   <img style="aspect-ratio:215/71;" src="4_General formatting_image.png"
@@ -50,8 +50,7 @@
 </ul>
 <p>Alternatively, Markdown-like formatting can be used:</p>
 <ul>
-  <li><strong>Bold</strong>: Type <code spellcheck="false">**text**</code> or
-    <code
+  <li><strong>Bold</strong>: Type <code spellcheck="false">**text**</code> or <code
     spellcheck="false">__text__</code>
   </li>
   <li><em>Italic</em>: Type <code spellcheck="false">*text*</code> or <code spellcheck="false">_text_</code>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Images.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Images.html
@@ -105,23 +105,22 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <h2>Compression</h2>
-  <p>Since Trilium isn't really meant to be primary storage for image data,
-    it attempts to compress and resize (with pretty aggressive settings) uploaded
-    images before storing them to the database. You may then notice some quality
-    degradation. Basic quality settings is available in&nbsp;<a class="reference-link"
-    href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Media</em>.</p>
-  <p>If you want to save images in their original resolution, it is recommended
-    to save them as attachment to note (look for the contextual menu in&nbsp;
-    <a
-    class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Import files</em>).</p>
-  <h2>Aligning images side-by-side</h2>
-  <p>There are generally two ways to display images side by side:</p>
-  <ul>
-    <li>If they are roughly the same size, simply make the two images in-line,
-      according to the alignment section above. The images can be dragged &amp;
-      dropped onto the same line.</li>
-    <li>If they are on different size, create a <a href="#root/_help_NdowYOC1GFKS">table</a> with
-      invisible borders.</li>
-  </ul>
+</figure>
+<h2>Compression</h2>
+<p>Since Trilium isn't really meant to be primary storage for image data,
+  it attempts to compress and resize (with pretty aggressive settings) uploaded
+  images before storing them to the database. You may then notice some quality
+  degradation. Basic quality settings is available in&nbsp;<a class="reference-link"
+  href="#root/_help_4TIF1oA4VQRO">Options</a>&nbsp;→ <em>Media</em>.</p>
+<p>If you want to save images in their original resolution, it is recommended
+  to save them as attachment to note (look for the contextual menu in&nbsp;<a
+  class="reference-link" href="#root/_help_8YBEPzcpUgxw">Note buttons</a>&nbsp;→ <em>Import files</em>).</p>
+<h2>Aligning images side-by-side</h2>
+<p>There are generally two ways to display images side by side:</p>
+<ul>
+  <li>If they are roughly the same size, simply make the two images in-line,
+    according to the alignment section above. The images can be dragged &amp;
+    dropped onto the same line.</li>
+  <li>If they are on different size, create a <a href="#root/_help_NdowYOC1GFKS">table</a> with
+    invisible borders.</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/In-editor AI assistant.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/In-editor AI assistant.html
@@ -56,9 +56,9 @@
   at the document around them. This surrounding text is context only, it
   is never rewritten.</p>
 <aside class="admonition important">
-  <p>That means a single run sends more than the passage you highlighted. See&nbsp;
-    <a
-    class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for exactly what leaves your machine.</p>
+  <p>That means a single run sends more than the passage you highlighted. See&nbsp;<a
+    class="reference-link" href="#root/_help_cRRrdZjgyhNc">Privacy</a>&nbsp;for exactly
+    what leaves your machine.</p>
 </aside>
 <h2>Quick actions</h2>
 <p>The arrow beside the toolbar button opens a menu of ready-made instructions,

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Include Note.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Include Note.html
@@ -18,9 +18,9 @@
 <p>Since v0.104.0, included notes might become interactive depending on their
   note type:</p>
 <ul>
-  <li><a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>&nbsp;(e.g.&nbsp;
-    <a
-    class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>) will render fully interactive, including creating new notes.</li>
+  <li><a class="reference-link" href="#root/_help_GTwFsgaA0lCt">Collections</a>&nbsp;(e.g.&nbsp;<a
+    class="reference-link" href="#root/_help_81SGnPGMk7Xc">Geo Map</a>) will render
+    fully interactive, including creating new notes.</li>
   <li><a class="reference-link" href="#root/_help_m523cpzocqaD">Saved Search</a>&nbsp;will
     also display the results.</li>
   <li><a class="reference-link" href="#root/_help_1vHRoWCEjj0L">Web View</a>&nbsp;provides

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Insert buttons.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Insert buttons.html
@@ -14,13 +14,12 @@
   a category and a desired emoji to insert it.</p>
 <p>Emojis can also be searched by their English name and the skin tone can
   be selected via a combo box to the right.</p>
-<p>There is also the possibility of inserting emojis directly by typing
-  <code
-  spellcheck="false">:</code>followed by a name of an emoji, triggering the display of a list
-    of emojis. Simply use the arrow keys to select one and press <kbd>Enter</kbd> to
-    insert it.</p>
-<img src="1_Insert buttons_plus.png" width="272"
-height="187">
+<p>There is also the possibility of inserting emojis directly by typing <code
+  spellcheck="false">:</code> followed by a name of an emoji, triggering the
+  display of a list of emojis. Simply use the arrow keys to select one and
+  press <kbd>Enter</kbd> to insert it.</p>
+<img src="1_Insert buttons_plus.png"
+width="272" height="187">
 <h2>Symbols</h2>
 <figure class="image image-style-align-right">
   <img style="aspect-ratio:346/322;" src="1_Insert buttons_image.png"
@@ -59,24 +58,23 @@ height="187">
   width="18" height="16">button in the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>.</p>
 <img
 src="3_Insert buttons_image.png" width="502" height="95">
-  <p>Alternatively, it's possible to insert a horizontal ruler by typing
-    <code
-    spellcheck="false">---</code>.</p>
-  <h2>Page break</h2>
-  <figure class="image image-style-align-right">
-    <img style="aspect-ratio:371/79;" src="8_Insert buttons_image.png"
-    width="371" height="79">
-  </figure>
-  <p>Page breaks provide a way to force the next paragraph or block (table,
-    image, etc.) to be displayed onto the next page when printing (either to
-    a real printer to <a href="#root/_help_NRnIZmSMc5sj">when exporting to PDF</a>).</p>
-  <p>Page breaks are marked in the editor with the words <em>Page break</em>,
-    but they will not actually be shown when printed.</p>
-  <ul>
-    <li>To insert a page break, press the
-      <img src="Insert buttons_image.png"
-      width="20" height="19">in the formatting toolbar.</li>
-    <li>To insert many page breaks at once, insert a page break first, click on
-      it and press <kbd>Ctrl</kbd>+<kbd>C</kbd>. Then use <kbd>Ctrl</kbd>+<kbd>V</kbd>,
-      to paste as many times as needed.</li>
-  </ul>
+<p>Alternatively, it's possible to insert a horizontal ruler by typing <code
+  spellcheck="false">---</code>.</p>
+<h2>Page break</h2>
+<figure class="image image-style-align-right">
+  <img style="aspect-ratio:371/79;" src="8_Insert buttons_image.png"
+  width="371" height="79">
+</figure>
+<p>Page breaks provide a way to force the next paragraph or block (table,
+  image, etc.) to be displayed onto the next page when printing (either to
+  a real printer to <a href="#root/_help_NRnIZmSMc5sj">when exporting to PDF</a>).</p>
+<p>Page breaks are marked in the editor with the words <em>Page break</em>,
+  but they will not actually be shown when printed.</p>
+<ul>
+  <li>To insert a page break, press the
+    <img src="Insert buttons_image.png"
+    width="20" height="19">in the formatting toolbar.</li>
+  <li>To insert many page breaks at once, insert a page break first, click on
+    it and press <kbd>Ctrl</kbd>+<kbd>C</kbd>. Then use <kbd>Ctrl</kbd>+<kbd>V</kbd>,
+    to paste as many times as needed.</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Keyboard shortcuts.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Keyboard shortcuts.html
@@ -86,10 +86,10 @@
 <aside class="admonition tip">
   <p>This section of keyboard shortcuts presents a subset of the keyboard shortcuts
     as supported by the editor technology we are using,&nbsp;<a class="reference-link"
-    href="#root/_help_MI26XDLSAlCD">CKEditor</a>. The shortcuts were taken from the
-    <a
-    href="https://ckeditor.com/docs/ckeditor5/latest/features/accessibility.html#keyboard-shortcuts">official documentation</a>. Note that not all the shortcuts in the original
-      documentation are applicable (due to using a different configuration).</p>
+    href="#root/_help_MI26XDLSAlCD">CKEditor</a>. The shortcuts were taken from the <a
+    href="https://ckeditor.com/docs/ckeditor5/latest/features/accessibility.html#keyboard-shortcuts">official documentation</a>.
+    Note that not all the shortcuts in the original documentation are applicable
+    (due to using a different configuration).</p>
 </aside>
 <h3>Content editing</h3>
 <figure class="table">

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Link Previews.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Link Previews.html
@@ -75,55 +75,53 @@ class="admonition note">
   <p>A URL is only auto-converted when the pasted text <em>is</em> the URL. Links
     with a display name (e.g. <a href="https://triliumnotes.org">Trilium Notes website</a>)
     are left as plain links.</p>
-  </aside>
-  <h3>2. By using the "Link preview" toolbar button</h3>
-  <p>Click <strong>Link preview</strong> in the formatting toolbar to open the <em>Link preview</em> popup.
-    Paste the URL and choose the type of preview.</p>
-  <h2>Altering an existing link preview</h2>
-  <p>Click on an inserted link preview to select it, and a small toolbar will
-    appear with the following options:</p>
-  <ul>
-    <li>The normal link operations (opening in a new tab, copying the link, unlinking).</li>
-    <li>A button to edit the title of the link preview. This is especially useful
-      if the title is hidden behind a login screen.</li>
-    <li>A way to switch between the link preview modes (Inline, Card or Embed)
-      as well as to convert it to a normal link instead.
-      <ul>
-        <li>The Embed option is only enabled when the URL points to a supported service
-          (YouTube today).</li>
-      </ul>
-    </li>
-  </ul>
-  <h2>Where the preview data comes from</h2>
-  <p>When you insert a link preview, Trilium fetches metadata once and stores
-    it inside the note's HTML:</p>
-  <ul>
-    <li><strong>YouTube URLs</strong> — title, channel name, and thumbnail are
-      fetched via YouTube's public oEmbed endpoint.</li>
-    <li><strong>All other URLs</strong> — Trilium fetches the page and reads OpenGraph
-      tags (<code spellcheck="false">og:title</code>, <code spellcheck="false">og:description</code>,
-      <code
-      spellcheck="false">og:image</code>, <code spellcheck="false">og:site_name</code>), falling
-        back to the page's <code spellcheck="false">&lt;title&gt;</code> and
-        <code
-        spellcheck="false">&lt;meta name="description"&gt;</code>. The site's favicon is downloaded
-          and inlined.</li>
-  </ul>
-  <p>Because the data is stored in the note itself, link previews continue
-    to render correctly when you reopen the note, share/publish it, or export
-    to HTML — without any further network requests.</p>
-  <p>The metadata is captured <strong>at insertion time</strong> and is not automatically
-    refreshed. If the linked page later changes its title or thumbnail, you'll
-    need to re-insert the link to pick up the new values. To refresh a link,
-    simply create it again.</p>
-  <p>When accessing a&nbsp;<a class="reference-link" href="#root/_help_WOcw2SLH6tbX">Server Installation</a>,
-    the data is fetched from the remote URL by the server and not the client.</p>
-  <h2>Known limitations</h2>
-  <ul>
-    <li>The Embed display mode currently only supports YouTube. Other video and
-      media platforms fall back to a Card preview.</li>
-    <li>Pages that block automated fetches may produce a minimal preview (hostname
-      only).</li>
-    <li>Link previews require the Trilium server to reach the target URL, so they
-      won't generate previews for pages on networks the server can't see.</li>
-  </ul>
+</aside>
+<h3>2. By using the "Link preview" toolbar button</h3>
+<p>Click <strong>Link preview</strong> in the formatting toolbar to open the <em>Link preview</em> popup.
+  Paste the URL and choose the type of preview.</p>
+<h2>Altering an existing link preview</h2>
+<p>Click on an inserted link preview to select it, and a small toolbar will
+  appear with the following options:</p>
+<ul>
+  <li>The normal link operations (opening in a new tab, copying the link, unlinking).</li>
+  <li>A button to edit the title of the link preview. This is especially useful
+    if the title is hidden behind a login screen.</li>
+  <li>A way to switch between the link preview modes (Inline, Card or Embed)
+    as well as to convert it to a normal link instead.
+    <ul>
+      <li>The Embed option is only enabled when the URL points to a supported service
+        (YouTube today).</li>
+    </ul>
+  </li>
+</ul>
+<h2>Where the preview data comes from</h2>
+<p>When you insert a link preview, Trilium fetches metadata once and stores
+  it inside the note's HTML:</p>
+<ul>
+  <li><strong>YouTube URLs</strong> — title, channel name, and thumbnail are
+    fetched via YouTube's public oEmbed endpoint.</li>
+  <li><strong>All other URLs</strong> — Trilium fetches the page and reads OpenGraph
+    tags (<code spellcheck="false">og:title</code>, <code spellcheck="false">og:description</code>, <code
+    spellcheck="false">og:image</code>, <code spellcheck="false">og:site_name</code>),
+    falling back to the page's <code spellcheck="false">&lt;title&gt;</code> and <code
+    spellcheck="false">&lt;meta name="description"&gt;</code>. The site's favicon
+    is downloaded and inlined.</li>
+</ul>
+<p>Because the data is stored in the note itself, link previews continue
+  to render correctly when you reopen the note, share/publish it, or export
+  to HTML — without any further network requests.</p>
+<p>The metadata is captured <strong>at insertion time</strong> and is not automatically
+  refreshed. If the linked page later changes its title or thumbnail, you'll
+  need to re-insert the link to pick up the new values. To refresh a link,
+  simply create it again.</p>
+<p>When accessing a&nbsp;<a class="reference-link" href="#root/_help_WOcw2SLH6tbX">Server Installation</a>,
+  the data is fetched from the remote URL by the server and not the client.</p>
+<h2>Known limitations</h2>
+<ul>
+  <li>The Embed display mode currently only supports YouTube. Other video and
+    media platforms fall back to a Card preview.</li>
+  <li>Pages that block automated fetches may produce a minimal preview (hostname
+    only).</li>
+  <li>Link previews require the Trilium server to reach the target URL, so they
+    won't generate previews for pages on networks the server can't see.</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Backlinks.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Backlinks.html
@@ -32,50 +32,49 @@
 <aside
 class="admonition note">
   <p>Only some note types have their content scanned for links:&nbsp;<a class="reference-link"
-    href="#root/_help_iPIMuisry3hd">Text</a>,&nbsp;<a class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>,&nbsp;
-    <a
-    class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>&nbsp;and&nbsp;<a class="reference-link" href="#root/_help_GBBMSlVSOIGP">AI</a>&nbsp;chats.
-      A link written inside a&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note
-      is not registered and will not appear as a backlink on the target note.
-      A relation set manually on a code note does still count.</p>
-  </aside>
-  <h2>How entries are displayed</h2>
-  <p>Each entry names the note the reference comes from, followed by one of:</p>
-  <ul>
-    <li><strong>An excerpt</strong> of the surrounding content, with the link itself
-      highlighted. This is available for&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes
-      and for&nbsp;<a class="reference-link" href="#root/_help_GBBMSlVSOIGP">AI</a>&nbsp;chat
-      notes. Roughly 200 characters of context are quoted around the link, trimmed
-      with an ellipsis where the surrounding text is longer, and images are left
-      out.</li>
-    <li><strong>The name of the relation</strong>, for every other note type where
-      the source cannot be quoted. This is the case for&nbsp;<a class="reference-link"
-      href="#root/_help_iRwzGnHPzonm">Relation Map</a>&nbsp;notes and for any note
-      carrying a relation you defined yourself.</li>
-  </ul>
-  <p>A note is listed once per reference it makes, so a note that links to
-    the current one three times occupies three rows.</p>
-  <p>Of note:</p>
-  <ul>
-    <li>For AI chat notes, only the assistant's own prose is quoted. A chat that
-      reached the note purely through tool calls has nothing to quote and is
-      listed by relation name instead.</li>
-    <li>Excerpts are only generated for roughly the first 50 sources. On a heavily
-      referenced note, the remaining entries fall back to showing the relation
-      name.</li>
-  </ul>
-  <h2>Where backlinks are shown</h2>
-  <ul>
-    <li>In the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>&nbsp;of
-      the&nbsp;<a class="reference-link" href="#root/_help_RnaPdbciOfeq">Right Sidebar</a>,
-      as a dedicated section.</li>
-    <li>As a badge in the&nbsp;<a class="reference-link" href="#root/_help_AlJ73vBCjWDw">Status bar</a>&nbsp;showing
-      the number of backlinks. The badge only appears when the note is being
-      read normally (not in a revision or attachment view) and when there is
-      at least one backlink; pressing it opens the section above.</li>
-    <li>Incoming links are also drawn on the link map, see&nbsp;<a class="reference-link"
-      href="#root/_help_BCkXAVs63Ttv">Note Map (Link map, Tree map)</a>.</li>
-    <li>On the old layout, backlinks are showed as a dedicated button in the&nbsp;
-      <a
-      class="reference-link" href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;area.</li>
-  </ul>
+    href="#root/_help_iPIMuisry3hd">Text</a>,&nbsp;<a class="reference-link" href="#root/_help_6RM1Q7ppFVoj">Markdown</a>,&nbsp;<a
+    class="reference-link" href="#root/_help_iRwzGnHPzonm">Relation Map</a>&nbsp;and&nbsp;<a
+    class="reference-link" href="#root/_help_GBBMSlVSOIGP">AI</a>&nbsp;chats. A link
+    written inside a&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note
+    is not registered and will not appear as a backlink on the target note.
+    A relation set manually on a code note does still count.</p>
+</aside>
+<h2>How entries are displayed</h2>
+<p>Each entry names the note the reference comes from, followed by one of:</p>
+<ul>
+  <li><strong>An excerpt</strong> of the surrounding content, with the link itself
+    highlighted. This is available for&nbsp;<a class="reference-link" href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes
+    and for&nbsp;<a class="reference-link" href="#root/_help_GBBMSlVSOIGP">AI</a>&nbsp;chat
+    notes. Roughly 200 characters of context are quoted around the link, trimmed
+    with an ellipsis where the surrounding text is longer, and images are left
+    out.</li>
+  <li><strong>The name of the relation</strong>, for every other note type where
+    the source cannot be quoted. This is the case for&nbsp;<a class="reference-link"
+    href="#root/_help_iRwzGnHPzonm">Relation Map</a>&nbsp;notes and for any note
+    carrying a relation you defined yourself.</li>
+</ul>
+<p>A note is listed once per reference it makes, so a note that links to
+  the current one three times occupies three rows.</p>
+<p>Of note:</p>
+<ul>
+  <li>For AI chat notes, only the assistant's own prose is quoted. A chat that
+    reached the note purely through tool calls has nothing to quote and is
+    listed by relation name instead.</li>
+  <li>Excerpts are only generated for roughly the first 50 sources. On a heavily
+    referenced note, the remaining entries fall back to showing the relation
+    name.</li>
+</ul>
+<h2>Where backlinks are shown</h2>
+<ul>
+  <li>In the&nbsp;<a class="reference-link" href="#root/_help_KRlZFoIH0j6p">Connections tab</a>&nbsp;of
+    the&nbsp;<a class="reference-link" href="#root/_help_RnaPdbciOfeq">Right Sidebar</a>,
+    as a dedicated section.</li>
+  <li>As a badge in the&nbsp;<a class="reference-link" href="#root/_help_AlJ73vBCjWDw">Status bar</a>&nbsp;showing
+    the number of backlinks. The badge only appears when the note is being
+    read normally (not in a revision or attachment view) and when there is
+    at least one backlink; pressing it opens the section above.</li>
+  <li>Incoming links are also drawn on the link map, see&nbsp;<a class="reference-link"
+    href="#root/_help_BCkXAVs63Ttv">Note Map (Link map, Tree map)</a>.</li>
+  <li>On the old layout, backlinks are showed as a dedicated button in the&nbsp;<a
+    class="reference-link" href="#root/_help_XpOYSgsLkTJy">Floating buttons</a>&nbsp;area.</li>
+</ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Links/Internal (reference) links.html
@@ -11,10 +11,10 @@
     width="34" height="16">menu in the&nbsp;<a class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>.</li>
   <li>Searching for the title of the desired note to link. It's also possible
     to create new notes from this dialog by typing a non-existing note title
-    and selecting either <em>Create note</em>, which places it in the&nbsp;<a class="reference-link"
-    href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(today's day note, or the
-    top level, when no inbox is set), or <em>Create child note</em>, which places
-    it under the note being edited.</li>
+    and selecting either <em>Create note</em>, which places it in the&nbsp;<a
+    class="reference-link" href="#root/_help_S0Fos78ZfcY7">Note Inbox</a>&nbsp;(today's
+    day note, or the top level, when no inbox is set), or <em>Create child note</em>,
+    which places it under the note being edited.</li>
 </ol>
 <p>There are two link types which you can select when creating the link to
   the note:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Lists.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Lists.html
@@ -16,12 +16,10 @@
 <ul>
   <li>To create a new list:
     <ul>
-      <li>Bulleted list: Start a line with <code spellcheck="false">*</code> or
-        <code
-        spellcheck="false">-</code>followed by a space;</li>
-      <li>Numbered list: Start a line with <code spellcheck="false">1.</code> or
-        <code
-        spellcheck="false">1)</code>followed by a space;</li>
+      <li>Bulleted list: Start a line with <code spellcheck="false">*</code> or <code
+        spellcheck="false">-</code> followed by a space;</li>
+      <li>Numbered list: Start a line with <code spellcheck="false">1.</code> or <code
+        spellcheck="false">1)</code> followed by a space;</li>
       <li>To-do list: Start a line with <code spellcheck="false">- [ ]</code> for
         an unchecked item or <code spellcheck="false">[x]</code> for a checked item.</li>
     </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Markdown-like formatting.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Markdown-like formatting.html
@@ -2,11 +2,9 @@
   the Markdown equivalent. Note that this does not mean that&nbsp;<a class="reference-link"
   href="#root/_help_iPIMuisry3hd">Text</a>&nbsp;notes supports Markdown, these
   are just some convenience shortcuts.</p>
-<p>To import more complex formatting into text notes, consider using the
-  <a
-  href="#root/_help_dEHYtoWWi8ct"><em>Import from Markdown</em>
-    </a>function. For fully-fleged Markdown notes imports, consider using the
-    dedicated <a href="#root/_help_Oau6X9rCuegd">import</a> function.</p>
+<p>To import more complex formatting into text notes, consider using the <a
+  href="#root/_help_dEHYtoWWi8ct"><em>Import from Markdown</em></a> function. For
+  fully-fleged Markdown notes imports, consider using the dedicated <a href="#root/_help_Oau6X9rCuegd">import</a> function.</p>
 <ul>
   <li>For <a href="#root/_help_Gr6xFaF6ioJ5">headings:</a>
     <ul>
@@ -20,8 +18,7 @@
   </li>
   <li>For&nbsp;<a class="reference-link" href="#root/_help_Gr6xFaF6ioJ5">General formatting</a>:
     <ul>
-      <li><strong>Bold</strong>: Type <code spellcheck="false">**text**</code> or
-        <code
+      <li><strong>Bold</strong>: Type <code spellcheck="false">**text**</code> or <code
         spellcheck="false">__text__</code>
       </li>
       <li><em>Italic</em>: Type <code spellcheck="false">*text*</code> or <code spellcheck="false">_text_</code>
@@ -32,12 +29,10 @@
   </li>
   <li>For&nbsp;<a class="reference-link" href="#root/_help_S6Xx8QIWTV66">Lists</a>:
     <ul>
-      <li>Bulleted list: Start a line with <code spellcheck="false">*</code> or
-        <code
-        spellcheck="false">-</code>followed by a space;</li>
-      <li>Numbered list: Start a line with <code spellcheck="false">1.</code> or
-        <code
-        spellcheck="false">1)</code>followed by a space;</li>
+      <li>Bulleted list: Start a line with <code spellcheck="false">*</code> or <code
+        spellcheck="false">-</code> followed by a space;</li>
+      <li>Numbered list: Start a line with <code spellcheck="false">1.</code> or <code
+        spellcheck="false">1)</code> followed by a space;</li>
       <li>To-do list: Start a line with <code spellcheck="false">[ ]</code> for an
         unchecked item or <code spellcheck="false">[x]</code> for a checked item.</li>
     </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Math Equations.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Math Equations.html
@@ -15,17 +15,16 @@
   can be part of the text.</p>
 <h2>Keyboard shortcuts</h2>
 <p>If inserting equations frequently, using the <kbd>Ctrl</kbd>+<kbd>M</kbd> keyboard
-  shortcut can be more comfortable. Alternatively, type <code spellcheck="false">$$</code> or
-  <code
-  spellcheck="false">\[</code>to trigger the popup directly.</p>
+  shortcut can be more comfortable. Alternatively, type <code spellcheck="false">$$</code> or <code
+  spellcheck="false">\[</code> to trigger the popup directly.</p>
 <p>There is currently no quick way to turn an already typed-out equation,
   such as surrounding it with <code spellcheck="false">$</code> or pressing <kbd>Ctrl</kbd>+<kbd>M</kbd>.</p>
 <h2>Supported math features</h2>
 <p>Technically we are using the KaTeX library which allows for a subset of
-  the TeX format. To see the full list of supported features, consult the
-  <a
-  href="https://katex.org/docs/supported">Supported Functions</a>and the <a href="https://katex.org/docs/support_table">Support Table</a> from
-    the official documentation.</p>
+  the TeX format. To see the full list of supported features, consult the <a
+  href="https://katex.org/docs/supported">Supported Functions</a> and the <a
+  href="https://katex.org/docs/support_table">Support Table</a> from the official
+  documentation.</p>
 <h2>Markdown support</h2>
 <p>Math equations will be preserved when exporting to or importing from Markdown,
   surrounded by <code spellcheck="false">$</code> characters for inline math

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Other features.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Other features.html
@@ -3,8 +3,7 @@
   <img style="aspect-ratio:201/124;" src="6_Other features_image.png"
   width="201" height="124">
 </figure>
-<p>Paragraphs can be indented to the right using the &nbsp;button from the&nbsp;
-  <a
+<p>Paragraphs can be indented to the right using the &nbsp;button from the&nbsp;<a
   class="reference-link" href="#root/_help_nRhnJkTT8cPs">Formatting toolbar</a>.</p>
 <ul>
   <li>Press

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Spell Check.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Spell Check.html
@@ -18,69 +18,68 @@
 <aside
 class="admonition note">
   <p>The changes take effect only after restarting the application.</p>
-  </aside>
-  <h3>Custom dictionary</h3>
-  <aside class="admonition tip">
-    <p>This function is available starting with Trilium v0.103.0.</p>
-  </aside>
-  <p>Words you add to the dictionary (e.g. via the right-click context menu
-    → "Add to dictionary") are stored in a <strong>synced note</strong> inside
-    Trilium. This means your custom dictionary automatically syncs across all
-    your devices.</p>
-  <p>You can view and edit the dictionary directly from <em>Settings</em> → <em>Spell Check</em> → <em>Custom Dictionary</em> → <em>Edit dictionary</em>.
-    This opens the underlying note, which contains one word per line. You can
-    add, remove, or modify entries as you like.</p>
-  <aside class="admonition note">
-    <p>Changes to the custom dictionary (whether from the editor or the context
-      menu) take effect after restarting the application.</p>
-  </aside>
-  <h4>How the custom dictionary works</h4>
-  <ul>
-    <li>When you right-click a misspelled word and choose "Add to dictionary",
-      the word is saved both to Electron's local spellchecker and to the synced
-      dictionary note.</li>
-    <li>On startup, Trilium loads all words from the dictionary note into the
-      spellchecker session.</li>
-    <li>If Trilium detects words in Electron's local dictionary but the dictionary
-      note is empty (e.g. on first use), it performs a <strong>one-time import</strong> of
-      those words into the note.</li>
-    <li>Words that are in Electron's local dictionary but <em>not</em> in the note
-      (e.g. you removed them manually) are cleaned up from the local dictionary
-      on startup.</li>
-  </ul>
-  <h4>Known limitations</h4>
-  <p>On Windows and macOS, Electron delegates "Add to dictionary" to the operating
-    system's user dictionary. This means:</p>
-  <ul>
-    <li>Words added via the context menu are also written to the OS-level dictionary
-      (e.g. <code spellcheck="false">%APPDATA%\Microsoft\Spelling\&lt;language&gt;\default.dic</code> on
-      Windows).</li>
-    <li><strong>Removing a word</strong> from the Trilium dictionary note prevents
-      it from being loaded into the spellchecker on next startup, but does <em>not</em> remove
-      it from the OS dictionary. The word may still be accepted by the OS spellchecker
-      until you remove it from the OS dictionary manually.</li>
-  </ul>
-  <h2>Web browser</h2>
-  <p>When accessing Trilium through a web browser, spell checking is handled
-    entirely by the browser itself. Trilium does not control the browser's
-    spellchecker — language selection, dictionaries, and all other settings
-    are managed through your browser's preferences.</p>
-  <p>The Spell Check settings page in Trilium will indicate that these options
-    apply only to desktop builds.</p>
-  <h2>Frequently asked questions</h2>
-  <h3>Do I need to restart after every change?</h3>
-  <p>Yes. Spell check language selection and the custom dictionary are loaded
-    once at startup. Any changes require a restart to take effect.</p>
-  <h3>Can I use multiple spell check languages at the same time?</h3>
-  <p>Yes. Select as many languages as you need from the checklist. The spellchecker
-    will accept words from any of the selected languages.</p>
-  <h3>My custom words disappeared after syncing to a new device — what happened?</h3>
-  <p>On the first launch of a new device, Trilium may import existing local
-    dictionary words into the note. If the note already has words from another
-    device (via sync), those are preserved. Make sure sync completes before
-    restarting the application on a new device.</p>
-  <h3>I removed a word from the dictionary note but it's still accepted</h3>
-  <p>This is likely due to the OS-level dictionary retaining the word (see
-    <a
-    href="#known-limitations">Known limitations</a>above). You can manually remove it from your operating
-      system's user dictionary.</p>
+</aside>
+<h3>Custom dictionary</h3>
+<aside class="admonition tip">
+  <p>This function is available starting with Trilium v0.103.0.</p>
+</aside>
+<p>Words you add to the dictionary (e.g. via the right-click context menu
+  → "Add to dictionary") are stored in a <strong>synced note</strong> inside
+  Trilium. This means your custom dictionary automatically syncs across all
+  your devices.</p>
+<p>You can view and edit the dictionary directly from <em>Settings</em> → <em>Spell Check</em> → <em>Custom Dictionary</em> → <em>Edit dictionary</em>.
+  This opens the underlying note, which contains one word per line. You can
+  add, remove, or modify entries as you like.</p>
+<aside class="admonition note">
+  <p>Changes to the custom dictionary (whether from the editor or the context
+    menu) take effect after restarting the application.</p>
+</aside>
+<h4>How the custom dictionary works</h4>
+<ul>
+  <li>When you right-click a misspelled word and choose "Add to dictionary",
+    the word is saved both to Electron's local spellchecker and to the synced
+    dictionary note.</li>
+  <li>On startup, Trilium loads all words from the dictionary note into the
+    spellchecker session.</li>
+  <li>If Trilium detects words in Electron's local dictionary but the dictionary
+    note is empty (e.g. on first use), it performs a <strong>one-time import</strong> of
+    those words into the note.</li>
+  <li>Words that are in Electron's local dictionary but <em>not</em> in the note
+    (e.g. you removed them manually) are cleaned up from the local dictionary
+    on startup.</li>
+</ul>
+<h4>Known limitations</h4>
+<p>On Windows and macOS, Electron delegates "Add to dictionary" to the operating
+  system's user dictionary. This means:</p>
+<ul>
+  <li>Words added via the context menu are also written to the OS-level dictionary
+    (e.g. <code spellcheck="false">%APPDATA%\Microsoft\Spelling\&lt;language&gt;\default.dic</code> on
+    Windows).</li>
+  <li><strong>Removing a word</strong> from the Trilium dictionary note prevents
+    it from being loaded into the spellchecker on next startup, but does <em>not</em> remove
+    it from the OS dictionary. The word may still be accepted by the OS spellchecker
+    until you remove it from the OS dictionary manually.</li>
+</ul>
+<h2>Web browser</h2>
+<p>When accessing Trilium through a web browser, spell checking is handled
+  entirely by the browser itself. Trilium does not control the browser's
+  spellchecker — language selection, dictionaries, and all other settings
+  are managed through your browser's preferences.</p>
+<p>The Spell Check settings page in Trilium will indicate that these options
+  apply only to desktop builds.</p>
+<h2>Frequently asked questions</h2>
+<h3>Do I need to restart after every change?</h3>
+<p>Yes. Spell check language selection and the custom dictionary are loaded
+  once at startup. Any changes require a restart to take effect.</p>
+<h3>Can I use multiple spell check languages at the same time?</h3>
+<p>Yes. Select as many languages as you need from the checklist. The spellchecker
+  will accept words from any of the selected languages.</p>
+<h3>My custom words disappeared after syncing to a new device — what happened?</h3>
+<p>On the first launch of a new device, Trilium may import existing local
+  dictionary words into the note. If the note already has words from another
+  device (via sync), those are preserved. Make sure sync completes before
+  restarting the application on a new device.</p>
+<h3>I removed a word from the dictionary note but it's still accepted</h3>
+<p>This is likely due to the OS-level dictionary retaining the word (see <a
+  href="#known-limitations">Known limitations</a> above). You can manually
+  remove it from your operating system's user dictionary.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Tables.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Tables.html
@@ -10,185 +10,185 @@
 <p>When a table is selected, a special formatting toolbar will appear:</p>
 <img
 src="10_Tables_image.png" width="384" height="100">
-  <h2>Navigating a table</h2>
-  <ul>
-    <li>Using the mouse:
-      <ul>
-        <li>Click on a cell to focus it.</li>
-        <li>Click the
-          <img src="11_Tables_image.png" width="28"
-          height="27">button at the top or the bottom of a table to insert an empty paragraph
-          near it.</li>
-        <li>Click the
-          <img src="5_Tables_image.png" width="24"
-          height="26">button at the top-left of the table to select it entirely (for easy copy-pasting
-          or cutting) or drag and drop it to relocate the table.</li>
-      </ul>
-    </li>
-    <li>Using the keyboard:
-      <ul>
-        <li>Use the arrow keys on the keyboard to easily navigate between cells.</li>
-        <li>It's also possible to use <kbd>Tab</kbd> to go to the next cell and Shift+Tab
-          to go to the previous cell.</li>
-        <li>Unlike arrow keys, pressing <kbd>Tab</kbd> at the end of the table (last
-          row, last column) will create a new row automatically.</li>
-        <li>To select multiple cells, hold <kbd>Shift</kbd> while using the arrow keys.</li>
-      </ul>
-    </li>
-  </ul>
-  <h2>Resizing cells</h2>
-  <ul>
-    <li>Columns can be resized by hovering the mouse over the border of two adjacent
-      cells and dragging it.</li>
-    <li>By default, the row height is not adjustable using the mouse, but it can
-      be configured from the cell settings (see below).</li>
-    <li>To adjust exactly the width (in pixels or percentages) of a cell, select
-      the
-      <img src="8_Tables_image.png" width="19" height="19">button.</li>
-  </ul>
-  <h2>Inserting new rows and new columns</h2>
-  <ul>
-    <li>To insert a new column, click on a desired location, then press the
-      <img
-      src="Tables_image.png" width="18" height="20">button from the formatting toolbar and select <em>Insert column left or right.</em>
-    </li>
-    <li>To insert a new row, click on a desired location, then press the
-      <img src="7_Tables_image.png"
-      width="20" height="18">button and select <em>Insert row above</em> or <em>below</em>.
-      <ul>
-        <li>A quicker alternative to creating a new row while at the end of the table
-          is to press the <kbd>Tab</kbd> key.</li>
-      </ul>
-    </li>
-  </ul>
-  <h2>Merging cells</h2>
-  <p>To merge two or more cells together, simply select them via drag &amp;
-    drop and press the
-    <img src="1_Tables_image.png"
-    width="19" height="19">button from the formatting toolbar.</p>
-  <p>More options are available by pressing the arrow next to it:</p>
-  <ul>
-    <li>Click on a single cell and select Merge cell up/down/right/left to merge
-      with an adjacent cell.</li>
-    <li>Select <em>Split cell vertically</em> or <em>horizontally</em>, to split
-      a cell into multiple cells (can also be used to undo a merge).</li>
-  </ul>
-  <h2>Table properties</h2>
-  <figure class="image image-style-align-right">
-    <img style="aspect-ratio:312/311;" src="2_Tables_image.png"
-    width="312" height="311">
-  </figure>
-  <p>The table properties can be accessed via the
-    <img src="13_Tables_image.png"
-    width="19" height="19">button and allows for the following adjustments:</p>
-  <ul>
-    <li>Border (not the border of the cells, but the outer rim of the table),
-      which includes the style (single, double), color and width.</li>
-    <li>The background color, with none set by default.</li>
-    <li>The width and height of the table in percentage (must end with <code spellcheck="false">%</code>)
-      or pixels (must end with <code spellcheck="false">px</code>).</li>
-    <li>The alignment of the table.
-      <ul>
-        <li>Left or right-aligned, case in which the text will flow next to it.</li>
-        <li>Centered, case in which text will avoid the table, regardless of the table
-          width.</li>
-      </ul>
-    </li>
-  </ul>
-  <p>The table will immediately update to reflect the changes, but the <em>Save</em> button
-    must be pressed for the changes to persist.</p>
-  <h2>Cell properties</h2>
-  <figure class="image image-style-align-right">
-    <img style="aspect-ratio:320/386;" src="3_Tables_image.png"
-    width="320" height="386">
-  </figure>
-  <p>Similarly to table properties, the
-    <img src="12_Tables_image.png"
-    width="19" height="19">button opens a popup which adjusts the styling of one or more cells (based
-    on the user's selection).</p>
-  <p>The following options can be adjusted:</p>
-  <ul>
-    <li>The border style, color and width (same as table properties), but applying
-      to the current cell only.</li>
-    <li>The background color, with none set by default.</li>
-    <li>The width and height of the cell in percentage (must end with <code spellcheck="false">%</code>)
-      or pixels (must end with <code spellcheck="false">px</code>).</li>
-    <li>The padding (the distance of the text compared to the cell's borders).</li>
-    <li>The alignment of the text, both horizontally (left, centered, right, justified)
-      and vertically (top, middle or bottom).</li>
-  </ul>
-  <p>The cell will immediately update to reflect the changes, but the <em>Save</em> button
-    must be pressed for the changes to persist.</p>
-  <h2>Caption</h2>
-  <p>Press the
-    <img src="4_Tables_image.png" width="18"
-    height="17">button to insert a caption or a text description of the table, which is
-    going to be displayed above the table.</p>
-  <h2>Table borders</h2>
-  <p>By default, tables will come with a predefined gray border.</p>
-  <p>To adjust the borders, follow these steps:</p>
-  <ol>
-    <li>Select the table.</li>
-    <li>In the floating panel, select the <em>Table properties</em> option (
-      <img
-      src="14_Tables_image.png" width="21" height="21">).
-        <ol>
-          <li>Look for the <em>Border</em> section at the top of the newly opened panel.</li>
-          <li>This will control the outer borders of the table.</li>
-          <li>Select a style for the border. Generally <em>Single</em> is the desirable
-            option.</li>
-          <li>Select a color for the border.</li>
-          <li>Select a width for the border, expressed in pixels.</li>
-        </ol>
-    </li>
-    <li>Select all the cells of the table and then press the <em>Cell properties</em> option
-      (
-      <img src="9_Tables_image.png" width="21" height="21">).
-      <ol>
-        <li>This will control the inner borders of the table, at cell level.</li>
-        <li>Note that it's possible to change the borders individually by selecting
-          one or more cells, case in which it will only change the borders that intersect
-          these cells.</li>
-        <li>Repeat the same steps as from step (2).</li>
-      </ol>
-    </li>
-  </ol>
-  <h3>Tables with invisible borders</h3>
-  <p>Tables can be set to have invisible borders in order to allow for basic
-    layouts (columns, grids) of text or <a href="#root/_help_mT0HEkOsz6i1">images</a> without
-    the distraction of their border:</p>
-  <ol>
-    <li>First insert a table with the desired number of columns and rows.</li>
-    <li>Select the entire table.</li>
-    <li>In <em>Table properties</em>, set:
-      <ol>
-        <li><em>Style</em> to <em>Single</em>
-        </li>
-        <li><em>Color</em> to <code spellcheck="false">transparent</code>
-        </li>
-        <li>Width to <code spellcheck="false">1px</code>.</li>
-      </ol>
-    </li>
-    <li>In Cell Properties, set the same as on the previous step.</li>
-  </ol>
-  <h2>Table indentation</h2>
-  <p>Since v0.104.1, tables can be indented as a block (the whole table moves,
-    rather than just the content of a cell).</p>
-  <ol>
-    <li>Click the
-      <img src="5_Tables_image.png" width="24"
-      height="26">button to select the entire table. Otherwise, the indentation applies
-      only to the current cell's content.</li>
-    <li>Press <kbd>Tab</kbd> to increase the indent, or <kbd>Shift</kbd>+<kbd>Tab</kbd> to
-      decrease it. Alternatively, use the indentation buttons in the formatting
-      toolbar.</li>
-  </ol>
-  <p>Markdown does not support indented tables, so the indentation is lost
-    when converting to Markdown.</p>
-  <h2>Markdown import/export</h2>
-  <p>Simple tables are exported in GitHub-flavored Markdown format (e.g. a
-    series of <code spellcheck="false">|</code> items). If the table is found
-    to be more complex (it contains HTML elements, has custom sizes or images),
-    the table is converted to a HTML one instead.</p>
-  <p>Generally formatting loss should be minimal when exported to Markdown
-    due to the fallback to HTML formatting.</p>
+<h2>Navigating a table</h2>
+<ul>
+  <li>Using the mouse:
+    <ul>
+      <li>Click on a cell to focus it.</li>
+      <li>Click the
+        <img src="11_Tables_image.png" width="28"
+        height="27">button at the top or the bottom of a table to insert an empty paragraph
+        near it.</li>
+      <li>Click the
+        <img src="5_Tables_image.png" width="24"
+        height="26">button at the top-left of the table to select it entirely (for easy copy-pasting
+        or cutting) or drag and drop it to relocate the table.</li>
+    </ul>
+  </li>
+  <li>Using the keyboard:
+    <ul>
+      <li>Use the arrow keys on the keyboard to easily navigate between cells.</li>
+      <li>It's also possible to use <kbd>Tab</kbd> to go to the next cell and Shift+Tab
+        to go to the previous cell.</li>
+      <li>Unlike arrow keys, pressing <kbd>Tab</kbd> at the end of the table (last
+        row, last column) will create a new row automatically.</li>
+      <li>To select multiple cells, hold <kbd>Shift</kbd> while using the arrow keys.</li>
+    </ul>
+  </li>
+</ul>
+<h2>Resizing cells</h2>
+<ul>
+  <li>Columns can be resized by hovering the mouse over the border of two adjacent
+    cells and dragging it.</li>
+  <li>By default, the row height is not adjustable using the mouse, but it can
+    be configured from the cell settings (see below).</li>
+  <li>To adjust exactly the width (in pixels or percentages) of a cell, select
+    the
+    <img src="8_Tables_image.png" width="19" height="19">button.</li>
+</ul>
+<h2>Inserting new rows and new columns</h2>
+<ul>
+  <li>To insert a new column, click on a desired location, then press the
+    <img
+    src="Tables_image.png" width="18" height="20">button from the formatting toolbar and select <em>Insert column left or right.</em>
+  </li>
+  <li>To insert a new row, click on a desired location, then press the
+    <img src="7_Tables_image.png"
+    width="20" height="18">button and select <em>Insert row above</em> or <em>below</em>.
+    <ul>
+      <li>A quicker alternative to creating a new row while at the end of the table
+        is to press the <kbd>Tab</kbd> key.</li>
+    </ul>
+  </li>
+</ul>
+<h2>Merging cells</h2>
+<p>To merge two or more cells together, simply select them via drag &amp;
+  drop and press the
+  <img src="1_Tables_image.png"
+  width="19" height="19">button from the formatting toolbar.</p>
+<p>More options are available by pressing the arrow next to it:</p>
+<ul>
+  <li>Click on a single cell and select Merge cell up/down/right/left to merge
+    with an adjacent cell.</li>
+  <li>Select <em>Split cell vertically</em> or <em>horizontally</em>, to split
+    a cell into multiple cells (can also be used to undo a merge).</li>
+</ul>
+<h2>Table properties</h2>
+<figure class="image image-style-align-right">
+  <img style="aspect-ratio:312/311;" src="2_Tables_image.png"
+  width="312" height="311">
+</figure>
+<p>The table properties can be accessed via the
+  <img src="13_Tables_image.png"
+  width="19" height="19">button and allows for the following adjustments:</p>
+<ul>
+  <li>Border (not the border of the cells, but the outer rim of the table),
+    which includes the style (single, double), color and width.</li>
+  <li>The background color, with none set by default.</li>
+  <li>The width and height of the table in percentage (must end with <code spellcheck="false">%</code>)
+    or pixels (must end with <code spellcheck="false">px</code>).</li>
+  <li>The alignment of the table.
+    <ul>
+      <li>Left or right-aligned, case in which the text will flow next to it.</li>
+      <li>Centered, case in which text will avoid the table, regardless of the table
+        width.</li>
+    </ul>
+  </li>
+</ul>
+<p>The table will immediately update to reflect the changes, but the <em>Save</em> button
+  must be pressed for the changes to persist.</p>
+<h2>Cell properties</h2>
+<figure class="image image-style-align-right">
+  <img style="aspect-ratio:320/386;" src="3_Tables_image.png"
+  width="320" height="386">
+</figure>
+<p>Similarly to table properties, the
+  <img src="12_Tables_image.png"
+  width="19" height="19">button opens a popup which adjusts the styling of one or more cells (based
+  on the user's selection).</p>
+<p>The following options can be adjusted:</p>
+<ul>
+  <li>The border style, color and width (same as table properties), but applying
+    to the current cell only.</li>
+  <li>The background color, with none set by default.</li>
+  <li>The width and height of the cell in percentage (must end with <code spellcheck="false">%</code>)
+    or pixels (must end with <code spellcheck="false">px</code>).</li>
+  <li>The padding (the distance of the text compared to the cell's borders).</li>
+  <li>The alignment of the text, both horizontally (left, centered, right, justified)
+    and vertically (top, middle or bottom).</li>
+</ul>
+<p>The cell will immediately update to reflect the changes, but the <em>Save</em> button
+  must be pressed for the changes to persist.</p>
+<h2>Caption</h2>
+<p>Press the
+  <img src="4_Tables_image.png" width="18"
+  height="17">button to insert a caption or a text description of the table, which is
+  going to be displayed above the table.</p>
+<h2>Table borders</h2>
+<p>By default, tables will come with a predefined gray border.</p>
+<p>To adjust the borders, follow these steps:</p>
+<ol>
+  <li>Select the table.</li>
+  <li>In the floating panel, select the <em>Table properties</em> option (
+    <img
+    src="14_Tables_image.png" width="21" height="21">).
+    <ol>
+      <li>Look for the <em>Border</em> section at the top of the newly opened panel.</li>
+      <li>This will control the outer borders of the table.</li>
+      <li>Select a style for the border. Generally <em>Single</em> is the desirable
+        option.</li>
+      <li>Select a color for the border.</li>
+      <li>Select a width for the border, expressed in pixels.</li>
+    </ol>
+  </li>
+  <li>Select all the cells of the table and then press the <em>Cell properties</em> option
+    (
+    <img src="9_Tables_image.png" width="21" height="21">).
+    <ol>
+      <li>This will control the inner borders of the table, at cell level.</li>
+      <li>Note that it's possible to change the borders individually by selecting
+        one or more cells, case in which it will only change the borders that intersect
+        these cells.</li>
+      <li>Repeat the same steps as from step (2).</li>
+    </ol>
+  </li>
+</ol>
+<h3>Tables with invisible borders</h3>
+<p>Tables can be set to have invisible borders in order to allow for basic
+  layouts (columns, grids) of text or <a href="#root/_help_mT0HEkOsz6i1">images</a> without
+  the distraction of their border:</p>
+<ol>
+  <li>First insert a table with the desired number of columns and rows.</li>
+  <li>Select the entire table.</li>
+  <li>In <em>Table properties</em>, set:
+    <ol>
+      <li><em>Style</em> to <em>Single</em>
+      </li>
+      <li><em>Color</em> to <code spellcheck="false">transparent</code>
+      </li>
+      <li>Width to <code spellcheck="false">1px</code>.</li>
+    </ol>
+  </li>
+  <li>In Cell Properties, set the same as on the previous step.</li>
+</ol>
+<h2>Table indentation</h2>
+<p>Since v0.104.1, tables can be indented as a block (the whole table moves,
+  rather than just the content of a cell).</p>
+<ol>
+  <li>Click the
+    <img src="5_Tables_image.png" width="24"
+    height="26">button to select the entire table. Otherwise, the indentation applies
+    only to the current cell's content.</li>
+  <li>Press <kbd>Tab</kbd> to increase the indent, or <kbd>Shift</kbd>+<kbd>Tab</kbd> to
+    decrease it. Alternatively, use the indentation buttons in the formatting
+    toolbar.</li>
+</ol>
+<p>Markdown does not support indented tables, so the indentation is lost
+  when converting to Markdown.</p>
+<h2>Markdown import/export</h2>
+<p>Simple tables are exported in GitHub-flavored Markdown format (e.g. a
+  series of <code spellcheck="false">|</code> items). If the table is found
+  to be more complex (it contains HTML elements, has custom sizes or images),
+  the table is converted to a HTML one instead.</p>
+<p>Generally formatting loss should be minimal when exported to Markdown
+  due to the fallback to HTML formatting.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Text Snippets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/Text Snippets.html
@@ -34,8 +34,7 @@
 <aside class="admonition tip">
   <p>A newly created snippet doesn't appear? Generally it takes up to a few
     seconds to refresh the list of templates once you make a change.</p>
-  <p>If this doesn't happen, <a href="#root/_help_s8alTXmpFR61">reload the application</a> and
-    <a
+  <p>If this doesn't happen, <a href="#root/_help_s8alTXmpFR61">reload the application</a> and <a
     href="#root/_help_wy8So3yZZlH9">report the issue</a>to us.&nbsp;</p>
 </aside>
 <h2>Limitations</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/To-do Lists.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Note Types/Text/To-do Lists.html
@@ -16,9 +16,9 @@
   href="#root/_help_6RM1Q7ppFVoj">Markdown</a>&nbsp;notes, in both directions.</p>
 <h3>Customizing the extended task states</h3>
 <p>Task states are customizable: you can reorder them, create new ones with
-  different colors and symbols, or delete the ones you don't need. See&nbsp;
-  <a
-  class="reference-link" href="#root/_help_i16PM6A7GXdU">Customizing to-do task states</a>&nbsp;for more details.</p>
+  different colors and symbols, or delete the ones you don't need. See&nbsp;<a
+  class="reference-link" href="#root/_help_i16PM6A7GXdU">Customizing to-do task states</a>&nbsp;for
+  more details.</p>
 <h2>Keyboard shortcuts</h2>
 <p>When at the beginning on an empty paragraph, type the following to insert
   a to-do list:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting.html
@@ -33,15 +33,13 @@
   by Trilium runtime so when we restart Trilium, button won't be there.</p>
 <p>We need to execute it every time Trilium starts up, but we probably don't
   want to have to manually click on play button on every start up.</p>
-<p>The solution is marked by red circle at the bottom - this note has <a href="#root/_help_zEY4DaJG4YT5">label</a> 
-  <code
-  spellcheck="false">#run=frontendStartup</code>- this is one of the "system" labels which
-    Trilium understands. As you might guess, this will cause all such labeled
-    script notes to be executed once Trilium frontend starts up.</p>
-<p>(<code spellcheck="false">#run=frontendStartup</code> does not work for
-  <a
-  href="#root/_help_RDslemsQ6gCp">Mobile frontend</a>- if you want to have scripts running there, give the
-    script <code spellcheck="false">#run=mobileStartup</code> label).</p>
+<p>The solution is marked by red circle at the bottom - this note has <a href="#root/_help_zEY4DaJG4YT5">label</a>  <code
+  spellcheck="false">#run=frontendStartup</code> - this is one of the "system"
+  labels which Trilium understands. As you might guess, this will cause all
+  such labeled script notes to be executed once Trilium frontend starts up.</p>
+<p>(<code spellcheck="false">#run=frontendStartup</code> does not work for <a
+  href="#root/_help_RDslemsQ6gCp">Mobile frontend</a> - if you want to have scripts
+  running there, give the script <code spellcheck="false">#run=mobileStartup</code> label).</p>
 <h3>Execute button</h3>
 <p>Runnable code notes (frontend or backend) and saved SQL consoles can optionally
   have a dedicated execute button alongside a description.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Backend scripts/Backend Events.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Backend scripts/Backend Events.html
@@ -146,14 +146,12 @@
   </table>
 </figure>
 <h2>Origin entity</h2>
-<p>When a script is run by an event such as the ones described above,
-  <code
-  spellcheck="false">api.originEntity</code>will get populated with the note, branch or attribute
-    that triggered the change.</p>
+<p>When a script is run by an event such as the ones described above, <code
+  spellcheck="false">api.originEntity</code> will get populated with the note,
+  branch or attribute that triggered the change.</p>
 <p>For example, here's a script with <code spellcheck="false">~runOnAttributeChange</code> which
-  automatically changes the color of a note based on the value of the
-  <code
-  spellcheck="false">mycategory</code>label:</p><pre><code class="language-text-javascript">const attr = api.originEntity;
+  automatically changes the color of a note based on the value of the <code
+  spellcheck="false">mycategory</code> label:</p><pre><code class="language-text-javascript">const attr = api.originEntity;
 if (attr.name !== "mycategory") return;
 const note = api.getNote(attr.noteId);
 if (attr.value === "Health") {

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Backend scripts/Server-side imports.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Backend scripts/Server-side imports.html
@@ -4,6 +4,5 @@ api.dayjs.extend(isBetween)</code></pre>
 <p>For newer versions, Node.js imports are <strong>not officially supported anymore</strong>,
   since we've added a bundler which makes it more difficult to reuse dependencies.</p>
 <p>Theoretically it's still possible to use imports by manually setting up
-  a <code spellcheck="false">node_modules</code> in the server directory via
-  <code
-  spellcheck="false">npm</code>or <code spellcheck="false">pnpm</code>.</p>
+  a <code spellcheck="false">node_modules</code> in the server directory via <code
+  spellcheck="false">npm</code> or <code spellcheck="false">pnpm</code>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.102.0 Upgrade to jQuery 4.0.0.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.102.0 Upgrade to jQuery 4.0.0.html
@@ -1,26 +1,20 @@
 <p>jQuery 4 removes legacy browser support (such as IE11 support), but it
   also removes some APIs that are considered deprecated such as:</p>
 <blockquote>
-  <p><code spellcheck="false">jQuery.isArray</code>, <code spellcheck="false">jQuery.parseJSON</code>,
-    <code
-    spellcheck="false">jQuery.trim</code>, <code spellcheck="false">jQuery.type</code>, <code spellcheck="false">jQuery.now</code>,
-      <code
-      spellcheck="false">jQuery.isNumeric</code>, <code spellcheck="false">jQuery.isFunction</code>,
-        <code
-        spellcheck="false">jQuery.isWindow</code>, <code spellcheck="false">jQuery.camelCase</code>,
-          <code
-          spellcheck="false">jQuery.nodeName</code>, <code spellcheck="false">jQuery.cssNumber</code>,
-            <code
-            spellcheck="false">jQuery.cssProps</code>, and <code spellcheck="false">jQuery.fx.interval</code>.</p>
-  <p>Use native equivalents like <code spellcheck="false">Array.isArray()</code>,
-    <code
+  <p><code spellcheck="false">jQuery.isArray</code>, <code spellcheck="false">jQuery.parseJSON</code>, <code
+    spellcheck="false">jQuery.trim</code>, <code spellcheck="false">jQuery.type</code>, <code
+    spellcheck="false">jQuery.now</code>, <code spellcheck="false">jQuery.isNumeric</code>, <code
+    spellcheck="false">jQuery.isFunction</code>, <code spellcheck="false">jQuery.isWindow</code>, <code
+    spellcheck="false">jQuery.camelCase</code>, <code spellcheck="false">jQuery.nodeName</code>, <code
+    spellcheck="false">jQuery.cssNumber</code>, <code spellcheck="false">jQuery.cssProps</code>,
+    and <code spellcheck="false">jQuery.fx.interval</code>.</p>
+  <p>Use native equivalents like <code spellcheck="false">Array.isArray()</code>, <code
     spellcheck="false">JSON.parse()</code>, <code spellcheck="false">String.prototype.trim()</code>,
-      and <code spellcheck="false">Date.now()</code> instead.</p>
+    and <code spellcheck="false">Date.now()</code> instead.</p>
 </blockquote>
 <p>This may affect custom scripts if they (or the custom jQuery libraries
   used) depend on the deprecated APIs.</p>
-<p>Note that Trilium polyfills <code spellcheck="false">jQuery.isArray</code>,
-  <code
-  spellcheck="false">isFunction</code>and <code spellcheck="false">isPlainObject</code> because
-    they were required by one of our dependencies (the autocomplete).</p>
+<p>Note that Trilium polyfills <code spellcheck="false">jQuery.isArray</code>, <code
+  spellcheck="false">isFunction</code> and <code spellcheck="false">isPlainObject</code> because
+  they were required by one of our dependencies (the autocomplete).</p>
 <p>For more information, consult <a href="https://blog.jquery.com/2026/01/17/jquery-4-0-0/">the official blog post</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.103.0 Removal of axios.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.103.0 Removal of axios.html
@@ -11,9 +11,8 @@
   trojan. The Trilium's main developer almost got compromised, but <code spellcheck="false">pnpm</code> not
   trusting unknown post-install scripts successfully avoided that.</p>
 <h2>Migration</h2>
-<p>Replace <code spellcheck="false">api.axios</code> calls with the native
-  <code
-  spellcheck="false">fetch()</code>API.</p>
+<p>Replace <code spellcheck="false">api.axios</code> calls with the native <code
+  spellcheck="false">fetch()</code> API.</p>
 <h3><code spellcheck="false">GET</code> calls</h3>
 <p>Before (Axios):</p><pre><code class="language-text-javascript">const response = await api.axios.get('https://api.example.com/data');
 const data = response.data;</code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.103.0 `cheerio` is now deprecated.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.103.0 `cheerio` is now deprecated.html
@@ -1,15 +1,14 @@
 <p>The <code spellcheck="false">api.cheerio</code> library is deprecated and
   will be removed in a future version.</p>
 <aside class="admonition note">
-  <p><code spellcheck="false">cheerio</code> was removed in v0.106.0. See
-    <a
-    class="reference-link" href="#root/_help_kTx7WqLdZ3Ry">v0.106.0: Removal of cheerio</a>for the full migration guide.</p>
+  <p><code spellcheck="false">cheerio</code> was removed in v0.106.0. See <a
+    class="reference-link" href="#root/_help_kTx7WqLdZ3Ry">v0.106.0: Removal of cheerio</a> for
+    the full migration guide.</p>
 </aside>
 <h2>Reasoning</h2>
 <p>Cheerio is only used for the scripting API while the server internally
-  uses <code spellcheck="false">node-html-parser</code> for HTML parsing. Removing
-  <code
-  spellcheck="false">cheerio</code>reduces bundle size and maintenance overhead.</p>
+  uses <code spellcheck="false">node-html-parser</code> for HTML parsing. Removing <code
+  spellcheck="false">cheerio</code> reduces bundle size and maintenance overhead.</p>
 <h2>Migration</h2>
 <p>Before (<code spellcheck="false">cheerio</code>):</p><pre><code class="language-text-javascript">const $ = api.cheerio.load(html);
 const title = $('h1').text();

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.104.0 Disabling the Node integration in Electron.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Breaking changes/v0.104.0 Disabling the Node integration in Electron.html
@@ -16,25 +16,24 @@ class="admonition note">
       have a greater degree of freedom.</li>
     <li><a href="#root/_help_wy8So3yZZlH9">Reporting</a> it as a feature request.</li>
   </ul>
-  </aside>
-  <h2>Overview of the API</h2>
-  <p>The Frontend and Backend APIs reside in a global variable, <code spellcheck="false">api</code>,
-    that can be used anywhere in the script. For example, to display a message
-    to the user the following front-end script can be used:</p><pre><code class="language-text-javascript">api.showMessage("Hello world.");</code></pre>
-  <p>The Electron API is different: it lives on <code spellcheck="false">window.electronApi</code> (exposed
-    by the desktop preload script), not on <code spellcheck="false">api</code>,
-    and is only available in the Electron desktop build. Frontend scripts that
-    use it should guard with <code spellcheck="false">if (window.electronApi)</code> so
-    they degrade cleanly in the browser and standalone (WASM) builds.</p><pre><code class="language-text-javascript">window.electronApi?.window.setZoomFactor(1.2);</code></pre>
-  <h2>Additional protection</h2>
-  <p>Some of the APIs have additional safe-guards built in which prevent unauthorized
-    access.</p>
-  <p>The <code spellcheck="false">shell</code> group is the most heavily validated:
-    <code
-    spellcheck="false">openExternal</code>is restricted to an allowlisted set of URL schemes
-      (blocking <code spellcheck="false">file:</code>, <code spellcheck="false">smb:</code>,
-      Follina-class schemes, etc.), <code spellcheck="false">openPath</code> must
-      resolve under the Trilium data directory or temporary directory, and
-      <code
-      spellcheck="false">downloadURL</code>is locked to the app's own origin. Invalid input throws
-        on the main side rather than being silently passed through.</p>
+</aside>
+<h2>Overview of the API</h2>
+<p>The Frontend and Backend APIs reside in a global variable, <code spellcheck="false">api</code>,
+  that can be used anywhere in the script. For example, to display a message
+  to the user the following front-end script can be used:</p><pre><code class="language-text-javascript">api.showMessage("Hello world.");</code></pre>
+<p>The Electron API is different: it lives on <code spellcheck="false">window.electronApi</code> (exposed
+  by the desktop preload script), not on <code spellcheck="false">api</code>,
+  and is only available in the Electron desktop build. Frontend scripts that
+  use it should guard with <code spellcheck="false">if (window.electronApi)</code> so
+  they degrade cleanly in the browser and standalone (WASM) builds.</p><pre><code class="language-text-javascript">window.electronApi?.window.setZoomFactor(1.2);</code></pre>
+<h2>Additional protection</h2>
+<p>Some of the APIs have additional safe-guards built in which prevent unauthorized
+  access.</p>
+<p>The <code spellcheck="false">shell</code> group is the most heavily validated: <code
+  spellcheck="false">openExternal</code> is restricted to an allowlisted set
+  of URL schemes (blocking <code spellcheck="false">file:</code>, <code spellcheck="false">smb:</code>,
+  Follina-class schemes, etc.), <code spellcheck="false">openPath</code> must
+  resolve under the Trilium data directory or temporary directory, and <code
+  spellcheck="false">downloadURL</code> is locked to the app's own origin.
+  Invalid input throws on the main side rather than being silently passed
+  through.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Common concepts/Script bundles.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Common concepts/Script bundles.html
@@ -1,11 +1,11 @@
 <p>For both&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>&nbsp;and
   more complicated scripts, it's generally useful to split the code into
   multiple&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;notes.</p>
-<p>When a script is run, the sub-children of the script being run (or the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>) are checked for children. If the children are Code notes
-    of the corresponding type (front-end or backend) as the code being run,
-    they will be evaluated as well.</p>
+<p>When a script is run, the sub-children of the script being run (or the&nbsp;<a
+  class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>) are checked
+  for children. If the children are Code notes of the corresponding type
+  (front-end or backend) as the code being run, they will be evaluated as
+  well.</p>
 <p>The collection of a script and its child notes is called a <em>bundle</em>.
   A child note inside a bundle is called a <em>module</em>.</p>
 <p>As a basic example of dependencies, consider the following note structure:</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics.html
@@ -49,8 +49,7 @@
   them into the UI.</p>
 <ul>
   <li>For legacy widgets, the script note must export a <code spellcheck="false">BasicWidget</code> or
-    a derived one (see&nbsp;<a class="reference-link" href="#root/_help_GhurYZjh8e1V">Note context aware widget</a>&nbsp;or&nbsp;
-    <a
+    a derived one (see&nbsp;<a class="reference-link" href="#root/_help_GhurYZjh8e1V">Note context aware widget</a>&nbsp;or&nbsp;<a
     class="reference-link" href="#root/_help_M8IppdwVHSjG">Right pane widget</a>).</li>
   <li>For Preact widgets, a built-in helper called <code spellcheck="false">defineWidget</code> needs
     to be used.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets.html
@@ -10,10 +10,10 @@
   Both legacy and Preact widgets have the same capabilities, with a single
   difference:</p>
 <ul>
-  <li>Preact widgets are content-sized by default whereas legacy widgets need
-    <code
-    spellcheck="false">this.contentSized()</code>applied in the constructor. For more information,
-      see the corresponding section in&nbsp;<a class="reference-link" href="#root/_help_gMkgcLJ6jBkg">Troubleshooting</a>.</li>
+  <li>Preact widgets are content-sized by default whereas legacy widgets need <code
+    spellcheck="false">this.contentSized()</code> applied in the constructor.
+    For more information, see the corresponding section in&nbsp;<a class="reference-link"
+    href="#root/_help_gMkgcLJ6jBkg">Troubleshooting</a>.</li>
 </ul>
 <p>Wherever possible, widget examples will be both in the legacy and Preact
   format.</p>
@@ -112,8 +112,7 @@ class="table">
               instance of the class (e.g. <code spellcheck="false">no new</code>) because
               it needs to be multiplied for each note, so that splits work correctly.</li>
             <li>Since the <code spellcheck="false">class</code> is exported instead of an
-              instance, the <code spellcheck="false">parentWidget</code> getter must be
-              <code
+              instance, the <code spellcheck="false">parentWidget</code> getter must be <code
               spellcheck="false">static</code>, otherwise the widget is ignored.</li>
           </ul>
         </td>
@@ -134,26 +133,56 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <p>To position the widget somewhere else, just change the value passed to
-    <code
-    spellcheck="false">get parentWidget()</code>for legacy widgets or the <code spellcheck="false">parent</code> field
-      for Preact. Do note that some positions such as <code spellcheck="false">note-detail-pane</code> and
-      <code
-      spellcheck="false">right-pane</code>have special requirements that need to be accounted for
-        (see the table above).</p>
-  <h2>Launch bar widgets</h2>
-  <p>Launch bar widgets are similar to <em>Custom widgets</em> but are specific
-    to the&nbsp;<a class="reference-link" href="#root/_help_xYmIYSP6wE3F">Launch Bar</a>.
-    See&nbsp;<a class="reference-link" href="#root/_help_4Gn3psZKsfSm">Launch Bar Widgets</a>&nbsp;for
-    more information.</p>
-  <h2>Custom position</h2>
-  <p>The position of a custom widget is defined via a <code spellcheck="false">position</code> integer.</p>
-  <p>In legacy widgets:</p><pre><code class="language-text-x-trilium-auto">class MyWidget extends api.BasicWidget {
+</figure>
+<p>To position the widget somewhere else, just change the value passed to <code
+  spellcheck="false">get parentWidget()</code> for legacy widgets or the <code
+  spellcheck="false">parent</code> field for Preact. Do note that some positions
+  such as <code spellcheck="false">note-detail-pane</code> and <code spellcheck="false">right-pane</code> have
+  special requirements that need to be accounted for (see the table above).</p>
+<h2>Multiple widgets in a single note</h2>
+<p>A widget note usually returns one widget, but it can also return an array
+  of them. This is useful when several widgets share code or state, since
+  they can all live in the same note instead of being split across notes
+  that need a shared module.</p>
+<p>Each widget of the array is registered on its own, so they can have different
+  parents and positions. A widget that is missing its <code spellcheck="false">parentWidget</code> (or <code
+  spellcheck="false">parent</code> for Preact) is reported as an error without
+  affecting the other widgets of the note.</p>
+<h3>Legacy version (jQuery)</h3><pre><code class="language-text-x-trilium-auto">class TreeWidget extends api.BasicWidget {
+    get parentWidget() { return "left-pane"; }
+    doRender() { this.$widget = $("&lt;span&gt;Left pane&lt;/span&gt;"); }
+}
+
+class SidebarWidget extends api.BasicWidget {
+    get parentWidget() { return "right-pane"; }
+    doRender() { this.$widget = $("&lt;span&gt;Right pane&lt;/span&gt;"); }
+}
+
+module.exports = [ new TreeWidget(), new SidebarWidget() ];</code></pre>
+<h3>Preact version</h3><pre><code class="language-text-x-trilium-auto">import { defineWidget } from "trilium:preact";
+
+export default [
+    defineWidget({
+        parent: "left-pane",
+        render: () =&gt; &lt;span&gt;Left pane from Preact.&lt;/span&gt;
+    }),
+    defineWidget({
+        parent: "right-pane",
+        render: () =&gt; &lt;span&gt;Right pane from Preact.&lt;/span&gt;
+    })
+];</code></pre>
+<h2>Launch bar widgets</h2>
+<p>Launch bar widgets are similar to <em>Custom widgets</em> but are specific
+  to the&nbsp;<a class="reference-link" href="#root/_help_xYmIYSP6wE3F">Launch Bar</a>.
+  See&nbsp;<a class="reference-link" href="#root/_help_4Gn3psZKsfSm">Launch Bar Widgets</a>&nbsp;for
+  more information.</p>
+<h2>Custom position</h2>
+<p>The position of a custom widget is defined via a <code spellcheck="false">position</code> integer.</p>
+<p>In legacy widgets:</p><pre><code class="language-text-x-trilium-auto">class MyWidget extends api.BasicWidget {
 	// [..
 	get position() { return 10; }
 }</code></pre>
-  <p>In Preact widgets:</p><pre><code class="language-text-x-trilium-auto">export default defineWidget({
+<p>In Preact widgets:</p><pre><code class="language-text-x-trilium-auto">export default defineWidget({
     // [...]
     position: 10
 });</code></pre>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Note context aware widget.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Note context aware widget.html
@@ -6,8 +6,7 @@
     instance of the class (e.g. <code spellcheck="false">no new</code>) because
     it needs to be multiplied for each note, so that splits work correctly.</li>
   <li>Since the <code spellcheck="false">class</code> is exported instead of an
-    instance, the <code spellcheck="false">parentWidget</code> getter must be
-    <code
+    instance, the <code spellcheck="false">parentWidget</code> getter must be <code
     spellcheck="false">static</code>, otherwise the widget is ignored.</li>
 </ul>
 <h2>Example displaying the current note title</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Right pane widget.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Right pane widget.html
@@ -1,11 +1,10 @@
 <h2>Key highlights</h2>
 <ul>
-  <li><code spellcheck="false">doRender</code> must not be overridden, instead
-    <code
-    spellcheck="false">doRenderBody()</code>has to be overridden.
-      <ul>
-        <li><code spellcheck="false">doRenderBody</code> can optionally be <code spellcheck="false">async</code>.</li>
-      </ul>
+  <li><code spellcheck="false">doRender</code> must not be overridden, instead <code
+    spellcheck="false">doRenderBody()</code> has to be overridden.
+    <ul>
+      <li><code spellcheck="false">doRenderBody</code> can optionally be <code spellcheck="false">async</code>.</li>
+    </ul>
   </li>
   <li><code spellcheck="false">parentWidget()</code> must be set to <code spellcheck="false">“rightPane”</code>.</li>
   <li><code spellcheck="false">widgetTitle()</code> getter can optionally be

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Widget Basics.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Widget Basics.html
@@ -46,9 +46,8 @@ module.exports = new MyWidget();</code></pre>
 <h3>Step 3: Styling the Widget</h3>
 <p>To make the button more visually appealing and position it correctly,
   we'll apply some custom styling. Trilium includes <a href="https://boxicons.com">Box Icons</a>,
-  which we'll use to replace the button text with an icon. For example the
-  <code
-  spellcheck="false">bx bxs-magic-wand</code>icon.</p>
+  which we'll use to replace the button text with an icon. For example the <code
+  spellcheck="false">bx bxs-magic-wand</code> icon.</p>
 <p>Here's the updated template:</p><pre><code class="language-text-x-trilium-auto">const template = `&lt;div id="my-widget"&gt;&lt;button class="tree-floating-button bx bxs-magic-wand tree-settings-button"&gt;&lt;/button&gt;&lt;/div&gt;`;</code></pre>
 <p>Next, we'll adjust the button's position using CSS:</p><pre><code class="language-text-x-trilium-auto">class MyWidget extends api.BasicWidget {
     get position() { return 1; }

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Word count widget.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Custom Widgets/Word count widget.html
@@ -3,9 +3,8 @@
     href="#root/_help_6tZeKvSHEUiB">Demo Notes</a>.</p>
 </aside>
 <p>Create a&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note
-  of type JavaScript (Trilium frontend) and <strong>give it a</strong> 
-  <code
-  spellcheck="false">#widget</code> <strong>label</strong>.</p><pre><code class="language-text-x-trilium-auto">/*
+  of type JavaScript (Trilium frontend) and <strong>give it a</strong>  <code
+  spellcheck="false">#widget</code>  <strong>label</strong>.</p><pre><code class="language-text-x-trilium-auto">/*
  * This defines a custom widget which displays number of words and characters in a current text note.
  * To be activated for a given note, add label 'wordCount' to the note, you can also make it inheritable and thus activate it for the whole subtree.
  * 
@@ -90,4 +89,4 @@ module.exports = new WordCountWidget();</code></pre>
 class="image">
   <img style="aspect-ratio:792/603;" src="Word count widget_image.png"
   width="792" height="603">
-  </figure>
+</figure>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Examples/New Task launcher button.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Examples/New Task launcher button.html
@@ -1,7 +1,7 @@
 <aside class="admonition warning">
-  <p>This documentation is outdated, as it refers to using the deprecated
-    <code
-    spellcheck="false">addButtonToToolbar</code>API which will only create widgets for desktop.</p>
+  <p>This documentation is outdated, as it refers to using the deprecated <code
+    spellcheck="false">addButtonToToolbar</code> API which will only create
+    widgets for desktop.</p>
   <p>Instead, a custom launcher widget can be created using the&nbsp;<a class="reference-link"
     href="#root/_help_4Gn3psZKsfSm">Launch Bar Widgets</a>&nbsp;documentation.</p>
 </aside>
@@ -14,8 +14,7 @@
 <ol>
   <li>First, create a new&nbsp;<a class="reference-link" href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note
     type with the <em>JavaScript (Trilium frontend)</em> language.</li>
-  <li>Define the <code spellcheck="false">#run=frontendStartup</code> label in&nbsp;
-    <a
+  <li>Define the <code spellcheck="false">#run=frontendStartup</code> label in&nbsp;<a
     class="reference-link" href="#root/_help_zEY4DaJG4YT5">Attributes</a>.</li>
 </ol>
 <h2>Content of the script</h2>
@@ -35,8 +34,7 @@
     }
 });</code></pre>
 <h2>Testing the functionality</h2>
-<p>Since we set the script to be run on start-up, all we need to do is to
-  <a
+<p>Since we set the script to be run on start-up, all we need to do is to <a
   href="#root/_help_s8alTXmpFR61">refresh the application</a>.</p>
 <h2>Understanding how the script works</h2>
 <figure class="table">
@@ -92,10 +90,10 @@
         </td>
         <td>
           <ul>
-            <li>Here we identify a note with the <a href="#root/_help_zEY4DaJG4YT5">label</a> 
-              <code
-              spellcheck="false">#taskTodoRoot</code>. This is how the&nbsp;<a class="reference-link" href="#root/_help_xYjQUYhpbUEW">Task Manager</a>&nbsp;showcase
-                knows where to place all the different tasks.</li>
+            <li>Here we identify a note with the <a href="#root/_help_zEY4DaJG4YT5">label</a>  <code
+              spellcheck="false">#taskTodoRoot</code>. This is how the&nbsp;<a class="reference-link"
+              href="#root/_help_xYjQUYhpbUEW">Task Manager</a>&nbsp;showcase knows where to
+              place all the different tasks.</li>
             <li>Normally this might return a <code spellcheck="false">null</code> value
               if no such note could be identified, but error handling is outside the
               scope of this example.&nbsp;</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Frontend Events.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Frontend Events.html
@@ -14,9 +14,9 @@
 </aside>
 <p>Backend scripts have more powerful triggering conditions, for example
   they can run automatically on a hourly or daily basis, but also on events
-  such as when a note is created or an attribute is modified. See the server-side&nbsp;
-  <a
-  class="reference-link" href="#root/_help_GPERMystNGTB">Events</a>&nbsp;for more information.</p>
+  such as when a note is created or an attribute is modified. See the server-side&nbsp;<a
+  class="reference-link" href="#root/_help_GPERMystNGTB">Events</a>&nbsp;for more
+  information.</p>
 <h2>Safe mode</h2>
 <p>While <a href="#root/_help_64ZTlUPgEPtW">safe mode</a> is active, scripts with
   events won't trigger.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Launch Bar Widgets.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Launch Bar Widgets.html
@@ -9,10 +9,9 @@
     widgets).
     <ul>
       <li>The script itself uses the same concepts as&nbsp;<a class="reference-link"
-        href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>, including the use of a
-        <code
-        spellcheck="false">NoteContextAwareWidget</code>or a <code spellcheck="false">BasicWidget</code> (according
-          to needs).</li>
+        href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>, including the use of a <code
+        spellcheck="false">NoteContextAwareWidget</code> or a <code spellcheck="false">BasicWidget</code> (according
+        to needs).</li>
       <li>As examples in both legacy and Preact format, see&nbsp;<a class="reference-link"
         href="#root/_help_IPArqVfDQ4We">Note Title Widget</a>&nbsp;and&nbsp;<a class="reference-link"
         href="#root/_help_gcI7RPbaNSh3">Analog Watch</a>.</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact.html
@@ -9,11 +9,11 @@
 </ul>
 <p>To get started, the first step is to enable JSX in the list of Code languages.
   Go to Options → Code Notes and check the “JSX” language. Afterwards, proceed
-  with the documentation in either&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>&nbsp;or&nbsp;
-  <a
-  class="reference-link" href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>, which will both have a section on how to use the new
-    Preact integration.</p>
-<aside class="admonition important">
+  with the documentation in either&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>&nbsp;or&nbsp;<a
+  class="reference-link" href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>, which
+  will both have a section on how to use the new Preact integration.</p>
+<aside
+class="admonition important">
   <p>The documentation assumes prior knowledge with React or Preact. As a starting
     point, consider the <a href="https://www.freecodecamp.org/learn/front-end-development-libraries-v9/">FreeCodeCamp course on Front End Development Libraries</a> or
     the <a href="https://preactjs.com/tutorial/">Preact Tutorial</a>.</p>
@@ -44,20 +44,18 @@ const [ myState, setMyState ] = useState("Hi");</code></pre>
     );
 }</code></pre>
 <h3>Import/export are not required</h3>
-<p>These imports are syntactic sugar meant to replace the usage for the
-  <code
-  spellcheck="false">api</code>global object (see&nbsp;<a class="reference-link" href="#root/_help_GLks18SNjxmC">Script API</a>).&nbsp;</p>
-<aside
-class="admonition note">
+<p>These imports are syntactic sugar meant to replace the usage for the <code
+  spellcheck="false">api</code> global object (see&nbsp;<a class="reference-link"
+  href="#root/_help_GLks18SNjxmC">Script API</a>).&nbsp;</p>
+<aside class="admonition note">
   <p>The <code spellcheck="false">import</code> and <code spellcheck="false">export</code> syntax
-    work only for JSX notes. Standard/jQuery code notes still need to use the
-    <code
-    spellcheck="false">api</code>global and <code spellcheck="false">module.exports</code>.</p>
-  </aside>
-  <h2>Under the hood</h2>
-  <p>Unlike JavaScript, JSX requires pre-processing to turn it into JavaScript
-    (just like TypeScript). To do so, Trilium uses <a href="https://github.com/alangpierce/sucrase">Sucrase</a>,
-    a JavaScript library which processes the JSX to pure JavaScript. The processing
-    is done each time a script is run (for widgets this happens at every program
-    startup). If you notice any performance degradation due to long compilation,
-    consider <a href="#root/_help_wy8So3yZZlH9">reporting the issue</a> to us.</p>
+    work only for JSX notes. Standard/jQuery code notes still need to use the <code
+    spellcheck="false">api</code> global and <code spellcheck="false">module.exports</code>.</p>
+</aside>
+<h2>Under the hood</h2>
+<p>Unlike JavaScript, JSX requires pre-processing to turn it into JavaScript
+  (just like TypeScript). To do so, Trilium uses <a href="https://github.com/alangpierce/sucrase">Sucrase</a>,
+  a JavaScript library which processes the JSX to pure JavaScript. The processing
+  is done each time a script is run (for widgets this happens at every program
+  startup). If you notice any performance degradation due to long compilation,
+  consider <a href="#root/_help_wy8So3yZZlH9">reporting the issue</a> to us.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact/Built-in components.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact/Built-in components.html
@@ -4,8 +4,7 @@
   <figcaption>A partial screenshot from the Widget showcase example (see below).</figcaption>
 </figure>
 <p>Trilium comes with its own set of Preact components, some of which are
-  also available to&nbsp;<a class="reference-link" href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>&nbsp;and&nbsp;
-  <a
+  also available to&nbsp;<a class="reference-link" href="#root/_help_MgibgPcfeuGz">Custom Widgets</a>&nbsp;and&nbsp;<a
   class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>.</p>
 <p>To use these components, simply import them from <code spellcheck="false">trilium:preact</code>:</p><pre><code class="language-text-jsx">import { ActionButton, Button, LinkButton } from "trilium:preact";</code></pre>
 <p>and then use them:</p><pre><code class="language-text-jsx">export default function MyRenderNote() {
@@ -24,8 +23,7 @@
 }</code></pre>
 <h2>Widget showcase</h2>
 <aside class="admonition tip">
-  <p>Starting with v0.101.0, the widget showcase is also available in the&nbsp;
-    <a
+  <p>Starting with v0.101.0, the widget showcase is also available in the&nbsp;<a
     class="reference-link" href="#root/_help_6tZeKvSHEUiB">Demo Notes</a>.</p>
 </aside>
 <p>This is a&nbsp;<a class="reference-link" href="#root/_help_HcABDtFCkbFN">Render Note</a>&nbsp;example
@@ -34,8 +32,7 @@
 <p>To use it, simply:</p>
 <ol>
   <li>Create a render note.</li>
-  <li>Create a child code note of JSX type with the content of this file:&nbsp;
-    <a
+  <li>Create a child code note of JSX type with the content of this file:&nbsp;<a
     class="reference-link" href="#root/_help_i9B4IW7b6V6z">Widget showcase</a>
   </li>
   <li>Set the <code spellcheck="false">~renderNote</code> relation of the parent

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact/Hooks.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Frontend Basics/Preact/Hooks.html
@@ -27,9 +27,8 @@ export default defineWidget({
   widget is not within the note detail section and it automatically switches
   the note context as the user is navigating around between tabs and splits.</p>
 <h3><code spellcheck="false">useNoteProperty</code></h3>
-<p>This hook allows “listening” for changes to a particular property of a
-  <code
-  spellcheck="false">FNote</code>, such as the <code spellcheck="false">title</code> or
-    <code
-    spellcheck="false">type</code>of a note. The benefit from using the hook is that it actually
-      reacts to changes, for example if the note title or type is changed.</p>
+<p>This hook allows “listening” for changes to a particular property of a <code
+  spellcheck="false">FNote</code>, such as the <code spellcheck="false">title</code> or <code
+  spellcheck="false">type</code> of a note. The benefit from using the hook
+  is that it actually reacts to changes, for example if the note title or
+  type is changed.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Logging.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Logging.html
@@ -7,16 +7,14 @@
 <p>The API log feature integrates with the script editor and it displays
   all the messages logged via <code spellcheck="false">api.log</code>. This
   works for both back-end and front-end scripts.</p>
-<p>The API log panel will appear after executing a script that uses
-  <code
-  spellcheck="false">api.log</code>and it can be dismissed temporarily by pressing the close
-    button in the top-right of the panel.</p>
+<p>The API log panel will appear after executing a script that uses <code
+  spellcheck="false">api.log</code> and it can be dismissed temporarily by
+  pressing the close button in the top-right of the panel.</p>
 <p>Apart from strings, an object can be passed as well in which case it will
   be pretty-formatted if possible (e.g. recursive objects are not supported).</p>
 <h2>Console logging</h2>
-<p>For logs that are not directly visible to the user, the standard
-  <code
-  spellcheck="false">console.log</code>can be used as well.</p>
+<p>For logs that are not directly visible to the user, the standard <code
+  spellcheck="false">console.log</code> can be used as well.</p>
 <ul>
   <li>For front-end scripts, the log will be shown in the Developer Tools (also
     known as Inspect).</li>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Script API.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Scripting/Script API.html
@@ -16,4 +16,4 @@ class="admonition note">
   <p><strong>Note</strong>
     <br>The Script API is currently experimental and may undergo changes in future
     updates.</p>
-  </aside>
+</aside>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Creating an icon pack.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Creating an icon pack.html
@@ -1,7 +1,6 @@
 <aside class="admonition note">
   <p>This page explains, step‑by‑step, how to create a custom icon pack. For
-    a general description of how to use already existing icon packs, see&nbsp;
-    <a
+    a general description of how to use already existing icon packs, see&nbsp;<a
     class="reference-link" href="#root/_help_gOKqSJgXLcIj">Icon Packs</a>.</p>
 </aside>
 <p>First read the quick flow to get the overall steps. After that there is
@@ -114,11 +113,10 @@
   </ul>
 </aside>
 <h2>Concrete example: Phosphor Icons</h2>
-<p><a href="https://phosphoricons.com/">Phosphor Icons</a> provide a
-  <code
-  spellcheck="false">selection.json</code>that includes <code spellcheck="false">properties.code</code> (the
-    codepoint) and <code spellcheck="false">properties.name</code> (the icon
-    name). The goal: convert that into Trilium's manifest.</p>
+<p><a href="https://phosphoricons.com/">Phosphor Icons</a> provide a <code
+  spellcheck="false">selection.json</code> that includes <code spellcheck="false">properties.code</code> (the
+  codepoint) and <code spellcheck="false">properties.name</code> (the icon
+  name). The goal: convert that into Trilium's manifest.</p>
 <p>Sample <code spellcheck="false">selection.json</code> excerpt:</p><pre><code class="language-text-x-trilium-auto">{
   "icons": [
     {
@@ -222,21 +220,19 @@ processIconPack("light");</code></pre>
   <li>Copy and paste the manifest generated in the previous step as the content
     of this note.</li>
   <li>Go to the <a href="#root/_help_0vhv7lsOLy82">note attachment</a> and upload the
-    font file (in <code spellcheck="false">.woff2</code>, <code spellcheck="false">.woff</code>,
-    <code
+    font file (in <code spellcheck="false">.woff2</code>, <code spellcheck="false">.woff</code>, <code
     spellcheck="false">.ttf</code>) format.
-      <ol>
-        <li>Trilium identifies the font to use from attachments via the MIME type,
-          make sure the MIME type is displayed correctly after uploading the attachment
-          (for example <code spellcheck="false">font/woff2</code>).</li>
-        <li>Make sure the <code spellcheck="false">role</code> appears as <code spellcheck="false">file</code>,
-          otherwise the font will not be identified.</li>
-        <li>Multiple attachments are supported, but only one font will actually be
-          used in Trilium's order of preference: <code spellcheck="false">.woff2</code>,
-          <code
-          spellcheck="false">.woff</code>, <code spellcheck="false">.ttf</code>. As such, there's not
-            much reason to upload more than one font per icon pack.</li>
-      </ol>
+    <ol>
+      <li>Trilium identifies the font to use from attachments via the MIME type,
+        make sure the MIME type is displayed correctly after uploading the attachment
+        (for example <code spellcheck="false">font/woff2</code>).</li>
+      <li>Make sure the <code spellcheck="false">role</code> appears as <code spellcheck="false">file</code>,
+        otherwise the font will not be identified.</li>
+      <li>Multiple attachments are supported, but only one font will actually be
+        used in Trilium's order of preference: <code spellcheck="false">.woff2</code>, <code
+        spellcheck="false">.woff</code>, <code spellcheck="false">.ttf</code>. As
+        such, there's not much reason to upload more than one font per icon pack.</li>
+    </ol>
   </li>
   <li>Add label: <code spellcheck="false">#iconPack=&lt;prefix&gt;</code> (for
     Phosphor example: <code spellcheck="false">#iconPack=ph</code>).</li>
@@ -275,8 +271,7 @@ processIconPack("light");</code></pre>
     The server logs will indicate if this situation occurs.</li>
   <li>Make sure the prefix consists only of letters, digits, hyphens, underscores
     and non-ASCII characters.</li>
-  <li>If the pack loads but individual icons are missing, check the logs for
-    <code
-    spellcheck="false">Skipping icon '&lt;key&gt;' of icon pack</code>— that key uses characters
-      outside the allowed set and needs renaming in the manifest.</li>
+  <li>If the pack loads but individual icons are missing, check the logs for <code
+    spellcheck="false">Skipping icon '&lt;key&gt;' of icon pack</code> — that
+    key uses characters outside the allowed set and needs renaming in the manifest.</li>
 </ul>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Custom app-wide CSS.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Custom app-wide CSS.html
@@ -73,9 +73,9 @@
 </figure>
 <ol>
   <li>Insert an image in any note and take the URL of the image.</li>
-  <li>Use the following CSS, adjusting the <code spellcheck="false">background-image</code> and
-    <code
-    spellcheck="false">width</code>and <code spellcheck="false">height</code> to the desired values.</li>
+  <li>Use the following CSS, adjusting the <code spellcheck="false">background-image</code> and <code
+    spellcheck="false">width</code> and <code spellcheck="false">height</code> to
+    the desired values.</li>
 </ol><pre><code class="language-text-x-trilium-auto">.note-split.my-workspace .scrolling-container:after {
     position: fixed;
     content: "";

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Reference.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Theme development/Reference.html
@@ -1,7 +1,6 @@
 <h2>Detecting mobile vs. desktop</h2>
-<p>The mobile layout is different than the one on the desktop. Use <code spellcheck="false">body.mobile</code> and
-  <code
-  spellcheck="false">body.desktop</code>to differentiate between them.</p><pre><code class="language-text-css">body.mobile #root-widget {
+<p>The mobile layout is different than the one on the desktop. Use <code spellcheck="false">body.mobile</code> and <code
+  spellcheck="false">body.desktop</code> to differentiate between them.</p><pre><code class="language-text-css">body.mobile #root-widget {
 	/* Do something on mobile */
 }
 
@@ -42,10 +41,9 @@ body.layout-horizontal #center-pane {
 	/* Do something else */	
 }</code></pre>
 <p>The two different layouts use different containers (but they are present
-  in the DOM regardless of the user's choice), for example <code spellcheck="false">#horizontal-main-container</code> and
-  <code
-  spellcheck="false">#vertical-main-container</code>can be used to customize the background
-    of the content section.</p>
+  in the DOM regardless of the user's choice), for example <code spellcheck="false">#horizontal-main-container</code> and <code
+  spellcheck="false">#vertical-main-container</code> can be used to customize
+  the background of the content section.</p>
 <h2>Detecting platform (Windows, macOS) or Electron</h2>
 <p>It is possible to add particular styles that only apply to a given platform
   by using the classes in <code spellcheck="false">body</code>:</p>
@@ -67,66 +65,66 @@ class="table">
       </tr>
     </tbody>
   </table>
-  </figure>
-  <p>It is also possible to only apply a style if running under Electron (desktop
-    application):</p><pre><code class="language-text-x-trilium-auto">body.electron {
+</figure>
+<p>It is also possible to only apply a style if running under Electron (desktop
+  application):</p><pre><code class="language-text-x-trilium-auto">body.electron {
 	background: blue;
 }</code></pre>
-  <h3>Native title bar</h3>
-  <p>It's possible to detect if the user has selected the native title bar
-    or the custom title bar by querying against <code spellcheck="false">body</code>:</p><pre><code class="language-text-x-trilium-auto">body.electron.native-titlebar {
+<h3>Native title bar</h3>
+<p>It's possible to detect if the user has selected the native title bar
+  or the custom title bar by querying against <code spellcheck="false">body</code>:</p><pre><code class="language-text-x-trilium-auto">body.electron.native-titlebar {
 	/* Do something */
 }
 
 body.electron:not(.native-titlebar) {
 	/* Do something else */
 }</code></pre>
-  <h3>Native window buttons</h3>
-  <p>When running under Electron with native title bar off, a feature was introduced
-    to use the platform-specific window buttons such as the semaphore on macOS.</p>
-  <p>See <a href="https://github.com/TriliumNext/Notes/pull/702">Native title bar buttons by eliandoran · Pull Request #702 · TriliumNext/Notes</a> for
-    the original implementation of this feature, including screenshots.</p>
-  <h4>On Windows</h4>
-  <p>The colors of the native window button area can be adjusted using a RGB
-    hex color:</p><pre><code class="language-text-x-trilium-auto">body {
+<h3>Native window buttons</h3>
+<p>When running under Electron with native title bar off, a feature was introduced
+  to use the platform-specific window buttons such as the semaphore on macOS.</p>
+<p>See <a href="https://github.com/TriliumNext/Notes/pull/702">Native title bar buttons by eliandoran · Pull Request #702 · TriliumNext/Notes</a> for
+  the original implementation of this feature, including screenshots.</p>
+<h4>On Windows</h4>
+<p>The colors of the native window button area can be adjusted using a RGB
+  hex color:</p><pre><code class="language-text-x-trilium-auto">body {
 	--native-titlebar-foreground: #ffffff;
 	--native-titlebar-background: #ff0000;
 }</code></pre>
-  <p>It is also possible to use transparency at the cost of reduced hover colors
-    using a RGBA hex color:</p><pre><code class="language-text-x-trilium-auto">body {
+<p>It is also possible to use transparency at the cost of reduced hover colors
+  using a RGBA hex color:</p><pre><code class="language-text-x-trilium-auto">body {
 	--native-titlebar-background: #ff0000aa;
 }</code></pre>
-  <p>Note that the value is read when the window is initialized and then it
-    is refreshed only when the user changes their light/dark mode preference.</p>
-  <h4>On macOS</h4>
-  <p>On macOS the semaphore window buttons are enabled by default when the
-    native title bar is disabled. The offset of the buttons can be adjusted
-    using:</p><pre><code class="language-text-css">body {
+<p>Note that the value is read when the window is initialized and then it
+  is refreshed only when the user changes their light/dark mode preference.</p>
+<h4>On macOS</h4>
+<p>On macOS the semaphore window buttons are enabled by default when the
+  native title bar is disabled. The offset of the buttons can be adjusted
+  using:</p><pre><code class="language-text-css">body {
     --native-titlebar-darwin-x-offset: 12;
     --native-titlebar-darwin-y-offset: 14 !important;
 }</code></pre>
-  <h3>Background/transparency effects on Windows (Mica)</h3>
-  <p>Windows 11 offers a special background/transparency effect called Mica,
-    which can be enabled by themes by setting the <code spellcheck="false">--background-material</code> variable
-    at <code spellcheck="false">body</code> level:</p><pre><code class="language-text-css">body.electron.platform-win32 {
+<h3>Background/transparency effects on Windows (Mica)</h3>
+<p>Windows 11 offers a special background/transparency effect called Mica,
+  which can be enabled by themes by setting the <code spellcheck="false">--background-material</code> variable
+  at <code spellcheck="false">body</code> level:</p><pre><code class="language-text-css">body.electron.platform-win32 {
 	--background-material: tabbed; 
 }</code></pre>
-  <p>The value can be either <code spellcheck="false">tabbed</code> (especially
-    useful for the horizontal layout) or <code spellcheck="false">mica</code> (ideal
-    for the vertical layout).</p>
-  <p>Do note that the Mica effect is applied at <code spellcheck="false">body</code> level
-    and the theme needs to make the entire hierarchy (semi-)transparent in
-    order for it to be visible. Use the TrilumNext theme as an inspiration.</p>
-  <h2>Note icons, tab workspace accent color</h2>
-  <p>Theme capabilities are small adjustments done through CSS variables that
-    can affect the layout or the visual aspect of the application.</p>
-  <p>In the tab bar, to display the icons of notes instead of the icon of the
-    workspace:</p><pre><code class="language-text-css">:root {
+<p>The value can be either <code spellcheck="false">tabbed</code> (especially
+  useful for the horizontal layout) or <code spellcheck="false">mica</code> (ideal
+  for the vertical layout).</p>
+<p>Do note that the Mica effect is applied at <code spellcheck="false">body</code> level
+  and the theme needs to make the entire hierarchy (semi-)transparent in
+  order for it to be visible. Use the TrilumNext theme as an inspiration.</p>
+<h2>Note icons, tab workspace accent color</h2>
+<p>Theme capabilities are small adjustments done through CSS variables that
+  can affect the layout or the visual aspect of the application.</p>
+<p>In the tab bar, to display the icons of notes instead of the icon of the
+  workspace:</p><pre><code class="language-text-css">:root {
 	--tab-note-icons: true;
 }</code></pre>
-  <p>When a workspace is hoisted for a given tab, it is possible to get the
-    background color of that workspace, for example to apply a small strip
-    on the tab instead of the whole background color:</p><pre><code class="language-text-css">.note-tab .note-tab-wrapper {
+<p>When a workspace is hoisted for a given tab, it is possible to get the
+  background color of that workspace, for example to apply a small strip
+  on the tab instead of the whole background color:</p><pre><code class="language-text-css">.note-tab .note-tab-wrapper {
     --tab-background-color: initial !important;
 }
 
@@ -139,28 +137,28 @@ body.electron:not(.native-titlebar) {
     height: 3px;
     background-color: var(--workspace-tab-background-color);
 }</code></pre>
-  <h2>Custom fonts</h2>
-  <p>The recommended way of using customized fonts is to import a font directly
-    in Trilium. See&nbsp;<a class="reference-link" href="#root/_help_w4rMEhJsALlA">Personalizing the font</a>&nbsp;for
-    information on how to do so.</p>
-  <p>Alternatively, for a theme providing its own font, <a href="#root/_help_d3fAXQ2diepH">Custom resource providers</a> can
-    be used: Import a font into Trilium and assign it <code spellcheck="false">#customResourceProvider=fonts/myfont.ttf</code> and
-    then import the font in CSS via <code spellcheck="false">/custom/fonts/myfont.ttf</code>.
-    Use <code spellcheck="false">../../../custom/fonts/myfont.ttf</code> if you
-    run your Trilium server on a different path than <code spellcheck="false">/</code>.</p>
-  <h2>Dark and light themes</h2>
-  <p>A light theme needs to have the following CSS:</p><pre><code class="language-text-css">:root {
+<h2>Custom fonts</h2>
+<p>The recommended way of using customized fonts is to import a font directly
+  in Trilium. See&nbsp;<a class="reference-link" href="#root/_help_w4rMEhJsALlA">Personalizing the font</a>&nbsp;for
+  information on how to do so.</p>
+<p>Alternatively, for a theme providing its own font, <a href="#root/_help_d3fAXQ2diepH">Custom resource providers</a> can
+  be used: Import a font into Trilium and assign it <code spellcheck="false">#customResourceProvider=fonts/myfont.ttf</code> and
+  then import the font in CSS via <code spellcheck="false">/custom/fonts/myfont.ttf</code>.
+  Use <code spellcheck="false">../../../custom/fonts/myfont.ttf</code> if you
+  run your Trilium server on a different path than <code spellcheck="false">/</code>.</p>
+<h2>Dark and light themes</h2>
+<p>A light theme needs to have the following CSS:</p><pre><code class="language-text-css">:root {
 	--theme-style: light;
 }</code></pre>
-  <p>if the theme is dark, then <code spellcheck="false">--theme-style</code> needs
-    to be <code spellcheck="false">dark</code>.</p>
-  <p>If the theme is auto (e.g. supports both light or dark based on <code spellcheck="false">prefers-color-scheme</code>)
-    it must also declare (in addition to setting <code spellcheck="false">--theme-style</code> to
-    either <code spellcheck="false">light</code> or <code spellcheck="false">dark</code>):</p><pre><code class="language-text-css">:root {
+<p>if the theme is dark, then <code spellcheck="false">--theme-style</code> needs
+  to be <code spellcheck="false">dark</code>.</p>
+<p>If the theme is auto (e.g. supports both light or dark based on <code spellcheck="false">prefers-color-scheme</code>)
+  it must also declare (in addition to setting <code spellcheck="false">--theme-style</code> to
+  either <code spellcheck="false">light</code> or <code spellcheck="false">dark</code>):</p><pre><code class="language-text-css">:root {
 
     --theme-style-auto: true;
 
 }</code></pre>
-  <p>This will affect the behavior of the Electron application by informing
-    the operating system of the color preference (e.g. background effects will
-    appear correct on Windows).</p>
+<p>This will affect the behavior of the Electron application by informing
+  the operating system of the color preference (e.g. background effects will
+  appear correct on Windows).</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting.html
@@ -13,16 +13,14 @@
   Trilium to crash. If Trilium attempts to reload the problematic note upon
   restart, it will continue to crash.</p>
 <p>To resolve this, use the <code spellcheck="false">TRILIUM_START_NOTE_ID</code> environment
-  variable to reset the open tabs to a single specified note ID (e.g.,
-  <code
+  variable to reset the open tabs to a single specified note ID (e.g., <code
   spellcheck="false">root</code>). In Linux, you can set it as follows:</p><pre><code class="language-text-x-trilium-auto">TRILIUM_START_NOTE_ID=root ./trilium</code></pre>
 <h2>Broken Script Prevents Application Startup</h2>
 <p>If a custom script causes Trilium to crash, and it is set as a startup
   script or in an active <a href="#root/_help_MgibgPcfeuGz">custom widget</a>, start
   Triliumin "safe mode" to prevent any custom scripts from executing:</p><pre><code class="language-text-x-trilium-auto">TRILIUM_SAFE_MODE=true ./trilium</code></pre>
 <p>Depending on your Trilium distribution, you may have pre-made scripts
-  available: <code spellcheck="false">trilium-safe-mode.bat</code> and
-  <code
+  available: <code spellcheck="false">trilium-safe-mode.bat</code> and <code
   spellcheck="false">trilium-safe-mode.sh</code>.</p>
 <p>Once Trilium starts, locate and fix or delete the problematic note.</p>
 <h2>Sync and Consistency Checks</h2>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting/Error logs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting/Error logs.html
@@ -9,8 +9,7 @@
 </ul>
 <h2>Providing sensitive data</h2>
 <p>If you don't feel comfortable attaching the logs or anything sensitive
-  to the public GitHub issues, feel free to contact the devs in our Matrix
-  <a
+  to the public GitHub issues, feel free to contact the devs in our Matrix <a
   href="https://github.com/TriliumNext/Trilium#-discuss-with-us">support channel</a>.</p>
 <p>Use this email to also provide anything which could assist in analysing
   the bug - e.g. files/images/ZIPs being imported or <a href="#root/_help_x59R8J8KV5Bp">anonymized database</a>.</p>

--- a/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting/Error logs/Backend (server) logs.html
+++ b/apps/server/src/assets/doc_notes/en/User Guide/User Guide/Troubleshooting/Error logs/Backend (server) logs.html
@@ -12,10 +12,10 @@
     href="#root/_help_6f9hih2hXXZk">Code</a>&nbsp;note.</li>
 </ul>
 <h2>Location on the disk</h2>
-<p>Backend logs are stored on the file system. To find them, open the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_tAassRL4RSQL">Data directory</a>, go to the <code spellcheck="false">log</code> subdirectory
-    and find the latest log file, e.g. <code spellcheck="false">trilium-2022-12-14.log</code>.&nbsp;</p>
+<p>Backend logs are stored on the file system. To find them, open the&nbsp;<a
+  class="reference-link" href="#root/_help_tAassRL4RSQL">Data directory</a>, go
+  to the <code spellcheck="false">log</code> subdirectory and find the latest
+  log file, e.g. <code spellcheck="false">trilium-2022-12-14.log</code>.&nbsp;</p>
 <h2>Reporting backend bugs</h2>
 <p>You can attach the whole file to the bug report (preferable) or open it
   and copy-paste only the last lines / lines you believe are relevant.</p>
@@ -23,11 +23,9 @@
 <p>The backend logs are fully managed by the Trilium server. By default the
   last 90 days worth of logs are kept; the logs older than that are deleted
   in order to reduce the space consumption.</p>
-<p>It's possible to change the retention period by modifying the&nbsp;
-  <a
-  class="reference-link" href="#root/_help_Gzjqa934BdH4">Configuration (config.ini or environment variables)</a>&nbsp;via the
-    <code
-    spellcheck="false">.ini</code>file:</p><pre><code class="language-text-x-trilium-auto">[Logging]
+<p>It's possible to change the retention period by modifying the&nbsp;<a
+  class="reference-link" href="#root/_help_Gzjqa934BdH4">Configuration (config.ini or environment variables)</a>&nbsp;via
+  the <code spellcheck="false">.ini</code> file:</p><pre><code class="language-text-x-trilium-auto">[Logging]
 retentionDays=7</code></pre>
 <p>Or via the environment variable <code spellcheck="false">TRILIUM_LOGGING_RETENTION_DAYS</code>.</p>
 <p>Special cases:</p>

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Navigation/Search.md
@@ -6,7 +6,7 @@ Note search enables you to find notes by searching for text in the title, conten
 ## Accessing the search
 
 *   From the <a class="reference-link" href="../UI%20Elements/Launch%20Bar.md">Launch Bar</a>, look for the dedicated search button.
-*   To limit the search to a note and its children, select _Search from subtree_ from the <a class="reference-link" href="../UI%20Elements/Note%20Tree/Note%20tree%20contextual%20menu.md">Note tree contextual menu</a> or press <kbd spellcheck="false">Ctrl</kbd>+<kbd spellcheck="false">Shift</kbd>+<kbd spellcheck="false">S</kbd>.
+*   To limit the search to a note and its children, select _Search from subtree_ from the <a class="reference-link" href="../UI%20Elements/Note%20Tree/Note%20tree%20contextual%20menu.md">Note tree contextual menu</a> or press <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>.
 
 ## Interaction
 

--- a/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
+++ b/docs/User Guide/User Guide/Basic Concepts and Features/Notes/Note Inbox.md
@@ -7,7 +7,7 @@ The inbox is the default destination for quickly captured notes. When a note is 
 *   The global _Create note into inbox_ shortcut (default <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd>).
 *   The _New note_ action in the [tray icon menu](../../Installation%20%26%20Setup/Desktop%20Installation/Tray%20icon%20%26%20automatic%20startup.md).
 *   The <a class="reference-link" href="../../Installation%20%26%20Setup/Web%20Clipper.md">Web Clipper</a> extension.
-*   The _Create note_ option offered when a search finds no match, in <a class="reference-link" href="../Navigation/Jump%20to%20%26%20command%20palette.md">Jump to & command palette</a>, in an empty tab and in the `@` completion of a text note.
+*   The _Create note_ option offered when a search finds no match, in <a class="reference-link" href="../Navigation/Jump%20to%20%26%20command%20palette.md">Jump to &amp; command palette</a>, in an empty tab and in the `@` completion of a text note.
 
 ## Setting a note inbox
 

--- a/packages/trilium-core/src/services/export/zip/html.spec.ts
+++ b/packages/trilium-core/src/services/export/zip/html.spec.ts
@@ -96,6 +96,21 @@ describe("HtmlExportProvider", () => {
             expect(rewriteFn.mock.calls[0][1]).toBe(noteMeta);
         });
 
+        it("keeps the space after an inline tag that the pretty-printer wraps inside of", () => {
+            const { provider } = buildProvider({ zipExportOptions: { skipHtmlTemplate: true } });
+            const noteMeta: NoteMeta = { format: "html", notePath: ["root", "leaf"] };
+            // Long enough that the 70-column wrap lands inside the third <code> tag.
+            const content = "<p>When given a value, it will sort by other criteria instead: a comma-separated "
+                + "list of levels, each <code spellcheck=\"false\">title</code>, "
+                + "<code spellcheck=\"false\">dateCreated</code>, "
+                + "<code spellcheck=\"false\">dateModified</code> or the name of a label on the child notes.</p>";
+
+            const result = provider.prepareContent("Sorting", content, noteMeta) as string;
+
+            expect(result).not.toMatch(/<\/code>[A-Za-z]/);
+            expect(result.replace(/\s+/g, " ")).toContain("</code> or the name of a label");
+        });
+
         it("uses a bare style.css path for a top-level note (notePath length 1)", () => {
             const { provider } = buildProvider();
             const result = provider.prepareContent("T", "<p>x</p>", {

--- a/patches/html@1.0.0.patch
+++ b/patches/html@1.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/html.js b/lib/html.js
+index 455c1ae8e1d23cb57bf71c0421d5a7430e86c3f4..8de8b08a283eea8e115c3e1545a6e8e9d77bbe06 100644
+--- a/lib/html.js
++++ b/lib/html.js
+@@ -227,8 +227,8 @@ function style_html(html_source, options) {
+ 
+       var tag_complete = content.join('');
+       var tag_index;
+-      if (tag_complete.indexOf(' ') != -1) { //if there's whitespace, thats where the tag name ends
+-        tag_index = tag_complete.indexOf(' ');
++      if (tag_complete.search(/\s/) != -1) { //if there's whitespace, thats where the tag name ends
++        tag_index = tag_complete.search(/\s/);
+       }
+       else { //otherwise go with the tag ending
+         tag_index = tag_complete.indexOf('>');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,7 @@ overrides:
 
 patchedDependencies:
   '@excalidraw/excalidraw@0.18.1': 859531a8ff622291b895d36bcd33e07ced6fcb3bcc90631ccaf776789b03f0c2
+  html@1.0.0: 8acc288f8e9cde3c8a0c6e89f0b3796aeeb8251b88db9d1ba313e2352a591d68
 
 importers:
 
@@ -733,7 +734,7 @@ importers:
         version: 8.3.0
       html:
         specifier: 1.0.0
-        version: 1.0.0
+        version: 1.0.0(patch_hash=8acc288f8e9cde3c8a0c6e89f0b3796aeeb8251b88db9d1ba313e2352a591d68)
       http-proxy-agent:
         specifier: 9.1.0
         version: 9.1.0(supports-color@10.2.2)
@@ -21155,7 +21156,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html@1.0.0:
+  html@1.0.0(patch_hash=8acc288f8e9cde3c8a0c6e89f0b3796aeeb8251b88db9d1ba313e2352a591d68):
     dependencies:
       concat-stream: 1.6.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -123,6 +123,7 @@ ignoredOptionalDependencies:
 
 patchedDependencies:
   '@excalidraw/excalidraw@0.18.1': patches/@excalidraw__excalidraw@0.18.1.patch
+  html@1.0.0: patches/html@1.0.0.patch
 
 allowBuilds:
   "@parcel/watcher": false


### PR DESCRIPTION
The bundled help (`apps/server/src/assets/doc_notes/…`) has 150 places where two words run together after an inline tag — `dateModified</code>or`, `localhost:8080</code>is completed`, `scripting</a>support`. This fixes the exporter that produces them and regenerates the pages.

## Cause

The HTML export pretty-prints with the `html` package, a 2013 fork of the js-beautifier. When its 70-column wrap falls inside an inline tag it emits a newline there:

```html
<code
  spellcheck="false">dateModified</code>
```

and the tag-name check then does `indexOf(' ')`, reads the name as `code\n`, misses the inline-tag list and formats the tag as a **block**: a newline before it and the space after `</code>` dropped.

## Fix

- `patches/html@1.0.0.patch` — one line, `indexOf(' ')` → `search(/\s/)`, so the name is read up to any whitespace and the tag keeps its inline treatment. Same mechanism the repo already uses for excalidraw. The line break inside the tag is left as it was: removing it too would move wrap points across most of the help pages for no gain in readability.
- A spec in `html.spec.ts` formats a paragraph whose wrap lands inside a `<code>` and checks the boundary survives. It fails on the unpatched package.
- `docs(user): sync` — a real `pnpm edit-docs:edit-docs` re-export on the patched formatter. Lost boundaries go from 150 to 9. Every `href` and `src` value is kept, and each page's visible text, whitespace aside, is unchanged.

The nine that remain are faithful to their Markdown, which has no space there either (`[scripting](…)support`, `[relations](…)between`) — source typos for a separate docs pass.

Split out of #11424, where greptile flagged the joins in the regenerated Sorting Notes page.
