### PR TITLE
TOTP: accept each code only once, and one time step of clock drift

### DIFF
--- a/apps/server/src/routes/api/totp.spec.ts
+++ b/apps/server/src/routes/api/totp.spec.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGenerateKey, mockValidate } = vi.hoisted(() => ({
     mockGenerateKey: vi.fn<(opts: { issuer: string; user: string }) => { secret: string; url: string }>(),
-    mockValidate: vi.fn<(args: { passcode: string; secret: string }) => boolean>()
+    mockValidate: vi.fn<typeof import("time2fa").Hotp.validate>()
 }));
 
-vi.mock("time2fa", () => ({
-    Totp: { generateKey: mockGenerateKey, validate: mockValidate }
+vi.mock("time2fa", async (importOriginal) => ({
+    ...await importOriginal<typeof import("time2fa")>(),
+    Totp: { generateKey: mockGenerateKey },
+    Hotp: { validate: mockValidate }
 }));
 
 import recoveryCodes from "../../services/encryption/recovery_codes.js";
@@ -46,7 +48,8 @@ describe("TOTP API", () => {
             { success: boolean; recoveryCodes?: string[] };
         expect(result.success).toBe(true);
         expect(result.recoveryCodes).toHaveLength(8);
-        expect(mockValidate).toHaveBeenCalledWith({ passcode: "000000", secret: SECRET });
+        expect(mockValidate).toHaveBeenCalledWith(
+            { passcode: "000000", secret: SECRET, counter: expect.any(Number) }, expect.anything());
         // Verifying alone must neither enable TOTP nor store the recovery codes.
         expect(totpRoute.getTOTPStatus().set).toBe(false);
         expect(recoveryCodes.isRecoveryCodeSet()).toBe(false);

--- a/apps/server/src/services/auth.spec.ts
+++ b/apps/server/src/services/auth.spec.ts
@@ -493,7 +493,7 @@ describe("Auth", () => {
         it("does not consume a recovery code when the password is wrong", async () => {
             vi.spyOn(passwordEncryptionService, "verifyPassword").mockResolvedValue(false as never);
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(true);
-            const validateSpy = vi.spyOn(totp, "validateTOTP").mockReturnValue(false);
+            const validateSpy = vi.spyOn(totp, "verifyTOTP").mockReturnValue(false);
             const recoverySpy = vi.spyOn(recoveryCodeService, "verifyRecoveryCode").mockReturnValue(true);
 
             expect(await verifyLoginCredentials("wrong-password", RECOVERY_CODE)).toBe("password");
@@ -508,7 +508,7 @@ describe("Auth", () => {
         it("returns null for a correct password when TOTP is disabled", async () => {
             vi.spyOn(passwordEncryptionService, "verifyPassword").mockResolvedValue(true as never);
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(false);
-            const validateSpy = vi.spyOn(totp, "validateTOTP").mockReturnValue(false);
+            const validateSpy = vi.spyOn(totp, "verifyTOTP").mockReturnValue(false);
 
             expect(await verifyLoginCredentials("correct", "")).toBeNull();
             // With TOTP disabled the second factor is skipped entirely.
@@ -518,7 +518,7 @@ describe("Auth", () => {
         it("returns null for a correct password with a valid TOTP token, without touching recovery codes", async () => {
             vi.spyOn(passwordEncryptionService, "verifyPassword").mockResolvedValue(true as never);
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(true);
-            vi.spyOn(totp, "validateTOTP").mockReturnValue(true);
+            vi.spyOn(totp, "verifyTOTP").mockReturnValue(true);
             const recoverySpy = vi.spyOn(recoveryCodeService, "verifyRecoveryCode").mockReturnValue(false);
 
             expect(await verifyLoginCredentials("correct", "123456")).toBeNull();
@@ -529,7 +529,7 @@ describe("Auth", () => {
         it("consumes a recovery code only after the password is verified", async () => {
             vi.spyOn(passwordEncryptionService, "verifyPassword").mockResolvedValue(true as never);
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(true);
-            vi.spyOn(totp, "validateTOTP").mockReturnValue(false);
+            vi.spyOn(totp, "verifyTOTP").mockReturnValue(false);
             const recoverySpy = vi.spyOn(recoveryCodeService, "verifyRecoveryCode").mockReturnValue(true);
 
             expect(await verifyLoginCredentials("correct", RECOVERY_CODE)).toBeNull();
@@ -539,7 +539,7 @@ describe("Auth", () => {
         it("rejects a correct password paired with an invalid second factor", async () => {
             vi.spyOn(passwordEncryptionService, "verifyPassword").mockResolvedValue(true as never);
             vi.spyOn(totp, "isTotpEnabled").mockReturnValue(true);
-            vi.spyOn(totp, "validateTOTP").mockReturnValue(false);
+            vi.spyOn(totp, "verifyTOTP").mockReturnValue(false);
             vi.spyOn(recoveryCodeService, "verifyRecoveryCode").mockReturnValue(false);
 
             expect(await verifyLoginCredentials("correct", "000000")).toBe("totp");

--- a/apps/server/src/services/auth.ts
+++ b/apps/server/src/services/auth.ts
@@ -300,7 +300,7 @@ export async function verifyLoginCredentials(password: string, totpToken: string
 }
 
 function verifyTOTP(submittedTotpToken: string) {
-    if (totp.validateTOTP(submittedTotpToken)) {
+    if (totp.verifyTOTP(submittedTotpToken)) {
         return true;
     }
 

--- a/apps/server/src/services/totp.spec.ts
+++ b/apps/server/src/services/totp.spec.ts
@@ -237,9 +237,37 @@ describe("totp", () => {
             vi.setSystemTime(new Date("2026-01-01T00:00:40Z"));
             expect(verify(step + 1)).toBe(true);
 
+            // At step + 2 the window reaches back to step + 1, whose code is already used.
+            vi.setSystemTime(new Date("2026-01-01T00:01:10Z"));
+            expect(verify(step + 1)).toBe(false);
+            // A code from an authenticator one step ahead passes, and after it nothing older does.
+            expect(verify(step + 3)).toBe(true);
+            expect(verify(step + 2)).toBe(false);
+
             // Enrolling a secret clears the recorded step.
             cls.init(() => totp.setSecret(SECRET));
-            expect(verify(step + 1)).toBe(true);
+            expect(verify(step + 2)).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("enrollment accepts a step either side, the wizard only the current one", async () => {
+        const codeFor = await useRealCodes();
+        vi.useFakeTimers({ toFake: [ "Date" ] });
+        try {
+            cls.init(() => totp.setSecret(SECRET));
+            vi.setSystemTime(new Date("2026-01-01T00:00:40Z"));
+            const step = Math.floor(Date.now() / 1000 / 30);
+
+            expect(totp.validateTOTPForSecret(SECRET, codeFor(step - 1))).toBe(true);
+            expect(totp.validateTOTPForSecret(SECRET, codeFor(step + 1))).toBe(true);
+            expect(totp.validateTOTPForSecret(SECRET, codeFor(step - 2))).toBe(false);
+            expect(totp.validateTOTPForSecret(SECRET, codeFor(step + 2))).toBe(false);
+
+            expect(cls.init(() => totp.validateTOTP(codeFor(step)))).toBe(true);
+            expect(cls.init(() => totp.validateTOTP(codeFor(step - 1)))).toBe(false);
+            expect(cls.init(() => totp.validateTOTP(codeFor(step + 1)))).toBe(false);
         } finally {
             vi.useRealTimers();
         }

--- a/apps/server/src/services/totp.spec.ts
+++ b/apps/server/src/services/totp.spec.ts
@@ -2,11 +2,13 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockGenerateKey, mockValidate } = vi.hoisted(() => ({
     mockGenerateKey: vi.fn<(opts: { issuer: string; user: string }) => { secret: string; url: string }>(),
-    mockValidate: vi.fn<(args: { passcode: string; secret: string }) => boolean>()
+    mockValidate: vi.fn<typeof import("time2fa").Hotp.validate>()
 }));
 
-vi.mock("time2fa", () => ({
-    Totp: { generateKey: mockGenerateKey, validate: mockValidate }
+vi.mock("time2fa", async (importOriginal) => ({
+    ...await importOriginal<typeof import("time2fa")>(),
+    Totp: { generateKey: mockGenerateKey },
+    Hotp: { validate: mockValidate }
 }));
 
 import type { OptionNames } from "@triliumnext/commons";
@@ -175,7 +177,8 @@ describe("totp", () => {
 
         mockValidate.mockReturnValue(true);
         expect(totp.validateTOTPForSecret(SECRET, "000000")).toBe(true);
-        expect(mockValidate).toHaveBeenCalledWith({ passcode: "000000", secret: SECRET });
+        expect(mockValidate).toHaveBeenCalledWith(
+            { passcode: "000000", secret: SECRET, counter: expect.any(Number) }, expect.anything());
 
         mockValidate.mockReturnValue(false);
         expect(totp.validateTOTPForSecret(SECRET, "000000")).toBe(false);
@@ -194,7 +197,7 @@ describe("totp", () => {
         expect(mockValidate).not.toHaveBeenCalled();
     });
 
-    it("validateTOTP delegates to Totp.validate when a secret is set", () => {
+    it("validateTOTP delegates to Hotp.validate when a secret is set", () => {
         cls.init(() => {
             totp.setSecret(SECRET);
         });
@@ -206,7 +209,7 @@ describe("totp", () => {
         expect(totp.validateTOTP("000000")).toBe(false);
     });
 
-    it("validateTOTP returns false when Totp.validate throws", () => {
+    it("validateTOTP returns false when Hotp.validate throws", () => {
         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         cls.init(() => {
             totp.setSecret(SECRET);
@@ -216,6 +219,30 @@ describe("totp", () => {
         });
         expect(totp.validateTOTP("bad")).toBe(false);
         errorSpy.mockRestore();
+    });
+
+    it("verifyTOTP accepts a code only once, while validateTOTP records nothing", async () => {
+        const codeFor = await useRealCodes();
+        const verify = (counter: number) => cls.init(() => totp.verifyTOTP(codeFor(counter)));
+        vi.useFakeTimers({ toFake: [ "Date" ] });
+        try {
+            cls.init(() => totp.setSecret(SECRET));
+            vi.setSystemTime(new Date("2026-01-01T00:00:10Z"));
+            const step = Math.floor(Date.now() / 1000 / 30);
+
+            expect(cls.init(() => totp.validateTOTP(codeFor(step)))).toBe(true);
+            expect(verify(step)).toBe(true);
+            expect(verify(step)).toBe(false);
+
+            vi.setSystemTime(new Date("2026-01-01T00:00:40Z"));
+            expect(verify(step + 1)).toBe(true);
+
+            // Enrolling a secret clears the recorded step.
+            cls.init(() => totp.setSecret(SECRET));
+            expect(verify(step + 1)).toBe(true);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it("resetTotp clears the secret and recovery codes", () => {
@@ -235,3 +262,12 @@ describe("totp", () => {
         expect(recoveryCodes.isRecoveryCodeSet()).toBe(false);
     });
 });
+
+/** Routes the mocked `Hotp.validate` to the real one and returns the real code for a time step. */
+async function useRealCodes() {
+    const actual = await vi.importActual<typeof import("time2fa")>("time2fa");
+    const config = actual.generateConfig();
+    mockValidate.mockImplementation(actual.Hotp.validate.bind(actual.Hotp));
+
+    return (counter: number) => actual.Hotp.generatePasscode({ secret: SECRET, counter }, config);
+}

--- a/apps/server/src/services/totp.spec.ts
+++ b/apps/server/src/services/totp.spec.ts
@@ -252,6 +252,26 @@ describe("totp", () => {
         }
     });
 
+    it("verifyTOTP only tries steps after the last used one", () => {
+        // Six-digit codes can repeat between steps; a code that matches every step stands in.
+        mockValidate.mockReturnValue(true);
+        vi.useFakeTimers({ toFake: [ "Date" ] });
+        try {
+            cls.init(() => totp.setSecret(SECRET));
+            vi.setSystemTime(new Date("2026-01-01T00:00:40Z"));
+            const step = Math.floor(Date.now() / 1000 / 30);
+            const verify = () => cls.init(() => totp.verifyTOTP("000000"));
+
+            for (const expected of [ step - 1, step, step + 1 ]) {
+                expect(verify()).toBe(true);
+                expect(options.getOption("totpLastUsedStep")).toBe(String(expected));
+            }
+            expect(verify()).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("enrollment accepts a step either side, the wizard only the current one", async () => {
         const codeFor = await useRealCodes();
         vi.useFakeTimers({ toFake: [ "Date" ] });

--- a/apps/server/src/services/totp.ts
+++ b/apps/server/src/services/totp.ts
@@ -1,5 +1,5 @@
 import { options } from "@triliumnext/core";
-import { Totp } from "time2fa";
+import { generateConfig, Hotp, Totp } from "time2fa";
 
 import recoveryCodesService from "./encryption/recovery_codes.js";
 import totpEncryptionService from "./encryption/totp_encryption.js";
@@ -38,9 +38,13 @@ function generateSecret(accountName = "Trilium"): { success: boolean; message?: 
     }
 }
 
-/** Persists a (previously verified) TOTP secret, making TOTP the active second factor at login. */
+/**
+ * Persists a (previously verified) TOTP secret, making TOTP the active second factor at login, and
+ * clears the time step the previous secret last used (see {@link verifyTOTP}).
+ */
 function setSecret(secret: string): void {
     totpEncryptionService.setTotpSecret(secret);
+    options.setOption("totpLastUsedStep", "");
 }
 
 function getTotpSecret(): string | null {
@@ -51,6 +55,20 @@ function checkForTotpSecret(): boolean {
     return totpEncryptionService.isTotpSecretSet();
 }
 
+/** Returns the time step `submittedPasscode` was generated for, or `null` if it matches none. */
+function findTimeStep(secret: string, submittedPasscode: string): number | null {
+    const config = generateConfig();
+    const currentStep = Math.floor(Date.now() / 1000 / config.period);
+
+    try {
+        const code = { passcode: submittedPasscode, secret: secret.trim(), counter: currentStep };
+        return Hotp.validate(code, config) ? currentStep : null;
+    } catch (e) {
+        console.error("Failed to validate TOTP:", e);
+        return null;
+    }
+}
+
 /**
  * Validates a passcode against an explicitly supplied secret. Used during enrollment to verify the
  * user's authenticator before the secret is persisted (see {@link generateSecret}).
@@ -58,23 +76,34 @@ function checkForTotpSecret(): boolean {
 function validateTOTPForSecret(secret: string, submittedPasscode: string): boolean {
     if (!secret) return false;
 
-    try {
-        return Totp.validate({
-            passcode: submittedPasscode,
-            secret: secret.trim()
-        });
-    } catch (e) {
-        console.error("Failed to validate TOTP:", e);
-        return false;
-    }
+    return findTimeStep(secret, submittedPasscode) !== null;
 }
 
-/** Validates a passcode against the persisted secret. Used at login. */
+/**
+ * Validates a passcode against the persisted secret and records nothing. Used by the setup wizard,
+ * which must not write options while becca is unloaded (see `SetupSecondFactor.verify`).
+ */
 function validateTOTP(submittedPasscode: string): boolean {
     const secret = getTotpSecret();
     if (!secret) return false;
 
     return validateTOTPForSecret(secret, submittedPasscode);
+}
+
+/**
+ * Validates a passcode against the persisted secret and records its time step, so that neither it
+ * nor a code from an earlier step is accepted again (RFC 6238, section 5.2). Used at login.
+ */
+function verifyTOTP(submittedPasscode: string): boolean {
+    const secret = getTotpSecret();
+    if (!secret) return false;
+
+    const step = findTimeStep(secret, submittedPasscode);
+    const lastUsedStep = options.getOptionOrNull("totpLastUsedStep");
+    if (step === null || (lastUsedStep && step <= Number(lastUsedStep))) return false;
+
+    options.setOption("totpLastUsedStep", String(step));
+    return true;
 }
 
 function resetTotp(): void {
@@ -90,5 +119,6 @@ export default {
     checkForTotpSecret,
     validateTOTP,
     validateTOTPForSecret,
+    verifyTOTP,
     resetTotp
 };

--- a/apps/server/src/services/totp.ts
+++ b/apps/server/src/services/totp.ts
@@ -60,14 +60,20 @@ const CLOCK_DRIFT_STEPS = 1;
 
 /**
  * Returns the time step `submittedPasscode` was generated for, or `null` if it matches none of the
- * steps within `drift` of the current one.
+ * steps within `drift` of the current one. Steps up to `lastUsedStep` are never tried.
  */
-function findTimeStep(secret: string, submittedPasscode: string, drift: number): number | null {
+function findTimeStep(
+    secret: string,
+    submittedPasscode: string,
+    drift: number,
+    lastUsedStep = -Infinity
+): number | null {
     const config = generateConfig();
     const currentStep = Math.floor(Date.now() / 1000 / config.period);
+    const firstStep = Math.max(currentStep - drift, lastUsedStep + 1);
 
     try {
-        for (let step = currentStep - drift; step <= currentStep + drift; step++) {
+        for (let step = firstStep; step <= currentStep + drift; step++) {
             const code = { passcode: submittedPasscode, secret: secret.trim(), counter: step };
             if (Hotp.validate(code, config)) return step;
         }
@@ -107,9 +113,9 @@ function verifyTOTP(submittedPasscode: string): boolean {
     const secret = getTotpSecret();
     if (!secret) return false;
 
-    const step = findTimeStep(secret, submittedPasscode, CLOCK_DRIFT_STEPS);
-    const lastUsedStep = options.getOptionOrNull("totpLastUsedStep");
-    if (step === null || (lastUsedStep && step <= Number(lastUsedStep))) return false;
+    const lastUsedStep = Number(options.getOptionOrNull("totpLastUsedStep")) || -Infinity;
+    const step = findTimeStep(secret, submittedPasscode, CLOCK_DRIFT_STEPS, lastUsedStep);
+    if (step === null) return false;
 
     options.setOption("totpLastUsedStep", String(step));
     return true;

--- a/apps/server/src/services/totp.ts
+++ b/apps/server/src/services/totp.ts
@@ -55,18 +55,27 @@ function checkForTotpSecret(): boolean {
     return totpEncryptionService.isTotpSecretSet();
 }
 
-/** Returns the time step `submittedPasscode` was generated for, or `null` if it matches none. */
-function findTimeStep(secret: string, submittedPasscode: string): number | null {
+/** Time steps accepted on either side of the current one, so clocks a step apart still agree. */
+const CLOCK_DRIFT_STEPS = 1;
+
+/**
+ * Returns the time step `submittedPasscode` was generated for, or `null` if it matches none of the
+ * steps within `drift` of the current one.
+ */
+function findTimeStep(secret: string, submittedPasscode: string, drift: number): number | null {
     const config = generateConfig();
     const currentStep = Math.floor(Date.now() / 1000 / config.period);
 
     try {
-        const code = { passcode: submittedPasscode, secret: secret.trim(), counter: currentStep };
-        return Hotp.validate(code, config) ? currentStep : null;
+        for (let step = currentStep - drift; step <= currentStep + drift; step++) {
+            const code = { passcode: submittedPasscode, secret: secret.trim(), counter: step };
+            if (Hotp.validate(code, config)) return step;
+        }
     } catch (e) {
         console.error("Failed to validate TOTP:", e);
-        return null;
     }
+
+    return null;
 }
 
 /**
@@ -76,18 +85,18 @@ function findTimeStep(secret: string, submittedPasscode: string): number | null 
 function validateTOTPForSecret(secret: string, submittedPasscode: string): boolean {
     if (!secret) return false;
 
-    return findTimeStep(secret, submittedPasscode) !== null;
+    return findTimeStep(secret, submittedPasscode, CLOCK_DRIFT_STEPS) !== null;
 }
 
 /**
- * Validates a passcode against the persisted secret and records nothing. Used by the setup wizard,
- * which must not write options while becca is unloaded (see `SetupSecondFactor.verify`).
+ * Validates a passcode for the current step only, since it records nothing. Used by the setup
+ * wizard, which must not write options while becca is unloaded (see `SetupSecondFactor.verify`).
  */
 function validateTOTP(submittedPasscode: string): boolean {
     const secret = getTotpSecret();
     if (!secret) return false;
 
-    return validateTOTPForSecret(secret, submittedPasscode);
+    return findTimeStep(secret, submittedPasscode, 0) !== null;
 }
 
 /**
@@ -98,7 +107,7 @@ function verifyTOTP(submittedPasscode: string): boolean {
     const secret = getTotpSecret();
     if (!secret) return false;
 
-    const step = findTimeStep(secret, submittedPasscode);
+    const step = findTimeStep(secret, submittedPasscode, CLOCK_DRIFT_STEPS);
     const lastUsedStep = options.getOptionOrNull("totpLastUsedStep");
     if (step === null || (lastUsedStep && step <= Number(lastUsedStep))) return false;
 

--- a/packages/commons/src/lib/options_interface.ts
+++ b/packages/commons/src/lib/options_interface.ts
@@ -116,6 +116,7 @@ export interface OptionDefinitions extends KeyboardShortcutsOptions<KeyboardActi
     totpEncryptionSalt: string;
     totpEncryptedSecret: string;
     totpVerificationHash: string;
+    totpLastUsedStep: number;
     encryptedRecoveryCodes: boolean;
     recoveryCodeInitialVector: string;
     recoveryCodeSecurityKey: string;


### PR DESCRIPTION
Refs https://github.com/orgs/TriliumNext/discussions/11439 and #5650.

Two commits, meant to be read in order. The first makes a TOTP code single-use at login, which RFC 6238 requires. The second accepts a code from the time step on either side of the current one at enrollment and login, within what the RFC allows for clock drift. The order matters: the second commit keeps a code valid at login for up to 90 seconds instead of 30, and the first is what stops that longer window from being usable to replay a code.

## Single use at login (RFC 6238, section 5.2)

A code that had just been used to log in stayed valid for the rest of its 30-second step, so it could be sent again and be accepted a second time. The RFC rules that out: "The verifier MUST NOT accept the second attempt of the OTP after the successful validation has been issued for the first OTP, which ensures one-time only use of an OTP."

`Totp.validate` from time2fa only returns a boolean, so the new `findTimeStep` checks the step with `Hotp.validate` and returns the step that matched. `verifyTOTP`, which `verifyLoginCredentials` now calls, records that step in `totpLastUsedStep` and refuses any code from the same step or an earlier one. That covers both callers of `verifyLoginCredentials`: the login form, and the token handler behind `/api/login/token` and `/api/sender/login`. The password is still checked first, so a step is only recorded once the password has matched, as with recovery codes. `setSecret` clears the recorded step, so the first code of a newly enrolled secret is not refused over a step the previous secret used.

- `totpLastUsedStep` is local to the instance, like the TOTP secret. It is not in `ALLOWED_OPTIONS`, so the options API neither returns nor accepts it.
- Reading, comparing and writing it happen in one synchronous call, so two concurrent requests with the same code cannot both pass.
- `validateTOTP` keeps checking without recording anything, for the setup wizard. The wizard runs with becca unloaded, where options must not be written (see `SetupSecondFactor.verify`), which is also why `matchesRecoveryCode` leaves a recovery code unspent there. Enrollment records nothing either: the secret is not persisted yet when `validateTOTPForSecret` checks the code.

## One time step of clock drift

Only the server's current step was tried, as `Totp.validate` does without a `drift` option. A code generated one step earlier or later was rejected with `{"success":false}` and nothing in the log, so a phone clock a few seconds off, or a code typed in the last seconds of its step, failed enrollment and login with no way to tell why. That is the failure in the discussion above: on `triliumnext/trilium:v0.105.0`, enrolling with the previous step's code produces the reporter's exact log line, `200 POST /api/totp/verify with 17 bytes took 1ms`. The reporter has not confirmed yet that clock skew is what hit them, since the same response also comes back when the request body arrives without the secret.

`findTimeStep` now takes how many steps on either side of the current one also match, and enrollment and login pass `CLOCK_DRIFT_STEPS`, which is 1. RFC 6238, section 6, recommends a limit on how many steps a client can be "out of synch", which "can be set both forward and backward from the calculated time step", and section 5.2 recommends "that at most one time step is allowed as the network delay". Enrollment and login share the window, so a user cannot enroll with a code that login would then reject.

The setup wizard's check stays on the current step. It records nothing, so a wider window there would keep a code usable for 90 seconds instead of 30.

Login sits behind the existing `loginRateLimiter`, 10 failed attempts per IP per 15 minutes, so accepting three codes instead of one leaves a blind guess at about 30 in a million per 15-minute window.

## Tests

`totp.spec.ts` runs the real time2fa under fake timers for the new cases, and each assertion was checked against a mutated `totp.ts`:

- `verifyTOTP accepts a code only once, while validateTOTP records nothing` fails with the `totpLastUsedStep` check removed (`expected true to be false` on the second use of the same code), with `setSecret` no longer clearing the step, and with a `validateTOTP` that records the step.
- The second commit extends it: one step later the used code, still inside the wider window, is refused, and after a code one step ahead nothing older passes. With the window widened and the check removed, the first of those fails on its own.
- `enrollment accepts a step either side, the wizard only the current one` fails without the second commit, and with the wizard given the wider window.
- The two TOTP specs now mock `Hotp.validate` where they mocked `Totp.validate`, and `auth.spec.ts` stubs `verifyTOTP` where it stubbed `validateTOTP`.

The server specs for TOTP, auth, login, recovery codes, OpenID, the routes index and setup pass: 18 files and 278 tests on the branch, and 184 tests in the same areas on the first commit alone. `pnpm typecheck` is clean on each commit.

End to end, one script against a server started from this branch and against the published `triliumnext/trilium:v0.105.0` image: enroll through `/api/totp/*`, then log in through `/login` without a session, every request inside the same server step S. I did not run the nightly build; `main` at 5d0bff15f, which this branch is based on, has the same TOTP login code as v0.105.0 (no diff in `services/totp.ts`, `services/auth.ts` or `routes/login.ts`).

| `/login` with | v0.105.0 | This branch |
|---|---|---|
| The code for S-1 (phone behind) | 401 | 302 |
| The same S-1 code again | 401 | 401 |
| The code for S | 302 | 302 |
| The same S code again | **302** | 401 |
| The code for S+1 (phone ahead) | 401 | 302 |
| The S-1 code after S+1 was used | 401 | 401 |

## For users

Signing in twice within the same 30 seconds, for example on two devices, now needs the next code for the second sign-in. The User Guide page "Multi-factor authentication with TOTP" stays accurate as it is, since it already describes a one-time password, so I left it unchanged.

## Not covered

- #8920 adds a TOTP check to `checkCredentials` for desktop sync setup and calls `totp.validateTOTP` there. If it lands after this, that check should call `totp.verifyTOTP`, so the code is single-use on that path too.
