### PR TITLE
fix(client/collections): stop a failed page load from failing the client suite

### DIFF
--- a/apps/client/src/widgets/collections/NoteList.spec.tsx
+++ b/apps/client/src/widgets/collections/NoteList.spec.tsx
@@ -18,11 +18,19 @@ import Component from "../../components/component";
 import type FNote from "../../entities/fnote";
 import type { EntityChange } from "../../server_types";
 import LoadResults from "../../services/load_results";
-import { buildNote } from "../../test/easy-froca";
+import { buildNote, buildNotes } from "../../test/easy-froca";
 import { ParentComponent } from "../react/react_utils";
 import { CustomNoteList, useNoteIds } from "./NoteList";
 
 let currentNoteIds: string[] = [];
+
+// The child ids below stand for real notes: a collection view resolves the ids it is given through
+// froca.getNotes(), which round-trips to the server for anything the mock does not hold.
+buildNotes([
+    { id: "child-a", title: "Child A" },
+    { id: "child-b", title: "Child B" },
+    { id: "child-new", title: "Child New" }
+]);
 
 /** Drains the chained awaits in `refreshNoteIds` (getNoteIds → search promise → setNoteIds). */
 async function flushMicrotasks() {

--- a/apps/client/src/widgets/collections/Pagination.spec.tsx
+++ b/apps/client/src/widgets/collections/Pagination.spec.tsx
@@ -167,19 +167,28 @@ describe("usePagination", () => {
         }
     });
 
-    it("reports a failed note load instead of leaving the rejection unhandled", async () => {
-        const getNotesSpy = vi.spyOn(froca, "getNotes")
-            .mockRejectedValue(new Error("tree/load failed"));
+    it("reports a failed note load, and stays quiet about a superseded one", async () => {
+        // Hand out the reject side of each load, so the page-1 load can be failed after the flip
+        // to page 2 has already superseded it.
+        const pending: Array<(reason: Error) => void> = [];
+        const getNotesSpy = vi.spyOn(froca, "getNotes").mockImplementation(() =>
+            new Promise<FNote[]>((_resolve, reject) => pending.push(reject))
+        );
         const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         try {
             const note = buildNote({ title: "Search", type: "search" });
             await mount(note, 10);
-            await settle();
+            await act(async () => observed?.setPage?.(2));
+            expect(pending).toHaveLength(2);
 
-            // An unhandled rejection here fails the whole Vitest run, not just this test.
-            expect(consoleSpy).toHaveBeenCalled();
+            const [ supersededLoad, currentLoad ] = pending;
+            await act(async () => supersededLoad(new Error("tree/load failed")));
+            expect(consoleSpy).not.toHaveBeenCalled();
+
+            await act(async () => currentLoad(new Error("tree/load failed")));
+            expect(consoleSpy).toHaveBeenCalledTimes(1);
+            expect(observed?.page).toBe(2);
             expect(observed?.pageNotes).toBeUndefined();
-            expect(observed?.page).toBe(1);
         } finally {
             consoleSpy.mockRestore();
             getNotesSpy.mockRestore();

--- a/apps/client/src/widgets/collections/Pagination.spec.tsx
+++ b/apps/client/src/widgets/collections/Pagination.spec.tsx
@@ -166,4 +166,23 @@ describe("usePagination", () => {
             getNotesSpy.mockRestore();
         }
     });
+
+    it("reports a failed note load instead of leaving the rejection unhandled", async () => {
+        const getNotesSpy = vi.spyOn(froca, "getNotes")
+            .mockRejectedValue(new Error("tree/load failed"));
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const note = buildNote({ title: "Search", type: "search" });
+            await mount(note, 10);
+            await settle();
+
+            // An unhandled rejection here fails the whole Vitest run, not just this test.
+            expect(consoleSpy).toHaveBeenCalled();
+            expect(observed?.pageNotes).toBeUndefined();
+            expect(observed?.page).toBe(1);
+        } finally {
+            consoleSpy.mockRestore();
+            getNotesSpy.mockRestore();
+        }
+    });
 });

--- a/apps/client/src/widgets/collections/Pagination.tsx
+++ b/apps/client/src/widgets/collections/Pagination.tsx
@@ -173,11 +173,15 @@ export function usePagination(
         // Overlapping loads (rapid page flips, a shrinking result set) can resolve out of order;
         // the cleanup flag makes sure a superseded load can no longer overwrite the current page.
         let cancelled = false;
-        froca.getNotes(pageNoteIds).then((notes) => {
-            if (!cancelled) {
-                setPageNotes(notes);
-            }
-        });
+        froca.getNotes(pageNoteIds)
+            .then((notes) => {
+                if (!cancelled) {
+                    setPageNotes(notes);
+                }
+            })
+            // froca.getNotes() rejects when its `tree/load` request fails. Report it and leave
+            // `pageNotes` as it stands, so the rejection reaches a handler.
+            .catch((e) => console.error(`Loading the notes of page ${effectivePage} failed`, e));
         return () => {
             cancelled = true;
         };

--- a/apps/client/src/widgets/collections/Pagination.tsx
+++ b/apps/client/src/widgets/collections/Pagination.tsx
@@ -179,9 +179,14 @@ export function usePagination(
                     setPageNotes(notes);
                 }
             })
