### PR TITLE
feat(ETAPI): accept optional dateModified/utcDateModified on create-note

### DIFF
--- a/apps/server/spec/etapi/create-entities.spec.ts
+++ b/apps/server/spec/etapi/create-entities.spec.ts
@@ -106,6 +106,41 @@ describe("etapi/create-entities", () => {
         );
     });
 
+    it("restores modification dates via PATCH after a content rewrite", async () => {
+        const created = await createNoteWithTimestamps("modified-patch-restore", {
+            dateModified: "2024-05-06 10:11:12.456+0200",
+            utcDateModified: "2024-05-06 08:11:12.456Z"
+        });
+        const noteId = created.body.note.noteId;
+
+        // A content rewrite (e.g. attachment URL replacement) re-stamps now.
+        await supertest(app)
+            .put(`/etapi/notes/${noteId}/content`)
+            .auth(USER, token, { "type": "basic"})
+            .set("Content-Type", "text/plain")
+            .send("rewritten <p>content</p>")
+            .expect(204);
+
+        const bumped = await supertest(app)
+            .get(`/etapi/notes/${noteId}`)
+            .auth(USER, token, { "type": "basic"})
+            .expect(200);
+        expect(asInstant(bumped.body.utcDateModified)).toBeGreaterThan(
+            Date.parse("2024-05-06T08:11:12.456Z")
+        );
+
+        // PATCH restores the source date despite save() re-stamping now.
+        const restored = await supertest(app)
+            .patch(`/etapi/notes/${noteId}`)
+            .auth(USER, token, { "type": "basic"})
+            .send({ utcDateModified: "2024-05-06 08:11:12.456Z" })
+            .expect(200);
+        expect(restored.body.utcDateModified).toStrictEqual("2024-05-06 08:11:12.456Z");
+        expect(asInstant(restored.body.dateModified)).toStrictEqual(
+            Date.parse("2024-05-06T08:11:12.456Z")
+        );
+    });
+
     it("obtains attribute information", async () => {
         const response = await supertest(app)
             .get(`/etapi/attributes/${createdAttributeId}`)

--- a/apps/server/spec/etapi/create-entities.spec.ts
+++ b/apps/server/spec/etapi/create-entities.spec.ts
@@ -76,6 +76,36 @@ describe("etapi/create-entities", () => {
         });
     });
 
+    it("preserves modification dates on create-note", async () => {
+        const explicit = await createNoteWithTimestamps("modified-override", {
+            dateCreated: "2023-08-21 23:38:51.123+0200",
+            utcDateCreated: "2023-08-21 21:38:51.123Z",
+            dateModified: "2024-05-06 10:11:12.456+0200",
+            utcDateModified: "2024-05-06 08:11:12.456Z"
+        });
+        // The server re-derives the local column from UTC, so compare instants.
+        expect(explicit.body.note.title).toStrictEqual("modified-override");
+        expect(explicit.body.note.utcDateModified).toStrictEqual("2024-05-06 08:11:12.456Z");
+        expect(asInstant(explicit.body.note.dateModified)).toStrictEqual(
+            Date.parse("2024-05-06T08:11:12.456Z")
+        );
+
+        const localOnly = await createNoteWithTimestamps("modified-local-only", {
+            dateModified: "2024-05-06 10:11:12.456+0200"
+        });
+        expect(localOnly.body.note.utcDateModified).toStrictEqual("2024-05-06 08:11:12.456Z");
+        expect(asInstant(localOnly.body.note.dateModified)).toStrictEqual(
+            Date.parse("2024-05-06T08:11:12.456Z")
+        );
+
+        const before = Date.now();
+        const defaulted = await createNoteWithTimestamps("modified-default", {});
+        // UTC DB format is "YYYY-MM-DD HH:mm:ss.SSSZ".
+        expect(asInstant(defaulted.body.note.utcDateModified)).toBeGreaterThanOrEqual(
+            before - 60_000
+        );
+    });
+
     it("obtains attribute information", async () => {
         const response = await supertest(app)
             .get(`/etapi/attributes/${createdAttributeId}`)
@@ -154,6 +184,21 @@ describe("etapi/create-entities", () => {
         });
     });
 });
