### PR TITLE
Board: massive performance improvements

### DIFF
--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -583,7 +583,13 @@ function startCard(
     const noteId = element?.dataset.noteId;
     if (!element || !columnElement || !noteId) return null;
 
-    const cards = [ ...columnElement.querySelectorAll(".board-note") ];
+    // A windowed column draws a slice of its cards, so the card says which place it holds rather
+    // than being counted among the ones on screen.
+    const stated = element.dataset.index;
+    const place = stated === undefined ? Number.NaN : Number(stated);
+    const index = Number.isFinite(place)
+        ? place
+        : [ ...columnElement.querySelectorAll(".board-note") ].indexOf(element);
     const noteIds = carriedWith(noteId);
     return {
         kind: "card",
@@ -593,7 +599,7 @@ function startCard(
             noteId,
             noteIds,
             fromColumn: columnElement.dataset.column ?? "",
-            index: cards.indexOf(element),
+            index,
             height: carriedHeight(element, noteIds)
         },
         position: null,

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -3,10 +3,13 @@ import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
 import { useTrackedElement } from "../../react/hooks";
 import {
-    type CardBox, cardInsertionIndex, columnAt, columnCovers, columnInsertionIndex
+    type CardBox, cardInsertionIndex, columnAt, type ColumnBox, columnCovers, columnInsertionIndex
 } from "./drag_geometry";
-import { type BoardMeasurement, measureBoard, toAreaY, toBoardX } from "./drag_measure";
+import {
+    type BoardMeasurement, measureBoard, placeInModel, toAreaY, toBoardX
+} from "./drag_measure";
 import { createEdgeScroller, type ScrollTarget } from "../../react/edge_scroll";
+import { getColumnModel } from "./windowing";
 
 /** How far a pointer travels before a press with a button held is taken for a drag. */
 const MOUSE_THRESHOLD = 4;
@@ -247,7 +250,7 @@ export function useBoardDrag(
                 ? {
                     column: column.value,
                     index: area
-                        ? placeIn(column.cards, toAreaY(area, topY), held.card, column.value)
+                        ? placeAt(area, toAreaY(area, topY), held.card, column)
                         : 0
                 }
                 : null;
@@ -539,6 +542,21 @@ function row(held: Gesture & { kind: "column" }) {
     }
 
     return { lefts, stride: (boxes[held.index]?.width ?? 0) + gap };
+}
+
+/**
+ * The place a carried card would take in a column.
+ *
+ * A windowed column is asked what it is drawing with now: the boxes a gesture measures at its start
+ * only estimate the cards it was not drawing then, and an auto-scroll draws them for real.
+ */
+function placeAt(area: HTMLElement, y: number, card: DraggedCard, column: ColumnBox): number {
+    const model = getColumnModel(area);
+    if (!model) {
+        return placeIn(column.cards, y, card, column.value);
+    }
+
+    return placeInModel(model, y, column.value === card.fromColumn ? card.index : undefined);
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/board_drag.ts
+++ b/apps/client/src/widgets/collections/board/board_drag.ts
@@ -547,8 +547,9 @@ function row(held: Gesture & { kind: "column" }) {
 /**
  * The place a carried card would take in a column.
  *
- * A windowed column is asked what it is drawing with now: the boxes a gesture measures at its start
- * only estimate the cards it was not drawing then, and an auto-scroll draws them for real.
+ * For a windowed column this reads the column's current `ColumnModel`: the boxes `measureBoard`
+ * takes at the start of a gesture only estimate the cards that were not drawn then, and an
+ * auto-scroll goes on to draw them at their own heights.
  */
 function placeAt(area: HTMLElement, y: number, card: DraggedCard, column: ColumnBox): number {
     const model = getColumnModel(area);
@@ -556,7 +557,8 @@ function placeAt(area: HTMLElement, y: number, card: DraggedCard, column: Column
         return placeIn(column.cards, y, card, column.value);
     }
 
-    return placeInModel(model, y, column.value === card.fromColumn ? card.index : undefined);
+    return placeInModel(
+        model, y - column.origin, column.value === card.fromColumn ? card.index : undefined);
 }
 
 /**
@@ -601,8 +603,8 @@ function startCard(
     const noteId = element?.dataset.noteId;
     if (!element || !columnElement || !noteId) return null;
 
-    // A windowed column draws a slice of its cards, so the card says which place it holds rather
-    // than being counted among the ones on screen.
+    // A windowed column draws a slice of its cards, so the index comes from `data-index` rather
+    // than from the card's position among the ones on screen.
     const stated = element.dataset.index;
     const place = stated === undefined ? Number.NaN : Number(stated);
     const index = Number.isFinite(place)

--- a/apps/client/src/widgets/collections/board/card.tsx
+++ b/apps/client/src/widgets/collections/board/card.tsx
@@ -270,6 +270,7 @@ function Card({
                 }
             }}
             data-note-id={note.noteId}
+            data-index={index}
             onContextMenu={handleContextMenu}
             onDragStart={handleDragStart}
             onClick={!isEditing ? handleClick : undefined}

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -47,6 +47,9 @@ import { DEFAULT_CARD_ICON, DEFAULT_COLUMN_ICON, INBOX_COLUMN } from "./columns"
 import { openColumnContextMenu, openColumnSortMenu, openCreateCardMenu } from "./context_menu";
 import type { ColumnSort } from "./data";
 import { cardSpacing } from "./drag_measure";
+import {
+    REVEAL_CARD, type RevealCardDetail, useColumnWindow, WINDOW_THRESHOLD
+} from "./windowing";
 import { BoardDropStateContext, useDropIndex, useIsDropTarget } from "./drop_state";
 
 interface DragContext {
@@ -210,6 +213,15 @@ export default function Column({
     const headerRef = useRef<HTMLHeadingElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
     const scrollFade = useScrollFade(contentRef);
+    const noteIds = useMemo(
+        () => (columnItems ?? []).map(({ note }) => note.noteId), [ columnItems ]);
+    // A column of thousands draws only what the reader can see. Left off below the threshold, so
+    // an ordinary board keeps the code path it has always had.
+    const isWindowed = noteIds.length > WINDOW_THRESHOLD;
+    const { bounds, windowChanged, scrollToCard } = useColumnWindow(contentRef, noteIds, isWindowed);
+    const shownItems = isWindowed
+        ? (columnItems ?? []).slice(bounds.from, bounds.until)
+        : (columnItems ?? []);
     // Cards slide to follow the drop gap opening and closing. Measured only when the column's own
     // cards have changed: reading one position costs a layout of the whole board, and anything
     // else that redraws it would have every column read one per card.
@@ -221,10 +233,13 @@ export default function Column({
         // Paused where nothing has moved the cards, so the places it knows are still good.
         paused: !cardsChanged,
         // Off for the length of a gesture, so the commit that ends one records where the cards
-        // landed rather than sliding them there.
-        disabled: !!draggedCard || !!draggedColumn || !!isResizing
+        // landed rather than sliding them there. A window that has just swapped its cards is the
+        // same case: the places recorded before it name cards that are no longer drawn, and
+        // sliding from them would animate a scroll as though the column had been reordered.
+        disabled: !!draggedCard || !!draggedColumn || !!isResizing || windowChanged
     });
 
+    const windowFrom = isWindowed ? bounds.from : 0;
     // The gap is a standing element that slides, and the cards beside it are transformed: putting
     // one among the cards, or taking one out, restyles every element the board holds.
     const gapRef = useRef<HTMLDivElement>(null);
@@ -250,16 +265,24 @@ export default function Column({
         // moves, and the ones past its foot are left alone whatever it holds.
         const reach = Math.ceil(area.clientHeight / MIN_CARD_HEIGHT) + 1;
 
+        // A windowed column draws a slice of its cards, so a place in the column has to be read
+        // as a place among the ones drawn before it can name an element.
+        const placeOf = (index: number) => index - windowFrom;
+
         // Read before anything is written, and `offsetTop` is no business of a transform anyway.
         if (dropIndex !== null) {
-            const standing = cards[dropIndex];
+            const standing = cards[placeOf(dropIndex)];
             // `lift()` sets `display: none` on the carried card, so a gap past the last one
             // measures against the last card still laid out.
             const drawn = [ ...cards ].filter(card => card.style.display !== "none");
             const last = drawn[drawn.length - 1];
             const top = standing
                 ? standing.offsetTop
-                : (last ? last.offsetTop + last.offsetHeight + cardSpacing() : 0);
+                // A gap above the window stands at the first drawn card; one below it stands
+                // after the last, which is where the cards run out either way.
+                : (placeOf(dropIndex) < 0
+                    ? (cards[0]?.offsetTop ?? 0)
+                    : (last ? last.offsetTop + last.offsetHeight + cardSpacing() : 0));
             gap.style.transform = `translateY(${top}px)`;
             gap.style.height = `${height}px`;
         }
@@ -278,7 +301,7 @@ export default function Column({
             return;
         }
 
-        const from = dropIndex;
+        const from = Math.max(0, placeOf(dropIndex));
         const until = Math.min(cards.length, from + reach);
         const last = aside.current;
         // A step of a drag moves the gap by a card, so only the few cards it passed change what
@@ -298,7 +321,7 @@ export default function Column({
             }
         }
         aside.current = { from, until, room };
-    }, [ dropIndex, draggedCard, columnItems ]);
+    }, [ dropIndex, draggedCard, columnItems, windowFrom ]);
     const { handleDragOver, handleDragLeave, handleDrop } = useDragging({
         column, columnIndex, columnItems, isEditing, api, parentNote, onLanded: setCreatedNoteId
     });
@@ -516,6 +539,36 @@ export default function Column({
         return () => window.clearTimeout(timer);
     }, [ insertedNoteId, columnItems ]);
 
+    // A card just made at the foot of a long column stands outside the window, and the card's own
+    // effect that scrolls to it cannot run while it is not drawn. The column brings it into view
+    // instead, which is what draws it.
+    const arrived = createdNoteId ?? landedNoteId;
+    useEffect(() => {
+        if (!isWindowed || !arrived) return;
+
+        const index = noteIds.indexOf(arrived);
+        if (index >= 0 && (index < bounds.from || index >= bounds.until)) {
+            scrollToCard(index);
+        }
+    }, [ arrived, isWindowed, noteIds, bounds.from, bounds.until, scrollToCard ]);
+
+    // The keyboard can walk onto a card the window leaves undrawn, which cannot be focused until
+    // it is in the page.
+    useEffect(() => {
+        const board = contentRef.current?.closest<HTMLElement>(".board-view-container");
+        if (!board || !isWindowed) return;
+
+        const reveal = (event: Event) => {
+            const { detail } = event as CustomEvent<RevealCardDetail>;
+            if (detail.column === column) {
+                scrollToCard(detail.index);
+            }
+        };
+
+        board.addEventListener(REVEAL_CARD, reveal);
+        return () => board.removeEventListener(REVEAL_CARD, reveal);
+    }, [ column, isWindowed, scrollToCard ]);
+
     // The board raises its backdrop for any open field, and each column holds its own.
     useEffect(() => {
         setInsertingColumn(column, !!insertBefore);
@@ -550,6 +603,7 @@ export default function Column({
                 "with-hue": hue !== undefined,
                 "board-column-archived": archived,
                 "editing-open": hasEditedCard || !!insertBefore,
+                windowed: isWindowed,
                 "over-limit": isOverLimit,
                 collapsed: isCollapsed,
                 "quick-collapse": isCollapsingByHand,
@@ -674,8 +728,11 @@ export default function Column({
                 className={clsx("board-column-content", scrollFade.className)}
                 style={scrollFade.style}
                 onWheel={handleScroll}
+                data-window-from={isWindowed ? windowFrom : undefined}
+                data-window-count={isWindowed ? noteIds.length : undefined}
             >
-                {(columnItems ?? []).map(({ note, branch }, index) => (
+                <div className="board-window-spacer" style={{ height: `${bounds.above}px` }} />
+                {shownItems.map(({ note, branch }, offset) => (
                     <Fragment key={note.noteId}>
                         {insertBefore?.branchId === branch.branchId && insertField}
                         <Card
@@ -683,7 +740,7 @@ export default function Column({
                             note={note}
                             branch={branch}
                             column={column}
-                            index={index}
+                            index={bounds.from + offset}
                             statusAttribute={api.statusAttribute}
                             isNew={note.noteId === createdNoteId
                                 || note.noteId === landedNoteId}
@@ -696,6 +753,7 @@ export default function Column({
                         />
                     </Fragment>
                 ))}
+                <div className="board-window-spacer" style={{ height: `${bounds.below}px` }} />
                 {insertBefore && !insertBefore.branchId && insertField}
                 {/* Both stand here for the length of the board's life: an element appearing
                     among the cards, or leaving them, is what a drag cannot afford. */}

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -278,8 +278,8 @@ export default function Column({
             const last = drawn[drawn.length - 1];
             const top = standing
                 ? standing.offsetTop
-                // A gap above the window stands at the first drawn card; one below it stands
-                // after the last, which is where the cards run out either way.
+                // Above the window, place the gap at the first rendered card; below it, after
+                // the last.
                 : (placeOf(dropIndex) < 0
                     ? (cards[0]?.offsetTop ?? 0)
                     : (last ? last.offsetTop + last.offsetHeight + cardSpacing() : 0));
@@ -539,9 +539,8 @@ export default function Column({
         return () => window.clearTimeout(timer);
     }, [ insertedNoteId, columnItems ]);
 
-    // A card just made at the foot of a long column stands outside the window, and the card's own
-    // effect that scrolls to it cannot run while it is not drawn. The column brings it into view
-    // instead, which is what draws it.
+    // A card created at the foot of a long column falls outside the window, so the card's own
+    // scroll effect never runs. Scroll to it here, which renders it.
     const arrived = createdNoteId ?? landedNoteId;
     useEffect(() => {
         if (!isWindowed || !arrived) return;

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -561,7 +561,7 @@ export default function Column({
         const reveal = (event: Event) => {
             const { detail } = event as CustomEvent<RevealCardDetail>;
             if (detail.column === column) {
-                scrollToCard(detail.index);
+                scrollToCard(detail.index, detail.immediate);
             }
         };
 

--- a/apps/client/src/widgets/collections/board/column.tsx
+++ b/apps/client/src/widgets/collections/board/column.tsx
@@ -186,7 +186,7 @@ export default function Column({
     // `isNew` stays true until another column is added, so the reveal is recorded here rather than
     // replayed on every redraw of the board.
     const [ isRevealed, setIsRevealed ] = useState(false);
-    const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn } =
+    const { setColumnNameToEdit, setColumnLimitToEdit, setActiveColumn, setInsertingColumn } =
         useContext(BoardActionsContext);
     const { branchIdToEdit, columnNameToEdit, draggedCard, draggedColumn } =
         useContext(BoardDragStateContext);
@@ -516,6 +516,16 @@ export default function Column({
         return () => window.clearTimeout(timer);
     }, [ insertedNoteId, columnItems ]);
 
+    // The board raises its backdrop for any open field, and each column holds its own.
+    useEffect(() => {
+        setInsertingColumn(column, !!insertBefore);
+        return () => setInsertingColumn(column, false);
+    }, [ column, insertBefore, setInsertingColumn ]);
+
+    // Whether the title being edited is one of this column's, which lifts the mask below.
+    const hasEditedCard = !!branchIdToEdit
+        && !!columnItems?.some(({ branch }) => branch.branchId === branchIdToEdit);
+
     // The field a card is inserted in, drawn where the reader asked for the card. The same field
     // as the one below the column, so a card is made the same way wherever it goes.
     const insertField = insertBefore && (
@@ -539,6 +549,7 @@ export default function Column({
                 // The class the themes key a hue off, worn here as anywhere else that carries one.
                 "with-hue": hue !== undefined,
                 "board-column-archived": archived,
+                "editing-open": hasEditedCard || !!insertBefore,
                 "over-limit": isOverLimit,
                 collapsed: isCollapsed,
                 "quick-collapse": isCollapsingByHand,

--- a/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.spec.ts
@@ -12,6 +12,7 @@ function columns(cards: Record<string, CardBox[]> = {}): ColumnBox[] {
         left: index * 120,
         width: 100,
         top: 0,
+        origin: 0,
         height: 400,
         cards: cards[value] ?? []
     }));
@@ -79,7 +80,7 @@ describe("columnCovers", () => {
      */
     it("tells the column from the empty space below a short one", () => {
         const strip: ColumnBox = {
-            value: "Parked", left: 0, width: 36, top: 0, height: 90, cards: []
+            value: "Parked", left: 0, width: 36, top: 0, height: 90, origin: 0, cards: []
         };
 
         expect(columnCovers(strip, 18, 0)).toBe(true);

--- a/apps/client/src/widgets/collections/board/drag_geometry.ts
+++ b/apps/client/src/widgets/collections/board/drag_geometry.ts
@@ -28,6 +28,14 @@ export interface ColumnBox {
     top: number;
     height: number;
     /**
+     * Where the column's first card begins, in the space {@link toAreaY} reads a point into.
+     *
+     * The column's own top padding, which the boxes below already include but a place counted from
+     * the heights alone does not. Left out, every such place is short by it, and a point near a
+     * boundary falls into the slot below the one the gap is drawn at.
+     */
+    origin: number;
+    /**
      * The cards as drawn, in order, the dragged one included. Counting it keeps the index in the
      * same terms as the list the board holds, which is what a move is expressed in.
      */

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -285,3 +285,85 @@ describe("placeInModel", () => {
         expect(placeInModel({ heights: [], spacing: 9 }, 40, undefined)).toBe(0);
     });
 });
+
+describe("measuring a windowed column", () => {
+    /**
+     * A column that draws a slice of its cards states what it holds and where the slice begins, and
+     * stands a spacer at either end for the rest. The measurement counts those in, so an index it
+     * leads to names a place in the column rather than a place among the cards on screen.
+     */
+    function buildWindowed({ total = 100, from = 40, above = 2400, below = 3300 } = {}) {
+        const board = buildBoard({ cardCounts: [ 2 ], areaScrollTop: 0 });
+        const area = board.querySelector<HTMLElement>(".board-column-content");
+        if (!area) throw new Error("expected a card area");
+
+        area.dataset.windowCount = String(total);
+        area.dataset.windowFrom = String(from);
+
+        // The drawn cards stand below the spacer, which is where a windowed column draws them.
+        for (const [ index, card ] of [ ...area.querySelectorAll<HTMLElement>(".board-note") ].entries()) {
+            place(card, { left: 0, top: 40 + above + 10 + index * 60, width: 100, height: 50 });
+        }
+        for (const [ index, height ] of [ above, below ].entries()) {
+            const spacer = document.createElement("div");
+            spacer.className = "board-window-spacer";
+            Object.defineProperty(spacer, "offsetHeight", { value: height, configurable: true });
+            // The one above stands before the cards, the one below after them.
+            if (index === 0) {
+                area.insertBefore(spacer, area.firstChild);
+            } else {
+                area.appendChild(spacer);
+            }
+        }
+
+        return board;
+    }
+
+    it("counts the cards the column is not drawing, so an index names a place in the column", () => {
+        const board = buildWindowed();
+
+        const [ column ] = measureBoard(board).columns;
+
+        // Two drawn cards, and the rest of the hundred stood for by the spacers.
+        expect(column.cards).toHaveLength(100);
+        expect(column.cards[40].height).toBe(50);
+        expect(column.cards[41].height).toBe(50);
+    });
+
+    it("stands the undrawn cards in order, above the drawn ones and below them", () => {
+        const board = buildWindowed();
+
+        const [ column ] = measureBoard(board).columns;
+        const tops = column.cards.map((card) => card.top);
+
+        expect(tops).toHaveLength(100);
+        // Never doubles back: a drop read against these has to walk them in order.
+        for (const [ index, top ] of tops.entries()) {
+            if (index > 0) {
+                expect(top).toBeGreaterThanOrEqual(tops[index - 1]);
+            }
+        }
+        expect(tops[0]).toBe(0);
+        expect(tops[39]).toBeLessThan(tops[40]);
+    });
+
+    it("measures a column drawing all of itself exactly as it always did", () => {
+        const board = buildBoard({ cardCounts: [ 2 ], areaScrollTop: 0 });
+
+        const [ column ] = measureBoard(board).columns;
+
+        expect(column.cards).toHaveLength(2);
+    });
+
+    it("counts a column that states a window but is drawing none of it", () => {
+        const board = buildWindowed({ total: 60, from: 60, above: 3600, below: 0 });
+        const area = board.querySelector<HTMLElement>(".board-column-content");
+        for (const card of area?.querySelectorAll(".board-note") ?? []) {
+            card.remove();
+        }
+
+        const [ column ] = measureBoard(board).columns;
+
+        expect(column.cards).toHaveLength(60);
+    });
+});

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -355,6 +355,33 @@ describe("measuring a windowed column", () => {
         expect(column.cards).toHaveLength(2);
     });
 
+    /**
+     * A place counted from the heights alone starts at zero, while a point read into the area's
+     * space starts at the column's own top padding. Losing that shifts every place by it, and a
+     * point near a boundary lands in the slot below the one the gap is drawn at.
+     */
+    it("reports where the column's cards begin, which is its own padding", () => {
+        const board = buildWindowed({ above: 2400 });
+        const area = board.querySelector<HTMLElement>(".board-column-content");
+        const spacer = area?.querySelector<HTMLElement>(".board-window-spacer");
+        if (!area || !spacer) throw new Error("expected a spacer at the head of the cards");
+
+        // The head spacer begins 8px into the area, which is what the column is padded by.
+        place(spacer, { left: 0, top: 48, width: 100, height: 2400 });
+
+        const [ column ] = measureBoard(board).columns;
+
+        expect(column.origin).toBe(8);
+    });
+
+    it("reports no origin for a column measured without its cards", () => {
+        const board = buildWindowed();
+
+        const [ column ] = measureBoard(board, false).columns;
+
+        expect(column.origin).toBe(0);
+    });
+
     it("counts a column that states a window but is drawing none of it", () => {
         const board = buildWindowed({ total: 60, from: 60, above: 3600, below: 0 });
         const area = board.querySelector<HTMLElement>(".board-column-content");

--- a/apps/client/src/widgets/collections/board/drag_measure.spec.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.spec.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { cardInsertionIndex, columnAt } from "./drag_geometry";
-import { forgetCardHeights, measureBoard, toAreaY, toBoardX } from "./drag_measure";
+import {
+    forgetCardHeights, measureBoard, placeInModel, toAreaY, toBoardX
+} from "./drag_measure";
 
 let container: HTMLElement | undefined;
 
@@ -224,5 +226,62 @@ describe("reading a point against a measurement", () => {
             expect(columnAt(columns, toBoardX(board, onScreen))?.value).toBe("To Do");
             board.remove();
         }
+    });
+});
+
+describe("placeInModel", () => {
+    /** The boxes a column of these heights lays out, for comparing against the geometry. */
+    const boxesOf = (heights: number[], spacing: number) => {
+        let top = 0;
+        return heights.map((height) => {
+            const box = { top, height };
+            top += height + spacing;
+            return box;
+        });
+    };
+
+    /**
+     * The model has to answer exactly what the geometry answers from the boxes: it stands in for
+     * reading the page, and a column that drifts between the two puts the gap somewhere the drop
+     * does not go.
+     */
+    it("agrees with the geometry at every point down a column", () => {
+        const heights = Array.from({ length: 40 }, (_, i) => 40 + (i % 5) * 20);
+        const spacing = 9;
+        const boxes = boxesOf(heights, spacing);
+        const foot = boxes[boxes.length - 1].top + boxes[boxes.length - 1].height;
+
+        for (let y = -20; y < foot + 40; y += 7) {
+            expect(placeInModel({ heights, spacing }, y, undefined))
+                .toBe(cardInsertionIndex(boxes, y));
+        }
+    });
+
+    it("agrees with the geometry for a card carried within the same column", () => {
+        const heights = Array.from({ length: 30 }, (_, i) => 50 + (i % 3) * 30);
+        const spacing = 9;
+
+        for (const carried of [ 0, 7, 29 ]) {
+            // The carried card is out of the flow, so the column lays out without it.
+            const rest = heights.filter((_, index) => index !== carried);
+            const boxes = boxesOf(rest, spacing);
+            const foot = boxes[boxes.length - 1].top + boxes[boxes.length - 1].height;
+
+            for (let y = -20; y < foot + 40; y += 11) {
+                const place = cardInsertionIndex(boxes, y);
+                const expected = place >= carried ? place + 1 : place;
+                expect(placeInModel({ heights, spacing }, y, carried)).toBe(expected);
+            }
+        }
+    });
+
+    it("puts a point above the column at the front and one below it at the back", () => {
+        const model = { heights: [ 60, 60, 60 ], spacing: 10 };
+        expect(placeInModel(model, -500, undefined)).toBe(0);
+        expect(placeInModel(model, 99_999, undefined)).toBe(3);
+    });
+
+    it("answers for a column holding nothing", () => {
+        expect(placeInModel({ heights: [], spacing: 9 }, 40, undefined)).toBe(0);
     });
 });

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -1,4 +1,5 @@
 import { type CardBox, type ColumnBox } from "./drag_geometry";
+import { type ColumnModel } from "./windowing";
 
 /** What a drag measures once at its start, and reads for the rest of the gesture. */
 export interface BoardMeasurement {
@@ -56,6 +57,47 @@ export function measureBoard(container: HTMLElement, withCards = true): BoardMea
 /** A point in the board's content space, which its horizontal scrolling does not move columns in. */
 export function toBoardX(container: HTMLElement, clientX: number): number {
     return clientX - container.getBoundingClientRect().left + container.scrollLeft;
+}
+
+/**
+ * The place a carried card would take in a windowed column, counted from what the column lays its
+ * cards out with rather than from the page.
+ *
+ * The same answer {@link cardInsertionIndex} gives for a column drawn in full, and the same
+ * treatment of the carried card: it is out of the flow while it is held, so the cards below it
+ * stand one place higher and the index is counted back afterwards.
+ *
+ * Worked out per move rather than once per gesture. A window that has moved under an auto-scroll
+ * draws cards the gesture had only estimated, and an index counted from the estimate drifts further
+ * from the gap the longer the scroll runs.
+ *
+ * @param carrying the place the carried card holds here, or `undefined` if it came from elsewhere.
+ */
+export function placeInModel(model: ColumnModel, y: number, carrying: number | undefined): number {
+    const { heights, spacing } = model;
+    let offset = 0;
+    /** How many cards have been passed, the carried one not counted among them. */
+    let place = 0;
+
+    for (const [ index, height ] of heights.entries()) {
+        if (index === carrying) {
+            continue;
+        }
+
+        const foot = offset + height;
+        const isLast = index === heights.length - 1
+            || (carrying === heights.length - 1 && index === heights.length - 2);
+        // Halfway into the gap below a card is where the next place begins.
+        const boundary = isLast ? foot : foot + spacing / 2;
+        if (y < boundary) {
+            return carrying !== undefined && place >= carrying ? place + 1 : place;
+        }
+
+        offset = foot + spacing;
+        place++;
+    }
+
+    return carrying !== undefined && place >= carrying ? place + 1 : place;
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -47,11 +47,28 @@ export function measureBoard(container: HTMLElement, withCards = true): BoardMea
             width: rect.width,
             top: rect.top,
             height: rect.height,
+            origin: withCards ? contentOrigin(area) : 0,
             cards: withCards ? measureCards(area) : []
         });
     }
 
     return { columns, areas };
+}
+
+/**
+ * Where a column's first card begins, in the space {@link toAreaY} reads a point into.
+ *
+ * Taken from the spacer standing at the head of the cards, which begins where they do whatever the
+ * column is drawing. Read once per gesture: a column's padding does not change while one runs.
+ */
+function contentOrigin(area: HTMLElement | null) {
+    const spacer = area?.querySelector<HTMLElement>(".board-window-spacer");
+    if (!area || !spacer) {
+        return 0;
+    }
+
+    return spacer.getBoundingClientRect().top
+        - (area.getBoundingClientRect().top - area.scrollTop);
 }
 
 /** A point in the board's content space, which its horizontal scrolling does not move columns in. */
@@ -63,9 +80,9 @@ export function toBoardX(container: HTMLElement, clientX: number): number {
  * The place a carried card would take in a windowed column, counted from what the column lays its
  * cards out with rather than from the page.
  *
- * The same answer {@link cardInsertionIndex} gives for a column drawn in full, and the same
- * treatment of the carried card: it is out of the flow while it is held, so the cards below it
- * stand one place higher and the index is counted back afterwards.
+ * Matches {@link cardInsertionIndex} for a column drawn in full, and treats the carried card the
+ * same way: it is out of the flow while held, so the cards below it stand one place higher and the
+ * index is converted back afterwards.
  *
  * Worked out per move rather than once per gesture. A window that has moved under an auto-scroll
  * draws cards the gesture had only estimated, and an index counted from the estimate drifts further
@@ -244,7 +261,7 @@ function countCards(area: HTMLElement, readEvery: boolean) {
     return { cards: [ ...above, ...cards, ...below ], elements, borrowed, top, drawnFrom: window.from };
 }
 
-/** What the column says it is drawing, or nothing where it draws all of itself. */
+/** The window a column states on its card area, or nothing where it draws every card. */
 function readWindow(area: HTMLElement) {
     const stated = area.dataset.windowCount;
     const total = stated === undefined ? Number.NaN : Number(stated);

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -58,8 +58,8 @@ export function measureBoard(container: HTMLElement, withCards = true): BoardMea
 /**
  * Where a column's first card begins, in the space {@link toAreaY} reads a point into.
  *
- * Taken from the spacer standing at the head of the cards, which begins where they do whatever the
- * column is drawing. Read once per gesture: a column's padding does not change while one runs.
+ * Read from the leading `.board-window-spacer`, which begins where the cards do whether or not the
+ * column is windowed. Read once per gesture: the padding does not change while one runs.
  */
 function contentOrigin(area: HTMLElement | null) {
     const spacer = area?.querySelector<HTMLElement>(".board-window-spacer");
@@ -80,20 +80,20 @@ export function toBoardX(container: HTMLElement, clientX: number): number {
  * The place a carried card would take in a windowed column, counted from what the column lays its
  * cards out with rather than from the page.
  *
- * Matches {@link cardInsertionIndex} for a column drawn in full, and treats the carried card the
- * same way: it is out of the flow while held, so the cards below it stand one place higher and the
+ * Matches {@link cardInsertionIndex} for a fully rendered column, and treats the dragged card the
+ * same way: it is out of the flow while held, so the cards below it shift up one place and the
  * index is converted back afterwards.
  *
- * Worked out per move rather than once per gesture. A window that has moved under an auto-scroll
- * draws cards the gesture had only estimated, and an index counted from the estimate drifts further
- * from the gap the longer the scroll runs.
+ * Computed per pointer move rather than once per gesture. An auto-scroll moves the window onto
+ * cards the gesture had only estimated, and an index computed from those estimates drifts further
+ * from the drop placeholder the longer the scroll runs.
  *
  * @param carrying the place the carried card holds here, or `undefined` if it came from elsewhere.
  */
 export function placeInModel(model: ColumnModel, y: number, carrying: number | undefined): number {
     const { heights, spacing } = model;
     let offset = 0;
-    /** How many cards have been passed, the carried one not counted among them. */
+    /** How many cards have been passed, excluding the dragged one. */
     let place = 0;
 
     for (const [ index, height ] of heights.entries()) {
@@ -104,7 +104,7 @@ export function placeInModel(model: ColumnModel, y: number, carrying: number | u
         const foot = offset + height;
         const isLast = index === heights.length - 1
             || (carrying === heights.length - 1 && index === heights.length - 2);
-        // Halfway into the gap below a card is where the next place begins.
+        // The next slot begins halfway into the gap below a card.
         const boundary = isLast ? foot : foot + spacing / 2;
         if (y < boundary) {
             return carrying !== undefined && place >= carrying ? place + 1 : place;
@@ -193,9 +193,8 @@ function measureCards(area: HTMLElement | null): CardBox[] {
 function countCards(area: HTMLElement, readEvery: boolean) {
     const top = area.getBoundingClientRect().top - area.scrollTop;
     const cards: CardBox[] = [];
-    // A windowed column draws a slice of itself. The cards it leaves undrawn are counted in below
-    // and above the ones it does, so an index here still names a place in the column rather than a
-    // place among what happens to be on screen.
+    // A windowed column renders a slice of its cards. Boxes for the unrendered ones are added
+    // above and below, so an index here is a position in the column, not among the visible cards.
     const window = readWindow(area);
     const elements: HTMLElement[] = [];
     /** Where the next card stands if it has to be counted rather than read. */
@@ -249,9 +248,8 @@ function countCards(area: HTMLElement, readEvery: boolean) {
         return { cards, elements, borrowed, top, drawnFrom: 0 };
     }
 
-    // The undrawn cards are spread evenly over the spacer standing for them: precise enough for a
-    // drop, which can only land where the reader can see, and it keeps every index in the column's
-    // own terms.
+    // Spread the unrendered cards evenly across the spacer covering them. Precise enough for a
+    // drop, which can only land where the reader can see, and it keeps every index in column terms.
     const above = spread(window.from, 0, window.above);
     const below = spread(
         window.total - window.from - cards.length,
@@ -278,7 +276,7 @@ function readWindow(area: HTMLElement) {
     };
 }
 
-/** Stands `count` cards evenly across a run of pixels, for the ones a column is not drawing. */
+/** Returns `count` boxes spread evenly across `span` pixels, for cards a column does not render. */
 function spread(count: number, from: number, span: number): CardBox[] {
     if (count <= 0) {
         return [];

--- a/apps/client/src/widgets/collections/board/drag_measure.ts
+++ b/apps/client/src/widgets/collections/board/drag_measure.ts
@@ -107,12 +107,13 @@ function measureCards(area: HTMLElement | null): CardBox[] {
 
     const counted = countCards(area, false);
     const { cards, elements } = counted;
-    const last = cards.length - 1;
+    // The last card the column actually draws, which in a windowed one is not the last it holds.
+    const last = counted.drawnFrom + elements.length - 1;
 
     // A card whose title or attributes changed stands a different height, and nothing says so, so
     // where the last card really is settles whether what was remembered still holds.
-    if (counted.borrowed && last > 0) {
-        const at = elements[last].getBoundingClientRect().top - counted.top;
+    if (counted.borrowed && elements.length > 1 && cards[last]) {
+        const at = elements[elements.length - 1].getBoundingClientRect().top - counted.top;
         if (Math.abs(at - cards[last].top) > 1) {
             for (const element of elements) {
                 heights.delete(element.dataset.noteId ?? "");
@@ -133,6 +134,10 @@ function measureCards(area: HTMLElement | null): CardBox[] {
 function countCards(area: HTMLElement, readEvery: boolean) {
     const top = area.getBoundingClientRect().top - area.scrollTop;
     const cards: CardBox[] = [];
+    // A windowed column draws a slice of itself. The cards it leaves undrawn are counted in below
+    // and above the ones it does, so an index here still names a place in the column rather than a
+    // place among what happens to be on screen.
+    const window = readWindow(area);
     const elements: HTMLElement[] = [];
     /** Where the next card stands if it has to be counted rather than read. */
     let next = 0;
@@ -181,5 +186,48 @@ function countCards(area: HTMLElement, readEvery: boolean) {
         next = stands + height + (spacing ?? 0);
     }
 
-    return { cards, elements, borrowed, top };
+    if (!window) {
+        return { cards, elements, borrowed, top, drawnFrom: 0 };
+    }
+
+    // The undrawn cards are spread evenly over the spacer standing for them: precise enough for a
+    // drop, which can only land where the reader can see, and it keeps every index in the column's
+    // own terms.
+    const above = spread(window.from, 0, window.above);
+    const below = spread(
+        window.total - window.from - cards.length,
+        window.above + (cards.length ? next - window.above : 0),
+        window.below);
+
+    return { cards: [ ...above, ...cards, ...below ], elements, borrowed, top, drawnFrom: window.from };
+}
+
+/** What the column says it is drawing, or nothing where it draws all of itself. */
+function readWindow(area: HTMLElement) {
+    const stated = area.dataset.windowCount;
+    const total = stated === undefined ? Number.NaN : Number(stated);
+    if (!Number.isFinite(total)) {
+        return undefined;
+    }
+
+    const spacers = area.querySelectorAll<HTMLElement>(".board-window-spacer");
+    return {
+        from: Number(area.dataset.windowFrom ?? "0") || 0,
+        total,
+        above: spacers[0]?.offsetHeight ?? 0,
+        below: spacers[1]?.offsetHeight ?? 0
+    };
+}
+
+/** Stands `count` cards evenly across a run of pixels, for the ones a column is not drawing. */
+function spread(count: number, from: number, span: number): CardBox[] {
+    if (count <= 0) {
+        return [];
+    }
+
+    const each = span / count;
+    return Array.from({ length: count }, (_, index) => ({
+        top: from + index * each,
+        height: Math.max(0, each - (spacing ?? 0))
+    }));
 }

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -625,6 +625,19 @@ body.mobile .board-view-container .board-add-column {
 /* A column contains only what it can scroll itself. `contain` on both axes would also hold a
    sideways swipe that starts on a card, which the column cannot scroll and the board can: Chrome
    stops it at the column instead of passing it on, and the board never moves. */
+/* Stands for the cards a windowed column is not drawing, so the column is the height it would be
+   were it drawing them. */
+.board-view-container .board-window-spacer {
+  margin: 0;
+}
+
+/* A measurement that corrects the spacer above moves everything below it, and the column moves its
+   own scroll position by as much to hold the reader still. The browser must not do so as well: the
+   two chase each other and never settle. */
+.board-view-container .board-column.windowed > .board-column-content {
+  overflow-anchor: none;
+}
+
 .board-view-container .board-column-content {
   overscroll-behavior-y: contain;
   /* What the gap is placed against, and what a card's `offsetTop` is then counted from. */

--- a/apps/client/src/widgets/collections/board/index.css
+++ b/apps/client/src/widgets/collections/board/index.css
@@ -678,10 +678,9 @@ body.mobile .board-view-container .board-add-column {
   transition: opacity 0.3s ease;
 }
 
-/* Matched on the field rather than on state in `index.tsx`: each column holds its own editing
-   state. `inserting` marks only the field that opens between two cards, so the one at the foot of
-   a column leaves the backdrop down. */
-.board-view:has(.board-note.editing, .board-new-item.inserting) .board-edit-backdrop {
+/* `editing-open` is set by `index.tsx` for a card being renamed or a field open between two cards;
+   the field at the foot of a column leaves the backdrop down. */
+.board-view.editing-open .board-edit-backdrop {
   opacity: 1;
 }
 
@@ -710,8 +709,7 @@ body.mobile .board-view-container .board-add-column {
 /* `motion-disabled` sets `transition: none !important` on everything, so `.board-edit-backdrop`
    fires no `transitionend` and `frozen` is never set. There is no fade to protect either, so the
    same fields freeze the board as soon as they open. */
-body#trilium-app.motion-disabled
-  .board-view:has(.board-note.editing, .board-new-item.inserting) :is(
+body#trilium-app.motion-disabled .board-view.editing-open :is(
   .board-column > h3,
   .board-column > .board-new-item,
   .board-column-content > *:not(.editing)
@@ -723,8 +721,7 @@ body#trilium-app.motion-disabled
    layer of its own, which the field being typed into could not rise out of. Taken off the one
    column that holds it, for as long as it stands. `!important` because `useScrollFade` writes the
    mask on the element itself. */
-.board-view-container .board-column:has(.board-note.editing, .board-new-item.inserting)
-    .board-column-content {
+.board-view-container .board-column.editing-open .board-column-content {
   mask: none !important;
 }
 

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3548,6 +3548,33 @@ describe("Board filtering", () => {
         return results;
     }
 
+    /**
+     * The move is drawn at once, into the unfiltered map. Counting the place among the shown cards
+     * instead puts the card partway up the column, and it jumps to the end when the write lands.
+     */
+    it("sends a card to the end of the column, not to the end of what the filter shows", async () => {
+        // "To Do" holds three cards and shows one, so the two counts are far enough apart to tell
+        // which of them the move used.
+        await setup({ matched: [ "filtered3", "filtered4" ] });
+        expect(cardTitles(0)).toEqual([ "Third" ]);
+        expect(cardTitles(1)).toEqual([ "Fourth" ]);
+
+        const carried = container.querySelectorAll<HTMLElement>(".board-column")[1]
+            ?.querySelector<HTMLElement>(".board-note");
+        if (!carried) throw new Error("expected a card in the second column");
+
+        carried.focus();
+        await act(async () => {
+            carried.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "ArrowLeft", ctrlKey: true, bubbles: true, cancelable: true
+            }));
+            await flush();
+        });
+
+        // Drawn behind the card already shown, which is where the end of the column is.
+        expect(cardTitles(0)).toEqual([ "Third", "Fourth" ]);
+    });
+
     it("shows only the matched cards, in their own order, keeping every column", async () => {
         // The matches arrive in score order; the board must keep branch order regardless.
         const note = await setup({ matched: [ "filtered3", "filtered1" ] });

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -4208,3 +4208,100 @@ describe("Board properties from the note menu", () => {
         return host;
     }
 });
+
+describe("a column windowed for its size", () => {
+    let container: HTMLElement | undefined;
+
+    beforeEach(() => {
+        saved.length = 0;
+        vi.restoreAllMocks();
+        vi.spyOn(server, "put").mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    it("draws a slice of a big column and stands spacers for the rest", async () => {
+        const board = await renderSized(200, 3);
+        const columns = board.querySelectorAll<HTMLElement>(".board-column");
+        const big = columns[0];
+        const small = columns[1];
+        if (!big || !small) throw new Error("expected two columns");
+
+        const drawn = big.querySelectorAll(".board-note");
+        expect(drawn.length).toBeGreaterThan(0);
+        expect(drawn.length).toBeLessThan(200);
+        expect(big.classList.contains("windowed")).toBe(true);
+
+        const area = big.querySelector<HTMLElement>(".board-column-content");
+        expect(area?.dataset.windowCount).toBe("200");
+        expect(area?.dataset.windowFrom).toBe("0");
+
+        // The cards it is not drawing are held by the spacer below them.
+        const spacers = big.querySelectorAll<HTMLElement>(".board-window-spacer");
+        expect(spacers).toHaveLength(2);
+        expect(spacers[0].style.height).toBe("0px");
+        expect(Number.parseFloat(spacers[1].style.height)).toBeGreaterThan(0);
+
+        // A column that fits keeps the path it has always had.
+        expect(small.classList.contains("windowed")).toBe(false);
+        expect(small.querySelectorAll(".board-note")).toHaveLength(3);
+        expect(small.querySelector<HTMLElement>(".board-column-content")?.dataset.windowCount)
+            .toBeUndefined();
+    });
+
+    /**
+     * The drag and the keyboard both name a card by the place it holds in its column. Counting
+     * drawn elements would name a place among whatever is on screen, which moves as it scrolls.
+     */
+    it("gives each card the place it holds in the column, not among the ones drawn", async () => {
+        const board = await renderSized(200, 3);
+        const drawn = [ ...board.querySelectorAll<HTMLElement>(".board-column-content .board-note") ];
+        const big = drawn.filter((card) => card.closest(".board-column")
+            === board.querySelector(".board-column"));
+
+        expect(big.map((card) => card.dataset.index))
+            .toEqual(big.map((_, index) => String(index)));
+    });
+
+    async function renderSized(big: number, small: number) {
+        const note = buildNote({
+            title: "Board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                ...Array.from({ length: big }, (_, i) => ({
+                    title: `Big ${i}`, "#status": "To Do"
+                })),
+                ...Array.from({ length: small }, (_, i) => ({
+                    title: `Small ${i}`, "#status": "Done"
+                }))
+            ]
+        });
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={new Component()}>
+                    <Harness
+                        note={note}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        initialConfig={{ columns: [ { value: "To Do" }, { value: "Done" } ] }}
+                    />
+                </ParentComponent.Provider>,
+                mountPoint
+            );
+        });
+        await act(async () => { await flush(); });
+
+        return mountPoint;
+    }
+});

--- a/apps/client/src/widgets/collections/board/index.spec.tsx
+++ b/apps/client/src/widgets/collections/board/index.spec.tsx
@@ -3223,6 +3223,83 @@ describe("Board editors and menus", () => {
         await act(async () => { await flush(); });
     }
 
+    /**
+     * The backdrop and the frozen cards are driven by classes rather than by `:has()`: a `:has()`
+     * naming a descendant makes every card insertion invalidate the whole board.
+     */
+    it("marks the board and the one column while a card title is being edited", async () => {
+        const board = await renderBoard();
+        const view = board.querySelector<HTMLElement>(".board-view");
+        const columns = board.querySelectorAll<HTMLElement>(".board-column");
+        const card = columns[0]?.querySelector<HTMLElement>(".board-note");
+        if (!view || !card || columns.length < 2) throw new Error("expected a card in two columns");
+
+        expect(view.classList.contains("editing-open")).toBe(false);
+
+        await act(async () => {
+            card.dispatchEvent(new KeyboardEvent("keydown", { key: "F2", bubbles: true }));
+            await flush();
+        });
+
+        expect(view.classList.contains("editing-open")).toBe(true);
+        expect(columns[0].classList.contains("editing-open")).toBe(true);
+        expect(columns[1].classList.contains("editing-open")).toBe(false);
+
+        const editor = card.querySelector<HTMLTextAreaElement>("textarea");
+        if (!editor) throw new Error("expected the card editor to be open");
+
+        await act(async () => {
+            editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+            await flush();
+        });
+
+        expect(view.classList.contains("editing-open")).toBe(false);
+        expect(columns[0].classList.contains("editing-open")).toBe(false);
+    });
+
+    it("marks a field opened between cards, and leaves the one at a column's foot unmarked", async () => {
+        const board = await renderBoard();
+        const view = board.querySelector<HTMLElement>(".board-view");
+        const columns = board.querySelectorAll<HTMLElement>(".board-column");
+        const card = columns[0]?.querySelector<HTMLElement>(".board-note");
+        if (!view || !card || columns.length < 2) throw new Error("expected a card in two columns");
+
+        await act(async () => {
+            card.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+            await flush();
+        });
+
+        expect(board.querySelector(".board-new-item.inserting")).toBeTruthy();
+        expect(view.classList.contains("editing-open")).toBe(true);
+        expect(columns[0].classList.contains("editing-open")).toBe(true);
+        expect(columns[1].classList.contains("editing-open")).toBe(false);
+
+        const field = columns[0].querySelector<HTMLTextAreaElement>(
+            ".board-new-item.inserting textarea");
+        if (!field) throw new Error("expected the insert field to be open");
+
+        await act(async () => {
+            field.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+            await flush();
+        });
+
+        expect(view.classList.contains("editing-open")).toBe(false);
+
+        // The field below a column makes a card the same way but leaves the board undimmed.
+        const footer = columns[1].querySelector<HTMLElement>(".board-new-item");
+        if (!footer) throw new Error("expected the column footer");
+
+        await act(async () => {
+            footer.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+            await flush();
+        });
+
+        expect(footer.classList.contains("editing")).toBe(true);
+        expect(footer.classList.contains("inserting")).toBe(false);
+        expect(view.classList.contains("editing-open")).toBe(false);
+        expect(columns[1].classList.contains("editing-open")).toBe(false);
+    });
+
     async function renderBoard() {
         const note = buildNote({
             title: "Board",

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -192,6 +192,13 @@ interface BoardActions {
     setDraggedColumn: (column: ColumnDrag | null) => void;
     setDropPosition: (position: ColumnDrag | null) => void;
     setDropTarget: (target: string | null) => void;
+    /**
+     * Reports whether a column holds an open insert field, which the board reads to raise the
+     * backdrop. Held here rather than matched with `:has()` in the stylesheet: a `:has()` naming a
+     * descendant makes every card insertion invalidate the whole board, which on a column of
+     * thousands is hundreds of milliseconds of style recalculation per card added.
+     */
+    setInsertingColumn: (column: string, isOpen: boolean) => void;
 }
 
 /**
@@ -221,7 +228,8 @@ export const BoardActionsContext = createContext<BoardActions>({
     setDraggedCard: () => undefined,
     setDraggedColumn: () => undefined,
     setDropPosition: () => undefined,
-    setDropTarget: () => undefined
+    setDropTarget: () => undefined,
+    setInsertingColumn: () => undefined
 });
 
 /**
@@ -251,6 +259,9 @@ export const BoardKeptCardsContext = createContext<Set<string>>(new Set());
  * board handles itself (see `keyboard.ts` and the card and column handlers), none of them
  * rebindable, so each is listed literally rather than through a registered action.
  */
+/** Stands for a board where no column has an insert field open, so no render allocates a set. */
+const NO_COLUMNS: ReadonlySet<string> = new Set();
+
 /** How long a finger stays on the create button before it offers where to put the card. */
 const HOLD_TO_PLACE_MS = 500;
 
@@ -389,6 +400,24 @@ export default function BoardView({
     const [ isEditingProperties, setIsEditingProperties ] = useState(false);
     /** Adds `frozen`, which takes `pointer-events` off the cards. Set once the backdrop has faded in. */
     const [ isFrozen, setIsFrozen ] = useState(false);
+    /** The columns holding an open insert field, which each column reports for itself. */
+    const [ insertingColumns, setInsertingColumns ] = useState<ReadonlySet<string>>(NO_COLUMNS);
+    const setInsertingColumn = useCallback((column: string, isOpen: boolean) => {
+        setInsertingColumns((current) => {
+            if (current.has(column) === isOpen) {
+                return current;
+            }
+
+            const next = new Set(current);
+            if (isOpen) {
+                next.add(column);
+            } else {
+                next.delete(column);
+            }
+
+            return next;
+        });
+    }, []);
     const selectColumn = useCallback<Dispatch<StateUpdater<string | undefined>>>((column) => {
         setIsPeekingAll(false);
         setActiveColumn(column);
@@ -571,10 +600,11 @@ export default function BoardView({
         setDraggedCard,
         setDraggedColumn,
         setDropPosition,
-        setDropTarget
+        setDropTarget,
+        setInsertingColumn
     }), [
         setBranchIdToEdit, setColumnNameToEdit, setColumnLimitToEdit, selectColumn,
-        setDraggedCard, setDraggedColumn, setDropPosition, setDropTarget
+        setDraggedCard, setDraggedColumn, setDropPosition, setDropTarget, setInsertingColumn
     ]);
 
     // Read off the config rather than off `columns`, which the resolver hands back as names alone.
@@ -1156,10 +1186,12 @@ export default function BoardView({
         : undefined;
 
     return (
-        <div className={clsx("board-view", { frozen: isFrozen })}>
+        <div className={clsx("board-view", {
+            frozen: isFrozen,
+            "editing-open": branchIdToEdit !== undefined || insertingColumns.size > 0
+        })}>
             {/* Dims the board while a title is being typed, with the edited card lifted above it.
-                Always rendered so that it can fade in. `index.css` picks the fields that raise it
-                with `:has()`, since each column holds its own editing state.
+                Always rendered so that it can fade in.
 
                 `frozen` waits for the fade to finish: setting it restyles every card, which in the
                 same frame drops the fade's frames. */}

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -260,7 +260,7 @@ export const BoardKeptCardsContext = createContext<Set<string>>(new Set());
  * board handles itself (see `keyboard.ts` and the card and column handlers), none of them
  * rebindable, so each is listed literally rather than through a registered action.
  */
-/** Stands for a board where no column has an insert field open, so no render allocates a set. */
+/** Shared empty set for a board with no insert field open, so no render allocates one. */
 const NO_COLUMNS: ReadonlySet<string> = new Set();
 
 /** How long a finger stays on the create button before it offers where to put the card. */

--- a/apps/client/src/widgets/collections/board/index.tsx
+++ b/apps/client/src/widgets/collections/board/index.tsx
@@ -49,6 +49,7 @@ import Api, { getPendingWrites, PendingColumnWrites, settleColumn } from "./api"
 import { useBoardDrag } from "./board_drag";
 import { columnGapStandsAside, columnStandsAside, movesColumn } from "./drag_geometry";
 import { forgetCardHeights } from "./drag_measure";
+import { forgetWindowHeights } from "./windowing";
 import { BoardDropStateContext, DropStateStore } from "./drop_state";
 import BoardApi from "./api";
 import { adoptLegacyColumns, readColumns } from "./column_storage";
@@ -658,8 +659,13 @@ export default function BoardView({
     // measured at. A phone gives a column a share of the window, so a window that changes size
     // takes the heights with it.
     useEffect(() => {
-        window.addEventListener("resize", forgetCardHeights);
-        return () => window.removeEventListener("resize", forgetCardHeights);
+        const forget = () => {
+            forgetCardHeights();
+            forgetWindowHeights();
+        };
+
+        window.addEventListener("resize", forget);
+        return () => window.removeEventListener("resize", forget);
     }, []);
 
     // Which columns stand narrow, as a line, so that one opening or closing is read off a single
@@ -1107,15 +1113,21 @@ export default function BoardView({
     const sendCardsToColumn = useCallback((
         cards: { noteId: string, branchId: string }[], targetColumn: string
     ) => holdMove(
-        cards, targetColumn, api.getColumnNoteIds(targetColumn).length,
+        // The end of the column itself, not of what a filter leaves showing of it: the move is
+        // drawn into `allByColumn`, so a place counted among the shown cards would put the card
+        // partway up the column and leave it to jump to the end as the write lands.
+        cards, targetColumn, allByColumn?.get(targetColumn)?.length ?? 0,
         api.moveToColumnEnd(cards, targetColumn)),
-    [ api, holdMove ]);
+    [ api, holdMove, allByColumn ]);
 
     /** Moves cards to a place among the ones already in a column. */
     const moveCardsWithin = useCallback((
         cards: { noteId: string, branchId: string }[], column: string, index: number
-    ) => holdMove(cards, column, index, api.moveWithinBoard(cards, column, index)),
-    [ api, holdMove ]);
+    ) => holdMove(
+        cards, column,
+        unfilteredCardIndex(byColumn?.get(column) ?? [], allByColumn?.get(column) ?? [], index),
+        api.moveWithinBoard(cards, column, index)),
+    [ api, holdMove, byColumn, allByColumn ]);
 
     const clearSelectionOutsideCards = useCallback((e: MouseEvent) => {
         if (!(e.target as HTMLElement | null)?.closest(".board-note")) {

--- a/apps/client/src/widgets/collections/board/keyboard.spec.tsx
+++ b/apps/client/src/widgets/collections/board/keyboard.spec.tsx
@@ -1274,3 +1274,171 @@ describe("Board keyboard", () => {
     }
 
 });
+
+/**
+ * A column of thousands draws only a slice of its cards, so walking it steps onto cards that are
+ * not in the page. The keyboard names a card by the place it holds in the column and asks the
+ * column to draw it, rather than counting the ones on screen.
+ */
+describe("Board keyboard over a windowed column", () => {
+    let container: HTMLElement | undefined;
+    const CARDS = 400;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        vi.spyOn(server, "put").mockResolvedValue(undefined);
+        vi.spyOn(server, "post").mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        if (container) {
+            render(null, container);
+            container.remove();
+            container = undefined;
+        }
+    });
+
+    it("draws fewer cards than it holds, and states what it holds", async () => {
+        const board = await renderBig();
+        const area = board.querySelector<HTMLElement>(".board-column-content");
+
+        expect(area?.dataset.windowCount).toBe(String(CARDS));
+        expect(area?.querySelectorAll(".board-note").length).toBeLessThan(CARDS);
+    });
+
+    it("walks onto a card the column is not drawing, and focuses it", async () => {
+        const board = await renderBig();
+        const column = board.querySelector<HTMLElement>(".board-column");
+        const drawn = [ ...(column?.querySelectorAll<HTMLElement>(".board-note") ?? []) ];
+        const last = drawn[drawn.length - 1];
+        if (!column || !last) throw new Error("expected the column to draw some cards");
+
+        const beyond = Number(last.dataset.index) + 1;
+        expect(column.querySelector(`.board-note[data-index="${beyond}"]`)).toBeNull();
+
+        last.focus();
+        await act(async () => {
+            last.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+            await flush();
+        });
+
+        const arrived = column.querySelector<HTMLElement>(`.board-note[data-index="${beyond}"]`);
+        expect(arrived).not.toBeNull();
+        expect(document.activeElement).toBe(arrived);
+    });
+
+    it("takes End to the last card of the column, not the last one drawn", async () => {
+        const board = await renderBig();
+        const first = board.querySelector<HTMLElement>(".board-note");
+        if (!first) throw new Error("expected a card");
+
+        first.focus();
+        await act(async () => {
+            first.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+            await flush();
+        });
+
+        const focused = (document.activeElement as HTMLElement | null)?.closest<HTMLElement>(".board-note");
+        expect(focused?.dataset.index).toBe(String(CARDS - 1));
+    });
+
+    it("walks back up out of the window it moved to", async () => {
+        const board = await renderBig();
+        const first = board.querySelector<HTMLElement>(".board-note");
+        if (!first) throw new Error("expected a card");
+
+        first.focus();
+        await act(async () => {
+            first.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+            await flush();
+        });
+
+        const atEnd = (document.activeElement as HTMLElement | null)?.closest<HTMLElement>(".board-note");
+        if (!atEnd) throw new Error("expected End to land on a card");
+
+        await act(async () => {
+            atEnd.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+            await flush();
+        });
+
+        const home = (document.activeElement as HTMLElement | null)?.closest<HTMLElement>(".board-note");
+        expect(home?.dataset.index).toBe("0");
+    });
+
+    /**
+     * The card lands at the end of a column that is not drawing its end, so there is nothing in the
+     * page to focus. The board asks that column for it and focuses it once it has been drawn.
+     */
+    it("focuses a card sent into a column that is not drawing where it lands", async () => {
+        const board = await renderBig();
+        const columns = board.querySelectorAll<HTMLElement>(".board-column");
+        const sent = columns[1]?.querySelector<HTMLElement>(".board-note");
+        if (!sent) throw new Error("expected a card in the small column");
+
+        const noteId = sent.dataset.noteId;
+        sent.focus();
+        await act(async () => {
+            sent.dispatchEvent(new KeyboardEvent("keydown", {
+                key: "ArrowLeft", ctrlKey: true, bubbles: true, cancelable: true
+            }));
+            await flush();
+        });
+        // The reveal waits for the column to draw the card, which takes a frame.
+        await act(async () => { await frame(); await flush(); });
+        await act(async () => { await frame(); await flush(); });
+
+        const arrived = board.querySelector<HTMLElement>(`.board-note[data-note-id="${noteId}"]`);
+        expect(arrived).not.toBeNull();
+        expect(arrived?.closest(".board-column")).toBe(columns[0]);
+        expect(document.activeElement).toBe(arrived);
+    });
+
+    function frame() {
+        return new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    }
+
+    async function renderBig() {
+        const note = buildNote({
+            title: "Big board",
+            "#collection": "",
+            "#viewType": "board",
+            children: [
+                ...Array.from({ length: CARDS }, (_, i) => ({
+                    title: `Card ${i}`, "#status": "To Do"
+                })),
+                { title: "Only", "#status": "Doing" }
+            ]
+        });
+
+        const mountPoint = document.createElement("div");
+        container = mountPoint;
+        document.body.appendChild(mountPoint);
+
+        await act(async () => {
+            render(
+                <ParentComponent.Provider value={new Component()}>
+                    <BoardView
+                        note={note}
+                        notePath={`root/${note.noteId}`}
+                        noteIds={[ ...note.getChildNoteIds() ]}
+                        highlightedTokens={null}
+                        viewConfig={{
+                            columns: [ { value: "To Do" }, { value: "Doing" } ]
+                        }}
+                        saveConfig={() => {}}
+                        media="screen"
+                        onReady={() => {}}
+                    />
+                </ParentComponent.Provider>,
+                mountPoint
+            );
+        });
+        await act(async () => { await flush(); });
+
+        return mountPoint;
+    }
+
+    function flush() {
+        return new Promise((resolve) => setTimeout(resolve));
+    }
+});

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -109,7 +109,7 @@ export function useBoardKeyboard({
     const pendingFocus = useRef<PendingFocus | null>(null);
     /** The card `askForCard` has already run for, so it does not run again on every render. */
     const asked = useRef<string | null>(null);
-    /** Where the reader last stood, for a key pressed while focus is between two draws. */
+    /** The last spot walked to, for a key pressed while focus is between two renders. */
     const lastSpot = useRef<Spot | null>(null);
 
     // Every render, since a redraw is the only thing that takes focus away here and more than one
@@ -201,8 +201,8 @@ export function useBoardKeyboard({
 
         const spot = spotOf(container, document.activeElement)
             // Focus can be left on nothing by a redraw that took the card it was on out of the
-            // page. The walk carries on from where it last stood rather than letting the key
-            // through, which would scroll the board instead of moving along it.
+            // page. Fall back to the previous spot rather than letting the key through, which
+            // would scroll the board instead of moving along it.
             ?? (NAVIGATION_KEYS.includes(e.key) ? lastSpot.current : null);
         if (!spot) return;
 

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -109,6 +109,8 @@ export function useBoardKeyboard({
     const pendingFocus = useRef<PendingFocus | null>(null);
     /** The card a column has been asked to draw, so it is not asked for again each render. */
     const asked = useRef<string | null>(null);
+    /** Where the reader last stood, for a key pressed while focus is between two draws. */
+    const lastSpot = useRef<Spot | null>(null);
 
     // Every render, since a redraw is the only thing that takes focus away here and more than one
     // of them follows a move.
@@ -197,7 +199,11 @@ export function useBoardKeyboard({
         // work over a board as over anything else.
         if (e.altKey && !e.ctrlKey) return;
 
-        const spot = spotOf(container, document.activeElement);
+        const spot = spotOf(container, document.activeElement)
+            // Focus can be left on nothing by a redraw that took the card it was on out of the
+            // page. The walk carries on from where it last stood rather than letting the key
+            // through, which would scroll the board instead of moving along it.
+            ?? (NAVIGATION_KEYS.includes(e.key) ? lastSpot.current : null);
         if (!spot) return;
 
         if (e.ctrlKey) {
@@ -274,7 +280,7 @@ export function useBoardKeyboard({
         if (NAVIGATION_KEYS.includes(e.key)) {
             // The plain arrows would otherwise scroll the page past the end of a column.
             take(e);
-            walk(container, spot, e.key);
+            lastSpot.current = walk(container, spot, e.key) ?? spot;
             return;
         }
 
@@ -453,14 +459,14 @@ function spotOf(container: HTMLElement, element: Element | null): Spot | null {
  * right cross to the next column's first card, or to its button where it holds none: its header is
  * reached by pressing up from there, which is the only way a header is reached at all.
  */
-function walk(container: HTMLElement, from: Spot, key: string) {
+function walk(container: HTMLElement, from: Spot, key: string): Spot | null {
     const next = destination(container, from, key);
-    if (!next) return false;
+    if (!next) return null;
 
     const element = elementAt(container, next);
     if (element) {
         reveal(element);
-        return true;
+        return next;
     }
 
     // A windowed column draws a slice of its cards, and the walk has stepped onto one outside it.
@@ -468,20 +474,20 @@ function walk(container: HTMLElement, from: Spot, key: string) {
     if (next.kind === "item") {
         const column = columnsOf(container)[next.column];
         const value = column?.dataset.column;
-        if (!column || value === undefined) return false;
+        if (!column || value === undefined) return null;
 
-        askForCard(container, value, next.item);
-        // Focused on the frame after the column has drawn it: the element does not exist yet.
-        requestAnimationFrame(() => {
-            const arrived = cardAt(column, next.item);
-            if (arrived) {
-                reveal(arrived);
-            }
-        });
-        return true;
+        // Drawn before the ask returns, so the card is focused in this keystroke. Left to a later
+        // frame, the scroll can take the card being walked from out of the page first, and focus
+        // falls to nothing: the next key then finds nowhere to walk from and the board scrolls.
+        askForCard(container, value, next.item, true);
+        const arrived = cardAt(column, next.item);
+        if (arrived) {
+            reveal(arrived);
+            return next;
+        }
     }
 
-    return false;
+    return null;
 }
 
 function destination(container: HTMLElement, from: Spot, key: string): Spot | null {

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -1,3 +1,4 @@
+import { askForCard } from "./windowing";
 import { cardFollows } from "./columns";
 import { RefObject } from "preact";
 import { useCallback, useLayoutEffect, useRef } from "preact/hooks";
@@ -106,6 +107,8 @@ export function useBoardKeyboard({
     sendCardsToColumn, moveCardsWithin
 }: BoardKeyboardOptions) {
     const pendingFocus = useRef<PendingFocus | null>(null);
+    /** The card a column has been asked to draw, so it is not asked for again each render. */
+    const asked = useRef<string | null>(null);
 
     // Every render, since a redraw is the only thing that takes focus away here and more than one
     // of them follows a move.
@@ -136,7 +139,28 @@ export function useBoardKeyboard({
 
         if (element) {
             reveal(element);
+            return;
         }
+
+        // The card has landed in a windowed column that is not drawing it, so there is nothing to
+        // focus yet. The column is asked to scroll to it, which draws it.
+        //
+        // Waited for here rather than left to this effect running again: the scroll re-renders the
+        // column alone, and the board this effect belongs to is not drawn again by it.
+        const { noteId } = pending.intent;
+        if (asked.current === noteId) return;
+
+        const place = placeOf(byColumn, noteId);
+        if (!place) return;
+
+        asked.current = noteId;
+        askForCard(container, place.column, place.index);
+        waitForCard(container, noteId, (card) => {
+            asked.current = null;
+            if (pendingFocus.current === pending && document.activeElement === document.body) {
+                reveal(card);
+            }
+        });
     });
 
     /**
@@ -419,7 +443,7 @@ function spotOf(container: HTMLElement, element: Element | null): Spot | null {
     const card = element.closest(".board-note");
     if (!card) return null;
 
-    return { kind: "item", column, item: cardsOf(columnElement).indexOf(card as HTMLElement) };
+    return { kind: "item", column, item: indexOfCard(card as HTMLElement, columnElement) };
 }
 
 /**
@@ -434,10 +458,30 @@ function walk(container: HTMLElement, from: Spot, key: string) {
     if (!next) return false;
 
     const element = elementAt(container, next);
-    if (!element) return false;
+    if (element) {
+        reveal(element);
+        return true;
+    }
 
-    reveal(element);
-    return true;
+    // A windowed column draws a slice of its cards, and the walk has stepped onto one outside it.
+    // The column is asked to bring it into view, which is what puts it in the page to be focused.
+    if (next.kind === "item") {
+        const column = columnsOf(container)[next.column];
+        const value = column?.dataset.column;
+        if (!column || value === undefined) return false;
+
+        askForCard(container, value, next.item);
+        // Focused on the frame after the column has drawn it: the element does not exist yet.
+        requestAnimationFrame(() => {
+            const arrived = cardAt(column, next.item);
+            if (arrived) {
+                reveal(arrived);
+            }
+        });
+        return true;
+    }
+
+    return false;
 }
 
 function destination(container: HTMLElement, from: Spot, key: string): Spot | null {
@@ -456,7 +500,7 @@ function destination(container: HTMLElement, from: Spot, key: string): Spot | nu
 
     if (from.kind === "add-column") return null;
 
-    const items = cardsOf(columnsOf(container)[from.column]).length;
+    const items = cardCountOf(columnsOf(container)[from.column]);
     if (key === "Home") return entryOf(container, from.column);
     if (key === "End") {
         return items
@@ -483,7 +527,7 @@ function entryOf(container: HTMLElement, column: number): Spot {
         return { kind: "header", column };
     }
 
-    return cardsOf(element).length
+    return cardCountOf(element)
         ? { kind: "item", column, item: 0 }
         : { kind: "add-item", column };
 }
@@ -655,7 +699,41 @@ function elementAt(container: HTMLElement, spot: Spot): HTMLElement | null {
 
     if (spot.kind === "header") return column.querySelector("h3");
     if (spot.kind === "add-item") return column.querySelector(".board-new-item");
-    return cardsOf(column)[spot.item] ?? null;
+    return cardAt(column, spot.item);
+}
+
+/**
+ * Watches for a card to be drawn, for the few frames a column takes to scroll to it.
+ *
+ * Given up on rather than waited for indefinitely: a card that never arrives means the move did not
+ * land where it was expected, and focus is better left alone than chased.
+ */
+function waitForCard(
+    container: HTMLElement, noteId: string, then: (card: HTMLElement) => void, tries = 8
+) {
+    const card = findCard(container, noteId);
+    if (card) {
+        then(card);
+        return;
+    }
+
+    if (tries > 0) {
+        requestAnimationFrame(() => waitForCard(container, noteId, then, tries - 1));
+    }
+}
+
+/** Which column holds a note and where in it, for a card the board is not drawing. */
+function placeOf(byColumn: ColumnMap | undefined, noteId: string) {
+    if (!byColumn) return undefined;
+
+    for (const [ column, items ] of byColumn) {
+        const index = items.findIndex((item) => item.note.noteId === noteId);
+        if (index >= 0) {
+            return { column, index };
+        }
+    }
+
+    return undefined;
 }
 
 /** Found by what it stands for rather than by where it sits, which a move is about to change. */
@@ -680,4 +758,32 @@ function cardsOf(column: Element | undefined) {
     }
 
     return [ ...column.querySelectorAll<HTMLElement>(".board-note") ];
+}
+
+/**
+ * How many cards a column holds, which a windowed one draws only part of.
+ *
+ * Read from what the column states rather than counted off the page, or walking one would stop at
+ * the edge of what happens to be drawn.
+ */
+function cardCountOf(column: Element | undefined) {
+    if (!column || column.classList.contains("collapsed")) {
+        return 0;
+    }
+
+    const stated = column.querySelector<HTMLElement>(".board-column-content")?.dataset.windowCount;
+    const count = stated === undefined ? Number.NaN : Number(stated);
+    return Number.isFinite(count) ? count : cardsOf(column).length;
+}
+
+/** The place a card holds in its column, which it states for a windowed one. */
+function indexOfCard(card: HTMLElement, column: Element | undefined) {
+    const stated = card.dataset.index;
+    const index = stated === undefined ? Number.NaN : Number(stated);
+    return Number.isFinite(index) ? index : cardsOf(column).indexOf(card);
+}
+
+/** The card at a place in a column, or nothing where the column is not drawing it. */
+function cardAt(column: Element, index: number) {
+    return column.querySelector<HTMLElement>(`.board-note[data-index="${index}"]`);
 }

--- a/apps/client/src/widgets/collections/board/keyboard.ts
+++ b/apps/client/src/widgets/collections/board/keyboard.ts
@@ -107,7 +107,7 @@ export function useBoardKeyboard({
     sendCardsToColumn, moveCardsWithin
 }: BoardKeyboardOptions) {
     const pendingFocus = useRef<PendingFocus | null>(null);
-    /** The card a column has been asked to draw, so it is not asked for again each render. */
+    /** The card `askForCard` has already run for, so it does not run again on every render. */
     const asked = useRef<string | null>(null);
     /** Where the reader last stood, for a key pressed while focus is between two draws. */
     const lastSpot = useRef<Spot | null>(null);
@@ -145,7 +145,7 @@ export function useBoardKeyboard({
         }
 
         // The card has landed in a windowed column that is not drawing it, so there is nothing to
-        // focus yet. The column is asked to scroll to it, which draws it.
+        // focus yet. `askForCard` scrolls that column, which draws the card.
         //
         // Waited for here rather than left to this effect running again: the scroll re-renders the
         // column alone, and the board this effect belongs to is not drawn again by it.
@@ -470,15 +470,16 @@ function walk(container: HTMLElement, from: Spot, key: string): Spot | null {
     }
 
     // A windowed column draws a slice of its cards, and the walk has stepped onto one outside it.
-    // The column is asked to bring it into view, which is what puts it in the page to be focused.
+    // `askForCard` scrolls that column, which puts the card in the page so it can be focused.
     if (next.kind === "item") {
         const column = columnsOf(container)[next.column];
         const value = column?.dataset.column;
         if (!column || value === undefined) return null;
 
-        // Drawn before the ask returns, so the card is focused in this keystroke. Left to a later
-        // frame, the scroll can take the card being walked from out of the page first, and focus
-        // falls to nothing: the next key then finds nowhere to walk from and the board scrolls.
+        // `immediate` draws the card before this returns, so it is focused in this keystroke.
+        // Deferred to a later frame, the scroll can unmount the card being walked from, leaving
+        // `document.activeElement` on the body: `spotOf` then finds no spot and the browser
+        // scrolls the board instead.
         askForCard(container, value, next.item, true);
         const arrived = cardAt(column, next.item);
         if (arrived) {

--- a/apps/client/src/widgets/collections/board/windowing.spec.tsx
+++ b/apps/client/src/widgets/collections/board/windowing.spec.tsx
@@ -3,8 +3,9 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-    type ColumnWindow, computeWindow, estimateFrom, forgetWindowHeights, NOMINAL_CARD_HEIGHT,
-    resolveHeights, sameWindow, useColumnWindow, type WindowInput
+    askForCard, type ColumnWindow, computeWindow, estimateFor, forgetWindowHeights,
+    NOMINAL_CARD_HEIGHT, resolveHeights, REVEAL_CARD, type RevealCardDetail, sameWindow,
+    useColumnWindow, type WindowInput
 } from "./windowing";
 
 /** A column of uniform cards, which makes every offset in a test arithmetic. */
@@ -134,34 +135,61 @@ describe("resolveHeights", () => {
     });
 });
 
-describe("estimateFrom", () => {
-    beforeEach(() => forgetWindowHeights());
+describe("estimateFor", () => {
+    const ids = (count: number, from = 0) =>
+        Array.from({ length: count }, (_, i) => `n${from + i}`);
+    const measuredAt = (count: number, height: number, from = 0) =>
+        new Map(ids(count, from).map((id) => [ id, height ] as const));
 
-    it("stands at the nominal height until enough cards have been measured", () => {
-        const measured = new Map([ [ "a", 200 ], [ "b", 200 ] ]);
-        expect(estimateFrom(measured)).toBe(NOMINAL_CARD_HEIGHT);
+    it("answers nothing until enough of the column's own cards have been measured", () => {
+        expect(estimateFor(ids(50), measuredAt(2, 200), undefined)).toBeUndefined();
     });
 
-    it("settles on the average once there are enough of them", () => {
-        const measured = new Map(
-            Array.from({ length: 12 }, (_, i) => [ `n${i}`, 100 ] as const));
-        expect(estimateFrom(measured)).toBe(100);
+    it("settles on the average of the column's measured cards", () => {
+        expect(estimateFor(ids(50), measuredAt(12, 100), undefined)).toBe(100);
     });
 
     /**
-     * The spacer above the window is counted from this, and the spacer is what holds the reader's
-     * place: a figure that kept being revised would move the column under them as they read it.
+     * The spacer above the window is counted from this and is what holds the reader's place: a
+     * figure that kept being revised would slide the column while they read it.
      */
-    it("never moves again once it has settled", () => {
-        const measured = new Map<string, number>(
-            Array.from({ length: 12 }, (_, i) => [ `n${i}`, 100 ]));
-        expect(estimateFrom(measured)).toBe(100);
+    it("answers back what a column has already settled on", () => {
+        const measured = new Map<string, number>(measuredAt(40, 500));
+        expect(estimateFor(ids(50), measured, 100)).toBe(100);
+    });
 
-        for (let i = 0; i < 40; i++) {
-            measured.set(`tall${i}`, 500);
-        }
+    /**
+     * Two boards, or two columns of one board, can carry different attributes and stand at quite
+     * different heights. Counting one column's cards at another's average puts its spacers, its
+     * scrollbar and its scroll destinations all in the wrong place.
+     */
+    it("counts only the cards the column holds, not every card measured anywhere", () => {
+        const measured = new Map<string, number>([
+            // A tall column measured earlier, whose cards this one does not hold.
+            ...measuredAt(40, 500, 100),
+            ...measuredAt(12, 60)
+        ]);
 
-        expect(estimateFrom(measured)).toBe(100);
+        expect(estimateFor(ids(50), measured, undefined)).toBe(60);
+    });
+});
+
+describe("askForCard", () => {
+    it("raises the ask on the board, naming the column, the card and how soon it is wanted", () => {
+        const board = document.createElement("div");
+        document.body.appendChild(board);
+        const seen: RevealCardDetail[] = [];
+        board.addEventListener(REVEAL_CARD, (e) =>
+            seen.push((e as CustomEvent<RevealCardDetail>).detail));
+
+        askForCard(board, "To Do", 42);
+        askForCard(board, "Done", 7, true);
+        board.remove();
+
+        expect(seen).toEqual([
+            { column: "To Do", index: 42, immediate: false },
+            { column: "Done", index: 7, immediate: true }
+        ]);
     });
 });
 
@@ -200,13 +228,14 @@ describe("useColumnWindow", () => {
 
     /** Renders a probe that does nothing but report what the hook hands back. */
     async function probe(noteIds: string[], enabled = true) {
-        const seen: { bounds: ColumnWindow, windowChanged: boolean }[] = [];
+        const seen: ReturnType<typeof useColumnWindow>[] = [];
         const ref = { current: area ?? null };
 
         function Probe() {
             seen.push(useColumnWindow(ref, noteIds, enabled));
             return null;
         }
+
 
         await act(async () => {
             render(<Probe />, host ?? document.body);
@@ -247,6 +276,58 @@ describe("useColumnWindow", () => {
         expect(moved.above).toBeGreaterThan(first.above);
         // The flip has to be told, or it slides cards from places that named other cards.
         expect(last().windowChanged).toBe(true);
+    });
+
+    it("scrolls to a card the column is not drawing, placing it inside the area", async () => {
+        const { last } = await probe(ids(2000));
+
+        await act(async () => last().scrollToCard(400));
+
+        // Cards stand at the nominal height until measured, so where card 400 begins is arithmetic.
+        const perCard = NOMINAL_CARD_HEIGHT + 9;
+        expect(area?.scrollTop).toBe(Math.max(0, 400 * perCard - 300));
+    });
+
+    it("leaves the scroll alone for a column it is switched off for", async () => {
+        const { last } = await probe(ids(2000), false);
+        if (area) area.scrollTop = 42;
+
+        await act(async () => last().scrollToCard(400));
+
+        expect(area?.scrollTop).toBe(42);
+    });
+
+    it("draws the card before the ask returns when it is wanted at once", async () => {
+        const { last } = await probe(ids(2000));
+        const before = last().bounds;
+
+        // No act(): the point is that the window has moved by the time the call returns, which is
+        // what lets a keyboard walk focus the card in the same keystroke.
+        last().scrollToCard(400, true);
+
+        expect(last().bounds.from).toBeGreaterThan(before.from);
+    });
+
+    it("counts a card at what it measures once the column has drawn it", async () => {
+        const noteIds = ids(2000);
+        const { last } = await probe(noteIds);
+        const tall = last().bounds.below;
+
+        // The cards the column drew, standing taller than the nominal height it assumed.
+        await act(async () => {
+            for (const noteId of noteIds.slice(0, 30)) {
+                const card = document.createElement("div");
+                card.className = "board-note";
+                card.dataset.noteId = noteId;
+                Object.defineProperty(card, "offsetHeight", { value: 200, configurable: true });
+                area?.appendChild(card);
+            }
+            if (area) area.scrollTop = 1;
+            area?.dispatchEvent(new Event("scroll"));
+        });
+
+        // A taller column has more of itself left below the window than it was counted at.
+        expect(last().bounds.below).toBeGreaterThan(tall);
     });
 
     it("leaves the window alone for a scroll that stays inside the chunk it is drawing", async () => {

--- a/apps/client/src/widgets/collections/board/windowing.spec.tsx
+++ b/apps/client/src/widgets/collections/board/windowing.spec.tsx
@@ -1,0 +1,264 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+    type ColumnWindow, computeWindow, estimateFrom, forgetWindowHeights, NOMINAL_CARD_HEIGHT,
+    resolveHeights, sameWindow, useColumnWindow, type WindowInput
+} from "./windowing";
+
+/** A column of uniform cards, which makes every offset in a test arithmetic. */
+function column(count: number, height = 100, spacing = 10): Omit<WindowInput, "scrollTop"> {
+    return { heights: Array(count).fill(height), spacing, viewport: 500 };
+}
+
+describe("computeWindow", () => {
+    it("draws nothing for a column holding nothing", () => {
+        expect(computeWindow({ heights: [], spacing: 10, scrollTop: 0, viewport: 500 }))
+            .toEqual({ from: 0, until: 0, above: 0, below: 0 });
+    });
+
+    it("draws the whole of a column that fits, with no spacer at either end", () => {
+        const win = computeWindow({ ...column(4), scrollTop: 0, overscan: 0, chunk: 1 });
+        expect(win).toEqual({ from: 0, until: 4, above: 0, below: 0 });
+    });
+
+    it("draws what the area shows plus the overscan, and stands the spacers on the rest", () => {
+        // Cards are 110px apart. At 1000px down, the area covers cards 9 through 13.
+        const win = computeWindow({ ...column(100), scrollTop: 1000, overscan: 0, chunk: 1 });
+
+        expect(win.from).toBe(9);
+        expect(win.until).toBe(14);
+        expect(win.above).toBe(9 * 110);
+        expect(win.below).toBe((100 - 14) * 110);
+        // What the spacers and the drawn cards stand at together is the column's own height.
+        expect(win.above + (win.until - win.from) * 110 + win.below).toBe(100 * 110);
+    });
+
+    it("widens the window by the overscan at both ends", () => {
+        const tight = computeWindow({ ...column(100), scrollTop: 1000, overscan: 0, chunk: 1 });
+        const loose = computeWindow({ ...column(100), scrollTop: 1000, overscan: 220, chunk: 1 });
+
+        expect(loose.from).toBe(tight.from - 2);
+        expect(loose.until).toBe(tight.until + 2);
+    });
+
+    it("rounds the edges outwards to whole chunks, so scrolling by a card redraws nothing", () => {
+        const first = computeWindow({ ...column(500), scrollTop: 1000, overscan: 0, chunk: 25 });
+        const nudged = computeWindow({ ...column(500), scrollTop: 1050, overscan: 0, chunk: 25 });
+
+        expect(first.from % 25).toBe(0);
+        expect(first.until % 25).toBe(0);
+        expect(sameWindow(first, nudged)).toBe(true);
+    });
+
+    it("moves the window on once the reader has passed a chunk", () => {
+        const near = computeWindow({ ...column(500), scrollTop: 1000, overscan: 0, chunk: 25 });
+        const far = computeWindow({ ...column(500), scrollTop: 6000, overscan: 0, chunk: 25 });
+
+        expect(sameWindow(near, far)).toBe(false);
+        expect(far.from).toBeGreaterThan(near.from);
+    });
+
+    it("keeps the top spacer at nothing while the reader is at the top", () => {
+        const win = computeWindow({ ...column(500), scrollTop: 0, overscan: 800, chunk: 25 });
+        expect(win.from).toBe(0);
+        expect(win.above).toBe(0);
+    });
+
+    it("keeps the foot spacer at nothing once the last card is drawn", () => {
+        const heights = Array(500).fill(100);
+        const total = 500 * 110;
+        const win = computeWindow({
+            heights, spacing: 10, viewport: 500, scrollTop: total - 500, overscan: 0, chunk: 25
+        });
+
+        expect(win.until).toBe(500);
+        expect(win.below).toBe(0);
+    });
+
+    it("draws the last cards rather than nothing when scrolled past the end", () => {
+        const win = computeWindow({
+            ...column(300), scrollTop: 999_999, overscan: 0, chunk: 25
+        });
+
+        expect(win.until).toBe(300);
+        expect(win.from).toBeLessThan(300);
+        expect(win.below).toBe(0);
+    });
+
+    it("draws from the top for a scroll position above it", () => {
+        const win = computeWindow({ ...column(300), scrollTop: -200, overscan: 0, chunk: 25 });
+        expect(win.from).toBe(0);
+        expect(win.above).toBe(0);
+    });
+
+    it("counts cards of differing heights rather than assuming one height", () => {
+        const heights = [ 50, 300, 50, 300, 50 ];
+        const win = computeWindow({
+            heights, spacing: 0, viewport: 100, scrollTop: 350, overscan: 0, chunk: 1
+        });
+
+        // 350px down is inside the third card, which begins at 350.
+        expect(win.from).toBe(2);
+        expect(win.above).toBe(350);
+        expect(win.above + heights.slice(win.from, win.until).reduce((a, b) => a + b, 0)
+            + win.below).toBe(750);
+    });
+
+    it("adds up to the column's own height at every scroll position", () => {
+        const heights = Array.from({ length: 200 }, (_, i) => 40 + (i % 7) * 15);
+        const total = heights.reduce((sum, h) => sum + h + 9, 0);
+
+        for (let scrollTop = 0; scrollTop < total; scrollTop += 137) {
+            const win = computeWindow({
+                heights, spacing: 9, viewport: 600, scrollTop, overscan: 300, chunk: 25
+            });
+            const drawn = heights.slice(win.from, win.until)
+                .reduce((sum, h) => sum + h + 9, 0);
+            expect(win.above + drawn + win.below).toBe(total);
+        }
+    });
+});
+
+describe("resolveHeights", () => {
+    it("uses the nominal height while nothing has been measured", () => {
+        expect(resolveHeights([ "a", "b" ], new Map()))
+            .toEqual([ NOMINAL_CARD_HEIGHT, NOMINAL_CARD_HEIGHT ]);
+    });
+
+    it("uses what was measured, and the figure it is given for the rest", () => {
+        const measured = new Map([ [ "a", 80 ], [ "c", 120 ] ]);
+        expect(resolveHeights([ "a", "b", "c", "d" ], measured, 90))
+            .toEqual([ 80, 90, 120, 90 ]);
+    });
+});
+
+describe("estimateFrom", () => {
+    beforeEach(() => forgetWindowHeights());
+
+    it("stands at the nominal height until enough cards have been measured", () => {
+        const measured = new Map([ [ "a", 200 ], [ "b", 200 ] ]);
+        expect(estimateFrom(measured)).toBe(NOMINAL_CARD_HEIGHT);
+    });
+
+    it("settles on the average once there are enough of them", () => {
+        const measured = new Map(
+            Array.from({ length: 12 }, (_, i) => [ `n${i}`, 100 ] as const));
+        expect(estimateFrom(measured)).toBe(100);
+    });
+
+    /**
+     * The spacer above the window is counted from this, and the spacer is what holds the reader's
+     * place: a figure that kept being revised would move the column under them as they read it.
+     */
+    it("never moves again once it has settled", () => {
+        const measured = new Map<string, number>(
+            Array.from({ length: 12 }, (_, i) => [ `n${i}`, 100 ]));
+        expect(estimateFrom(measured)).toBe(100);
+
+        for (let i = 0; i < 40; i++) {
+            measured.set(`tall${i}`, 500);
+        }
+
+        expect(estimateFrom(measured)).toBe(100);
+    });
+});
+
+describe("sameWindow", () => {
+    it("compares the cards drawn and not the spacers around them", () => {
+        const a = { from: 0, until: 25, above: 0, below: 100 };
+        const b = { from: 0, until: 25, above: 0, below: 250 };
+        const c = { from: 25, until: 50, above: 0, below: 100 };
+
+        expect(sameWindow(a, b)).toBe(true);
+        expect(sameWindow(a, c)).toBe(false);
+    });
+});
+
+describe("useColumnWindow", () => {
+    let host: HTMLElement | undefined;
+    let area: HTMLElement | undefined;
+
+    beforeEach(() => {
+        forgetWindowHeights();
+        host = document.createElement("div");
+        area = document.createElement("div");
+        document.body.appendChild(host);
+        document.body.appendChild(area);
+        // happy-dom lays nothing out, so the area is told what it stands at.
+        Object.defineProperty(area, "clientHeight", { value: 600, configurable: true });
+    });
+
+    afterEach(() => {
+        if (host) render(null, host);
+        host?.remove();
+        area?.remove();
+        host = undefined;
+        area = undefined;
+    });
+
+    /** Renders a probe that does nothing but report what the hook hands back. */
+    async function probe(noteIds: string[], enabled = true) {
+        const seen: { bounds: ColumnWindow, windowChanged: boolean }[] = [];
+        const ref = { current: area ?? null };
+
+        function Probe() {
+            seen.push(useColumnWindow(ref, noteIds, enabled));
+            return null;
+        }
+
+        await act(async () => {
+            render(<Probe />, host ?? document.body);
+        });
+        return { seen, last: () => seen[seen.length - 1] };
+    }
+
+    const ids = (count: number) => Array.from({ length: count }, (_, i) => `note${i}`);
+
+    it("draws every card of a column it is switched off for", async () => {
+        const { last } = await probe(ids(500), false);
+        expect(last().bounds).toEqual({ from: 0, until: 500, above: 0, below: 0 });
+        expect(last().windowChanged).toBe(false);
+    });
+
+    it("draws a slice of a column it is switched on for, with the rest in the spacers", async () => {
+        const { last } = await probe(ids(500));
+        const { bounds } = last();
+
+        expect(bounds.from).toBe(0);
+        expect(bounds.until).toBeGreaterThan(0);
+        expect(bounds.until).toBeLessThan(500);
+        expect(bounds.above).toBe(0);
+        expect(bounds.below).toBeGreaterThan(0);
+    });
+
+    it("moves the window when the column is scrolled, and says that it changed", async () => {
+        const { last } = await probe(ids(2000));
+        const first = last().bounds;
+
+        await act(async () => {
+            if (area) area.scrollTop = 20_000;
+            area?.dispatchEvent(new Event("scroll"));
+        });
+
+        const moved = last().bounds;
+        expect(moved.from).toBeGreaterThan(first.from);
+        expect(moved.above).toBeGreaterThan(first.above);
+        // The flip has to be told, or it slides cards from places that named other cards.
+        expect(last().windowChanged).toBe(true);
+    });
+
+    it("leaves the window alone for a scroll that stays inside the chunk it is drawing", async () => {
+        const { last } = await probe(ids(2000));
+        const first = last().bounds;
+
+        await act(async () => {
+            if (area) area.scrollTop = 1;
+            area?.dispatchEvent(new Event("scroll"));
+        });
+
+        expect(last().bounds.from).toBe(first.from);
+        expect(last().windowChanged).toBe(false);
+    });
+});

--- a/apps/client/src/widgets/collections/board/windowing.ts
+++ b/apps/client/src/widgets/collections/board/windowing.ts
@@ -9,6 +9,7 @@
  */
 
 import { RefObject } from "preact";
+import { flushSync } from "preact/compat";
 import {
     useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState
 } from "preact/hooks";
@@ -121,31 +122,49 @@ export function resolveHeights(
 }
 
 /**
- * What an unmeasured card is counted at, settled once from the first cards drawn and left alone
- * after that.
+ * What a column counts an unmeasured card at, from the cards of that column already measured.
  *
- * It has to stop moving. The spacer above the window is what holds the reader's place, and it is
- * counted from these: a figure that kept being revised would move every card under them on every
- * measurement, and the column would creep while they read it.
+ * A column's own cards, not every card the page has drawn: two boards, or two columns of one
+ * board, can carry different attributes and stand at quite different heights, and counting one
+ * column's cards at another's average puts its spacers, its scrollbar and its scroll destinations
+ * all in the wrong place.
+ *
+ * Answers nothing until enough of them have been measured, and the caller then holds what it is
+ * given for good. It has to stop moving: the spacer above the window holds the reader's place and
+ * is counted from this, so a figure that kept being revised would slide the column as they read.
+ *
+ * @param held what the column has already settled on, which is answered back unchanged.
  */
-export function estimateFrom(measured: ReadonlyMap<string, number>) {
-    if (estimate !== undefined || measured.size < ESTIMATE_SAMPLE) {
-        return estimate ?? NOMINAL_CARD_HEIGHT;
+export function estimateFor(
+    noteIds: readonly string[],
+    measured: ReadonlyMap<string, number>,
+    held: number | undefined
+) {
+    if (held !== undefined) {
+        return held;
     }
 
     let total = 0;
-    for (const height of measured.values()) {
-        total += height;
+    let seen = 0;
+    for (const noteId of noteIds) {
+        const height = measured.get(noteId);
+        if (height !== undefined) {
+            total += height;
+            seen++;
+        }
     }
 
-    estimate = total / measured.size;
-    return estimate;
+    return seen >= ESTIMATE_SAMPLE ? total / seen : undefined;
 }
 
-/** How many cards are measured before what the rest are counted at is settled. */
+/** How many of a column's cards are measured before what the rest are counted at is settled. */
 const ESTIMATE_SAMPLE = 12;
 
-let estimate: number | undefined;
+/**
+ * Bumped when what has been measured is dropped, so every column settles on a fresh estimate
+ * rather than holding one taken at a width the board no longer has.
+ */
+let generation = 0;
 
 /**
  * Whether two windows draw the same cards.
@@ -176,11 +195,19 @@ export function useColumnWindow(
 ) {
     const [ revision, setRevision ] = useState(0);
     const [ scroll, setScroll ] = useState({ top: 0, viewport: 0 });
+    /** What this column counts its unmeasured cards at, once its own have settled it. */
+    const estimate = useRef<{ at: number, value?: number }>({ at: generation });
+    if (estimate.current.at !== generation) {
+        estimate.current = { at: generation };
+    }
+    estimate.current.value = estimateFor(noteIds, cardHeights, estimate.current.value);
+
+    const settled = estimate.current.value;
     const heights = useMemo(
-        () => resolveHeights(noteIds, cardHeights, estimateFrom(cardHeights)),
+        () => resolveHeights(noteIds, cardHeights, settled ?? NOMINAL_CARD_HEIGHT),
         // `revision` stands for the measurements, which live outside the render.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [ noteIds, revision ]);
+        [ noteIds, revision, settled ]);
     const spacing = cardSpacing() || DEFAULT_SPACING;
 
     const bounds = useMemo(() => (enabled
@@ -259,11 +286,24 @@ export function useColumnWindow(
         }
     });
 
+    // Published after each commit, so a gesture reads what the column is drawing with now rather
+    // than what it was drawing with when the gesture started.
+    useLayoutEffect(() => {
+        const area = areaRef.current;
+        if (!area) return;
+
+        if (enabled) {
+            models.set(area, { heights, spacing });
+        } else {
+            models.delete(area);
+        }
+    }, [ areaRef, enabled, heights, spacing ]);
+
     /**
      * Brings a card into the window, for one the column has just made where the reader is not
      * looking. The scroll is what moves the window: it is worked out from the same heights.
      */
-    const scrollToCard = useCallback((index: number) => {
+    const scrollToCard = useCallback((index: number, immediate = false) => {
         const area = areaRef.current;
         if (!area || !enabled) return;
 
@@ -275,10 +315,36 @@ export function useColumnWindow(
 
         // Placed a little above the foot of the area, so the card is not left under its own edge.
         area.scrollTop = Math.max(0, offset - area.clientHeight / 2);
+
+        if (immediate) {
+            // The scroll event that would move the window arrives a frame later, so the window is
+            // moved here instead and the card is in the page before this returns.
+            flushSync(() => setScroll({ top: area.scrollTop, viewport: area.clientHeight }));
+        }
     }, [ areaRef, enabled, heights, spacing ]);
 
     return { bounds, windowChanged: changed, scrollToCard };
 }
+
+/**
+ * What a column lays its cards out from: the heights the spacers are counted with, and the gap
+ * between one card and the next.
+ *
+ * Published so a drag can work out where a card would land without reading the page. The page is
+ * the wrong source mid-gesture: the carried card is out of the flow, the gap stands over the cards,
+ * and the ones below it are moved aside by a transform.
+ */
+export interface ColumnModel {
+    heights: readonly number[];
+    spacing: number;
+}
+
+/** The model a column is drawing with, or nothing where it draws all of its cards. */
+export function getColumnModel(area: HTMLElement) {
+    return models.get(area);
+}
+
+const models = new WeakMap<HTMLElement, ColumnModel>();
 
 /**
  * Asks the column drawing `column` to bring a card into view.
@@ -286,8 +352,10 @@ export function useColumnWindow(
  * The keyboard walks a column by index and can step onto a card outside the window, which is not
  * in the page to be focused. The column answers by scrolling to it, which draws it.
  */
-export function askForCard(container: HTMLElement, column: string, index: number) {
-    container.dispatchEvent(new CustomEvent(REVEAL_CARD, { detail: { column, index } }));
+export function askForCard(
+    container: HTMLElement, column: string, index: number, immediate = false
+) {
+    container.dispatchEvent(new CustomEvent(REVEAL_CARD, { detail: { column, index, immediate } }));
 }
 
 /** The event {@link askForCard} raises, which a windowed column listens for. */
@@ -296,12 +364,21 @@ export const REVEAL_CARD = "board:reveal-card";
 export interface RevealCardDetail {
     column: string;
     index: number;
+    /**
+     * Whether the card must be in the page by the time the ask returns.
+     *
+     * For a keyboard walk, which has to focus it in the same keystroke: focus left on nothing
+     * while a frame is waited for makes the next key find no card to walk from, and the browser
+     * scrolls the board instead. Not for an ask made while the board is drawing, where drawing
+     * again in the middle of a commit is not safe.
+     */
+    immediate?: boolean;
 }
 
 /** Drops what has been measured, for a window whose size has changed under it. */
 export function forgetWindowHeights() {
     cardHeights.clear();
-    estimate = undefined;
+    generation++;
 }
 
 /**

--- a/apps/client/src/widgets/collections/board/windowing.ts
+++ b/apps/client/src/widgets/collections/board/windowing.ts
@@ -129,9 +129,9 @@ export function resolveHeights(
  * column's cards at another's average puts its spacers, its scrollbar and its scroll destinations
  * all in the wrong place.
  *
- * Answers nothing until enough of them have been measured, and the caller then holds what it is
- * given for good. It has to stop moving: the spacer above the window holds the reader's place and
- * is counted from this, so a figure that kept being revised would slide the column as they read.
+ * Returns `undefined` until enough of them have been measured; the caller then keeps the first
+ * figure it gets. It must stop changing: the spacer above the window is counted from it and is
+ * what holds the reader's place, so revising it would slide the column while they read.
  *
  * @param held what the column has already settled on, which is answered back unchanged.
  */
@@ -258,7 +258,7 @@ export function useColumnWindow(
         //
         // Only where the same cards are still drawn: a window that moved because the reader
         // scrolled has a different spacer above it by rights, and the scroll position that moved
-        // it is already the one they asked for.
+        // the scroll position that moved it is the one the reader chose.
         const held = above.current;
         const shift = held.from === bounds.from ? bounds.above - held.height : 0;
         above.current = { from: bounds.from, height: bounds.above };
@@ -316,8 +316,8 @@ export function useColumnWindow(
         // Placed a little above the foot of the area, so the card is not left under its own edge.
         area.scrollTop = Math.max(0, offset - area.clientHeight / 2);
 
-        // Moved here rather than left to the scroll event the write raises: that event arrives a
-        // frame later, and the card has to be drawn for the ask to have been worth making.
+        // Set here rather than left to the scroll event the write above raises: that event
+        // arrives a frame later, and the card must be drawn for this call to have any effect.
         const moved = { top: area.scrollTop, viewport: area.clientHeight };
         if (immediate) {
             // Drawn before this returns, for a keyboard walk that focuses the card in the same
@@ -352,10 +352,10 @@ export function getColumnModel(area: HTMLElement) {
 const models = new WeakMap<HTMLElement, ColumnModel>();
 
 /**
- * Asks the column drawing `column` to bring a card into view.
+ * Raises {@link REVEAL_CARD} so the column drawing `column` scrolls a card into view.
  *
  * The keyboard walks a column by index and can step onto a card outside the window, which is not
- * in the page to be focused. The column answers by scrolling to it, which draws it.
+ * in the page to be focused. The column handles the event by scrolling to it, which draws it.
  */
 export function askForCard(
     container: HTMLElement, column: string, index: number, immediate = false
@@ -370,12 +370,12 @@ export interface RevealCardDetail {
     column: string;
     index: number;
     /**
-     * Whether the card must be in the page by the time the ask returns.
+     * Whether the card must be in the page by the time {@link askForCard} returns.
      *
      * For a keyboard walk, which has to focus it in the same keystroke: focus left on nothing
      * while a frame is waited for makes the next key find no card to walk from, and the browser
-     * scrolls the board instead. Not for an ask made while the board is drawing, where drawing
-     * again in the middle of a commit is not safe.
+     * scrolls the board instead. Not set when the call is made from a layout effect, where
+     * drawing again in the middle of a commit is not safe.
      */
     immediate?: boolean;
 }

--- a/apps/client/src/widgets/collections/board/windowing.ts
+++ b/apps/client/src/widgets/collections/board/windowing.ts
@@ -1,0 +1,316 @@
+/**
+ * Which of a column's cards are drawn, for a column holding more of them than the page can carry.
+ *
+ * A board keeps every card of every column in the page, and the cost of that is not the elements
+ * inside a card but the card itself: the style rules the page holds are matched against each one,
+ * so a column of thousands makes scrolling, dragging and hovering it cost hundreds of milliseconds.
+ * Drawing only what the reader can see, with a spacer standing for the rest, takes those back to
+ * the frame budget.
+ */
+
+import { RefObject } from "preact";
+import {
+    useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState
+} from "preact/hooks";
+
+import { cardSpacing } from "./drag_measure";
+
+/** What a card stands at before anything has measured it: one line of title with its padding. */
+export const NOMINAL_CARD_HEIGHT = 64;
+
+/** How far past each edge of the area cards are still drawn, so scrolling has somewhere to go. */
+export const OVERSCAN_PX = 800;
+
+/** The window's edges move in steps of this many cards, so a scroll swaps them in batches. */
+export const WINDOW_CHUNK = 25;
+
+/** What a column holds before it is worth windowing at all. */
+export const WINDOW_THRESHOLD = 120;
+
+export interface ColumnWindow {
+    /** The first card drawn. */
+    from: number;
+    /** One past the last card drawn. */
+    until: number;
+    /** What the spacer above the drawn cards stands at, in pixels. */
+    above: number;
+    /** What the spacer below them stands at, in pixels. */
+    below: number;
+}
+
+export interface WindowInput {
+    /** What each card stands at, in the order the column holds them. */
+    heights: readonly number[];
+    /** What stands between one card and the next. */
+    spacing: number;
+    scrollTop: number;
+    /** What the area drawing the cards stands at. */
+    viewport: number;
+    overscan?: number;
+    /** How many cards the window's edges move by. One card, for a test that wants no batching. */
+    chunk?: number;
+}
+
+/**
+ * The cards to draw at a scroll position, and what the spacers around them stand at.
+ *
+ * The edges are rounded outwards to whole chunks so that scrolling by a card does not redraw the
+ * column: a window only changes once the reader has passed a chunk of them.
+ */
+export function computeWindow({
+    heights, spacing, scrollTop, viewport, overscan = OVERSCAN_PX, chunk = WINDOW_CHUNK
+}: WindowInput): ColumnWindow {
+    const count = heights.length;
+    if (count === 0) {
+        return { from: 0, until: 0, above: 0, below: 0 };
+    }
+
+    const top = scrollTop - overscan;
+    const bottom = scrollTop + viewport + overscan;
+    let first = count;
+    let last = -1;
+    let offset = 0;
+    /** Where each drawn edge stands, kept while walking so neither is measured a second time. */
+    const edges: number[] = [];
+
+    for (const [index, height] of heights.entries()) {
+        edges.push(offset);
+        const foot = offset + height;
+        if (foot > top && first === count) {
+            first = index;
+        }
+        if (offset < bottom) {
+            last = index;
+        }
+        offset += height + spacing;
+    }
+    edges.push(offset);
+
+    // Nothing is in view when the column is scrolled past its own end, which a shrinking column
+    // leaves the reader at. The last chunk is drawn instead, so the column is never blank.
+    if (last < 0 || first > last) {
+        first = Math.max(0, count - 1);
+        last = count - 1;
+    }
+
+    const from = Math.max(0, Math.floor(first / chunk) * chunk);
+    const until = Math.min(count, Math.ceil((last + 1) / chunk) * chunk);
+
+    return {
+        from,
+        until,
+        above: edges[from] ?? 0,
+        // The spacing below the last drawn card is its own margin, so the spacer stands for what
+        // is left after it.
+        below: Math.max(0, (edges[count] ?? 0) - (edges[until] ?? edges[count] ?? 0))
+    };
+}
+
+/**
+ * What each card stands at, measured where it has been drawn and estimated where it has not.
+ *
+ * The estimate is the average of what has been measured, so a column of tall cards is not counted
+ * as a column of short ones once any of them has been seen.
+ */
+export function resolveHeights(
+    noteIds: readonly string[],
+    measured: ReadonlyMap<string, number>,
+    nominal = NOMINAL_CARD_HEIGHT
+): number[] {
+    return noteIds.map((noteId) => measured.get(noteId) ?? nominal);
+}
+
+/**
+ * What an unmeasured card is counted at, settled once from the first cards drawn and left alone
+ * after that.
+ *
+ * It has to stop moving. The spacer above the window is what holds the reader's place, and it is
+ * counted from these: a figure that kept being revised would move every card under them on every
+ * measurement, and the column would creep while they read it.
+ */
+export function estimateFrom(measured: ReadonlyMap<string, number>) {
+    if (estimate !== undefined || measured.size < ESTIMATE_SAMPLE) {
+        return estimate ?? NOMINAL_CARD_HEIGHT;
+    }
+
+    let total = 0;
+    for (const height of measured.values()) {
+        total += height;
+    }
+
+    estimate = total / measured.size;
+    return estimate;
+}
+
+/** How many cards are measured before what the rest are counted at is settled. */
+const ESTIMATE_SAMPLE = 12;
+
+let estimate: number | undefined;
+
+/**
+ * Whether two windows draw the same cards.
+ *
+ * The spacers are left out: they follow from the heights, and a measurement that only corrects
+ * them must not count as a change that redraws the column.
+ */
+export function sameWindow(a: ColumnWindow, b: ColumnWindow) {
+    return a.from === b.from && a.until === b.until;
+}
+
+/**
+ * The window a column draws, kept in step with its scrolling and with what its cards measure.
+ *
+ * Heights are learned as cards are drawn and remembered by note, so a card that has been on screen
+ * once is counted at its own height afterwards rather than at the estimate. Correcting a height
+ * above the reader would slide the column under them, so the scroll position is moved by the same
+ * amount in the frame the correction lands.
+ *
+ * @param areaRef the scrolling element the cards are drawn in.
+ * @param noteIds the column's cards, in the order it holds them.
+ * @param enabled whether this column is windowed at all.
+ */
+export function useColumnWindow(
+    areaRef: RefObject<HTMLElement>,
+    noteIds: readonly string[],
+    enabled: boolean
+) {
+    const [ revision, setRevision ] = useState(0);
+    const [ scroll, setScroll ] = useState({ top: 0, viewport: 0 });
+    const heights = useMemo(
+        () => resolveHeights(noteIds, cardHeights, estimateFrom(cardHeights)),
+        // `revision` stands for the measurements, which live outside the render.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [ noteIds, revision ]);
+    const spacing = cardSpacing() || DEFAULT_SPACING;
+
+    const bounds = useMemo(() => (enabled
+        ? computeWindow({
+            heights, spacing, scrollTop: scroll.top, viewport: scroll.viewport
+        })
+        : { from: 0, until: noteIds.length, above: 0, below: 0 }
+    ), [ enabled, heights, spacing, scroll.top, scroll.viewport, noteIds.length ]);
+
+    /** What the last commit drew, so a change of window can be told from a change of spacer. */
+    const drawn = useRef(bounds);
+    const changed = enabled && !sameWindow(drawn.current, bounds);
+    drawn.current = bounds;
+
+    // Follows the column's own scrolling. Read in the event rather than through state, so the
+    // window keeps up with the finger instead of trailing it by a frame.
+    useEffect(() => {
+        const area = areaRef.current;
+        if (!area || !enabled) return;
+
+        const read = () => setScroll((current) => (
+            current.top === area.scrollTop && current.viewport === area.clientHeight
+                ? current
+                : { top: area.scrollTop, viewport: area.clientHeight }));
+
+        read();
+        area.addEventListener("scroll", read, { passive: true });
+        const resize = new ResizeObserver(read);
+        resize.observe(area);
+
+        return () => {
+            area.removeEventListener("scroll", read);
+            resize.disconnect();
+        };
+    }, [ areaRef, enabled ]);
+
+    /** What the spacer above stood at last, and for which first card, so a correction is spotted. */
+    const above = useRef({ from: bounds.from, height: bounds.above });
+    useLayoutEffect(() => {
+        const area = areaRef.current;
+        if (!area || !enabled) {
+            above.current = { from: bounds.from, height: bounds.above };
+            return;
+        }
+
+        // A correction to what the undrawn cards are counted at moves everything below it, so the
+        // column is scrolled by as much to leave what the reader is looking at where it was.
+        //
+        // Only where the same cards are still drawn: a window that moved because the reader
+        // scrolled has a different spacer above it by rights, and the scroll position that moved
+        // it is already the one they asked for.
+        const held = above.current;
+        const shift = held.from === bounds.from ? bounds.above - held.height : 0;
+        above.current = { from: bounds.from, height: bounds.above };
+        if (Math.abs(shift) > 1 && area.scrollTop > 0) {
+            area.scrollTop += shift;
+        }
+
+        let corrected = false;
+        for (const card of area.querySelectorAll<HTMLElement>(".board-note")) {
+            const noteId = card.dataset.noteId;
+            const height = card.offsetHeight;
+            // A card holding the field its title is typed in stands taller than the card does, and
+            // a carried one is out of the flow at no height at all.
+            if (!noteId || !height || card.classList.contains("editing")) continue;
+
+            const known = cardHeights.get(noteId);
+            if (known === undefined || Math.abs(known - height) > 0.5) {
+                cardHeights.set(noteId, height);
+                corrected = true;
+            }
+        }
+
+        if (corrected) {
+            setRevision((r) => r + 1);
+        }
+    });
+
+    /**
+     * Brings a card into the window, for one the column has just made where the reader is not
+     * looking. The scroll is what moves the window: it is worked out from the same heights.
+     */
+    const scrollToCard = useCallback((index: number) => {
+        const area = areaRef.current;
+        if (!area || !enabled) return;
+
+        let offset = 0;
+        for (const [ at, height ] of heights.entries()) {
+            if (at >= index) break;
+            offset += height + spacing;
+        }
+
+        // Placed a little above the foot of the area, so the card is not left under its own edge.
+        area.scrollTop = Math.max(0, offset - area.clientHeight / 2);
+    }, [ areaRef, enabled, heights, spacing ]);
+
+    return { bounds, windowChanged: changed, scrollToCard };
+}
+
+/**
+ * Asks the column drawing `column` to bring a card into view.
+ *
+ * The keyboard walks a column by index and can step onto a card outside the window, which is not
+ * in the page to be focused. The column answers by scrolling to it, which draws it.
+ */
+export function askForCard(container: HTMLElement, column: string, index: number) {
+    container.dispatchEvent(new CustomEvent(REVEAL_CARD, { detail: { column, index } }));
+}
+
+/** The event {@link askForCard} raises, which a windowed column listens for. */
+export const REVEAL_CARD = "board:reveal-card";
+
+export interface RevealCardDetail {
+    column: string;
+    index: number;
+}
+
+/** Drops what has been measured, for a window whose size has changed under it. */
+export function forgetWindowHeights() {
+    cardHeights.clear();
+    estimate = undefined;
+}
+
+/**
+ * What each card measured, by note, kept for as long as the page is open.
+ *
+ * Shared by every board: a card keeps its height wherever it is drawn, and a column that has never
+ * been scrolled still counts its cards at what they stood at somewhere else.
+ */
+const cardHeights = new Map<string, number>();
+
+/** What stands between two cards before a drag has measured it. Matches `.board-note`'s margin. */
+const DEFAULT_SPACING = 9;

--- a/apps/client/src/widgets/collections/board/windowing.ts
+++ b/apps/client/src/widgets/collections/board/windowing.ts
@@ -1,11 +1,10 @@
 /**
- * Which of a column's cards are drawn, for a column holding more of them than the page can carry.
+ * Picks which of a column's cards to render, for columns holding more than the page can carry.
  *
- * A board keeps every card of every column in the page, and the cost of that is not the elements
- * inside a card but the card itself: the style rules the page holds are matched against each one,
- * so a column of thousands makes scrolling, dragging and hovering it cost hundreds of milliseconds.
- * Drawing only what the reader can see, with a spacer standing for the rest, takes those back to
- * the frame budget.
+ * Without this the board renders every card of every column. The cost is the `.board-note` element
+ * itself, not its contents: the page's CSS rules are matched against each one, so a column of
+ * 10,000 cards costs hundreds of milliseconds per style recalculation. Rendering only the visible
+ * cards, with a spacer div for the rest, brings scrolling, dragging and hovering back to 60fps.
  */
 
 import { RefObject } from "preact";
@@ -16,47 +15,47 @@ import {
 
 import { cardSpacing } from "./drag_measure";
 
-/** What a card stands at before anything has measured it: one line of title with its padding. */
+/** Height assumed for a card before it is measured: one line of title plus its padding. */
 export const NOMINAL_CARD_HEIGHT = 64;
 
-/** How far past each edge of the area cards are still drawn, so scrolling has somewhere to go. */
+/** Extra pixels rendered past each edge of the area, so a scroll has cards ready. */
 export const OVERSCAN_PX = 800;
 
-/** The window's edges move in steps of this many cards, so a scroll swaps them in batches. */
+/** The window's edges move in steps of this many cards, batching re-renders. */
 export const WINDOW_CHUNK = 25;
 
-/** What a column holds before it is worth windowing at all. */
+/** Minimum cards in a column before windowing is worth its complexity. */
 export const WINDOW_THRESHOLD = 120;
 
 export interface ColumnWindow {
-    /** The first card drawn. */
+    /** Index of the first card rendered. */
     from: number;
-    /** One past the last card drawn. */
+    /** Index one past the last card rendered. */
     until: number;
-    /** What the spacer above the drawn cards stands at, in pixels. */
+    /** Height of the spacer above the rendered cards, in pixels. */
     above: number;
-    /** What the spacer below them stands at, in pixels. */
+    /** Height of the spacer below them, in pixels. */
     below: number;
 }
 
 export interface WindowInput {
-    /** What each card stands at, in the order the column holds them. */
+    /** Height of each card, in the column's own order. */
     heights: readonly number[];
-    /** What stands between one card and the next. */
+    /** Vertical gap between one card and the next. */
     spacing: number;
     scrollTop: number;
-    /** What the area drawing the cards stands at. */
+    /** Height of the scrolling area the cards are rendered in. */
     viewport: number;
     overscan?: number;
-    /** How many cards the window's edges move by. One card, for a test that wants no batching. */
+    /** Cards per step of the window's edges. Pass 1 in a test to disable batching. */
     chunk?: number;
 }
 
 /**
- * The cards to draw at a scroll position, and what the spacers around them stand at.
+ * Returns the cards to render at a scroll position, and the height of the spacer at each end.
  *
- * The edges are rounded outwards to whole chunks so that scrolling by a card does not redraw the
- * column: a window only changes once the reader has passed a chunk of them.
+ * `from` and `until` are rounded outwards to whole chunks, so scrolling by one card does not
+ * re-render the column: the window changes only after the reader passes a chunk.
  */
 export function computeWindow({
     heights, spacing, scrollTop, viewport, overscan = OVERSCAN_PX, chunk = WINDOW_CHUNK
@@ -71,7 +70,7 @@ export function computeWindow({
     let first = count;
     let last = -1;
     let offset = 0;
-    /** Where each drawn edge stands, kept while walking so neither is measured a second time. */
+    /** Offset of each card, accumulated once so neither edge is computed twice. */
     const edges: number[] = [];
 
     for (const [index, height] of heights.entries()) {
@@ -87,8 +86,8 @@ export function computeWindow({
     }
     edges.push(offset);
 
-    // Nothing is in view when the column is scrolled past its own end, which a shrinking column
-    // leaves the reader at. The last chunk is drawn instead, so the column is never blank.
+    // A column that has shrunk can leave `scrollTop` past its own end, where no card matches.
+    // Render the last chunk instead, so the column is never blank.
     if (last < 0 || first > last) {
         first = Math.max(0, count - 1);
         last = count - 1;
@@ -101,17 +100,14 @@ export function computeWindow({
         from,
         until,
         above: edges[from] ?? 0,
-        // The spacing below the last drawn card is its own margin, so the spacer stands for what
-        // is left after it.
+        // The last rendered card supplies its own bottom margin, so the spacer covers only what
+        // follows it.
         below: Math.max(0, (edges[count] ?? 0) - (edges[until] ?? edges[count] ?? 0))
     };
 }
 
 /**
- * What each card stands at, measured where it has been drawn and estimated where it has not.
- *
- * The estimate is the average of what has been measured, so a column of tall cards is not counted
- * as a column of short ones once any of them has been seen.
+ * Returns each card's height: the measured value where there is one, `nominal` otherwise.
  */
 export function resolveHeights(
     noteIds: readonly string[],
@@ -122,18 +118,17 @@ export function resolveHeights(
 }
 
 /**
- * What a column counts an unmeasured card at, from the cards of that column already measured.
+ * Returns the height to assume for a column's unmeasured cards, averaged over its measured ones.
  *
- * A column's own cards, not every card the page has drawn: two boards, or two columns of one
- * board, can carry different attributes and stand at quite different heights, and counting one
- * column's cards at another's average puts its spacers, its scrollbar and its scroll destinations
- * all in the wrong place.
+ * Averages only `noteIds`, not every card the page has measured. Two boards, or two columns of one
+ * board, can have different promoted attributes and so different heights; using another column's
+ * average gives the wrong spacer heights, scrollbar length and `scrollToCard` destinations.
  *
- * Returns `undefined` until enough of them have been measured; the caller then keeps the first
- * figure it gets. It must stop changing: the spacer above the window is counted from it and is
- * what holds the reader's place, so revising it would slide the column while they read.
+ * Returns `undefined` until `ESTIMATE_SAMPLE` cards are measured. The caller then keeps the first
+ * value: `bounds.above` derives from it and holds the reader's scroll position, so changing it
+ * later shifts the column under them.
  *
- * @param held what the column has already settled on, which is answered back unchanged.
+ * @param held a value the column already settled on, returned unchanged.
  */
 export function estimateFor(
     noteIds: readonly string[],
@@ -161,32 +156,31 @@ export function estimateFor(
 const ESTIMATE_SAMPLE = 12;
 
 /**
- * Bumped when what has been measured is dropped, so every column settles on a fresh estimate
- * rather than holding one taken at a width the board no longer has.
+ * Incremented by `forgetWindowHeights` so each column recomputes its estimate instead of keeping
+ * one measured at a column width the board no longer has.
  */
 let generation = 0;
 
 /**
- * Whether two windows draw the same cards.
+ * Returns whether two windows render the same cards.
  *
- * The spacers are left out: they follow from the heights, and a measurement that only corrects
- * them must not count as a change that redraws the column.
+ * Ignores `above` and `below`: they derive from the heights, and a measurement that only corrects
+ * them must not count as a re-render.
  */
 export function sameWindow(a: ColumnWindow, b: ColumnWindow) {
     return a.from === b.from && a.until === b.until;
 }
 
 /**
- * The window a column draws, kept in step with its scrolling and with what its cards measure.
+ * Tracks which cards a column renders, following its scroll position and its measured heights.
  *
- * Heights are learned as cards are drawn and remembered by note, so a card that has been on screen
- * once is counted at its own height afterwards rather than at the estimate. Correcting a height
- * above the reader would slide the column under them, so the scroll position is moved by the same
- * amount in the frame the correction lands.
+ * Measures each card as it is rendered and caches the height by note id, so a card seen once uses
+ * its real height afterwards. A correction above the viewport shifts the content below it, so
+ * `scrollTop` is adjusted by the same amount in that frame.
  *
- * @param areaRef the scrolling element the cards are drawn in.
- * @param noteIds the column's cards, in the order it holds them.
- * @param enabled whether this column is windowed at all.
+ * @param areaRef the column's scrolling element.
+ * @param noteIds the column's cards, in order.
+ * @param enabled whether to window this column at all.
  */
 export function useColumnWindow(
     areaRef: RefObject<HTMLElement>,
@@ -195,7 +189,7 @@ export function useColumnWindow(
 ) {
     const [ revision, setRevision ] = useState(0);
     const [ scroll, setScroll ] = useState({ top: 0, viewport: 0 });
-    /** What this column counts its unmeasured cards at, once its own have settled it. */
+    /** Height this column assumes for its unmeasured cards, once its own have settled it. */
     const estimate = useRef<{ at: number, value?: number }>({ at: generation });
     if (estimate.current.at !== generation) {
         estimate.current = { at: generation };
@@ -205,7 +199,7 @@ export function useColumnWindow(
     const settled = estimate.current.value;
     const heights = useMemo(
         () => resolveHeights(noteIds, cardHeights, settled ?? NOMINAL_CARD_HEIGHT),
-        // `revision` stands for the measurements, which live outside the render.
+        // `revision` tracks `cardHeights`, which is mutated outside the render.
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [ noteIds, revision, settled ]);
     const spacing = cardSpacing() || DEFAULT_SPACING;
@@ -217,13 +211,13 @@ export function useColumnWindow(
         : { from: 0, until: noteIds.length, above: 0, below: 0 }
     ), [ enabled, heights, spacing, scroll.top, scroll.viewport, noteIds.length ]);
 
-    /** What the last commit drew, so a change of window can be told from a change of spacer. */
+    /** The previous commit's window, to distinguish a window change from a spacer correction. */
     const drawn = useRef(bounds);
     const changed = enabled && !sameWindow(drawn.current, bounds);
     drawn.current = bounds;
 
-    // Follows the column's own scrolling. Read in the event rather than through state, so the
-    // window keeps up with the finger instead of trailing it by a frame.
+    // Reads the scroll position in the listener rather than from state, so the window keeps up
+    // with the pointer instead of trailing it by a frame.
     useEffect(() => {
         const area = areaRef.current;
         if (!area || !enabled) return;
@@ -244,7 +238,7 @@ export function useColumnWindow(
         };
     }, [ areaRef, enabled ]);
 
-    /** What the spacer above stood at last, and for which first card, so a correction is spotted. */
+    /** The previous `above` and `from`, used to detect an estimate correction. */
     const above = useRef({ from: bounds.from, height: bounds.above });
     useLayoutEffect(() => {
         const area = areaRef.current;
@@ -253,12 +247,11 @@ export function useColumnWindow(
             return;
         }
 
-        // A correction to what the undrawn cards are counted at moves everything below it, so the
-        // column is scrolled by as much to leave what the reader is looking at where it was.
+        // Correcting the estimate changes `bounds.above`, which shifts every card below it, so
+        // `scrollTop` moves by the same amount to keep the viewport on the same cards.
         //
-        // Only where the same cards are still drawn: a window that moved because the reader
-        // scrolled has a different spacer above it by rights, and the scroll position that moved
-        // the scroll position that moved it is the one the reader chose.
+        // Only when `bounds.from` is unchanged. A window that moved because the reader scrolled
+        // has a different `above` by rights, and their scroll position is already correct.
         const held = above.current;
         const shift = held.from === bounds.from ? bounds.above - held.height : 0;
         above.current = { from: bounds.from, height: bounds.above };
@@ -270,8 +263,8 @@ export function useColumnWindow(
         for (const card of area.querySelectorAll<HTMLElement>(".board-note")) {
             const noteId = card.dataset.noteId;
             const height = card.offsetHeight;
-            // A card holding the field its title is typed in stands taller than the card does, and
-            // a carried one is out of the flow at no height at all.
+            // A card with its title editor open is taller than the card itself, and a dragged one
+            // is out of the flow with no height.
             if (!noteId || !height || card.classList.contains("editing")) continue;
 
             const known = cardHeights.get(noteId);
@@ -286,8 +279,8 @@ export function useColumnWindow(
         }
     });
 
-    // Published after each commit, so a gesture reads what the column is drawing with now rather
-    // than what it was drawing with when the gesture started.
+    // Republished after each commit, so `placeInModel` reads the current heights rather than the
+    // ones measured when a drag started.
     useLayoutEffect(() => {
         const area = areaRef.current;
         if (!area) return;
@@ -300,8 +293,8 @@ export function useColumnWindow(
     }, [ areaRef, enabled, heights, spacing ]);
 
     /**
-     * Brings a card into the window, for one the column has just made where the reader is not
-     * looking. The scroll is what moves the window: it is worked out from the same heights.
+     * Scrolls a card into the window, for one created outside it. The scroll moves the window,
+     * and the offset comes from the same `heights`.
      */
     const scrollToCard = useCallback((index: number, immediate = false) => {
         const area = areaRef.current;
@@ -332,19 +325,18 @@ export function useColumnWindow(
 }
 
 /**
- * What a column lays its cards out from: the heights the spacers are counted with, and the gap
- * between one card and the next.
+ * The heights a column lays its cards out from, and the gap between one card and the next.
  *
- * Published so a drag can work out where a card would land without reading the page. The page is
- * the wrong source mid-gesture: the carried card is out of the flow, the gap stands over the cards,
- * and the ones below it are moved aside by a transform.
+ * Published so a drag can compute where a card would land without reading the DOM. The DOM is
+ * wrong mid-gesture: the dragged card is out of the flow, the drop placeholder overlays the cards,
+ * and the ones below it are offset by a transform.
  */
 export interface ColumnModel {
     heights: readonly number[];
     spacing: number;
 }
 
-/** The model a column is drawing with, or nothing where it draws all of its cards. */
+/** Returns the model a column renders with, or `undefined` if it renders every card. */
 export function getColumnModel(area: HTMLElement) {
     return models.get(area);
 }
@@ -380,19 +372,19 @@ export interface RevealCardDetail {
     immediate?: boolean;
 }
 
-/** Drops what has been measured, for a window whose size has changed under it. */
+/** Clears the measured heights, for a window resize that changes card widths. */
 export function forgetWindowHeights() {
     cardHeights.clear();
     generation++;
 }
 
 /**
- * What each card measured, by note, kept for as long as the page is open.
+ * Measured height of each card, by note id, for the lifetime of the page.
  *
- * Shared by every board: a card keeps its height wherever it is drawn, and a column that has never
- * been scrolled still counts its cards at what they stood at somewhere else.
+ * Shared across boards: a note has the same height wherever it is rendered, so a column opened for
+ * the first time can reuse heights measured elsewhere.
  */
 const cardHeights = new Map<string, number>();
 
-/** What stands between two cards before a drag has measured it. Matches `.board-note`'s margin. */
+/** Gap between two cards before a drag measures it. Matches `.board-note`'s bottom margin. */
 const DEFAULT_SPACING = 9;

--- a/apps/client/src/widgets/collections/board/windowing.ts
+++ b/apps/client/src/widgets/collections/board/windowing.ts
@@ -316,10 +316,15 @@ export function useColumnWindow(
         // Placed a little above the foot of the area, so the card is not left under its own edge.
         area.scrollTop = Math.max(0, offset - area.clientHeight / 2);
 
+        // Moved here rather than left to the scroll event the write raises: that event arrives a
+        // frame later, and the card has to be drawn for the ask to have been worth making.
+        const moved = { top: area.scrollTop, viewport: area.clientHeight };
         if (immediate) {
-            // The scroll event that would move the window arrives a frame later, so the window is
-            // moved here instead and the card is in the page before this returns.
-            flushSync(() => setScroll({ top: area.scrollTop, viewport: area.clientHeight }));
+            // Drawn before this returns, for a keyboard walk that focuses the card in the same
+            // keystroke.
+            flushSync(() => setScroll(moved));
+        } else {
+            setScroll(moved);
         }
     }, [ areaRef, enabled, heights, spacing ]);
 


### PR DESCRIPTION
Boards containing very large columns are now usable. A column holding several thousand cards previously caused visible stuttering when scrolling, dragging a card, or simply moving the pointer across it, and adding a card could freeze the board for over a second. The board now renders only the cards that are actually visible, so a column of ten thousand cards behaves like a column of forty. Several defects in card placement have also been corrected, including a card appearing part way up a column before jumping to its final position, and the drop indicator drifting away from the position a card would actually land in.

### Measurements

Recorded in headless Chromium against a development build, on a board whose largest column holds 10,027 cards. Frame figures are the median and worst frame observed during the interaction; long tasks are the total main-thread blocking time it produced.

| Interaction (before →  after) | Median frame | Worst frame | Long tasks |
|---|---|---|---|
| Scrolling the column | 37.7ms → 16.8ms | 286ms → 40ms | 900ms → 0ms |
| Picking up a card | 16.8ms → 16.7ms | 294ms → 33ms | 435ms → 0ms |
| Releasing a card | 16.7ms → 16.7ms | 110ms → 19ms | 176ms → 0ms |
| Moving the pointer across the cards | 18.1ms → 16.5ms | 56ms → 19ms | 165ms → 0ms |
| Scrolling the board sideways | 16.7ms → 16.7ms | 41ms → 17ms | 0ms → 0ms |

| Measure | Before | After |
|---|---|---|
| DOM elements rendered by the board | 50,022 | 390 |
| Style recalculation per structural change within the board | 435ms | 22ms |
| Drop indicator displacement over 70,800px of auto-scroll | 1,510px | 86px |

### Rendering of large columns

- Render only the cards near a column's scroll position, with spacer elements preserving the height of those omitted, for columns holding more than 120 cards.
- Move the rendered window in steps of 25 cards, so that scrolling past a single card does not re-render the column.
- Cache each card's measured height by note id and reuse it wherever that card is rendered.
- Settle the height assumed for a column's unmeasured cards after 12 of its own cards have been measured, and hold that value thereafter.
- Scope the assumed height to each column, so that columns with differing promoted attributes do not inherit one another's estimates.
- Clear all cached heights on window resize, which alters column width and therefore card heights.
- Adjust a column's scroll position when a height correction changes the space above the viewport, so that the content under the reader does not shift.
- Disable `overflow-anchor` on a windowed column, so that the browser does not compete with that adjustment.
- Suppress the card FLIP animation for the commit in which the window changes, so that scrolling is not animated as a reorder.
- Scroll a column to a card created outside the rendered window, since such a card cannot scroll itself into view.

### Style recalculation

- Replace the three board `:has()` selectors with an `editing-open` class set from board state, eliminating a full-board style recalculation on every structural change within the board.
- Report an open insert field from each column to the board, replacing the `:has()` detection this previously required.
- Mark the column holding an open editor with its own `editing-open` class, replacing the per-column `:has()` selector that lifted its mask.

### Card movement

- Compute the drop index from a column's current card heights rather than from measurements taken when the drag began, so that the drop indicator no longer drifts from the resulting position during an auto-scroll.
- Offset the drop index by the column's top padding, which previously displaced every computed position by eight pixels and could select the following slot.
- Record each card's index within its column as a `data-index` attribute, so that a drag identifies a position in the column rather than among the rendered cards.
- Synthesise measurement boxes for the cards a windowed column does not render, keeping every drag index expressed in the column's own terms.
- Use the unfiltered column length when placing a card moved into another column, so that a card no longer appears part way up a filtered column before jumping to the end.
- Convert a filtered index to its unfiltered position when reordering cards within a column.
- Place the drop indicator against the first rendered card when the drop position lies above the rendered window.

### Keyboard navigation

- Navigate a column by card index rather than by position among the rendered cards, so that `Home` and `End` reach the column's true first and last card.
- Scroll a column to a card it is not currently rendering and focus that card within the same keystroke.
- Focus a card moved into a column that is not rendering the position it lands in.
- Fall back to the previously focused position when a redraw removes the focused card, so that a navigation key no longer scrolls the board instead of moving through it.

### Tests

- Add unit tests covering window computation, height resolution, per-column height estimation, and the scroll and reveal operations.
- Add board-level tests covering a windowed column's rendered slice, its spacer heights, and the indices assigned to its cards.
- Add keyboard tests covering navigation onto unrendered cards, `Home` and `End` across the full column, and a move into a column that is not rendering the destination.
- Add drag measurement tests covering the synthesised boxes for unrendered cards and the reported content origin.
- Add a regression test confirming that a card sent to a filtered column is placed at the column's end.
- Add tests confirming that the editing backdrop and the per-column mask are driven by state rather than by selector matching.
