### PR TITLE
chore(renovate): group the fullcalendar packages into one update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,7 +58,7 @@
             "groupName": "ckeditor monorepo"
         },
         {
-            "description": "fullcalendar and @fullcalendar/rrule both pin @fullcalendar/core and @full-ui/headless-calendar to their exact version, so bumping one alone installs two copies of core and the calendar rejects the plugin built against the other",
+            "description": "Group FullCalendar packages because mixed core versions make plugins incompatible.",
             "matchPackageNames": [
                 "fullcalendar",
                 "@fullcalendar/**",

--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,15 @@
             "groupName": "ckeditor monorepo"
         },
         {
+            "description": "fullcalendar and @fullcalendar/rrule both pin @fullcalendar/core and @full-ui/headless-calendar to their exact version, so bumping one alone installs two copies of core and the calendar rejects the plugin built against the other",
+            "matchPackageNames": [
+                "fullcalendar",
+                "@fullcalendar/**",
+                "@full-ui/**"
+            ],
+            "groupName": "fullcalendar monorepo"
+        },
+        {
             "matchPackageNames": "@univerjs/**",
             "groupName": "univer monorepo"
         },


### PR DESCRIPTION
## Why

FullCalendar 7.1.0 arrived as two Renovate PRs, #11418 for `fullcalendar` and #11417 for `@fullcalendar/rrule`, and neither one builds on its own. Both fail the `Test development` typecheck gate.

Both packages depend on `@fullcalendar/core` and `@full-ui/headless-calendar` at an exact version, so bumping one leaves the other pinned to 7.0.2, and `nodeLinker: hoisted` resolves the loser into a nested `node_modules/fullcalendar/node_modules` copy. Trilium loads both into the same `Calendar`: `usePlugins()` in the calendar collection widget pushes `fullcalendar/daygrid`, `/timegrid`, `/list`, `/multimonth` and `/themes/forma` alongside `@fullcalendar/rrule`, so the rrule plugin ends up built against a different core than the calendar it registers with.

`pnpm typecheck` reports it at the push of `@fullcalendar/rrule`:

```
apps/client/src/widgets/collections/calendar/index.tsx(529,26): error TS2345:
  Argument of type '{ name: string; recurringTypes: ... }' is not assignable to
  parameter of type 'PluginInput'.
    ...
    Property 'instantMs' is missing in type 'ExpandedZonedMarker' but required
    in type 'ExpandedZonedInstant'.
```

7.0.2's `DateEnv` has no `toZonedInstant`, and its formatting data carries `ExpandedZonedMarker` where 7.1.0 wants `ExpandedZonedInstant`. That is the type-level shadow of a runtime mismatch: whichever copy loses the hoist would hand the other a date object it cannot read. #11417 shows the mirror image of the same error.

## What this changes

One `packageRules` entry grouping `fullcalendar`, `@fullcalendar/**` and `@full-ui/**` under a `fullcalendar monorepo` group name, so Renovate raises a single PR that moves every specifier at once — the way `ckeditor`, `univer` and the `ai sdk` groups already work in this config.

The pattern covers the `@full-ui` scope as well. `@full-ui/headless-calendar` is part of the same release train and is only transitive today, but a direct dependency or a pnpm override on it would have to move with the rest.

## Verification

Bumping all three specifiers together (`fullcalendar` in `apps/client` and `apps/standalone`, `@fullcalendar/rrule` in `apps/client`) resolves a single 7.1.0 core and gives a clean run:

| Check | Result |
| --- | --- |
| `pnpm typecheck` | No errors |
| `pnpm --filter client test collections/calendar` | 125 passed |
| Installed copies of `@full-ui/headless-calendar` | 1, at 7.1.0 |

The split state reproduces the CI error verbatim, so the failure is attributable to the version skew rather than to 7.1.0 itself.

7.1.0 needs no code change here. Its one breaking change applies only under `dayMaxEvents`, which the widget never sets, and its raised Preact floor of `>=10.29.8` is already met by the `10.29.8` both apps pin. The User Guide names FullCalendar but no version, so nothing to update there.

The bump itself is **not** in this PR — once this rule lands, Renovate should replace #11417 and #11418 with a single grouped PR.

## Note

Both Renovate PRs also report 12 further typecheck errors, in client spec files and in the build-docs entrypoint. They reproduce in neither a clean tree nor the split-version state that reproduces the FullCalendar error, and none of the files involved touch FullCalendar, so they look like a separate problem rather than something these bumps introduce.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPgLdHhzA5YRLYi389wn4K


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPgLdHhzA5YRLYi389wn4K)_