-            // froca.getNotes() rejects when its `tree/load` request fails. Report it and leave
-            // `pageNotes` as it stands, so the rejection reaches a handler.
-            .catch((e) => console.error(`Loading the notes of page ${effectivePage} failed`, e));
+            // froca.getNotes() rejects when its `tree/load` request fails. The page keeps the notes
+            // it already has, and a superseded load stays as quiet about failing as it does about
+            // succeeding.
+            .catch((e) => {
+                if (!cancelled) {
+                    console.error(`Loading the notes of page ${effectivePage} failed`, e);
+                }
+            });
         return () => {
             cancelled = true;
         };


### PR DESCRIPTION
## Why

[#11467](https://github.com/TriliumNext/Trilium/pull/11467) (maplibre-gl 6.9.0) failed CI on a job that has nothing to do with maplibre. The `Test development` job's client-test step reported:

```
 Test Files  438 passed (438)
      Tests  5718 passed (5718)
     Errors  1 error
```

Not a failing test — a single unhandled promise rejection:

```
Error: A module tried to load from the server the following notes: child-a
This is not supported, use Froca mocking instead and ensure the note exist in the mock.
 ❯ Object.post            apps/client/src/test/setup.ts:110:27
 ❯ FrocaImpl.reloadNotes  apps/client/src/services/froca.ts:193:35
 ❯ FrocaImpl.getNotes     apps/client/src/services/froca.ts:269:20
 ❯ Object.__              apps/client/src/widgets/collections/Pagination.tsx:176:15
 ❯ preact/hooks → preact/test-utils (act)
originated in "apps/client/src/widgets/collections/NoteList.spec.tsx"
```

`apps/client/vite.config.mts` sets neither `dangerouslyIgnoreUnhandledErrors` nor `retry`, so one stray rejection reddens a suite whose tests all pass.

That failure is not the dependency's. The same error, with the same stack and the same `438 passed / 5718 passed / 1 error`, failed [#11468](https://github.com/TriliumNext/Trilium/pull/11468) (zod 4.6.1) in the same CI wave at 00:22 UTC; #11468 then went green on a re-run at 07:19 and merged. Two causes have to line up for it to fire, and this fixes both.

## `usePagination` had no rejection handler

`usePagination` resolved its page slice with `froca.getNotes(pageNoteIds).then(...)` and nothing on the rejection path, so a failed `tree/load` had no handler at all. In the browser that leaves the console with a bare rejection and no indication of which view asked for the notes; under Vitest it fails the entire run.

It now reports the failure and leaves `pageNotes` as it stands, so a view that cannot load its page keeps showing the last one it had.

## `NoteList.spec.tsx` used note ids froca never held

The spec fed `useNoteIds` the bare strings `child-a`, `child-b` and `child-new`. A collection view resolves the ids it is handed through `froca.getNotes()`, and `apps/client/src/test/setup.ts` makes a `tree/load` for an unknown id throw — so whenever a pagination effect carrying one of those ids was flushed, the mock refused it. They are now built with `buildNotes()`, the way `Pagination.spec.tsx` already builds its own 25, so the slice resolves from the cache and never reaches for the server.

## Verification

- New spec in `Pagination.spec.tsx` covers the rejection path. With the `.catch` reverted it fails **and** raises the unhandled rejection (`1 failed | 6 passed`, `Errors 1 error`); with the fix in place, `7 passed`.
- `pnpm --filter client test collections` — 66 files, 1331 tests, green, and green again over 6 consecutive runs.
- `pnpm typecheck` — no errors.

Nothing user-visible changes, so no User Guide page is affected.

## Not covered here

The client suite stays vulnerable to this class of failure in general: on plain `main`, a full `pnpm --filter client test` run here ended `439 test files passed, 5753 tests passed, 4 errors`, all four being Bootstrap `transitionend` timers firing after the test that queued them (`item_picker`, `backup.options` ×2, `ocr_text`). That is a separate leak, left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8kR3XXUJ6urDt1p2iuk3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8kR3XXUJ6urDt1p2iuk3u)_