### PR TITLE
fix(ci): unbreak the Windows nightly and release builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,6 +65,12 @@ jobs:
               shell: bash
               forge_platform: linux
     runs-on: ${{ matrix.os.image }}
+    defaults:
+      run:
+        # Under pnpm/action-setup's pnpm 12 bootstrap, `pnpm` invoked from PowerShell on the
+        # win-signing runner exits 0 without running anything, so the steps below have to
+        # reach it through the same shell the build uses.
+        shell: ${{ matrix.os.shell }}
     env:
       # "Update nightly version" rewrites the version field of six workspace manifests, which
       # makes the next `pnpm run` re-install the whole workspace even though the dependency

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,19 +65,33 @@ jobs:
               shell: bash
               forge_platform: linux
     runs-on: ${{ matrix.os.image }}
+    env:
+      # "Update nightly version" rewrites the version field of six workspace manifests, which
+      # makes the next `pnpm run` re-install the whole workspace even though the dependency
+      # graph is unchanged. "Install dependencies" below is the authoritative install.
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false"
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      # pnpm derives its store from PNPM_HOME, which pnpm/action-setup points inside the
+      # directory it reinstalls on every run. The win-signing runner is persistent, so the
+      # store has to sit somewhere that survives between jobs, and packages have to be copied
+      # out of it: rebuilding better-sqlite3 and electron-forge's pruning both write into
+      # node_modules, which a hardlink would carry back into the shared store.
+      - name: Keep the pnpm store outside the pnpm installation
+        if: ${{ matrix.os.name == 'windows' }}
+        shell: powershell
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "PNPM_CONFIG_STORE_DIR=C:\pnpm-store"
+          Add-Content -Path $env:GITHUB_ENV -Value "PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy"
       - name: Set up node & dependencies
         uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        env:
-          npm_config_package_import_method: copy
       - name: Update nightly version
         run: pnpm run chore:ci-update-nightly-version
       - name: Run the build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
               shell: bash
               forge_platform: linux
     runs-on: ${{ matrix.os.image }}
+    defaults:
+      run:
+        # Under pnpm/action-setup's pnpm 12 bootstrap, `pnpm` invoked from PowerShell on the
+        # win-signing runner exits 0 without running anything, so the steps below have to
+        # reach it through the same shell the build uses.
+        shell: ${{ matrix.os.shell }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The nightly has failed every night since Sep 9, always and only on the two Windows jobs. Two separate defects on the `win-signing` runner were stacked on top of each other, both dating from the `pnpm/action-setup` v6.1.0 bump in 69c383cf30.

## pnpm does nothing when launched from PowerShell

Under the pnpm 12 bootstrap that v6.1.0 added, `pnpm` invoked from PowerShell on that runner writes no output and exits 0 without installing anything. The same command under `cmd` works. Job-level `run:` steps default to PowerShell on Windows, so `pnpm install --frozen-lockfile` and `pnpm run chore:ci-update-nightly-version` have both been silent no-ops there for weeks.

Nothing surfaced this because a third defect was covering for it, see below. The version bump was also quietly not happening, so Windows nightlies were not getting their `-test-YYMMDD-HHMMSS` suffix either.

Both affected jobs now take their default shell from the matrix, so pnpm is reached through `cmd` on Windows and `bash` elsewhere, matching what `build-electron` already does. `release.yml`'s `make-electron` runs on the same runner and had the identical defect. It has not run since the bump, the last release being v0.105.0 on Aug 19, so the next tag push would have hit exactly what the nightly hit.

## Every job re-downloaded the whole dependency tree

pnpm derives its store from `PNPM_HOME`, which `pnpm/action-setup` points at `<dest>/node_modules/.bin`. That is inside the directory the action deletes and reinstalls on every run, so the store started empty each time. The last green run reports `reused 0, downloaded 2284`.

That put roughly 2,300 tarballs on the wire per job, and the runner's link to npm could not carry it. Sep 9 timed out, Sep 10 produced hundreds of connection resets, Sep 11 crawled at 1 to 29 KiB/s before failing to import from a half-written store, after which the arm64 job built against the incomplete tree and share-theme's esbuild reported 43 missing files.

The store is now pinned to `C:\pnpm-store`, outside what the action manages. Packages are copied out of it rather than hardlinked, because the better-sqlite3 rebuild and electron-forge's pruning both write into `node_modules` and would otherwise write through into the shared store.

The `npm_config_package_import_method` this replaces had never applied. pnpm 12 reads `PNPM_CONFIG_*`, not `npm_config_*`.

## The install ran twice

`chore:ci-update-nightly-version` rewrites the version field of six workspace manifests, so the next `pnpm run` re-installs the whole workspace before running the script it was asked for. That second install appears under `chore:update-build-info` in every Windows job, the last green one included. It was the only install actually happening, which is what masked the PowerShell defect.

With the shell fixed, `pnpm install --frozen-lockfile` is authoritative and the implicit re-install is genuinely redundant, so the job turns it off.

## Verification

Dispatched on this branch, where the ref gate uploads artifacts instead of publishing. The full run is green, all nine jobs, for the first time since Sep 8.

The two Windows jobs run back to back on one runner, and the store now survives between them:

| Windows job | Store reuse |
| --- | --- |
| x64, ran first | reused 1693, downloaded 558 |
| arm64, ran second | reused 2251, downloaded 0 |

Each job reports exactly one workspace install, against two before.

| Job | Duration |
| --- | --- |
| Sep 8 green, x64 | 33.4 min |
| This branch, x64 | 8.1 min |
| This branch, arm64 | 6.7 min |

## Upstream

There is nothing to pick up. v6.1.0 is the latest release of `pnpm/action-setup`, and the pinned `ea17c68` is the only commit after v6.0.10, so we are already on the tip of main. No issue upstream describes this. Worth knowing separately: in August upstream added a README note steering users to a successor action, `pnpm/setup`, now at v2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