+
+/**
+ * Parse a Trilium local or UTC datetime string to epoch ms.
+ */
+function asInstant(s: string) {
+    return new Date(s.replace(" ", "T")).getTime();
+}
+
+async function createNoteWithTimestamps(title: string, timestamps: Record<string, string>) {
+    return supertest(app)
+        .post("/etapi/create-note")
+        .auth(USER, token, { "type": "basic"})
+        .send({ parentNoteId: "root", title, type: "text", content: "x", ...timestamps })
+        .expect(201);
+}
 
 async function createNote() {
     const noteId = `forcedId${randomInt(1000)}`;

--- a/apps/server/src/assets/etapi.openapi.yaml
+++ b/apps/server/src/assets/etapi.openapi.yaml
@@ -1222,12 +1222,21 @@ components:
                     $ref: "#/components/schemas/LocalDateTime"
                 dateModified:
                     $ref: "#/components/schemas/LocalDateTime"
-                    readOnly: true
+                    description: >
+                        Local timestamp of the note's last modification. Writable via
+                        POST /create-note and PATCH /notes/{noteId}, e.g. for migration
+                        imports restoring the source date after content rewrites.
+                        If both modification timestamps are supplied, utcDateModified
+                        takes precedence.
                 utcDateCreated:
                     $ref: "#/components/schemas/UtcDateTime"
                 utcDateModified:
                     $ref: "#/components/schemas/UtcDateTime"
-                    readOnly: true
+                    description: >
+                        UTC timestamp of the note's last modification. Writable via
+                        POST /create-note and PATCH /notes/{noteId}, e.g. for migration
+                        imports restoring the source date after content rewrites.
+                        Takes precedence over dateModified when both are supplied.
         Branch:
             type: object
             description: Branch places the note into the tree, it represents the relationship between a parent note and child note

--- a/apps/server/src/assets/etapi.openapi.yaml
+++ b/apps/server/src/assets/etapi.openapi.yaml
@@ -1150,6 +1150,20 @@ components:
                 utcDateCreated:
                     $ref: "#/components/schemas/UtcDateTime"
                     description: UTC timestap of the note creation. Specify only if you want to override the default (current datetime).
+                dateModified:
+                    $ref: "#/components/schemas/LocalDateTime"
+                    description: >
+                        Local timestamp of the note's last modification. Optional, for migration
+                        imports that preserve the source's last-modified date. If both modification
+                        timestamps are supplied, utcDateModified takes precedence. Omit to stamp
+                        the current datetime.
+                utcDateModified:
+                    $ref: "#/components/schemas/UtcDateTime"
+                    description: >
+                        UTC timestamp of the note's last modification. Optional, for migration
+                        imports that preserve the source's last-modified date. If both modification
+                        timestamps are supplied, this value takes precedence. Omit to stamp the
+                        current datetime.
         Note:
             type: object
             properties:

--- a/apps/server/src/etapi/notes.ts
+++ b/apps/server/src/etapi/notes.ts
@@ -51,7 +51,9 @@ function register(router: Router) {
         isExpanded: [v.notNull, v.isBoolean],
         noteId: [v.notNull, v.isValidEntityId],
         dateCreated: [v.notNull, v.isString, v.isLocalDateTime],
-        utcDateCreated: [v.notNull, v.isString, v.isUtcDateTime]
+        utcDateCreated: [v.notNull, v.isString, v.isUtcDateTime],
+        dateModified: [v.notNull, v.isString, v.isLocalDateTime],
+        utcDateModified: [v.notNull, v.isString, v.isUtcDateTime]
     };
 
     eu.route(router, "post", "/etapi/create-note", (req, res, next) => {

--- a/apps/server/src/etapi/notes.ts
+++ b/apps/server/src/etapi/notes.ts
@@ -107,12 +107,8 @@ function register(router: Router) {
         eu.validateAndPatch(note, req.body, ALLOWED_PROPERTIES_FOR_PATCH);
         note.save();
 
-        // Every regular save() re-stamps "now" via BNote.beforeSaving, so a
-        // caller-supplied modification date would be lost. Re-apply it after
-        // the save with the same raw-SQL bypass the create-note path and the
-        // ENEX/OneNote/Notion importers use (BNote.setDateCreatedAndModified).
-        // This lets importers restore the source date after content rewrites
-        // (e.g. attachment URL replacement via PUT /content, which re-stamps).
+        // BNote.beforeSaving re-stamps the current time, so apply the caller-supplied
+        // modification date after note.save().
         const utcDateModified = req.body.utcDateModified
             ?? (req.body.dateModified
                 ? date_utils.utcDateTimeStr(date_utils.parseDateTime(req.body.dateModified))

--- a/apps/server/src/etapi/notes.ts
+++ b/apps/server/src/etapi/notes.ts
@@ -1,5 +1,5 @@
 import { type ExportFormat, note_service as noteService, NoteParams, search as searchService, SearchContext, SearchParams, TaskContext, zipExportService, zipImportService } from "@triliumnext/core";
-import { becca } from "@triliumnext/core";
+import { becca, date_utils } from "@triliumnext/core";
 import type { Request, Router } from "express";
 import type { ParsedQs } from "qs";
 
@@ -83,7 +83,9 @@ function register(router: Router) {
         type: [v.notNull, v.isString],
         mime: [v.notNull, v.isString],
         dateCreated: [v.notNull, v.isString, v.isLocalDateTime],
-        utcDateCreated: [v.notNull, v.isString, v.isUtcDateTime]
+        utcDateCreated: [v.notNull, v.isString, v.isUtcDateTime],
+        dateModified: [v.notNull, v.isString, v.isLocalDateTime],
+        utcDateModified: [v.notNull, v.isString, v.isUtcDateTime]
     };
 
     eu.route<{ noteId: string }>(router, "patch", "/etapi/notes/:noteId", (req, res, next) => {
@@ -104,6 +106,20 @@ function register(router: Router) {
         noteService.saveRevisionIfNeeded(note);
         eu.validateAndPatch(note, req.body, ALLOWED_PROPERTIES_FOR_PATCH);
         note.save();
+
+        // Every regular save() re-stamps "now" via BNote.beforeSaving, so a
+        // caller-supplied modification date would be lost. Re-apply it after
+        // the save with the same raw-SQL bypass the create-note path and the
+        // ENEX/OneNote/Notion importers use (BNote.setDateCreatedAndModified).
+        // This lets importers restore the source date after content rewrites
+        // (e.g. attachment URL replacement via PUT /content, which re-stamps).
+        const utcDateModified = req.body.utcDateModified
+            ?? (req.body.dateModified
+                ? date_utils.utcDateTimeStr(date_utils.parseDateTime(req.body.dateModified))
+                : undefined);
+        if (utcDateModified) {
+            note.setDateCreatedAndModified(undefined, utcDateModified);
+        }
 
         res.json(mappers.mapNoteToPojo(note));
     });

--- a/packages/trilium-core/src/services/image_download.spec.ts
+++ b/packages/trilium-core/src/services/image_download.spec.ts
@@ -257,6 +257,32 @@ describe("downloadImages (real DB)", () => {
         }
     });
 
+    it("keeps the note's dates when it goes back over it", async () => {
+        // An import preserving source dates (ETAPI dateModified) restores
+        // them after its own rewrite; the delayed download arriving later
+        // must not re-stamp them to now.
+        vi.useFakeTimers();
+
+        try {
+            const url = freshUrl();
+            const content = `<p><img src="${url}"></p>`;
+            const note = createNote(content);
+            getContext().init(() => note.setDateCreatedAndModified(
+                "2020-01-02 03:04:05.000Z", "2021-05-06 08:11:12.000Z"));
+
+            withDownloads(true, () => downloadImages(note.noteId, content));
+
+            await vi.advanceTimersByTimeAsync(10_000);
+
+            expect(note.getAttachments()).toHaveLength(1);
+            expect(String(note.getContent())).toContain("api/attachments/");
+            expect(note.utcDateCreated).toBe("2020-01-02 03:04:05.000Z");
+            expect(note.utcDateModified).toBe("2021-05-06 08:11:12.000Z");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("asks once for an address that appears twice before the first answer arrives", async () => {
         const note = createNote("<p>x</p>");
         const url = freshUrl();

--- a/packages/trilium-core/src/services/image_download.ts
+++ b/packages/trilium-core/src/services/image_download.ts
@@ -271,7 +271,17 @@ export function downloadImages(noteId: string, content: string) {
 
                 // update only if the links have not been already fixed.
                 if (updatedContent !== origContent) {
+                    // This is a background cosmetic swap (remote URL -> local
+                    // attachment) for content the reader already saved, not a
+                    // new edit: keep the note's dates so a delayed download
+                    // does not re-stamp them seconds later. That matters for
+                    // imports preserving source dates (ETAPI dateModified),
+                    // whose restore would otherwise be overwritten here.
+                    const prevUtcModified = origNote.utcDateModified;
                     origNote.setContent(updatedContent);
+                    if (prevUtcModified) {
+                        origNote.setDateCreatedAndModified(undefined, prevUtcModified);
+                    }
 
                     void noteService.asyncPostProcessContent(origNote, updatedContent);
 

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -61,6 +61,14 @@ export interface NoteParams {
     dateCreated?: string;
     utcDateCreated?: string;
     /**
+     * Optional override of the note's modification timestamps (ETAPI only).
+     * Applied after the note and its content are saved, since every regular
+     * save re-stamps "now". Migration importers use this to preserve the
+     * source's last-modified date. Omit both to keep the default behavior.
+     */
+    dateModified?: string;
+    utcDateModified?: string;
+    /**
      * Set internally when the client requested no `type` and it was derived from the parent note instead.
      * In that case a `child:template` of a different type is still applied (and converts the note), whereas
      * an explicitly chosen type wins over such a template (#3015).
@@ -243,6 +251,14 @@ function createNewNote(params: NoteParams): {
         throw new Error(error);
     }
 
+    if ((error = date_utils.validateLocalDateTime(params.dateModified))) {
+        throw new Error(error);
+    }
+
+    if ((error = date_utils.validateUtcDateTime(params.utcDateModified))) {
+        throw new Error(error);
+    }
+
     // When creating from a template, inherit the template's type and mime if not explicitly provided.
     // This ensures binary types (PDF, images, etc.) get the correct mime from the start.
     if (params.templateNoteId) {
@@ -323,6 +339,16 @@ function createNewNote(params: NoteParams): {
             copyAttachments(templateNote, note);
 
             // no special handling for ~inherit since it doesn't matter if it's assigned with the note creation or later
+        }
+
+        // Preserve the source's modification time after all content writes,
+        // since each save() re-stamps the current time.
+        const utcDateModified = params.utcDateModified
+            ?? (params.dateModified
+                ? date_utils.utcDateTimeStr(date_utils.parseDateTime(params.dateModified))
+                : undefined);
+        if (utcDateModified) {
+            note.setDateCreatedAndModified(undefined, utcDateModified);
         }
 
         copyChildAttributes(parentNote, note, params.isTypeDefaulted);

--- a/packages/trilium-core/src/services/notes.ts
+++ b/packages/trilium-core/src/services/notes.ts
@@ -1328,7 +1328,16 @@ function scanForLinks(note: BNote, content: string | Uint8Array) {
             const { forceFrontendReload, content: newContent } = saveLinks(note, content);
 
             if (content !== newContent) {
+                // A scan localizing already-fetched pictures (or normalizing
+                // links) is a background cosmetic swap, not a new edit: keep
+                // the note's dates. This runs deferred (image-download timers,
+                // ETAPI post-processing), so re-stamping here would overwrite
+                // dates an importer just restored via ETAPI dateModified.
+                const prevUtcModified = note.utcDateModified;
                 note.setContent(newContent, { forceFrontendReload });
+                if (prevUtcModified) {
+                    note.setDateCreatedAndModified(undefined, prevUtcModified);
+                }
             }
         });
     } catch (e: any) {


### PR DESCRIPTION
## Problem
Migration importers (e.g. Joplin -> Trilium via trilium-py, which reads the front matter `updated:` date) cannot preserve the source note's last-modified date: `POST /etapi/create-note` only accepts `dateCreated`/`utcDateCreated`, and every regular `save()` re-stamps `now` via `BNote.beforeSaving`. Imported notes all show the import time as last-modified.

## Change
- `NoteParams` gains optional `dateModified?: string` (local) and `utcDateModified?: string` (UTC).
- `createNewNote` validates both with the existing local/UTC datetime validators and, when either is supplied, applies them **after all content writes** (including the template path) via the same raw-SQL bypass the ENEX/OneNote/Notion/Keep/Anytype/Obsidian importers use (`BNote.setDateCreatedAndModified`, which also keeps the blob's stamp in sync). `utcDateModified` wins when both are given, otherwise it is derived from the local value.
- ETAPI allowlist and OpenAPI `CreateNoteDef` updated; no other endpoint touched.

## Backward compatibility
Both fields are optional. When omitted, behavior is exactly as before (import-time stamp). No existing request shape changes, and the response shape is unchanged.

## Scope note
`PATCH /etapi/notes/:noteId` is intentionally out of scope: its `note.save()` would need the same post-save treatment. Happy to follow up if maintainers want it.

## Tests
- New cases in `apps/server/spec/etapi/create-entities.spec.ts`: explicit pair round-trips, local-only derives the UTC value, omitted fields still stamp current time.
- Verified locally: `spec/etapi/` + Keep importer integration spec — 36 files, 175 tests, all pass.